### PR TITLE
fix: PostgreSQL migration compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.1.4-blue.svg" alt="Version"/>
+  <img src="https://img.shields.io/badge/version-0.1.6-blue.svg" alt="Version"/>
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"/>
   <img src="https://img.shields.io/badge/node-22_LTS-brightgreen.svg" alt="Node"/>
   <img src="https://img.shields.io/badge/NestJS-11.x-red.svg" alt="NestJS"/>

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.1.0-blue.svg" alt="Version"/>
+  <img src="https://img.shields.io/badge/version-0.1.6-blue.svg" alt="Version"/>
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"/>
   <img src="https://img.shields.io/badge/node-20_LTS-brightgreen.svg" alt="Node"/>
   <img src="https://img.shields.io/badge/NestJS-11.x-red.svg" alt="NestJS"/>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwa",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API for WhatsApp",
   "author": "Yudhi Armyndharis & OpenWA Contributors",
   "private": true,

--- a/src/database/migrations/1770108659848-AddMessageStatus.ts
+++ b/src/database/migrations/1770108659848-AddMessageStatus.ts
@@ -4,6 +4,30 @@ export class AddMessageStatus1770108659848 implements MigrationInterface {
   name = 'AddMessageStatus1770108659848';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
+    const isPostgres = queryRunner.connection.options.type === 'postgres';
+
+    if (isPostgres) {
+      await this.upPostgres(queryRunner);
+    } else {
+      await this.upSqlite(queryRunner);
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const isPostgres = queryRunner.connection.options.type === 'postgres';
+
+    if (isPostgres) {
+      await this.downPostgres(queryRunner);
+    } else {
+      await this.downSqlite(queryRunner);
+    }
+  }
+
+  // ──────────────────────────────────────────────
+  //  SQLite (original, unchanged)
+  // ──────────────────────────────────────────────
+
+  private async upSqlite(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
       `CREATE TABLE "sessions" ("id" varchar PRIMARY KEY NOT NULL, "name" varchar(100) NOT NULL, "status" varchar(50) NOT NULL DEFAULT ('created'), "phone" varchar(20), "pushName" varchar(100), "config" text NOT NULL DEFAULT ('{}'), "proxyUrl" varchar(255), "proxyType" varchar(10), "connectedAt" datetime, "lastActiveAt" datetime, "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "updatedAt" datetime NOT NULL DEFAULT (datetime('now')), CONSTRAINT "UQ_ac984ccbd8b01af155e1874e8cb" UNIQUE ("name"))`,
     );
@@ -41,7 +65,7 @@ export class AddMessageStatus1770108659848 implements MigrationInterface {
     await queryRunner.query(`ALTER TABLE "temporary_webhooks" RENAME TO "webhooks"`);
   }
 
-  public async down(queryRunner: QueryRunner): Promise<void> {
+  private async downSqlite(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`ALTER TABLE "webhooks" RENAME TO "temporary_webhooks"`);
     await queryRunner.query(
       `CREATE TABLE "webhooks" ("id" varchar PRIMARY KEY NOT NULL, "sessionId" varchar NOT NULL, "url" varchar(2048) NOT NULL, "events" text NOT NULL DEFAULT ('["message.received"]'), "secret" varchar(255), "headers" text NOT NULL DEFAULT ('{}'), "active" boolean NOT NULL DEFAULT (1), "retryCount" integer NOT NULL DEFAULT (3), "lastTriggeredAt" datetime, "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "updatedAt" datetime NOT NULL DEFAULT (datetime('now')))`,
@@ -50,6 +74,58 @@ export class AddMessageStatus1770108659848 implements MigrationInterface {
       `INSERT INTO "webhooks"("id", "sessionId", "url", "events", "secret", "headers", "active", "retryCount", "lastTriggeredAt", "createdAt", "updatedAt") SELECT "id", "sessionId", "url", "events", "secret", "headers", "active", "retryCount", "lastTriggeredAt", "createdAt", "updatedAt" FROM "temporary_webhooks"`,
     );
     await queryRunner.query(`DROP TABLE "temporary_webhooks"`);
+    await queryRunner.query(`DROP INDEX "IDX_c69efb19bf127c97e6740ad530"`);
+    await queryRunner.query(`DROP INDEX "IDX_dd2b6e43c767b6b5b2bb227ace"`);
+    await queryRunner.query(`DROP INDEX "IDX_741fa976d1e04e695f3aa23cb8"`);
+    await queryRunner.query(`DROP INDEX "IDX_cee5459245f652b75eb2759b4c"`);
+    await queryRunner.query(`DROP TABLE "audit_logs"`);
+    await queryRunner.query(`DROP INDEX "IDX_df3b25181df0b4b59bd93f16e1"`);
+    await queryRunner.query(`DROP TABLE "api_keys"`);
+    await queryRunner.query(`DROP TABLE "message_batches"`);
+    await queryRunner.query(`DROP INDEX "IDX_399833392126349ef0b04b9bed"`);
+    await queryRunner.query(`DROP INDEX "IDX_36bc604c820bb9adc4c75cd411"`);
+    await queryRunner.query(`DROP INDEX "IDX_befd307485dbf0559d17e4a4d2"`);
+    await queryRunner.query(`DROP INDEX "IDX_066163c46cda7e8187f96bc87a"`);
+    await queryRunner.query(`DROP TABLE "messages"`);
+    await queryRunner.query(`DROP TABLE "webhooks"`);
+    await queryRunner.query(`DROP TABLE "sessions"`);
+  }
+
+  // ──────────────────────────────────────────────
+  //  PostgreSQL
+  // ──────────────────────────────────────────────
+
+  private async upPostgres(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "sessions" ("id" varchar PRIMARY KEY NOT NULL, "name" varchar(100) NOT NULL, "status" varchar(50) NOT NULL DEFAULT 'created', "phone" varchar(20), "pushName" varchar(100), "config" text NOT NULL DEFAULT '{}', "proxyUrl" varchar(255), "proxyType" varchar(10), "connectedAt" timestamp, "lastActiveAt" timestamp, "createdAt" timestamp NOT NULL DEFAULT NOW(), "updatedAt" timestamp NOT NULL DEFAULT NOW(), CONSTRAINT "UQ_ac984ccbd8b01af155e1874e8cb" UNIQUE ("name"))`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "webhooks" ("id" varchar PRIMARY KEY NOT NULL, "sessionId" varchar NOT NULL, "url" varchar(2048) NOT NULL, "events" text NOT NULL DEFAULT '["message.received"]', "secret" varchar(255), "headers" text NOT NULL DEFAULT '{}', "active" boolean NOT NULL DEFAULT true, "retryCount" integer NOT NULL DEFAULT 3, "lastTriggeredAt" timestamp, "createdAt" timestamp NOT NULL DEFAULT NOW(), "updatedAt" timestamp NOT NULL DEFAULT NOW(), CONSTRAINT "FK_d209715bb62b12255e825580af6" FOREIGN KEY ("sessionId") REFERENCES "sessions" ("id") ON DELETE CASCADE ON UPDATE NO ACTION)`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "messages" ("id" varchar PRIMARY KEY NOT NULL, "sessionId" varchar NOT NULL, "waMessageId" varchar, "chatId" varchar NOT NULL, "from" varchar NOT NULL, "to" varchar NOT NULL, "body" text, "type" varchar NOT NULL DEFAULT 'text', "direction" varchar NOT NULL DEFAULT 'outgoing', "timestamp" bigint, "metadata" text, "status" varchar NOT NULL DEFAULT 'sent', "createdAt" timestamp NOT NULL DEFAULT NOW())`,
+    );
+    await queryRunner.query(`CREATE INDEX "IDX_066163c46cda7e8187f96bc87a" ON "messages" ("sessionId")`);
+    await queryRunner.query(`CREATE INDEX "IDX_befd307485dbf0559d17e4a4d2" ON "messages" ("status")`);
+    await queryRunner.query(`CREATE INDEX "IDX_36bc604c820bb9adc4c75cd411" ON "messages" ("chatId")`);
+    await queryRunner.query(`CREATE INDEX "IDX_399833392126349ef0b04b9bed" ON "messages" ("sessionId", "createdAt")`);
+    await queryRunner.query(
+      `CREATE TABLE "message_batches" ("id" varchar PRIMARY KEY NOT NULL, "batch_id" varchar NOT NULL, "session_id" varchar NOT NULL, "status" varchar NOT NULL DEFAULT 'pending', "messages" text NOT NULL, "options" text, "progress" text, "results" text, "current_index" integer NOT NULL DEFAULT 0, "created_at" timestamp NOT NULL DEFAULT NOW(), "updated_at" timestamp NOT NULL DEFAULT NOW(), "started_at" timestamp, "completed_at" timestamp, CONSTRAINT "UQ_ff274470c0dbaff6c7d1f9795f5" UNIQUE ("batch_id"))`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "api_keys" ("id" varchar PRIMARY KEY NOT NULL, "name" varchar(100) NOT NULL, "keyHash" varchar(64) NOT NULL, "keyPrefix" varchar(8) NOT NULL, "role" varchar(20) NOT NULL DEFAULT 'operator', "allowedIps" text, "allowedSessions" text, "isActive" boolean NOT NULL DEFAULT true, "expiresAt" timestamp, "lastUsedAt" timestamp, "usageCount" integer NOT NULL DEFAULT 0, "createdAt" timestamp NOT NULL DEFAULT NOW(), "updatedAt" timestamp NOT NULL DEFAULT NOW())`,
+    );
+    await queryRunner.query(`CREATE UNIQUE INDEX "IDX_df3b25181df0b4b59bd93f16e1" ON "api_keys" ("keyHash")`);
+    await queryRunner.query(
+      `CREATE TABLE "audit_logs" ("id" varchar PRIMARY KEY NOT NULL, "action" varchar(50) NOT NULL, "severity" varchar(10) NOT NULL DEFAULT 'info', "apiKeyId" varchar(36), "apiKeyName" varchar(100), "sessionId" varchar(36), "sessionName" varchar(100), "ipAddress" varchar(45), "userAgent" varchar(500), "method" varchar(10), "path" varchar(500), "statusCode" integer, "metadata" text, "errorMessage" text, "createdAt" timestamp NOT NULL DEFAULT NOW())`,
+    );
+    await queryRunner.query(`CREATE INDEX "IDX_cee5459245f652b75eb2759b4c" ON "audit_logs" ("action")`);
+    await queryRunner.query(`CREATE INDEX "IDX_741fa976d1e04e695f3aa23cb8" ON "audit_logs" ("apiKeyId")`);
+    await queryRunner.query(`CREATE INDEX "IDX_dd2b6e43c767b6b5b2bb227ace" ON "audit_logs" ("sessionId")`);
+    await queryRunner.query(`CREATE INDEX "IDX_c69efb19bf127c97e6740ad530" ON "audit_logs" ("createdAt")`);
+  }
+
+  private async downPostgres(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`DROP INDEX "IDX_c69efb19bf127c97e6740ad530"`);
     await queryRunner.query(`DROP INDEX "IDX_dd2b6e43c767b6b5b2bb227ace"`);
     await queryRunner.query(`DROP INDEX "IDX_741fa976d1e04e695f3aa23cb8"`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -144,7 +144,7 @@ async function bootstrap() {
   const config = new DocumentBuilder()
     .setTitle('OpenWA API')
     .setDescription('Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API')
-    .setVersion('0.1.0')
+    .setVersion('0.1.6')
     .addApiKey({ type: 'apiKey', name: 'X-API-Key', in: 'header' }, 'X-API-Key')
     .addTag('sessions', 'WhatsApp session management')
     .addTag('messages', 'Send and manage messages')


### PR DESCRIPTION
## Summary

Fixes #59 - PostgreSQL database setup failing with `QueryFailedError: type "datetime" does not exist`

## Root Cause

The migration `AddMessageStatus1770108659848` contained hardcoded SQLite-specific raw SQL (`datetime` type, `datetime('now')` function) that PostgreSQL doesn't recognize.

## Changes

### Migration (`1770108659848-AddMessageStatus.ts`)
<ul>
<li>Added conditional branching based on <code>queryRunner.connection.options.type</code></li>
<li><b>SQLite path</b>: Kept byte-for-byte identical to the original (zero regression)</li>
<li><b>PostgreSQL path</b>: Uses proper PostgreSQL types:</li>
<ul>
<li><code>timestamp</code> instead of <code>datetime</code></li>
<li><code>NOW()</code> instead of <code>datetime('now')</code></li>
<li><code>DEFAULT true</code> instead of <code>DEFAULT (1)</code> for booleans</li>
<li>Inline FK constraint (no temp table workaround needed)</li>
</ul>
</ul>

### Version Bump to 0.1.6
<ul>
<li><code>package.json</code></li>
<li><code>README.md</code> badge (was stale at 0.1.4)</li>
<li><code>docs/README.md</code> badge (was stale at 0.1.0)</li>
<li>Swagger API docs version (was stale at 0.1.0)</li>
</ul>

## Testing
<ul>
<li>TypeScript build: OK clean, zero errors</li>
<li>SQLite path: unchanged, no regression</li>
<li>PostgreSQL path: uses valid PostgreSQL SQL syntax</li>
</ul>