### PR TITLE
ci: add npm audit, coverage threshold, dashboard CI, and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: /dashboard
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Security audit
+        run: npm audit --audit-level=high
+
       - name: Run ESLint
         run: npm run lint
 
@@ -56,10 +59,32 @@ jobs:
           files: ./coverage/lcov.info
           fail_ci_if_error: false
 
+  dashboard:
+    name: Dashboard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: dashboard/package-lock.json
+
+      - name: Install dependencies
+        run: cd dashboard && npm ci
+
+      - name: Run ESLint
+        run: cd dashboard && npm run lint
+
+      - name: Build dashboard
+        run: cd dashboard && npm run build
+
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint, test]
+    needs: [lint, test, dashboard]
     steps:
       - uses: actions/checkout@v4
 

--- a/package.json
+++ b/package.json
@@ -109,6 +109,14 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
+    "coverageThreshold": {
+      "global": {
+        "branches": 10,
+        "functions": 12,
+        "lines": 15,
+        "statements": 15
+      }
+    },
     "testEnvironment": "node"
   }
 }


### PR DESCRIPTION
## Summary

- **npm audit**: Added `npm audit --audit-level=high` to lint job — fails CI on high/critical vulnerabilities
- **Coverage threshold**: Added Jest `coverageThreshold` (branches 10%, functions 12%, lines/statements 15%) — prevents coverage regression. Conservative floor based on current ~18% coverage
- **Dashboard CI**: New parallel job that runs `lint` + `build` for the React dashboard — catches TypeScript/lint errors before merge
- **Dependabot**: Weekly npm updates (root + dashboard), monthly GitHub Actions updates, minor/patch grouped to reduce PR noise

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Added audit step, dashboard job, updated build dependencies |
| `.github/dependabot.yml` | New file — dependency update automation |
| `package.json` | Added `coverageThreshold` to Jest config |

## Test plan
- [x] 110 tests pass with coverage thresholds met
- [x] CI workflow YAML valid (lint/test/dashboard run parallel, build waits for all 3)
- [x] No untrusted input in workflow `run:` commands