### PR TITLE
feat(dashboard): add Hebrew (he) translations and RTL support

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -10,9 +10,12 @@
       "dependencies": {
         "@tanstack/react-query": "^5.100.10",
         "@tanstack/react-table": "^8.21.3",
+        "i18next": "^23.16.8",
+        "i18next-browser-languagedetector": "^8.2.1",
         "lucide-react": "^0.575.0",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
+        "react-i18next": "^14.1.3",
         "react-router-dom": "^7.15.1",
         "socket.io-client": "^4.8.3"
       },
@@ -263,6 +266,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2398,6 +2410,47 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "23.16.8",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.8.tgz",
+      "integrity": "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.1.tgz",
+      "integrity": "sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2774,6 +2827,28 @@
       },
       "peerDependencies": {
         "react": "^19.2.6"
+      }
+    },
+    "node_modules/react-i18next": {
+      "version": "14.1.3",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-14.1.3.tgz",
+      "integrity": "sha512-wZnpfunU6UIAiJ+bxwOiTmBOAaB14ha97MjOEnLGac2RJ+h/maIYXZuTHlmyqQVX1UVHmU1YDTQ5vxLmwfXTjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-refresh": {
@@ -3154,6 +3229,15 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/which": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -12,9 +12,12 @@
   "dependencies": {
     "@tanstack/react-query": "^5.100.10",
     "@tanstack/react-table": "^8.21.3",
+    "i18next": "^23.16.8",
+    "i18next-browser-languagedetector": "^8.2.1",
     "lucide-react": "^0.575.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
+    "react-i18next": "^14.1.3",
     "react-router-dom": "^7.15.1",
     "socket.io-client": "^4.8.3"
   },

--- a/dashboard/src/components/ErrorBoundary.tsx
+++ b/dashboard/src/components/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { Component, type ReactNode, type ErrorInfo } from 'react';
 import { AlertCircle, RefreshCw } from 'lucide-react';
+import i18n from '../i18n';
 
 interface Props {
   children: ReactNode;
@@ -37,9 +38,9 @@ export class ErrorBoundary extends Component<Props, State> {
           fontFamily: 'system-ui, sans-serif', color: '#374151',
         }}>
           <AlertCircle size={48} style={{ color: '#DC2626', marginBottom: '1rem' }} />
-          <h1 style={{ fontSize: '1.5rem', marginBottom: '0.5rem' }}>Something went wrong</h1>
+          <h1 style={{ fontSize: '1.5rem', marginBottom: '0.5rem' }}>{i18n.t('errorBoundary.title')}</h1>
           <p style={{ color: '#6B7280', marginBottom: '1.5rem', textAlign: 'center' }}>
-            The dashboard encountered an unexpected error.
+            {i18n.t('errorBoundary.description')}
           </p>
           <button
             onClick={this.handleReload}
@@ -51,7 +52,7 @@ export class ErrorBoundary extends Component<Props, State> {
             }}
           >
             <RefreshCw size={18} />
-            Reload Dashboard
+            {i18n.t('errorBoundary.reload')}
           </button>
         </div>
       );

--- a/dashboard/src/components/Layout.css
+++ b/dashboard/src/components/Layout.css
@@ -336,3 +336,37 @@
     display: none;
   }
 }
+
+/* ==================== RTL support ==================== */
+[dir="rtl"] .sidebar {
+  border-right: none;
+  border-left: 1px solid var(--border);
+}
+
+[dir="rtl"] .collapse-toggle {
+  right: auto;
+  left: -14px;
+}
+
+[dir="rtl"] .collapse-toggle svg {
+  transform: scaleX(-1);
+}
+
+[dir="rtl"] .main-content {
+  margin-left: 0;
+  margin-right: 260px;
+  transition:
+    margin-right 0.3s ease,
+    width 0.3s ease;
+}
+
+[dir="rtl"] .main-content.expanded {
+  margin-right: 72px;
+}
+
+@media (max-width: 768px) {
+  [dir="rtl"] .main-content,
+  [dir="rtl"] .main-content.mobile {
+    margin-right: 0;
+  }
+}

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { NavLink, Outlet } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import {
   LayoutDashboard,
   Smartphone,
@@ -17,9 +18,11 @@ import {
   X,
   ChevronLeft,
   ChevronRight,
+  Languages,
 } from 'lucide-react';
 import { useTheme } from '../hooks/useTheme';
 import { type UserRole } from '../hooks/useRole';
+import { supportedLanguages, type SupportedLanguage } from '../i18n';
 import './Layout.css';
 
 interface LayoutProps {
@@ -28,58 +31,46 @@ interface LayoutProps {
 }
 
 const allNavItems = [
-  { to: '/', icon: LayoutDashboard, label: 'Dashboard', adminOnly: false },
-  { to: '/sessions', icon: Smartphone, label: 'Sessions', adminOnly: false },
-  { to: '/webhooks', icon: Webhook, label: 'Webhooks', adminOnly: false },
-  { to: '/api-keys', icon: Key, label: 'API Keys', adminOnly: true },
-  { to: '/message-tester', icon: Send, label: 'Message Tester', adminOnly: false },
-  { to: '/infrastructure', icon: Server, label: 'Infrastructure', adminOnly: false },
-  { to: '/plugins', icon: Puzzle, label: 'Plugins', adminOnly: true },
-  { to: '/logs', icon: FileText, label: 'Logs', adminOnly: false },
+  { to: '/', icon: LayoutDashboard, key: 'dashboard' as const, adminOnly: false },
+  { to: '/sessions', icon: Smartphone, key: 'sessions' as const, adminOnly: false },
+  { to: '/webhooks', icon: Webhook, key: 'webhooks' as const, adminOnly: false },
+  { to: '/api-keys', icon: Key, key: 'apiKeys' as const, adminOnly: true },
+  { to: '/message-tester', icon: Send, key: 'messageTester' as const, adminOnly: false },
+  { to: '/infrastructure', icon: Server, key: 'infrastructure' as const, adminOnly: false },
+  { to: '/plugins', icon: Puzzle, key: 'plugins' as const, adminOnly: true },
+  { to: '/logs', icon: FileText, key: 'logs' as const, adminOnly: false },
 ];
 
 const themeIcons = { light: Sun, dark: Moon, system: Monitor };
-const themeLabels = { light: 'Light', dark: 'Dark', system: 'System' };
 
 export function Layout({ onLogout, userRole }: LayoutProps) {
+  const { t, i18n } = useTranslation();
   const { theme, toggleTheme } = useTheme();
   const ThemeIcon = themeIcons[theme];
+  const themeLabel = t(`theme.${theme}`);
 
-  // Filter navigation items based on user role
   const navItems = allNavItems.filter(item => !item.adminOnly || userRole === 'admin');
 
-  // Sidebar state - collapsed on desktop, hidden on mobile
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [isMobileOpen, setIsMobileOpen] = useState(false);
   const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
 
-  // Handle window resize
   useEffect(() => {
     const handleResize = () => {
       const mobile = window.innerWidth < 768;
       setIsMobile(mobile);
-      if (!mobile) {
-        setIsMobileOpen(false);
-      }
+      if (!mobile) setIsMobileOpen(false);
     };
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
-  // Close mobile sidebar when nav item is clicked
   const handleNavClick = () => {
-    if (isMobile) {
-      setIsMobileOpen(false);
-    }
+    if (isMobile) setIsMobileOpen(false);
   };
 
-  // Handle body scroll lock when mobile menu is open
   useEffect(() => {
-    if (isMobileOpen) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = '';
-    }
+    document.body.style.overflow = isMobileOpen ? 'hidden' : '';
     return () => {
       document.body.style.overflow = '';
     };
@@ -88,26 +79,32 @@ export function Layout({ onLogout, userRole }: LayoutProps) {
   const toggleCollapse = () => setIsCollapsed(!isCollapsed);
   const toggleMobile = () => setIsMobileOpen(!isMobileOpen);
 
+  const currentLang = (i18n.resolvedLanguage || i18n.language || 'en').split('-')[0] as SupportedLanguage;
+  const cycleLanguage = () => {
+    const idx = supportedLanguages.indexOf(currentLang);
+    const next = supportedLanguages[(idx + 1) % supportedLanguages.length];
+    void i18n.changeLanguage(next);
+  };
+  const languageLabel = currentLang === 'he' ? 'עברית' : 'EN';
+  const isRtl = currentLang === 'he';
+
   return (
     <div className="layout">
-      {/* Mobile Header */}
       {isMobile && (
         <header className="mobile-header">
-          <button className="mobile-menu-btn" onClick={toggleMobile}>
+          <button className="mobile-menu-btn" onClick={toggleMobile} aria-label={t('common.expand')}>
             {isMobileOpen ? <X size={24} /> : <Menu size={24} />}
           </button>
           <div className="mobile-brand">
             <img src="/openwa_logo.webp" alt="OpenWA" className="sidebar-logo" />
-            <span className="brand-name">OpenWA</span>
+            <span className="brand-name">{t('common.appName')}</span>
           </div>
-          <div style={{ width: 40 }} /> {/* Spacer for centering */}
+          <div style={{ width: 40 }} />
         </header>
       )}
 
-      {/* Overlay for mobile */}
       {isMobile && isMobileOpen && <div className="sidebar-overlay" onClick={() => setIsMobileOpen(false)} />}
 
-      {/* Sidebar */}
       <aside
         className={`sidebar ${isCollapsed ? 'collapsed' : ''} ${isMobile ? 'mobile' : ''} ${isMobileOpen ? 'open' : ''}`}
       >
@@ -115,43 +112,65 @@ export function Layout({ onLogout, userRole }: LayoutProps) {
           <img src="/openwa_logo.webp" alt="OpenWA" className="sidebar-logo" />
           {!isCollapsed && (
             <div className="sidebar-brand">
-              <span className="brand-name">OpenWA</span>
-              <span className="brand-subtitle">WhatsApp API</span>
+              <span className="brand-name">{t('common.appName')}</span>
+              <span className="brand-subtitle">{t('common.appSubtitle')}</span>
             </div>
           )}
         </div>
 
-        {/* Collapse toggle button - positioned at edge */}
         {!isMobile && (
-          <button className="collapse-toggle" onClick={toggleCollapse} title={isCollapsed ? 'Expand' : 'Collapse'}>
-            {isCollapsed ? <ChevronRight size={16} /> : <ChevronLeft size={16} />}
+          <button
+            className="collapse-toggle"
+            onClick={toggleCollapse}
+            title={isCollapsed ? t('common.expand') : t('common.collapse')}
+            aria-label={isCollapsed ? t('common.expand') : t('common.collapse')}
+          >
+            {isCollapsed
+              ? (isRtl ? <ChevronLeft size={16} /> : <ChevronRight size={16} />)
+              : (isRtl ? <ChevronRight size={16} /> : <ChevronLeft size={16} />)}
           </button>
         )}
 
         <nav className="sidebar-nav">
-          {navItems.map(({ to, icon: Icon, label }) => (
-            <NavLink
-              key={to}
-              to={to}
-              className={({ isActive }) => `nav-item ${isActive ? 'active' : ''}`}
-              end={to === '/'}
-              onClick={handleNavClick}
-              title={isCollapsed ? label : undefined}
-            >
-              <Icon size={20} />
-              {!isCollapsed && <span>{label}</span>}
-            </NavLink>
-          ))}
+          {navItems.map(({ to, icon: Icon, key }) => {
+            const label = t(`nav.${key}`);
+            return (
+              <NavLink
+                key={to}
+                to={to}
+                className={({ isActive }) => `nav-item ${isActive ? 'active' : ''}`}
+                end={to === '/'}
+                onClick={handleNavClick}
+                title={isCollapsed ? label : undefined}
+              >
+                <Icon size={20} />
+                {!isCollapsed && <span>{label}</span>}
+              </NavLink>
+            );
+          })}
         </nav>
 
         <div className="sidebar-footer">
-          <button className="theme-toggle-btn" onClick={toggleTheme} title={`Theme: ${themeLabels[theme]}`}>
-            <ThemeIcon size={18} />
-            {!isCollapsed && <span>{themeLabels[theme]}</span>}
+          <button
+            className="theme-toggle-btn"
+            onClick={cycleLanguage}
+            title={t('common.language')}
+            aria-label={t('common.language')}
+          >
+            <Languages size={18} />
+            {!isCollapsed && <span>{languageLabel}</span>}
           </button>
-          <button className="logout-btn" onClick={onLogout} title={isCollapsed ? 'Logout' : undefined}>
+          <button
+            className="theme-toggle-btn"
+            onClick={toggleTheme}
+            title={t('theme.label', { value: themeLabel })}
+          >
+            <ThemeIcon size={18} />
+            {!isCollapsed && <span>{themeLabel}</span>}
+          </button>
+          <button className="logout-btn" onClick={onLogout} title={isCollapsed ? t('common.logout') : undefined}>
             <LogOut size={20} />
-            {!isCollapsed && <span>Logout</span>}
+            {!isCollapsed && <span>{t('common.logout')}</span>}
           </button>
         </div>
       </aside>

--- a/dashboard/src/i18n/index.ts
+++ b/dashboard/src/i18n/index.ts
@@ -1,0 +1,44 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import LanguageDetector from 'i18next-browser-languagedetector';
+import en from './locales/en.json';
+import he from './locales/he.json';
+
+export const supportedLanguages = ['en', 'he'] as const;
+export type SupportedLanguage = (typeof supportedLanguages)[number];
+
+export const rtlLanguages: SupportedLanguage[] = ['he'];
+
+void i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    resources: {
+      en: { translation: en },
+      he: { translation: he },
+    },
+    fallbackLng: 'en',
+    supportedLngs: supportedLanguages as unknown as string[],
+    nonExplicitSupportedLngs: true,
+    interpolation: { escapeValue: false },
+    detection: {
+      order: ['localStorage', 'navigator'],
+      lookupLocalStorage: 'openwa_language',
+      caches: ['localStorage'],
+    },
+    react: { useSuspense: false },
+  });
+
+function applyDirection(lang: string) {
+  const base = (lang || 'en').split('-')[0] as SupportedLanguage;
+  const dir = rtlLanguages.includes(base) ? 'rtl' : 'ltr';
+  if (typeof document !== 'undefined') {
+    document.documentElement.lang = base;
+    document.documentElement.dir = dir;
+  }
+}
+
+applyDirection(i18n.language);
+i18n.on('languageChanged', applyDirection);
+
+export default i18n;

--- a/dashboard/src/i18n/locales/en.json
+++ b/dashboard/src/i18n/locales/en.json
@@ -1,0 +1,512 @@
+{
+  "common": {
+    "appName": "OpenWA",
+    "appSubtitle": "WhatsApp API",
+    "loading": "Loading...",
+    "save": "Save",
+    "cancel": "Cancel",
+    "delete": "Delete",
+    "edit": "Edit",
+    "create": "Create",
+    "close": "Close",
+    "submit": "Submit",
+    "confirm": "Confirm",
+    "search": "Search",
+    "filter": "Filter",
+    "actions": "Actions",
+    "status": "Status",
+    "name": "Name",
+    "role": "Role",
+    "type": "Type",
+    "url": "URL",
+    "port": "Port",
+    "host": "Host",
+    "username": "Username",
+    "password": "Password",
+    "active": "Active",
+    "inactive": "Inactive",
+    "enabled": "Enabled",
+    "disabled": "Disabled",
+    "connected": "Connected",
+    "disconnected": "Disconnected",
+    "never": "Never",
+    "justNow": "Just now",
+    "minAgo": "{{count}} min ago",
+    "hoursAgo": "{{count}} hours ago",
+    "optional": "optional",
+    "language": "Language",
+    "english": "English",
+    "hebrew": "עברית",
+    "back": "Back",
+    "next": "Next",
+    "previous": "Previous",
+    "expand": "Expand",
+    "collapse": "Collapse",
+    "logout": "Logout",
+    "refresh": "Refresh",
+    "errorGeneric": "An error occurred",
+    "unknownError": "Unknown error"
+  },
+  "theme": {
+    "light": "Light",
+    "dark": "Dark",
+    "system": "System",
+    "label": "Theme: {{value}}"
+  },
+  "nav": {
+    "dashboard": "Dashboard",
+    "sessions": "Sessions",
+    "webhooks": "Webhooks",
+    "apiKeys": "API Keys",
+    "messageTester": "Message Tester",
+    "infrastructure": "Infrastructure",
+    "plugins": "Plugins",
+    "logs": "Logs"
+  },
+  "errorBoundary": {
+    "title": "Something went wrong",
+    "description": "The dashboard encountered an unexpected error.",
+    "reload": "Reload Dashboard"
+  },
+  "login": {
+    "apiKey": "API Key",
+    "apiKeyPlaceholder": "Enter your API key",
+    "apiKeyRequired": "API key is required",
+    "connect": "Connect",
+    "connecting": "Connecting...",
+    "invalidKey": "Invalid API key",
+    "connectionError": "Unable to connect to server. Please try again.",
+    "help": "Need help?",
+    "viewDocs": "View Documentation",
+    "footer": "Made with ❤️ by Yudhi Armyndharis and the OpenWA Community",
+    "version": "v{{version}} · {{date}}"
+  },
+  "dashboard": {
+    "title": "Dashboard",
+    "subtitle": "Overview of your WhatsApp sessions and activity",
+    "stats": {
+      "activeSessions": "Active Sessions",
+      "messagesToday": "Messages Today",
+      "webhooksConfigured": "Webhooks Configured",
+      "apiCalls": "API Calls (24h)"
+    },
+    "sessionsOverview": "Sessions Overview",
+    "showingSessions": "Showing {{shown}} of {{total}} sessions",
+    "columns": {
+      "sessionId": "Session ID",
+      "phone": "Phone Number",
+      "status": "Status",
+      "lastActive": "Last Active",
+      "actions": "Actions"
+    },
+    "noSessions": "No sessions found. Create one to get started.",
+    "view": "View",
+    "disconnect": "Disconnect",
+    "errorPrefix": "Error: {{message}}",
+    "loadError": "Failed to load data"
+  },
+  "sessionStatus": {
+    "created": "New",
+    "idle": "Idle",
+    "initializing": "Starting...",
+    "connecting": "Connecting...",
+    "qr_ready": "Scan QR",
+    "ready": "Connected",
+    "disconnected": "Disconnected"
+  },
+  "sessions": {
+    "title": "Sessions",
+    "subtitle": "Manage your WhatsApp sessions and QR code connections",
+    "newSession": "New Session",
+    "searchPlaceholder": "Search sessions...",
+    "filter": {
+      "all": "All Status",
+      "active": "Active (Connected)",
+      "inactive": "Inactive",
+      "connecting": "Connecting"
+    },
+    "empty": {
+      "title": "No sessions found",
+      "description": "Create a new session to get started"
+    },
+    "create": {
+      "title": "Create New Session",
+      "label": "Session Name",
+      "placeholder": "e.g., marketing-bot",
+      "hint": "Use lowercase letters, numbers, and hyphens only. Example: <code>customer-support</code>, <code>bot-1</code>",
+      "invalidChars": "Invalid characters. Only lowercase letters, numbers, and hyphens allowed.",
+      "tooLong": "Name must be 50 characters or less ({{length}}/50).",
+      "duplicate": "Session with this name already exists.",
+      "successTitle": "Session Created",
+      "successDesc": "Session \"{{name}}\" created successfully",
+      "errorTitle": "Create Failed",
+      "errorDefault": "Failed to create session"
+    },
+    "delete": {
+      "title": "Confirm Delete",
+      "message": "Are you sure you want to delete session <strong>\"{{name}}\"</strong>?",
+      "warning": "This action cannot be undone.",
+      "successTitle": "Session Deleted",
+      "successDescNamed": "Session \"{{name}}\" deleted",
+      "successDescGeneric": "Session deleted",
+      "errorTitle": "Delete Failed",
+      "errorDefault": "Failed to delete session"
+    },
+    "qr": {
+      "title": "Scan QR Code",
+      "step1": "<strong>1.</strong> Open WhatsApp on your phone",
+      "step2": "<strong>2.</strong> Tap <strong>Menu</strong> → <strong>Linked Devices</strong>",
+      "step3": "<strong>3.</strong> Tap <strong>Link a Device</strong> and scan this QR",
+      "autoRefresh": "QR updates automatically every 5 seconds",
+      "generating": "Generating QR code...",
+      "unavailable": "QR code not available yet. Try again in a moment.",
+      "preparing": "Preparing QR code...",
+      "showQr": "Show QR",
+      "loading": "Loading...",
+      "scanToConnect": "Scan QR code to connect"
+    },
+    "details": {
+      "title": "Session Details",
+      "name": "Name",
+      "status": "Status",
+      "sessionId": "Session ID",
+      "phone": "Phone Number",
+      "phoneNone": "Not connected",
+      "created": "Created",
+      "lastActive": "Last Active"
+    },
+    "actions": {
+      "view": "View",
+      "start": "Start",
+      "stop": "Stop",
+      "reconnect": "Reconnect",
+      "delete": "Delete"
+    },
+    "toasts": {
+      "readyTitle": "Session Ready",
+      "readyDesc": "WhatsApp session is now connected",
+      "disconnectedTitle": "Session Disconnected",
+      "disconnectedDesc": "WhatsApp session was disconnected"
+    },
+    "card": {
+      "phone": "Phone",
+      "sessionId": "Session ID",
+      "lastActive": "Last Active"
+    }
+  },
+  "webhooks": {
+    "title": "Webhooks",
+    "subtitle": "Configure HTTP callbacks for real-time event notifications",
+    "addWebhook": "Add Webhook",
+    "createTitle": "Create Webhook",
+    "editTitle": "Edit Webhook",
+    "deleteTitle": "Delete Webhook",
+    "deleteConfirm": "Are you sure you want to delete this webhook?",
+    "selectSession": "Select session...",
+    "session": "Session",
+    "events": "Events",
+    "available": "Available Events",
+    "saveChanges": "Save Changes",
+    "columns": {
+      "url": "URL",
+      "events": "Events",
+      "session": "Session",
+      "status": "Status",
+      "actions": "Actions"
+    },
+    "empty": {
+      "title": "No webhooks configured",
+      "description": "Add a webhook to receive real-time event notifications"
+    },
+    "toasts": {
+      "created": "Webhook created successfully",
+      "createFailed": "Failed to create webhook: {{message}}",
+      "deleted": "Webhook deleted successfully",
+      "deleteFailed": "Failed to delete webhook: {{message}}",
+      "updated": "Webhook updated successfully",
+      "updateFailed": "Failed to update webhook: {{message}}",
+      "testOk": "Webhook test successful! Status: {{status}}",
+      "testFailed": "Webhook test failed: {{message}}",
+      "testError": "Failed to test webhook: {{message}}"
+    },
+    "actions": {
+      "test": "Test",
+      "edit": "Edit",
+      "delete": "Delete"
+    },
+    "eventDescriptions": {
+      "message.received": "When a message is received",
+      "message.sent": "When a message is sent",
+      "session.connected": "When a session connects",
+      "session.disconnected": "When a session disconnects",
+      "session.qr": "When QR code is generated",
+      "all": "All events"
+    }
+  },
+  "apiKeys": {
+    "title": "API Keys",
+    "subtitle": "Manage API keys for authentication and access control",
+    "createBtn": "Create API Key",
+    "modalTitle": "Create API Key",
+    "createdTitle": "API Key Created",
+    "createdHint": "Copy this key now. You won't be able to see it again.",
+    "namePlaceholder": "e.g., Production Key",
+    "rolesTitle": "Roles Reference",
+    "roles": {
+      "admin": "Admin",
+      "operator": "Operator",
+      "viewer": "Viewer"
+    },
+    "roleDescriptions": {
+      "admin": "Full access to all resources",
+      "operator": "Session & message management",
+      "viewer": "Read-only access"
+    },
+    "columns": {
+      "name": "Name",
+      "key": "Key",
+      "role": "Role",
+      "status": "Status",
+      "lastUsed": "Last Used",
+      "actions": "Actions"
+    },
+    "statuses": {
+      "active": "Active",
+      "revoked": "Revoked"
+    },
+    "empty": {
+      "title": "No API keys created",
+      "description": "Create an API key to authenticate your requests"
+    },
+    "confirm": {
+      "deleteTitle": "Delete API Key",
+      "revokeTitle": "Revoke API Key",
+      "deleteMessage": "Are you sure you want to permanently delete <strong>{{name}}</strong>? This action cannot be undone.",
+      "revokeMessage": "Are you sure you want to revoke <strong>{{name}}</strong>? It will no longer work.",
+      "delete": "Delete",
+      "revoke": "Revoke"
+    },
+    "actions": {
+      "copy": "Copy",
+      "revoke": "Revoke",
+      "delete": "Delete"
+    }
+  },
+  "logs": {
+    "title": "Audit Logs",
+    "subtitle": "Track and review all API actions and system events",
+    "exportCsv": "Export CSV",
+    "searchPlaceholder": "Search logs...",
+    "severity": {
+      "all": "All Severities",
+      "info": "Info",
+      "warn": "Warning",
+      "error": "Error"
+    },
+    "columns": {
+      "timestamp": "Timestamp",
+      "action": "Action",
+      "session": "Session",
+      "apiKey": "API Key",
+      "ip": "IP Address",
+      "severity": "Severity"
+    },
+    "empty": {
+      "title": "No logs found",
+      "description": "Audit logs will appear here as actions are performed"
+    }
+  },
+  "messageTester": {
+    "title": "Message Tester",
+    "subtitle": "Send test messages through the API",
+    "compose": "Send Test Message",
+    "responseTitle": "API Response",
+    "session": "Session",
+    "noReadySessions": "No ready sessions",
+    "sessionOptionPhoneNone": "No phone",
+    "recipientType": "Recipient Type",
+    "personal": "Personal",
+    "group": "Group",
+    "selectGroup": "Select Group",
+    "recipientPhone": "Recipient Phone Number",
+    "loadingGroups": "Loading groups...",
+    "noGroupsFound": "No groups found",
+    "selectGroupHint": "Select a group from your WhatsApp",
+    "phoneHint": "Use international format without spaces",
+    "messageType": "Message Type",
+    "types": {
+      "text": "Text",
+      "image": "Image",
+      "video": "Video",
+      "audio": "Audio",
+      "document": "Document"
+    },
+    "messageContent": "Message Content",
+    "messagePlaceholder": "Enter your message here...",
+    "mediaUrl": "Media URL",
+    "caption": "Caption",
+    "filename": "Filename",
+    "captionPlaceholder": "Enter caption...",
+    "filenamePlaceholder": "document.pdf",
+    "send": "Send Message",
+    "sending": "Sending...",
+    "viewOnly": "View Only",
+    "responseEmpty": "Send a message to see the API response",
+    "successLabel": "200 OK - Success",
+    "failedLabel": "400 - Failed",
+    "response": {
+      "timestamp": "Timestamp",
+      "messageId": "Message ID",
+      "error": "Error"
+    },
+    "sendFailed": "Failed to send message"
+  },
+  "infrastructure": {
+    "title": "Infrastructure",
+    "subtitle": "Configure server, database, cache, storage, and engine settings",
+    "saveConfig": "Save Configuration",
+    "saving": "Saving...",
+    "server": {
+      "title": "Server Configuration",
+      "production": "Production",
+      "development": "Development",
+      "environment": "Environment",
+      "domain": "Domain",
+      "apiPort": "API Port",
+      "dashboardPort": "Dashboard Port",
+      "corsOrigins": "CORS Origins",
+      "corsPlaceholder": "* or comma-separated origins",
+      "publicApiUrl": "Public API URL (optional)",
+      "publicDashboardUrl": "Public Dashboard URL (optional)"
+    },
+    "webhook": {
+      "title": "Webhook & Rate Limiting",
+      "settings": "Webhook Settings",
+      "timeout": "Timeout (ms)",
+      "maxRetries": "Max Retries",
+      "retryDelay": "Retry Delay (ms)",
+      "rateLimit": "Rate Limiting",
+      "window": "Time Window (seconds)",
+      "maxReq": "Max Requests per Window"
+    },
+    "database": {
+      "title": "Database Configuration",
+      "sqlite": "SQLite",
+      "sqliteDesc": "Local file-based database",
+      "postgres": "PostgreSQL",
+      "postgresDesc": "Production-ready database",
+      "useBuiltIn": "Use Built-in PostgreSQL Container",
+      "builtInDesc": "OpenWA will manage a PostgreSQL container for you",
+      "dbName": "Database Name",
+      "poolSize": "Pool Size",
+      "ssl": "SSL Connection",
+      "sslDesc": "Enable TLS/SSL for secure database connections",
+      "migrationsTitle": "Database Migrations",
+      "migrationsStatus": "Schema is auto-synchronized with TypeORM",
+      "migrationsHint": "Migrations are managed automatically. Use CLI for manual migrations."
+    },
+    "redis": {
+      "title": "Redis",
+      "enable": "Enable Redis",
+      "enableDesc": "Required for caching, session storage, and BullMQ queues",
+      "useBuiltIn": "Use Built-in Redis Container",
+      "builtInDesc": "OpenWA will manage a Redis container for you",
+      "queueTitle": "Enable BullMQ Queue System",
+      "queueDesc": "Use message queues for reliable message and webhook delivery",
+      "statsTitle": "Queue Statistics",
+      "messageQueue": "Message Queue",
+      "webhookQueue": "Webhook Queue",
+      "pending": "Pending",
+      "completed": "Completed",
+      "failed": "Failed",
+      "clearFailed": "Clear Failed Jobs",
+      "viewBullMq": "View Bull MQ Dashboard",
+      "disabledTitle": "Redis is Disabled",
+      "disabledDesc": "Enable Redis for caching, session storage, and BullMQ message queues.",
+      "passwordOptional": "(optional)"
+    },
+    "storage": {
+      "title": "Storage Configuration",
+      "local": "Local Filesystem",
+      "localDesc": "Store media files locally",
+      "s3": "Amazon S3",
+      "s3Desc": "Cloud storage (S3 compatible)",
+      "useBuiltIn": "Use Built-in MinIO Container",
+      "builtInDesc": "OpenWA will manage a MinIO (S3-compatible) container for you",
+      "storagePath": "Storage Path",
+      "bucket": "Bucket Name",
+      "region": "Region",
+      "accessKey": "Access Key",
+      "secretKey": "Secret Key",
+      "endpoint": "Custom Endpoint (optional)",
+      "endpointHint": "For MinIO or other S3-compatible services"
+    },
+    "statusLabels": {
+      "connected": "Connected",
+      "disconnected": "Disconnected",
+      "disabled": "Disabled"
+    },
+    "restart": {
+      "idleTitle": "⚙️ Configuration Saved",
+      "restartingTitle": "🔄 Restarting Server...",
+      "waitingTitle": "⏳ Please Wait...",
+      "successTitle": "✅ Server Ready",
+      "errorTitle": "❌ Restart Failed",
+      "idleDesc": "Configuration has been saved to <code>.env.generated</code>.<br/>A server restart is required to apply the changes.",
+      "later": "Restart Later",
+      "now": "Restart Now",
+      "restartingMsg": "Server restarting... {{count}}s",
+      "checking": "Checking server status...",
+      "dontClose": "Please do not close this window",
+      "successMsg": "Server is back online! The page will reload automatically.",
+      "errorMsg": "Server did not respond after 30 seconds. Please check the Docker logs and restart manually.",
+      "reload": "Reload Page"
+    },
+    "toasts": {
+      "saveFailed": "Save Failed"
+    }
+  },
+  "plugins": {
+    "title": "Plugins",
+    "subtitle": "Manage engines, storage backends, and extensions",
+    "refresh": "Refresh",
+    "engineCard": "Active WhatsApp Engine",
+    "running": "Running",
+    "supportedFeatures": "Supported Features:",
+    "more": "+{{count}} more",
+    "builtIn": "Built-in",
+    "noDescription": "No description available",
+    "required": "Required",
+    "active": "Active",
+    "activate": "Activate",
+    "enable": "Enable",
+    "disable": "Disable",
+    "healthCheck": "Health Check",
+    "configure": "Configure",
+    "empty": {
+      "title": "No Plugins Found",
+      "description": "Install plugins to extend OpenWA functionality"
+    },
+    "config": {
+      "title": "Configure {{name}}",
+      "restartNotice": "Changes require server restart to take effect",
+      "engineType": "Engine Type",
+      "headless": "Headless Mode",
+      "headlessDesc": "Run browser without visible UI (recommended for production)",
+      "sessionDataPath": "Session Data Path",
+      "browserArgs": "Browser Arguments",
+      "noOptions": "No configuration options available for this plugin",
+      "save": "Save Configuration"
+    },
+    "toasts": {
+      "errorTitle": "Plugin Error",
+      "errorDefault": "Failed to toggle plugin",
+      "healthOk": "Health Check Passed",
+      "healthFail": "Health Check Failed",
+      "healthError": "Health Check Error",
+      "savedTitle": "Configuration Saved",
+      "savedDesc": "Server restart required to apply changes.",
+      "saveFailed": "Save Failed"
+    }
+  }
+}

--- a/dashboard/src/i18n/locales/he.json
+++ b/dashboard/src/i18n/locales/he.json
@@ -1,0 +1,512 @@
+{
+  "common": {
+    "appName": "OpenWA",
+    "appSubtitle": "ממשק WhatsApp API",
+    "loading": "טוען...",
+    "save": "שמירה",
+    "cancel": "ביטול",
+    "delete": "מחיקה",
+    "edit": "עריכה",
+    "create": "יצירה",
+    "close": "סגירה",
+    "submit": "שליחה",
+    "confirm": "אישור",
+    "search": "חיפוש",
+    "filter": "סינון",
+    "actions": "פעולות",
+    "status": "סטטוס",
+    "name": "שם",
+    "role": "תפקיד",
+    "type": "סוג",
+    "url": "כתובת URL",
+    "port": "פורט",
+    "host": "כתובת שרת",
+    "username": "שם משתמש",
+    "password": "סיסמה",
+    "active": "פעיל",
+    "inactive": "מושבת",
+    "enabled": "מופעל",
+    "disabled": "מושבת",
+    "connected": "מחובר",
+    "disconnected": "מנותק",
+    "never": "אף פעם",
+    "justNow": "ממש עכשיו",
+    "minAgo": "לפני {{count}} דקות",
+    "hoursAgo": "לפני {{count}} שעות",
+    "optional": "אופציונלי",
+    "language": "שפה",
+    "english": "English",
+    "hebrew": "עברית",
+    "back": "חזרה",
+    "next": "הבא",
+    "previous": "הקודם",
+    "expand": "הרחבה",
+    "collapse": "כיווץ",
+    "logout": "יציאה",
+    "refresh": "רענון",
+    "errorGeneric": "אירעה שגיאה",
+    "unknownError": "שגיאה לא ידועה"
+  },
+  "theme": {
+    "light": "בהיר",
+    "dark": "כהה",
+    "system": "מערכת",
+    "label": "ערכת נושא: {{value}}"
+  },
+  "nav": {
+    "dashboard": "דאשבורד",
+    "sessions": "Sessions",
+    "webhooks": "Webhooks",
+    "apiKeys": "מפתחות API",
+    "messageTester": "בדיקת הודעות",
+    "infrastructure": "תשתית",
+    "plugins": "תוספים",
+    "logs": "לוגים"
+  },
+  "errorBoundary": {
+    "title": "משהו השתבש",
+    "description": "הדאשבורד נתקל בשגיאה לא צפויה.",
+    "reload": "טעינה מחדש"
+  },
+  "login": {
+    "apiKey": "מפתח API",
+    "apiKeyPlaceholder": "יש להזין את מפתח ה-API",
+    "apiKeyRequired": "חובה להזין מפתח API",
+    "connect": "התחברות",
+    "connecting": "מתחבר...",
+    "invalidKey": "מפתח API שגוי",
+    "connectionError": "לא ניתן להתחבר לשרת. יש לנסות שוב.",
+    "help": "צריך עזרה?",
+    "viewDocs": "לצפייה בתיעוד",
+    "footer": "נבנה באהבה על ידי Yudhi Armyndharis וקהילת OpenWA",
+    "version": "v{{version}} · {{date}}"
+  },
+  "dashboard": {
+    "title": "דאשבורד",
+    "subtitle": "סקירה כללית של ה-Sessions והפעילות שלך ב-WhatsApp",
+    "stats": {
+      "activeSessions": "Sessions פעילים",
+      "messagesToday": "הודעות היום",
+      "webhooksConfigured": "Webhooks מוגדרים",
+      "apiCalls": "קריאות API (24 שעות)"
+    },
+    "sessionsOverview": "סקירת Sessions",
+    "showingSessions": "מוצגים {{shown}} מתוך {{total}} Sessions",
+    "columns": {
+      "sessionId": "מזהה Session",
+      "phone": "מספר טלפון",
+      "status": "סטטוס",
+      "lastActive": "פעילות אחרונה",
+      "actions": "פעולות"
+    },
+    "noSessions": "לא נמצאו Sessions. יש ליצור אחד כדי להתחיל.",
+    "view": "צפייה",
+    "disconnect": "ניתוק",
+    "errorPrefix": "שגיאה: {{message}}",
+    "loadError": "טעינת הנתונים נכשלה"
+  },
+  "sessionStatus": {
+    "created": "חדש",
+    "idle": "בהמתנה",
+    "initializing": "מאתחל...",
+    "connecting": "מתחבר...",
+    "qr_ready": "סריקת QR",
+    "ready": "מחובר",
+    "disconnected": "מנותק"
+  },
+  "sessions": {
+    "title": "Sessions",
+    "subtitle": "ניהול Sessions של WhatsApp והתחברות באמצעות QR",
+    "newSession": "Session חדש",
+    "searchPlaceholder": "חיפוש Sessions...",
+    "filter": {
+      "all": "כל הסטטוסים",
+      "active": "פעיל (מחובר)",
+      "inactive": "לא פעיל",
+      "connecting": "מתחבר"
+    },
+    "empty": {
+      "title": "לא נמצאו Sessions",
+      "description": "יש ליצור Session חדש כדי להתחיל"
+    },
+    "create": {
+      "title": "יצירת Session חדש",
+      "label": "שם Session",
+      "placeholder": "לדוגמה: marketing-bot",
+      "hint": "מותר להשתמש באותיות לועזיות קטנות, ספרות ומקפים בלבד. לדוגמה: <code>customer-support</code>, <code>bot-1</code>",
+      "invalidChars": "תווים לא חוקיים. מותרות אותיות לועזיות קטנות, ספרות ומקפים בלבד.",
+      "tooLong": "אורך השם מוגבל ל-50 תווים ({{length}}/50).",
+      "duplicate": "כבר קיים Session עם שם זה.",
+      "successTitle": "ה-Session נוצר",
+      "successDesc": "Session \"{{name}}\" נוצר בהצלחה",
+      "errorTitle": "היצירה נכשלה",
+      "errorDefault": "יצירת ה-Session נכשלה"
+    },
+    "delete": {
+      "title": "אישור מחיקה",
+      "message": "האם למחוק את ה-Session <strong>\"{{name}}\"</strong>?",
+      "warning": "לא ניתן לשחזר פעולה זו.",
+      "successTitle": "ה-Session נמחק",
+      "successDescNamed": "Session \"{{name}}\" נמחק",
+      "successDescGeneric": "ה-Session נמחק",
+      "errorTitle": "המחיקה נכשלה",
+      "errorDefault": "מחיקת ה-Session נכשלה"
+    },
+    "qr": {
+      "title": "סריקת QR",
+      "step1": "<strong>1.</strong> יש לפתוח את WhatsApp במכשיר",
+      "step2": "<strong>2.</strong> יש להקיש על <strong>תפריט</strong> ← <strong>מכשירים מקושרים</strong>",
+      "step3": "<strong>3.</strong> יש להקיש על <strong>קישור מכשיר</strong> ולסרוק את ה-QR",
+      "autoRefresh": "ה-QR מתעדכן אוטומטית כל 5 שניות",
+      "generating": "יוצר קוד QR...",
+      "unavailable": "קוד ה-QR אינו זמין כעת. יש לנסות שוב בעוד רגע.",
+      "preparing": "מכין קוד QR...",
+      "showQr": "הצגת QR",
+      "loading": "טוען...",
+      "scanToConnect": "יש לסרוק את ה-QR כדי להתחבר"
+    },
+    "details": {
+      "title": "פרטי Session",
+      "name": "שם",
+      "status": "סטטוס",
+      "sessionId": "מזהה Session",
+      "phone": "מספר טלפון",
+      "phoneNone": "לא מחובר",
+      "created": "נוצר בתאריך",
+      "lastActive": "פעילות אחרונה"
+    },
+    "actions": {
+      "view": "צפייה",
+      "start": "הפעלה",
+      "stop": "עצירה",
+      "reconnect": "התחברות מחדש",
+      "delete": "מחיקה"
+    },
+    "toasts": {
+      "readyTitle": "ה-Session מוכן",
+      "readyDesc": "ה-Session של WhatsApp מחובר",
+      "disconnectedTitle": "ה-Session נותק",
+      "disconnectedDesc": "ה-Session של WhatsApp נותק"
+    },
+    "card": {
+      "phone": "טלפון",
+      "sessionId": "מזהה Session",
+      "lastActive": "פעילות אחרונה"
+    }
+  },
+  "webhooks": {
+    "title": "Webhooks",
+    "subtitle": "הגדרת קריאות HTTP חוזרות להתראות בזמן אמת",
+    "addWebhook": "הוספת Webhook",
+    "createTitle": "יצירת Webhook",
+    "editTitle": "עריכת Webhook",
+    "deleteTitle": "מחיקת Webhook",
+    "deleteConfirm": "האם למחוק את ה-Webhook הזה?",
+    "selectSession": "בחירת Session...",
+    "session": "Session",
+    "events": "אירועים",
+    "available": "אירועים זמינים",
+    "saveChanges": "שמירת שינויים",
+    "columns": {
+      "url": "כתובת URL",
+      "events": "אירועים",
+      "session": "Session",
+      "status": "סטטוס",
+      "actions": "פעולות"
+    },
+    "empty": {
+      "title": "לא הוגדרו Webhooks",
+      "description": "יש להוסיף Webhook כדי לקבל התראות בזמן אמת"
+    },
+    "toasts": {
+      "created": "ה-Webhook נוצר בהצלחה",
+      "createFailed": "יצירת ה-Webhook נכשלה: {{message}}",
+      "deleted": "ה-Webhook נמחק בהצלחה",
+      "deleteFailed": "מחיקת ה-Webhook נכשלה: {{message}}",
+      "updated": "ה-Webhook עודכן בהצלחה",
+      "updateFailed": "עדכון ה-Webhook נכשל: {{message}}",
+      "testOk": "בדיקת ה-Webhook הצליחה! סטטוס: {{status}}",
+      "testFailed": "בדיקת ה-Webhook נכשלה: {{message}}",
+      "testError": "בדיקת ה-Webhook נכשלה: {{message}}"
+    },
+    "actions": {
+      "test": "בדיקה",
+      "edit": "עריכה",
+      "delete": "מחיקה"
+    },
+    "eventDescriptions": {
+      "message.received": "כאשר מתקבלת הודעה",
+      "message.sent": "כאשר נשלחת הודעה",
+      "session.connected": "כאשר Session מתחבר",
+      "session.disconnected": "כאשר Session מתנתק",
+      "session.qr": "כאשר נוצר קוד QR",
+      "all": "כל האירועים"
+    }
+  },
+  "apiKeys": {
+    "title": "מפתחות API",
+    "subtitle": "ניהול מפתחות API לאימות ובקרת גישה",
+    "createBtn": "יצירת מפתח API",
+    "modalTitle": "יצירת מפתח API",
+    "createdTitle": "מפתח ה-API נוצר",
+    "createdHint": "יש להעתיק את המפתח כעת. לא ניתן יהיה לצפות בו שוב.",
+    "namePlaceholder": "לדוגמה: Production Key",
+    "rolesTitle": "מדריך תפקידים",
+    "roles": {
+      "admin": "Admin",
+      "operator": "Operator",
+      "viewer": "Viewer"
+    },
+    "roleDescriptions": {
+      "admin": "גישה מלאה לכל המשאבים",
+      "operator": "ניהול Sessions והודעות",
+      "viewer": "גישת קריאה בלבד"
+    },
+    "columns": {
+      "name": "שם",
+      "key": "מפתח",
+      "role": "תפקיד",
+      "status": "סטטוס",
+      "lastUsed": "שימוש אחרון",
+      "actions": "פעולות"
+    },
+    "statuses": {
+      "active": "פעיל",
+      "revoked": "בוטל"
+    },
+    "empty": {
+      "title": "לא נוצרו מפתחות API",
+      "description": "יש ליצור מפתח API לאימות הבקשות"
+    },
+    "confirm": {
+      "deleteTitle": "מחיקת מפתח API",
+      "revokeTitle": "ביטול מפתח API",
+      "deleteMessage": "האם למחוק לצמיתות את <strong>{{name}}</strong>? לא ניתן לשחזר פעולה זו.",
+      "revokeMessage": "האם לבטל את <strong>{{name}}</strong>? המפתח יפסיק לפעול.",
+      "delete": "מחיקה",
+      "revoke": "ביטול"
+    },
+    "actions": {
+      "copy": "העתקה",
+      "revoke": "ביטול",
+      "delete": "מחיקה"
+    }
+  },
+  "logs": {
+    "title": "לוגים",
+    "subtitle": "מעקב וצפייה בכל פעולות ה-API ואירועי המערכת",
+    "exportCsv": "ייצוא CSV",
+    "searchPlaceholder": "חיפוש בלוגים...",
+    "severity": {
+      "all": "כל הרמות",
+      "info": "מידע",
+      "warn": "אזהרה",
+      "error": "שגיאה"
+    },
+    "columns": {
+      "timestamp": "חותמת זמן",
+      "action": "פעולה",
+      "session": "Session",
+      "apiKey": "מפתח API",
+      "ip": "כתובת IP",
+      "severity": "חומרה"
+    },
+    "empty": {
+      "title": "לא נמצאו לוגים",
+      "description": "הלוגים יופיעו כאן ככל שיבוצעו פעולות"
+    }
+  },
+  "messageTester": {
+    "title": "בדיקת הודעות",
+    "subtitle": "שליחת הודעות בדיקה דרך ה-API",
+    "compose": "שליחת הודעת בדיקה",
+    "responseTitle": "תגובת ה-API",
+    "session": "Session",
+    "noReadySessions": "אין Sessions מוכנים",
+    "sessionOptionPhoneNone": "אין טלפון",
+    "recipientType": "סוג נמען",
+    "personal": "אישי",
+    "group": "קבוצה",
+    "selectGroup": "בחירת קבוצה",
+    "recipientPhone": "מספר טלפון של הנמען",
+    "loadingGroups": "טוען קבוצות...",
+    "noGroupsFound": "לא נמצאו קבוצות",
+    "selectGroupHint": "יש לבחור קבוצה מתוך WhatsApp",
+    "phoneHint": "יש להשתמש בפורמט בינלאומי ללא רווחים",
+    "messageType": "סוג הודעה",
+    "types": {
+      "text": "טקסט",
+      "image": "תמונה",
+      "video": "וידאו",
+      "audio": "אודיו",
+      "document": "מסמך"
+    },
+    "messageContent": "תוכן ההודעה",
+    "messagePlaceholder": "יש להזין כאן את ההודעה...",
+    "mediaUrl": "כתובת המדיה",
+    "caption": "כיתוב",
+    "filename": "שם קובץ",
+    "captionPlaceholder": "יש להזין כיתוב...",
+    "filenamePlaceholder": "document.pdf",
+    "send": "שליחת הודעה",
+    "sending": "שולח...",
+    "viewOnly": "צפייה בלבד",
+    "responseEmpty": "יש לשלוח הודעה כדי לראות את תגובת ה-API",
+    "successLabel": "200 OK - הצלחה",
+    "failedLabel": "400 - נכשל",
+    "response": {
+      "timestamp": "חותמת זמן",
+      "messageId": "מזהה הודעה",
+      "error": "שגיאה"
+    },
+    "sendFailed": "שליחת ההודעה נכשלה"
+  },
+  "infrastructure": {
+    "title": "תשתית",
+    "subtitle": "הגדרת השרת, מסד נתונים, מטמון, אחסון ומנוע WhatsApp",
+    "saveConfig": "שמירת תצורה",
+    "saving": "שומר...",
+    "server": {
+      "title": "הגדרות שרת",
+      "production": "ייצור",
+      "development": "פיתוח",
+      "environment": "סביבה",
+      "domain": "דומיין",
+      "apiPort": "פורט API",
+      "dashboardPort": "פורט דאשבורד",
+      "corsOrigins": "מקורות CORS",
+      "corsPlaceholder": "* או רשימה מופרדת בפסיקים",
+      "publicApiUrl": "כתובת API ציבורית (אופציונלי)",
+      "publicDashboardUrl": "כתובת דאשבורד ציבורית (אופציונלי)"
+    },
+    "webhook": {
+      "title": "Webhooks והגבלת קצב",
+      "settings": "הגדרות Webhook",
+      "timeout": "זמן קצוב (ms)",
+      "maxRetries": "ניסיונות מקסימליים",
+      "retryDelay": "השהיה בין ניסיונות (ms)",
+      "rateLimit": "הגבלת קצב",
+      "window": "חלון זמן (שניות)",
+      "maxReq": "מקסימום בקשות בחלון"
+    },
+    "database": {
+      "title": "הגדרות מסד נתונים",
+      "sqlite": "SQLite",
+      "sqliteDesc": "מסד נתונים מקומי מבוסס קובץ",
+      "postgres": "PostgreSQL",
+      "postgresDesc": "מסד נתונים מוכן לייצור",
+      "useBuiltIn": "שימוש בקונטיינר PostgreSQL מובנה",
+      "builtInDesc": "OpenWA ינהל עבורך קונטיינר PostgreSQL",
+      "dbName": "שם מסד הנתונים",
+      "poolSize": "גודל Pool",
+      "ssl": "חיבור SSL",
+      "sslDesc": "הפעלת TLS/SSL לחיבור מאובטח למסד הנתונים",
+      "migrationsTitle": "Migrations של מסד הנתונים",
+      "migrationsStatus": "הסכמה מסונכרנת אוטומטית עם TypeORM",
+      "migrationsHint": "ה-Migrations מנוהלים אוטומטית. ניתן להשתמש ב-CLI ל-Migrations ידניים."
+    },
+    "redis": {
+      "title": "Redis",
+      "enable": "הפעלת Redis",
+      "enableDesc": "נדרש למטמון, אחסון Sessions ותורי BullMQ",
+      "useBuiltIn": "שימוש בקונטיינר Redis מובנה",
+      "builtInDesc": "OpenWA ינהל עבורך קונטיינר Redis",
+      "queueTitle": "הפעלת מערכת התורים BullMQ",
+      "queueDesc": "שימוש בתורי הודעות לאספקה אמינה של הודעות ו-Webhooks",
+      "statsTitle": "סטטיסטיקות תור",
+      "messageQueue": "תור הודעות",
+      "webhookQueue": "תור Webhooks",
+      "pending": "בהמתנה",
+      "completed": "הושלמו",
+      "failed": "נכשלו",
+      "clearFailed": "ניקוי משימות שנכשלו",
+      "viewBullMq": "פתיחת Bull MQ Dashboard",
+      "disabledTitle": "Redis מושבת",
+      "disabledDesc": "יש להפעיל את Redis למטמון, אחסון Sessions ותורי הודעות BullMQ.",
+      "passwordOptional": "(אופציונלי)"
+    },
+    "storage": {
+      "title": "הגדרות אחסון",
+      "local": "מערכת קבצים מקומית",
+      "localDesc": "אחסון קבצי מדיה מקומית",
+      "s3": "Amazon S3",
+      "s3Desc": "אחסון ענן (תואם S3)",
+      "useBuiltIn": "שימוש בקונטיינר MinIO מובנה",
+      "builtInDesc": "OpenWA ינהל עבורך קונטיינר MinIO (תואם S3)",
+      "storagePath": "נתיב אחסון",
+      "bucket": "שם Bucket",
+      "region": "אזור (Region)",
+      "accessKey": "Access Key",
+      "secretKey": "Secret Key",
+      "endpoint": "Endpoint מותאם (אופציונלי)",
+      "endpointHint": "עבור MinIO או שירותים אחרים תואמי S3"
+    },
+    "statusLabels": {
+      "connected": "מחובר",
+      "disconnected": "מנותק",
+      "disabled": "מושבת"
+    },
+    "restart": {
+      "idleTitle": "⚙️ התצורה נשמרה",
+      "restartingTitle": "🔄 מאתחל את השרת...",
+      "waitingTitle": "⏳ אנא להמתין...",
+      "successTitle": "✅ השרת מוכן",
+      "errorTitle": "❌ האתחול נכשל",
+      "idleDesc": "התצורה נשמרה ל-<code>.env.generated</code>.<br/>נדרש אתחול שרת כדי להחיל את השינויים.",
+      "later": "אתחול מאוחר יותר",
+      "now": "אתחול עכשיו",
+      "restartingMsg": "השרת מתאתחל... {{count}} שניות",
+      "checking": "בודק את סטטוס השרת...",
+      "dontClose": "אין לסגור חלון זה",
+      "successMsg": "השרת חזר לפעולה! הדף ייטען מחדש אוטומטית.",
+      "errorMsg": "השרת לא הגיב לאחר 30 שניות. יש לבדוק את לוגי Docker ולאתחל ידנית.",
+      "reload": "טעינת הדף מחדש"
+    },
+    "toasts": {
+      "saveFailed": "השמירה נכשלה"
+    }
+  },
+  "plugins": {
+    "title": "תוספים",
+    "subtitle": "ניהול מנועים, יעדי אחסון והרחבות",
+    "refresh": "רענון",
+    "engineCard": "מנוע WhatsApp פעיל",
+    "running": "פועל",
+    "supportedFeatures": "תכונות נתמכות:",
+    "more": "+{{count}} נוספים",
+    "builtIn": "מובנה",
+    "noDescription": "אין תיאור זמין",
+    "required": "נדרש",
+    "active": "פעיל",
+    "activate": "הפעלה",
+    "enable": "הפעלה",
+    "disable": "השבתה",
+    "healthCheck": "בדיקת תקינות",
+    "configure": "הגדרה",
+    "empty": {
+      "title": "לא נמצאו תוספים",
+      "description": "ניתן להתקין תוספים כדי להרחיב את היכולות של OpenWA"
+    },
+    "config": {
+      "title": "הגדרת {{name}}",
+      "restartNotice": "השינויים דורשים אתחול שרת כדי להיכנס לתוקף",
+      "engineType": "סוג מנוע",
+      "headless": "מצב Headless",
+      "headlessDesc": "הרצת דפדפן ללא ממשק גרפי (מומלץ לייצור)",
+      "sessionDataPath": "נתיב נתוני Session",
+      "browserArgs": "ארגומנטים של הדפדפן",
+      "noOptions": "אין אפשרויות הגדרה זמינות עבור תוסף זה",
+      "save": "שמירת תצורה"
+    },
+    "toasts": {
+      "errorTitle": "שגיאת תוסף",
+      "errorDefault": "החלפת מצב התוסף נכשלה",
+      "healthOk": "בדיקת התקינות הצליחה",
+      "healthFail": "בדיקת התקינות נכשלה",
+      "healthError": "שגיאה בבדיקת תקינות",
+      "savedTitle": "התצורה נשמרה",
+      "savedDesc": "נדרש אתחול שרת כדי להחיל את השינויים.",
+      "saveFailed": "השמירה נכשלה"
+    }
+  }
+}

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -1,7 +1,17 @@
+@import url('https://fonts.googleapis.com/css2?family=Heebo:wght@400;500;600;700&display=swap');
+
 :root {
   font-family: 'Plus Jakarta Sans', system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.6;
   font-weight: 400;
+}
+
+html[lang="he"],
+html[dir="rtl"] {
+  font-family: 'Heebo', 'Rubik', 'Noto Sans Hebrew', 'Segoe UI', Arial, sans-serif;
+}
+
+:root {
 
   color-scheme: light dark;
   color: var(--text-primary);
@@ -121,9 +131,7 @@ select:disabled {
   cursor: not-allowed;
 }
 
-/* ============================================
-   GLOBAL MODAL STYLES
-   ============================================ */
+/* GLOBAL MODAL STYLES */
 
 /* Modal Overlay */
 .modal-overlay {
@@ -298,3 +306,56 @@ code {
   font-size: 0.875em;
   color: var(--text-primary, #1e293b);
 }
+
+/* RTL / Hebrew direction support */
+
+/* Keep code, technical identifiers, and numbers LTR even inside RTL containers */
+[dir="rtl"] code,
+[dir="rtl"] .mono,
+[dir="rtl"] pre {
+  direction: ltr;
+  text-align: left;
+  unicode-bidi: embed;
+}
+
+/* Modal footer: actions should align to the start of the writing direction */
+[dir="rtl"] .modal-footer {
+  justify-content: flex-end;
+  flex-direction: row-reverse;
+}
+
+/* Select dropdown caret on the opposite side */
+[dir="rtl"] select {
+  padding: 0.75rem 1rem 0.75rem 2.5rem;
+  background-position: left 0.75rem center;
+}
+
+/* Inputs in modals: text aligns naturally */
+[dir="rtl"] .modal-body input,
+[dir="rtl"] .modal-body textarea,
+[dir="rtl"] input[type="text"],
+[dir="rtl"] input[type="url"],
+[dir="rtl"] input[type="password"],
+[dir="rtl"] input[type="number"],
+[dir="rtl"] textarea {
+  text-align: right;
+}
+
+/* URLs, emails, phones — force LTR even inside RTL */
+[dir="rtl"] input[type="url"],
+[dir="rtl"] input[type="email"],
+[dir="rtl"] input[type="tel"] {
+  direction: ltr;
+  text-align: left;
+}
+
+[dir="rtl"] .page-header__top {
+  flex-direction: row-reverse;
+}
+
+/* Toast container — slide in from the opposite side */
+[dir="rtl"] .toast-container {
+  right: auto;
+  left: 1rem;
+}
+

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import './i18n'
 import './index.css'
 import App from './App.tsx'
 

--- a/dashboard/src/pages/ApiKeys.tsx
+++ b/dashboard/src/pages/ApiKeys.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
 import {
   useReactTable,
   getCoreRowModel,
@@ -13,29 +14,23 @@ import { useApiKeysQuery, useCreateApiKeyMutation, useDeleteApiKeyMutation, useR
 import { PageHeader } from '../components/PageHeader';
 import './ApiKeys.css';
 
-const permissionsReference = [
-  { name: 'admin', description: 'Full access to all resources' },
-  { name: 'operator', description: 'Session & message management' },
-  { name: 'viewer', description: 'Read-only access' },
-];
+const roleNames = ['admin', 'operator', 'viewer'] as const;
 
-// Hook to track window size
 function useWindowSize() {
   const [width, setWidth] = useState(window.innerWidth);
-
   useEffect(() => {
     const handleResize = () => setWidth(window.innerWidth);
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, []);
-
   return width;
 }
 
 const columnHelper = createColumnHelper<ApiKey>();
 
 export function ApiKeys() {
-  useDocumentTitle('API Keys');
+  const { t } = useTranslation();
+  useDocumentTitle(t('apiKeys.title'));
   const { data: apiKeys = [], isLoading: loading } = useApiKeysQuery();
   const createMutation = useCreateApiKeyMutation();
   const deleteMutation = useDeleteApiKeyMutation();
@@ -52,15 +47,10 @@ export function ApiKeys() {
   const windowWidth = useWindowSize();
   const isMobile = windowWidth < 768;
   const isSmall = windowWidth < 640;
-
-  // Column visibility based on screen size
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
 
   useEffect(() => {
-    setColumnVisibility({
-      key: !isSmall, // Hide key column on very small screens
-      lastUsed: !isMobile, // Hide last used on mobile
-    });
+    setColumnVisibility({ key: !isSmall, lastUsed: !isMobile });
   }, [isMobile, isSmall]);
 
   const handleCreate = async () => {
@@ -92,11 +82,8 @@ export function ApiKeys() {
 
   const confirmAndExecute = () => {
     if (!confirmAction) return;
-    if (confirmAction.type === 'delete') {
-      handleDelete(confirmAction.id);
-    } else {
-      handleRevoke(confirmAction.id);
-    }
+    if (confirmAction.type === 'delete') handleDelete(confirmAction.id);
+    else handleRevoke(confirmAction.id);
     setConfirmAction(null);
   };
 
@@ -115,16 +102,15 @@ export function ApiKeys() {
     setTimeout(() => setCopied(null), 2000);
   };
 
-  // Define columns using TanStack Table
   const columns = useMemo(
     () => [
       columnHelper.accessor('name', {
-        header: 'Name',
+        header: () => t('apiKeys.columns.name'),
         cell: info => <span className="name-cell">{info.getValue()}</span>,
       }),
       columnHelper.accessor('keyPrefix', {
         id: 'key',
-        header: 'Key',
+        header: () => t('apiKeys.columns.key'),
         cell: info => {
           const apiKey = info.row.original;
           return (
@@ -138,41 +124,45 @@ export function ApiKeys() {
         },
       }),
       columnHelper.accessor('role', {
-        header: 'Role',
+        header: () => t('apiKeys.columns.role'),
         cell: info => <span className="permission-badge">{info.getValue()}</span>,
       }),
       columnHelper.accessor('isActive', {
-        header: 'Status',
+        header: () => t('apiKeys.columns.status'),
         cell: info => (
           <span className={`status-badge ${info.getValue() ? 'active' : 'inactive'}`}>
-            {info.getValue() ? 'Active' : 'Revoked'}
+            {info.getValue() ? t('apiKeys.statuses.active') : t('apiKeys.statuses.revoked')}
           </span>
         ),
       }),
       columnHelper.accessor('lastUsedAt', {
         id: 'lastUsed',
-        header: 'Last Used',
+        header: () => t('apiKeys.columns.lastUsed'),
         cell: info => (
           <span className="last-used">
-            {info.getValue() ? new Date(info.getValue()!).toLocaleDateString() : 'Never'}
+            {info.getValue() ? new Date(info.getValue()!).toLocaleDateString() : t('common.never')}
           </span>
         ),
       }),
       columnHelper.display({
         id: 'actions',
-        header: 'Actions',
+        header: () => t('apiKeys.columns.actions'),
         cell: info => {
           const apiKey = info.row.original;
           return (
             <span className="actions-cell">
-              <button className="icon-btn" onClick={() => copyToClipboard(apiKey.keyPrefix, apiKey.id)} title="Copy">
+              <button
+                className="icon-btn"
+                onClick={() => copyToClipboard(apiKey.keyPrefix, apiKey.id)}
+                title={t('apiKeys.actions.copy')}
+              >
                 {copied === apiKey.id ? <Check size={16} /> : <Copy size={16} />}
               </button>
               {apiKey.isActive && (
                 <button
                   className="icon-btn"
                   onClick={() => setConfirmAction({ type: 'revoke', id: apiKey.id, name: apiKey.name })}
-                  title="Revoke"
+                  title={t('apiKeys.actions.revoke')}
                 >
                   <RefreshCw size={16} />
                 </button>
@@ -180,7 +170,7 @@ export function ApiKeys() {
               <button
                 className="icon-btn danger"
                 onClick={() => setConfirmAction({ type: 'delete', id: apiKey.id, name: apiKey.name })}
-                title="Delete"
+                title={t('apiKeys.actions.delete')}
               >
                 <Trash2 size={16} />
               </button>
@@ -189,15 +179,13 @@ export function ApiKeys() {
         },
       }),
     ],
-    [visibleKeys, copied],
+    [visibleKeys, copied, t],
   );
 
   const table = useReactTable({
     data: apiKeys,
     columns,
-    state: {
-      columnVisibility,
-    },
+    state: { columnVisibility },
     onColumnVisibilityChange: setColumnVisibility,
     getCoreRowModel: getCoreRowModel(),
   });
@@ -216,12 +204,12 @@ export function ApiKeys() {
   return (
     <div className="api-keys-page">
       <PageHeader
-        title="API Keys"
-        subtitle="Manage API keys for authentication and access control"
+        title={t('apiKeys.title')}
+        subtitle={t('apiKeys.subtitle')}
         actions={
           <button className="btn-primary" onClick={() => setShowModal(true)}>
             <Plus size={18} />
-            Create API Key
+            {t('apiKeys.createBtn')}
           </button>
         }
       />
@@ -236,7 +224,7 @@ export function ApiKeys() {
         >
           <div className="modal" onClick={e => e.stopPropagation()}>
             <div className="modal-header">
-              <h2>{createdKey ? 'API Key Created' : 'Create API Key'}</h2>
+              <h2>{createdKey ? t('apiKeys.createdTitle') : t('apiKeys.modalTitle')}</h2>
               <button
                 className="btn-icon"
                 onClick={() => {
@@ -250,9 +238,7 @@ export function ApiKeys() {
             <div className="modal-body">
               {createdKey ? (
                 <div>
-                  <p style={{ marginBottom: '1rem', color: 'var(--text-muted)' }}>
-                    Copy this key now. You won't be able to see it again.
-                  </p>
+                  <p style={{ marginBottom: '1rem', color: 'var(--text-muted)' }}>{t('apiKeys.createdHint')}</p>
                   <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
                     <code
                       style={{
@@ -272,18 +258,20 @@ export function ApiKeys() {
                 </div>
               ) : (
                 <>
-                  <label>Name</label>
+                  <label>{t('common.name')}</label>
                   <input
                     type="text"
-                    placeholder="e.g., Production Key"
+                    placeholder={t('apiKeys.namePlaceholder')}
                     value={newKey.name}
                     onChange={e => setNewKey({ ...newKey, name: e.target.value })}
                   />
-                  <label>Role</label>
+                  <label>{t('common.role')}</label>
                   <select value={newKey.role} onChange={e => setNewKey({ ...newKey, role: e.target.value })}>
-                    <option value="admin">Admin</option>
-                    <option value="operator">Operator</option>
-                    <option value="viewer">Viewer</option>
+                    {roleNames.map(r => (
+                      <option key={r} value={r}>
+                        {t(`apiKeys.roles.${r}`)}
+                      </option>
+                    ))}
                   </select>
                 </>
               )}
@@ -291,10 +279,10 @@ export function ApiKeys() {
             {!createdKey && (
               <div className="modal-footer">
                 <button className="btn-secondary" onClick={() => setShowModal(false)}>
-                  Cancel
+                  {t('common.cancel')}
                 </button>
                 <button className="btn-primary" onClick={handleCreate}>
-                  Create
+                  {t('common.create')}
                 </button>
               </div>
             )}
@@ -307,8 +295,8 @@ export function ApiKeys() {
           {apiKeys.length === 0 ? (
             <div className="empty-table-state">
               <KeyRound size={48} strokeWidth={1} />
-              <h3>No API keys created</h3>
-              <p>Create an API key to authenticate your requests</p>
+              <h3>{t('apiKeys.empty.title')}</h3>
+              <p>{t('apiKeys.empty.description')}</p>
             </div>
           ) : (
             <table className="keys-table">
@@ -337,24 +325,27 @@ export function ApiKeys() {
         </div>
 
         <div className="permissions-reference">
-          <h3>Roles Reference</h3>
+          <h3>{t('apiKeys.rolesTitle')}</h3>
           <div className="permissions-list">
-            {permissionsReference.map(perm => (
-              <div key={perm.name} className="perm-item">
-                <code>{perm.name}</code>
-                <span>{perm.description}</span>
+            {roleNames.map(r => (
+              <div key={r} className="perm-item">
+                <code>{r}</code>
+                <span>{t(`apiKeys.roleDescriptions.${r}`)}</span>
               </div>
             ))}
           </div>
         </div>
       </div>
 
-      {/* Confirmation Modal */}
       {confirmAction && (
         <div className="modal-overlay" onClick={() => setConfirmAction(null)}>
           <div className="modal confirm-modal" onClick={e => e.stopPropagation()}>
             <div className="modal-header">
-              <h2>{confirmAction.type === 'delete' ? 'Delete API Key' : 'Revoke API Key'}</h2>
+              <h2>
+                {confirmAction.type === 'delete'
+                  ? t('apiKeys.confirm.deleteTitle')
+                  : t('apiKeys.confirm.revokeTitle')}
+              </h2>
               <button className="btn-icon" onClick={() => setConfirmAction(null)}>
                 <X size={20} />
               </button>
@@ -364,24 +355,25 @@ export function ApiKeys() {
                 <AlertTriangle size={48} className="confirm-warning-icon" />
               </div>
               <p className="confirm-message">
-                {confirmAction.type === 'delete' ? (
-                  <>
-                    Are you sure you want to permanently delete <strong>{confirmAction.name}</strong>? This action
-                    cannot be undone.
-                  </>
-                ) : (
-                  <>
-                    Are you sure you want to revoke <strong>{confirmAction.name}</strong>? It will no longer work.
-                  </>
-                )}
+                <Trans
+                  i18nKey={
+                    confirmAction.type === 'delete'
+                      ? 'apiKeys.confirm.deleteMessage'
+                      : 'apiKeys.confirm.revokeMessage'
+                  }
+                  values={{ name: confirmAction.name }}
+                  components={{ strong: <strong /> }}
+                />
               </p>
             </div>
             <div className="modal-footer">
               <button className="btn-secondary" onClick={() => setConfirmAction(null)}>
-                Cancel
+                {t('common.cancel')}
               </button>
-              <button className={`btn-danger`} onClick={confirmAndExecute}>
-                {confirmAction.type === 'delete' ? 'Delete' : 'Revoke'}
+              <button className="btn-danger" onClick={confirmAndExecute}>
+                {confirmAction.type === 'delete'
+                  ? t('apiKeys.confirm.delete')
+                  : t('apiKeys.confirm.revoke')}
               </button>
             </div>
           </div>

--- a/dashboard/src/pages/Dashboard.tsx
+++ b/dashboard/src/pages/Dashboard.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { MessageSquare, Send, Webhook, Activity, ArrowUpRight, ArrowDownRight, Loader2 } from 'lucide-react';
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { useSessionsQuery, useSessionStatsQuery, useWebhooksQuery, useStopSessionMutation } from '../hooks/queries';
@@ -6,14 +7,19 @@ import { PageHeader } from '../components/PageHeader';
 import './Dashboard.css';
 
 export function Dashboard() {
-  useDocumentTitle('Dashboard');
+  const { t } = useTranslation();
+  useDocumentTitle(t('dashboard.title'));
   const navigate = useNavigate();
   const { data: sessions = [], isLoading: loadingSessions, error: sessionsError } = useSessionsQuery();
   const { data: stats } = useSessionStatsQuery();
   const { data: webhooks = [] } = useWebhooksQuery();
   const stopMutation = useStopSessionMutation();
   const loading = loadingSessions;
-  const error = sessionsError instanceof Error ? sessionsError.message : sessionsError ? 'Failed to load data' : null;
+  const error = sessionsError instanceof Error
+    ? sessionsError.message
+    : sessionsError
+      ? t('dashboard.loadError')
+      : null;
   const webhookCount = webhooks.length;
 
   const handleDisconnect = async (id: string) => {
@@ -26,38 +32,27 @@ export function Dashboard() {
 
   const statsCards = [
     {
-      label: 'Active Sessions',
+      label: t('dashboard.stats.activeSessions'),
       value: stats?.active ?? 0,
       icon: MessageSquare,
       trend: `+${stats?.ready ?? 0}`,
       trendUp: true,
     },
-    { label: 'Messages Today', value: '—', icon: Send, trend: '0', trendUp: null },
-    { label: 'Webhooks Configured', value: webhookCount, icon: Webhook, trend: '0', trendUp: null },
-    { label: 'API Calls (24h)', value: '—', icon: Activity, trend: '0', trendUp: null },
+    { label: t('dashboard.stats.messagesToday'), value: '—', icon: Send, trend: '0', trendUp: null },
+    { label: t('dashboard.stats.webhooksConfigured'), value: webhookCount, icon: Webhook, trend: '0', trendUp: null },
+    { label: t('dashboard.stats.apiCalls'), value: '—', icon: Activity, trend: '0', trendUp: null },
   ];
 
   const formatLastActive = (date?: string) => {
-    if (!date) return 'Never';
+    if (!date) return t('common.never');
     const diff = Date.now() - new Date(date).getTime();
-    if (diff < 60000) return 'Just now';
-    if (diff < 3600000) return `${Math.floor(diff / 60000)} min ago`;
-    if (diff < 86400000) return `${Math.floor(diff / 3600000)} hours ago`;
+    if (diff < 60000) return t('common.justNow');
+    if (diff < 3600000) return t('common.minAgo', { count: Math.floor(diff / 60000) });
+    if (diff < 86400000) return t('common.hoursAgo', { count: Math.floor(diff / 3600000) });
     return new Date(date).toLocaleDateString();
   };
 
-  const formatStatus = (status: string) => {
-    const statusMap: Record<string, string> = {
-      created: 'New',
-      idle: 'Idle',
-      initializing: 'Starting...',
-      connecting: 'Connecting...',
-      qr_ready: 'Scan QR',
-      ready: 'Connected',
-      disconnected: 'Disconnected',
-    };
-    return statusMap[status] || status;
-  };
+  const formatStatus = (status: string) => t(`sessionStatus.${status}`, { defaultValue: status });
 
   if (loading) {
     return (
@@ -74,7 +69,7 @@ export function Dashboard() {
     return (
       <div className="dashboard" style={{ padding: '2rem' }}>
         <div style={{ background: '#FEE2E2', padding: '1rem', borderRadius: '8px', color: '#DC2626' }}>
-          Error: {error}
+          {t('dashboard.errorPrefix', { message: error })}
         </div>
       </div>
     );
@@ -83,11 +78,11 @@ export function Dashboard() {
   return (
     <div className="dashboard">
       <PageHeader
-        title="Dashboard"
-        subtitle="Overview of your WhatsApp sessions and activity"
+        title={t('dashboard.title')}
+        subtitle={t('dashboard.subtitle')}
         badge={
           <span className={`status-badge ${stats && stats.ready > 0 ? 'connected' : 'disconnected'}`}>
-            {stats && stats.ready > 0 ? 'Connected' : 'Disconnected'}
+            {stats && stats.ready > 0 ? t('common.connected') : t('common.disconnected')}
           </span>
         }
       />
@@ -113,23 +108,23 @@ export function Dashboard() {
 
       <section className="sessions-section">
         <div className="section-header">
-          <h2>Sessions Overview</h2>
+          <h2>{t('dashboard.sessionsOverview')}</h2>
           <span className="section-subtitle">
-            Showing {sessions.length} of {stats?.total ?? 0} sessions
+            {t('dashboard.showingSessions', { shown: sessions.length, total: stats?.total ?? 0 })}
           </span>
         </div>
 
         <div className="sessions-table">
           <div className="table-header">
-            <span>Session ID</span>
-            <span>Phone Number</span>
-            <span>Status</span>
-            <span>Last Active</span>
-            <span>Actions</span>
+            <span>{t('dashboard.columns.sessionId')}</span>
+            <span>{t('dashboard.columns.phone')}</span>
+            <span>{t('dashboard.columns.status')}</span>
+            <span>{t('dashboard.columns.lastActive')}</span>
+            <span>{t('dashboard.columns.actions')}</span>
           </div>
           {sessions.length === 0 ? (
             <div className="table-row" style={{ justifyContent: 'center', color: 'var(--text-muted)' }}>
-              No sessions found. Create one to get started.
+              {t('dashboard.noSessions')}
             </div>
           ) : (
             sessions.map(session => (
@@ -145,11 +140,11 @@ export function Dashboard() {
                 <span className="last-active">{formatLastActive(session.lastActive)}</span>
                 <div className="actions">
                   <button className="btn-sm" onClick={() => navigate('/sessions')}>
-                    View
+                    {t('dashboard.view')}
                   </button>
                   {['ready', 'initializing', 'connecting', 'qr_ready'].includes(session.status) && (
                     <button className="btn-sm danger" onClick={() => handleDisconnect(session.id)}>
-                      Disconnect
+                      {t('dashboard.disconnect')}
                     </button>
                   )}
                 </div>

--- a/dashboard/src/pages/Infrastructure.tsx
+++ b/dashboard/src/pages/Infrastructure.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
 import {
   Database,
   Server,
@@ -19,7 +20,6 @@ import { PageHeader } from '../components/PageHeader';
 import { useToast } from '../components/Toast';
 import './Infrastructure.css';
 
-// Watermark icons
 import sqliteIcon from '../assets/icons/sqlite.svg';
 import postgresIcon from '../assets/icons/postgresql.svg';
 import folderIcon from '../assets/icons/folder.svg';
@@ -84,7 +84,8 @@ interface RateLimitConfig {
 }
 
 export function Infrastructure() {
-  useDocumentTitle('Infrastructure');
+  const { t } = useTranslation();
+  useDocumentTitle(t('infrastructure.title'));
   const toast = useToast();
   const { data: infraStatus, isLoading: loading } = useInfraStatusQuery();
   const [saving, setSaving] = useState(false);
@@ -131,7 +132,7 @@ export function Infrastructure() {
   const [redisEnabled, setRedisEnabled] = useState(false);
   const [queueEnabled, setQueueEnabled] = useState(false);
   const [pendingProfiles, setPendingProfiles] = useState<string[]>([]);
-  const [previousProfiles, setPreviousProfiles] = useState<string[]>([]); // Track previously enabled for removal
+  const [previousProfiles, setPreviousProfiles] = useState<string[]>([]);
 
   const [serverConfig, setServerConfig] = useState<ServerConfig>({
     port: '2785',
@@ -154,7 +155,6 @@ export function Infrastructure() {
     max: 100,
   });
 
-  // Populate config state from infra status query data
   useEffect(() => {
     if (!infraStatus) return;
 
@@ -184,7 +184,6 @@ export function Infrastructure() {
     });
   }, [infraStatus]);
 
-  // Show loading state
   if (loading) {
     return (
       <div
@@ -196,97 +195,42 @@ export function Infrastructure() {
     );
   }
 
-  const updateDbConfig = (key: keyof DatabaseConfig, value: string | number | boolean) => {
+  const updateDbConfig = (key: keyof DatabaseConfig, value: string | number | boolean) =>
     setDbConfig(prev => ({ ...prev, [key]: value }));
-  };
-
-  const updateRedisConfig = (key: keyof RedisConfig, value: string | boolean) => {
+  const updateRedisConfig = (key: keyof RedisConfig, value: string | boolean) =>
     setRedisConfig(prev => ({ ...prev, [key]: value }));
-  };
-
-  const updateStorageConfig = (key: keyof StorageConfig, value: string | boolean) => {
+  const updateStorageConfig = (key: keyof StorageConfig, value: string | boolean) =>
     setStorageConfig(prev => ({ ...prev, [key]: value }));
-  };
-
-  const updateServerConfig = (key: keyof ServerConfig, value: string) => {
+  const updateServerConfig = (key: keyof ServerConfig, value: string) =>
     setServerConfig(prev => ({ ...prev, [key]: value }));
-  };
-
-  const updateWebhookConfig = (key: keyof WebhookConfig, value: number) => {
+  const updateWebhookConfig = (key: keyof WebhookConfig, value: number) =>
     setWebhookConfig(prev => ({ ...prev, [key]: value }));
-  };
-
-  const updateRateLimitConfig = (key: keyof RateLimitConfig, value: number) => {
+  const updateRateLimitConfig = (key: keyof RateLimitConfig, value: number) =>
     setRateLimitConfig(prev => ({ ...prev, [key]: value }));
-  };
 
-  // Save and restart handlers
   const handleSaveConfig = async () => {
     setSaving(true);
     try {
       const payload = {
-        database: {
-          type: dbConfig.type,
-          builtIn: dbConfig.builtIn,
-          host: dbConfig.host,
-          port: dbConfig.port,
-          username: dbConfig.username,
-          password: dbConfig.password,
-          database: dbConfig.database,
-          poolSize: dbConfig.poolSize,
-          sslEnabled: dbConfig.sslEnabled,
-        },
-        redis: {
-          enabled: redisEnabled,
-          builtIn: redisConfig.builtIn,
-          host: redisConfig.host,
-          port: redisConfig.port,
-          password: redisConfig.password,
-        },
-        queue: {
-          enabled: queueEnabled,
-        },
-        storage: {
-          type: storageConfig.type,
-          builtIn: storageConfig.builtIn,
-          localPath: storageConfig.localPath,
-          s3Bucket: storageConfig.s3Bucket,
-          s3Region: storageConfig.s3Region,
-          s3AccessKey: storageConfig.s3AccessKey,
-          s3SecretKey: storageConfig.s3SecretKey,
-          s3Endpoint: storageConfig.s3Endpoint,
-        },
-        server: {
-          port: serverConfig.port,
-          nodeEnv: serverConfig.nodeEnv,
-          domain: serverConfig.domain,
-          dashboardPort: serverConfig.dashboardPort,
-          baseUrl: serverConfig.baseUrl,
-          dashboardUrl: serverConfig.dashboardUrl,
-          corsOrigins: serverConfig.corsOrigins,
-        },
-        webhook: {
-          timeout: webhookConfig.timeout,
-          maxRetries: webhookConfig.maxRetries,
-          retryDelay: webhookConfig.retryDelay,
-        },
-        rateLimit: {
-          ttl: rateLimitConfig.ttl,
-          max: rateLimitConfig.max,
-        },
+        database: { ...dbConfig },
+        redis: { enabled: redisEnabled, ...redisConfig },
+        queue: { enabled: queueEnabled },
+        storage: { ...storageConfig },
+        server: { ...serverConfig },
+        webhook: { ...webhookConfig },
+        rateLimit: { ...rateLimitConfig },
       };
 
       const result = await infraApi.saveConfig(payload);
       if (result.saved) {
-        // Store current profiles as previous before updating to new ones
         setPreviousProfiles(pendingProfiles);
         setPendingProfiles(result.profiles || []);
         setShowRestartModal(true);
       } else {
-        toast.error('Save Failed', result.message);
+        toast.error(t('infrastructure.toasts.saveFailed'), result.message);
       }
     } catch (err) {
-      toast.error('Save Failed', err instanceof Error ? err.message : 'Unknown error');
+      toast.error(t('infrastructure.toasts.saveFailed'), err instanceof Error ? err.message : t('common.unknownError'));
     } finally {
       setSaving(false);
     }
@@ -294,27 +238,19 @@ export function Infrastructure() {
 
   const handleRestart = async () => {
     setRestartStatus('restarting');
-    setRestartCountdown(30); // Default, will be updated after API call
+    setRestartCountdown(30);
 
-    // Compute profiles to remove (were enabled before, now disabled)
     const profilesToRemove = previousProfiles.filter(p => !pendingProfiles.includes(p));
 
     try {
       const response = await infraApi.restart(pendingProfiles, profilesToRemove);
-      // Use server-provided estimated time if available
-      if (response.estimatedTime) {
-        setRestartCountdown(response.estimatedTime);
-      }
+      if (response.estimatedTime) setRestartCountdown(response.estimatedTime);
     } catch {
-      // Expected - server is shutting down, use default countdown
+      // Expected — server shutting down
     }
 
-    // Start countdown (visual feedback only)
     setRestartStatus('waiting');
-
-    // Store interval ID to allow early termination when health check succeeds
     let intervalRef: ReturnType<typeof setInterval> | null = null;
-
     const stopCountdown = () => {
       if (intervalRef) {
         clearInterval(intervalRef);
@@ -332,71 +268,61 @@ export function Infrastructure() {
       });
     }, 1000);
 
-    // Start health polling IMMEDIATELY - this is more accurate than countdown
-    // Server will respond as soon as it's ready, stopping countdown early
     checkServerHealth(stopCountdown);
   };
 
   const checkServerHealth = async (stopCountdown?: () => void) => {
     let attempts = 0;
-    const maxAttempts = 60; // Allow up to 60 attempts (60 seconds)
+    const maxAttempts = 60;
 
     const check = async () => {
       try {
         await infraApi.healthCheck();
-        // Server is back! Stop countdown and show success
         stopCountdown?.();
         setRestartCountdown(0);
         setRestartStatus('success');
-        // Reload page after 2 seconds
-        setTimeout(() => {
-          window.location.reload();
-        }, 2000);
+        setTimeout(() => window.location.reload(), 2000);
       } catch {
         attempts++;
-        if (attempts < maxAttempts) {
-          setTimeout(check, 1000);
-        } else {
-          setRestartStatus('error');
-        }
+        if (attempts < maxAttempts) setTimeout(check, 1000);
+        else setRestartStatus('error');
       }
     };
 
-    // Start checking immediately with a small delay for server to begin shutdown
     setTimeout(check, 3000);
   };
 
   return (
     <div className="infrastructure-page">
-      <PageHeader title="Infrastructure" subtitle="Configure server, database, cache, storage, and engine settings" />
+      <PageHeader title={t('infrastructure.title')} subtitle={t('infrastructure.subtitle')} />
 
       <div className="infra-sections">
-        {/* Server Configuration Section */}
+        {/* Server Configuration */}
         <section className="infra-card">
           <div className="card-header">
             <div className="header-left">
               <Globe size={20} />
-              <h2>Server Configuration</h2>
+              <h2>{t('infrastructure.server.title')}</h2>
             </div>
             <span className={`status-indicator ${serverConfig.nodeEnv === 'production' ? 'connected' : 'sqlite'}`}>
-              ● {serverConfig.nodeEnv === 'production' ? 'Production' : 'Development'}
+              ● {serverConfig.nodeEnv === 'production' ? t('infrastructure.server.production') : t('infrastructure.server.development')}
             </span>
           </div>
 
           <div className="config-form">
             <div className="form-row">
               <div className="form-group">
-                <label>Environment</label>
+                <label>{t('infrastructure.server.environment')}</label>
                 <select
                   value={serverConfig.nodeEnv}
                   onChange={e => updateServerConfig('nodeEnv', e.target.value as 'production' | 'development')}
                 >
-                  <option value="production">Production</option>
-                  <option value="development">Development</option>
+                  <option value="production">{t('infrastructure.server.production')}</option>
+                  <option value="development">{t('infrastructure.server.development')}</option>
                 </select>
               </div>
               <div className="form-group">
-                <label>Domain</label>
+                <label>{t('infrastructure.server.domain')}</label>
                 <input
                   type="text"
                   value={serverConfig.domain}
@@ -407,15 +333,11 @@ export function Infrastructure() {
             </div>
             <div className="form-row">
               <div className="form-group small">
-                <label>API Port</label>
-                <input
-                  type="text"
-                  value={serverConfig.port}
-                  onChange={e => updateServerConfig('port', e.target.value)}
-                />
+                <label>{t('infrastructure.server.apiPort')}</label>
+                <input type="text" value={serverConfig.port} onChange={e => updateServerConfig('port', e.target.value)} />
               </div>
               <div className="form-group small">
-                <label>Dashboard Port</label>
+                <label>{t('infrastructure.server.dashboardPort')}</label>
                 <input
                   type="text"
                   value={serverConfig.dashboardPort}
@@ -423,18 +345,18 @@ export function Infrastructure() {
                 />
               </div>
               <div className="form-group">
-                <label>CORS Origins</label>
+                <label>{t('infrastructure.server.corsOrigins')}</label>
                 <input
                   type="text"
                   value={serverConfig.corsOrigins}
                   onChange={e => updateServerConfig('corsOrigins', e.target.value)}
-                  placeholder="* or comma-separated origins"
+                  placeholder={t('infrastructure.server.corsPlaceholder')}
                 />
               </div>
             </div>
             <div className="form-row">
               <div className="form-group">
-                <label>Public API URL (optional)</label>
+                <label>{t('infrastructure.server.publicApiUrl')}</label>
                 <input
                   type="text"
                   value={serverConfig.baseUrl}
@@ -443,7 +365,7 @@ export function Infrastructure() {
                 />
               </div>
               <div className="form-group">
-                <label>Public Dashboard URL (optional)</label>
+                <label>{t('infrastructure.server.publicDashboardUrl')}</label>
                 <input
                   type="text"
                   value={serverConfig.dashboardUrl}
@@ -455,23 +377,23 @@ export function Infrastructure() {
           </div>
         </section>
 
-        {/* Webhook & Rate Limiting Section */}
+        {/* Webhook & Rate Limiting */}
         <section className="infra-card">
           <div className="card-header">
             <div className="header-left">
               <Webhook size={20} />
-              <h2>Webhook & Rate Limiting</h2>
+              <h2>{t('infrastructure.webhook.title')}</h2>
             </div>
           </div>
 
           <div className="config-form">
             <h3 style={{ margin: '0 0 1rem', fontSize: '0.9375rem', color: '#475569', fontWeight: 600 }}>
-              <Webhook size={16} style={{ marginRight: '0.5rem', verticalAlign: 'middle' }} />
-              Webhook Settings
+              <Webhook size={16} style={{ marginInlineEnd: '0.5rem', verticalAlign: 'middle' }} />
+              {t('infrastructure.webhook.settings')}
             </h3>
             <div className="form-row">
               <div className="form-group">
-                <label>Timeout (ms)</label>
+                <label>{t('infrastructure.webhook.timeout')}</label>
                 <input
                   type="number"
                   value={webhookConfig.timeout}
@@ -479,7 +401,7 @@ export function Infrastructure() {
                 />
               </div>
               <div className="form-group small">
-                <label>Max Retries</label>
+                <label>{t('infrastructure.webhook.maxRetries')}</label>
                 <input
                   type="number"
                   min="0"
@@ -489,7 +411,7 @@ export function Infrastructure() {
                 />
               </div>
               <div className="form-group">
-                <label>Retry Delay (ms)</label>
+                <label>{t('infrastructure.webhook.retryDelay')}</label>
                 <input
                   type="number"
                   value={webhookConfig.retryDelay}
@@ -500,12 +422,12 @@ export function Infrastructure() {
 
             <div style={{ borderTop: '1px solid var(--border)', margin: '1.5rem 0', paddingTop: '1.5rem' }}>
               <h3 style={{ margin: '0 0 1rem', fontSize: '0.9375rem', color: '#475569', fontWeight: 600 }}>
-                <Gauge size={16} style={{ marginRight: '0.5rem', verticalAlign: 'middle' }} />
-                Rate Limiting
+                <Gauge size={16} style={{ marginInlineEnd: '0.5rem', verticalAlign: 'middle' }} />
+                {t('infrastructure.webhook.rateLimit')}
               </h3>
               <div className="form-row">
                 <div className="form-group">
-                  <label>Time Window (seconds)</label>
+                  <label>{t('infrastructure.webhook.window')}</label>
                   <input
                     type="number"
                     value={rateLimitConfig.ttl}
@@ -513,7 +435,7 @@ export function Infrastructure() {
                   />
                 </div>
                 <div className="form-group">
-                  <label>Max Requests per Window</label>
+                  <label>{t('infrastructure.webhook.maxReq')}</label>
                   <input
                     type="number"
                     value={rateLimitConfig.max}
@@ -525,12 +447,12 @@ export function Infrastructure() {
           </div>
         </section>
 
-        {/* Database Section */}
+        {/* Database */}
         <section className="infra-card">
           <div className="card-header">
             <div className="header-left">
               <Database size={20} />
-              <h2>Database Configuration</h2>
+              <h2>{t('infrastructure.database.title')}</h2>
             </div>
             <span className={`status-indicator ${dbConfig.type === 'postgres' ? 'connected' : 'sqlite'}`}>
               ● {dbConfig.type === 'postgres' ? 'PostgreSQL' : 'SQLite'}
@@ -546,8 +468,8 @@ export function Infrastructure() {
                 onChange={() => updateDbConfig('type', 'sqlite')}
               />
               <img src={sqliteIcon} alt="" className="watermark-icon" />
-              <span>SQLite</span>
-              <small>Local file-based database</small>
+              <span>{t('infrastructure.database.sqlite')}</span>
+              <small>{t('infrastructure.database.sqliteDesc')}</small>
             </label>
             <label className={`radio-option ${dbConfig.type === 'postgres' ? 'selected' : ''}`}>
               <input
@@ -557,8 +479,8 @@ export function Infrastructure() {
                 onChange={() => updateDbConfig('type', 'postgres')}
               />
               <img src={postgresIcon} alt="" className="watermark-icon" />
-              <span>PostgreSQL</span>
-              <small>Production-ready database</small>
+              <span>{t('infrastructure.database.postgres')}</span>
+              <small>{t('infrastructure.database.postgresDesc')}</small>
             </label>
           </div>
 
@@ -566,8 +488,8 @@ export function Infrastructure() {
             <>
               <div className="toggle-row" style={{ marginTop: '1rem', marginBottom: '1rem' }}>
                 <div className="toggle-info">
-                  <span>Use Built-in PostgreSQL Container</span>
-                  <small>OpenWA will manage a PostgreSQL container for you</small>
+                  <span>{t('infrastructure.database.useBuiltIn')}</span>
+                  <small>{t('infrastructure.database.builtInDesc')}</small>
                 </div>
                 <label className="toggle-switch">
                   <input
@@ -583,17 +505,17 @@ export function Infrastructure() {
                 <div className="config-form">
                   <div className="form-row">
                     <div className="form-group">
-                      <label>Host</label>
+                      <label>{t('common.host')}</label>
                       <input type="text" value={dbConfig.host} onChange={e => updateDbConfig('host', e.target.value)} />
                     </div>
                     <div className="form-group small">
-                      <label>Port</label>
+                      <label>{t('common.port')}</label>
                       <input type="text" value={dbConfig.port} onChange={e => updateDbConfig('port', e.target.value)} />
                     </div>
                   </div>
                   <div className="form-row">
                     <div className="form-group">
-                      <label>Username</label>
+                      <label>{t('common.username')}</label>
                       <input
                         type="text"
                         value={dbConfig.username}
@@ -601,7 +523,7 @@ export function Infrastructure() {
                       />
                     </div>
                     <div className="form-group">
-                      <label>Password</label>
+                      <label>{t('common.password')}</label>
                       <input
                         type="password"
                         value={dbConfig.password}
@@ -611,7 +533,7 @@ export function Infrastructure() {
                   </div>
                   <div className="form-row">
                     <div className="form-group">
-                      <label>Database Name</label>
+                      <label>{t('infrastructure.database.dbName')}</label>
                       <input
                         type="text"
                         value={dbConfig.database}
@@ -619,7 +541,7 @@ export function Infrastructure() {
                       />
                     </div>
                     <div className="form-group small">
-                      <label>Pool Size</label>
+                      <label>{t('infrastructure.database.poolSize')}</label>
                       <input
                         type="number"
                         min="1"
@@ -631,8 +553,8 @@ export function Infrastructure() {
                   </div>
                   <div className="toggle-row">
                     <div className="toggle-info">
-                      <span>SSL Connection</span>
-                      <small>Enable TLS/SSL for secure database connections</small>
+                      <span>{t('infrastructure.database.ssl')}</span>
+                      <small>{t('infrastructure.database.sslDesc')}</small>
                     </div>
                     <label className="toggle-switch">
                       <input
@@ -660,7 +582,9 @@ export function Infrastructure() {
             }}
           >
             <Database size={32} style={{ color: '#22C55E', marginBottom: '1rem', opacity: 0.7 }} />
-            <p style={{ margin: 0, color: '#475569', fontSize: '0.9375rem', fontWeight: 500 }}>Database Migrations</p>
+            <p style={{ margin: 0, color: '#475569', fontSize: '0.9375rem', fontWeight: 500 }}>
+              {t('infrastructure.database.migrationsTitle')}
+            </p>
             <p
               style={{
                 margin: '0.75rem 0 0',
@@ -674,25 +598,29 @@ export function Infrastructure() {
               }}
             >
               <CheckCircle size={16} />
-              Schema is auto-synchronized with TypeORM
+              {t('infrastructure.database.migrationsStatus')}
             </p>
             <p style={{ margin: '0.5rem 0 0', color: '#64748B', fontSize: '0.8125rem', lineHeight: 1.5 }}>
-              Migrations are managed automatically. Use CLI for manual migrations.
+              {t('infrastructure.database.migrationsHint')}
             </p>
           </div>
         </section>
 
-        {/* Redis Section */}
+        {/* Redis */}
         <section className="infra-card">
           <div className="card-header">
             <div className="header-left">
               <Server size={20} />
-              <h2>Redis</h2>
+              <h2>{t('infrastructure.redis.title')}</h2>
             </div>
             <span
               className={`status-indicator ${redisEnabled && redisConfig.connected ? 'connected' : 'disconnected'}`}
             >
-              ● {redisEnabled ? (redisConfig.connected ? 'Connected' : 'Disconnected') : 'Disabled'}
+              ● {redisEnabled
+                ? redisConfig.connected
+                  ? t('infrastructure.statusLabels.connected')
+                  : t('infrastructure.statusLabels.disconnected')
+                : t('infrastructure.statusLabels.disabled')}
             </span>
           </div>
 
@@ -705,8 +633,8 @@ export function Infrastructure() {
             }}
           >
             <div className="toggle-info">
-              <span>Enable Redis</span>
-              <small>Required for caching, session storage, and BullMQ queues</small>
+              <span>{t('infrastructure.redis.enable')}</span>
+              <small>{t('infrastructure.redis.enableDesc')}</small>
             </div>
             <label className="toggle-switch">
               <input
@@ -725,8 +653,8 @@ export function Infrastructure() {
             <>
               <div className="toggle-row" style={{ marginBottom: '1rem' }}>
                 <div className="toggle-info">
-                  <span>Use Built-in Redis Container</span>
-                  <small>OpenWA will manage a Redis container for you</small>
+                  <span>{t('infrastructure.redis.useBuiltIn')}</span>
+                  <small>{t('infrastructure.redis.builtInDesc')}</small>
                 </div>
                 <label className="toggle-switch">
                   <input
@@ -742,7 +670,7 @@ export function Infrastructure() {
                 <div className="config-form">
                   <div className="form-row">
                     <div className="form-group">
-                      <label>Host</label>
+                      <label>{t('common.host')}</label>
                       <input
                         type="text"
                         value={redisConfig.host}
@@ -750,7 +678,7 @@ export function Infrastructure() {
                       />
                     </div>
                     <div className="form-group small">
-                      <label>Port</label>
+                      <label>{t('common.port')}</label>
                       <input
                         type="text"
                         value={redisConfig.port}
@@ -758,26 +686,25 @@ export function Infrastructure() {
                       />
                     </div>
                     <div className="form-group">
-                      <label>Password</label>
+                      <label>{t('common.password')}</label>
                       <input
                         type="password"
                         value={redisConfig.password}
                         onChange={e => updateRedisConfig('password', e.target.value)}
-                        placeholder="(optional)"
+                        placeholder={t('infrastructure.redis.passwordOptional')}
                       />
                     </div>
                   </div>
                 </div>
               )}
 
-              {/* BullMQ Queue Toggle */}
               <div
                 className="toggle-row"
                 style={{ borderTop: '1px solid var(--border)', paddingTop: '1.25rem', marginTop: '0.5rem' }}
               >
                 <div className="toggle-info">
-                  <span>Enable BullMQ Queue System</span>
-                  <small>Use message queues for reliable message and webhook delivery</small>
+                  <span>{t('infrastructure.redis.queueTitle')}</span>
+                  <small>{t('infrastructure.redis.queueDesc')}</small>
                 </div>
                 <label className="toggle-switch">
                   <input type="checkbox" checked={queueEnabled} onChange={e => setQueueEnabled(e.target.checked)} />
@@ -787,39 +714,39 @@ export function Infrastructure() {
 
               {queueEnabled && (
                 <div className="queue-stats">
-                  <h3>Queue Statistics</h3>
+                  <h3>{t('infrastructure.redis.statsTitle')}</h3>
                   <div className="stats-row">
                     <div className="queue-stat-card">
-                      <h4>Message Queue</h4>
+                      <h4>{t('infrastructure.redis.messageQueue')}</h4>
                       <div className="stat-values">
                         <div className="stat-item pending">
                           <span className="value">{queueStats.messages.pending}</span>
-                          <span className="label">Pending</span>
+                          <span className="label">{t('infrastructure.redis.pending')}</span>
                         </div>
                         <div className="stat-item completed">
                           <span className="value">{queueStats.messages.completed.toLocaleString()}</span>
-                          <span className="label">Completed</span>
+                          <span className="label">{t('infrastructure.redis.completed')}</span>
                         </div>
                         <div className="stat-item failed">
                           <span className="value">{queueStats.messages.failed}</span>
-                          <span className="label">Failed</span>
+                          <span className="label">{t('infrastructure.redis.failed')}</span>
                         </div>
                       </div>
                     </div>
                     <div className="queue-stat-card">
-                      <h4>Webhook Queue</h4>
+                      <h4>{t('infrastructure.redis.webhookQueue')}</h4>
                       <div className="stat-values">
                         <div className="stat-item pending">
                           <span className="value">{queueStats.webhooks.pending}</span>
-                          <span className="label">Pending</span>
+                          <span className="label">{t('infrastructure.redis.pending')}</span>
                         </div>
                         <div className="stat-item completed">
                           <span className="value">{queueStats.webhooks.completed.toLocaleString()}</span>
-                          <span className="label">Completed</span>
+                          <span className="label">{t('infrastructure.redis.completed')}</span>
                         </div>
                         <div className="stat-item failed">
                           <span className="value">{queueStats.webhooks.failed}</span>
-                          <span className="label">Failed</span>
+                          <span className="label">{t('infrastructure.redis.failed')}</span>
                         </div>
                       </div>
                     </div>
@@ -827,14 +754,14 @@ export function Infrastructure() {
                   <div className="queue-actions">
                     <button className="btn-danger-outline">
                       <Trash2 size={16} />
-                      Clear Failed Jobs
+                      {t('infrastructure.redis.clearFailed')}
                     </button>
                     <button
                       className="btn-outline"
                       onClick={() => window.open('http://localhost:2785/api/admin/queues', '_blank')}
                     >
                       <ExternalLink size={16} />
-                      View Bull MQ Dashboard
+                      {t('infrastructure.redis.viewBullMq')}
                     </button>
                   </div>
                 </div>
@@ -853,21 +780,22 @@ export function Infrastructure() {
               }}
             >
               <Server size={32} style={{ color: '#94A3B8', marginBottom: '1rem', opacity: 0.5 }} />
-              <p style={{ margin: 0, color: '#475569', fontSize: '0.9375rem', fontWeight: 500 }}>Redis is Disabled</p>
+              <p style={{ margin: 0, color: '#475569', fontSize: '0.9375rem', fontWeight: 500 }}>
+                {t('infrastructure.redis.disabledTitle')}
+              </p>
               <p style={{ margin: '0.5rem 0 0', color: '#64748B', fontSize: '0.8125rem', lineHeight: 1.5 }}>
-                Enable Redis for caching, session storage, <br />
-                and BullMQ message queues.
+                {t('infrastructure.redis.disabledDesc')}
               </p>
             </div>
           )}
         </section>
 
-        {/* Storage Section */}
+        {/* Storage */}
         <section className="infra-card">
           <div className="card-header">
             <div className="header-left">
               <HardDrive size={20} />
-              <h2>Storage Configuration</h2>
+              <h2>{t('infrastructure.storage.title')}</h2>
             </div>
           </div>
 
@@ -880,8 +808,8 @@ export function Infrastructure() {
                 onChange={() => updateStorageConfig('type', 'local')}
               />
               <img src={folderIcon} alt="" className="watermark-icon" />
-              <span>Local Filesystem</span>
-              <small>Store media files locally</small>
+              <span>{t('infrastructure.storage.local')}</span>
+              <small>{t('infrastructure.storage.localDesc')}</small>
             </label>
             <label className={`radio-option ${storageConfig.type === 's3' ? 'selected' : ''}`}>
               <input
@@ -891,15 +819,15 @@ export function Infrastructure() {
                 onChange={() => updateStorageConfig('type', 's3')}
               />
               <img src={s3Icon} alt="" className="watermark-icon" />
-              <span>Amazon S3</span>
-              <small>Cloud storage (S3 compatible)</small>
+              <span>{t('infrastructure.storage.s3')}</span>
+              <small>{t('infrastructure.storage.s3Desc')}</small>
             </label>
           </div>
 
           <div className="config-form">
             {storageConfig.type === 'local' && (
               <div className="form-group">
-                <label>Storage Path</label>
+                <label>{t('infrastructure.storage.storagePath')}</label>
                 <input
                   type="text"
                   value={storageConfig.localPath}
@@ -912,8 +840,8 @@ export function Infrastructure() {
               <>
                 <div className="toggle-row" style={{ marginTop: '1rem', marginBottom: '1rem' }}>
                   <div className="toggle-info">
-                    <span>Use Built-in MinIO Container</span>
-                    <small>OpenWA will manage a MinIO (S3-compatible) container for you</small>
+                    <span>{t('infrastructure.storage.useBuiltIn')}</span>
+                    <small>{t('infrastructure.storage.builtInDesc')}</small>
                   </div>
                   <label className="toggle-switch">
                     <input
@@ -929,7 +857,7 @@ export function Infrastructure() {
                   <>
                     <div className="form-row">
                       <div className="form-group">
-                        <label>Bucket Name</label>
+                        <label>{t('infrastructure.storage.bucket')}</label>
                         <input
                           type="text"
                           value={storageConfig.s3Bucket}
@@ -937,7 +865,7 @@ export function Infrastructure() {
                         />
                       </div>
                       <div className="form-group">
-                        <label>Region</label>
+                        <label>{t('infrastructure.storage.region')}</label>
                         <input
                           type="text"
                           value={storageConfig.s3Region}
@@ -947,7 +875,7 @@ export function Infrastructure() {
                     </div>
                     <div className="form-row">
                       <div className="form-group">
-                        <label>Access Key</label>
+                        <label>{t('infrastructure.storage.accessKey')}</label>
                         <input
                           type="text"
                           value={storageConfig.s3AccessKey}
@@ -955,7 +883,7 @@ export function Infrastructure() {
                         />
                       </div>
                       <div className="form-group">
-                        <label>Secret Key</label>
+                        <label>{t('infrastructure.storage.secretKey')}</label>
                         <input
                           type="password"
                           value={storageConfig.s3SecretKey}
@@ -964,12 +892,12 @@ export function Infrastructure() {
                       </div>
                     </div>
                     <div className="form-group">
-                      <label>Custom Endpoint (optional)</label>
+                      <label>{t('infrastructure.storage.endpoint')}</label>
                       <input
                         type="text"
                         value={storageConfig.s3Endpoint}
                         onChange={e => updateStorageConfig('s3Endpoint', e.target.value)}
-                        placeholder="For MinIO or other S3-compatible services"
+                        placeholder={t('infrastructure.storage.endpointHint')}
                       />
                     </div>
                   </>
@@ -980,32 +908,30 @@ export function Infrastructure() {
         </section>
       </div>
 
-      {/* Restart Modal */}
       {showRestartModal && (
         <div className="modal-overlay">
           <div className="modal" style={{ maxWidth: '500px', textAlign: 'center' }}>
             <div className="modal-header" style={{ justifyContent: 'center', borderBottom: 'none' }}>
               <h2>
-                {restartStatus === 'idle' && '⚙️ Configuration Saved'}
-                {restartStatus === 'restarting' && '🔄 Restarting Server...'}
-                {restartStatus === 'waiting' && '⏳ Please Wait...'}
-                {restartStatus === 'success' && '✅ Server Ready'}
-                {restartStatus === 'error' && '❌ Restart Failed'}
+                {restartStatus === 'idle' && t('infrastructure.restart.idleTitle')}
+                {restartStatus === 'restarting' && t('infrastructure.restart.restartingTitle')}
+                {restartStatus === 'waiting' && t('infrastructure.restart.waitingTitle')}
+                {restartStatus === 'success' && t('infrastructure.restart.successTitle')}
+                {restartStatus === 'error' && t('infrastructure.restart.errorTitle')}
               </h2>
             </div>
             <div className="modal-body" style={{ padding: '2rem' }}>
               {restartStatus === 'idle' && (
                 <>
                   <p style={{ fontSize: '1rem', color: '#475569', marginBottom: '1.5rem' }}>
-                    Configuration has been saved to <code>.env.generated</code>.<br />A server restart is required to
-                    apply the changes.
+                    <Trans i18nKey="infrastructure.restart.idleDesc" components={{ code: <code />, br: <br /> }} />
                   </p>
                   <div style={{ display: 'flex', gap: '1rem', justifyContent: 'center' }}>
                     <button className="btn-secondary" onClick={() => setShowRestartModal(false)}>
-                      Restart Later
+                      {t('infrastructure.restart.later')}
                     </button>
                     <button className="btn-primary" onClick={handleRestart}>
-                      Restart Now
+                      {t('infrastructure.restart.now')}
                     </button>
                   </div>
                 </>
@@ -1016,7 +942,9 @@ export function Infrastructure() {
                   <div style={{ marginBottom: '1.5rem' }}>
                     <Loader2 className="animate-spin" size={48} style={{ color: '#22C55E', marginBottom: '1rem' }} />
                     <p style={{ fontSize: '1.125rem', color: '#1E293B', fontWeight: 500 }}>
-                      {restartCountdown > 0 ? `Server restarting... ${restartCountdown}s` : 'Checking server status...'}
+                      {restartCountdown > 0
+                        ? t('infrastructure.restart.restartingMsg', { count: restartCountdown })
+                        : t('infrastructure.restart.checking')}
                     </p>
                   </div>
                   <div
@@ -1038,7 +966,7 @@ export function Infrastructure() {
                     />
                   </div>
                   <p style={{ marginTop: '1rem', fontSize: '0.875rem', color: '#64748B' }}>
-                    Please do not close this window
+                    {t('infrastructure.restart.dontClose')}
                   </p>
                 </>
               )}
@@ -1047,7 +975,7 @@ export function Infrastructure() {
                 <>
                   <CheckCircle size={48} style={{ color: '#22C55E', marginBottom: '1rem' }} />
                   <p style={{ fontSize: '1rem', color: '#475569' }}>
-                    Server is back online! The page will reload automatically.
+                    {t('infrastructure.restart.successMsg')}
                   </p>
                 </>
               )}
@@ -1055,12 +983,10 @@ export function Infrastructure() {
               {restartStatus === 'error' && (
                 <>
                   <p style={{ fontSize: '1rem', color: '#DC2626', marginBottom: '1rem' }}>
-                    Server did not respond after 30 seconds.
-                    <br />
-                    Please check the Docker logs and restart manually.
+                    {t('infrastructure.restart.errorMsg')}
                   </p>
                   <button className="btn-primary" onClick={() => window.location.reload()}>
-                    Reload Page
+                    {t('infrastructure.restart.reload')}
                   </button>
                 </>
               )}
@@ -1072,7 +998,7 @@ export function Infrastructure() {
       <footer className="page-footer">
         <button className="btn-primary large" onClick={handleSaveConfig} disabled={saving}>
           {saving ? <Loader2 className="animate-spin" size={20} /> : <Save size={20} />}
-          {saving ? 'Saving...' : 'Save Configuration'}
+          {saving ? t('infrastructure.saving') : t('infrastructure.saveConfig')}
         </button>
       </footer>
     </div>

--- a/dashboard/src/pages/Login.tsx
+++ b/dashboard/src/pages/Login.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Eye, EyeOff, Github } from 'lucide-react';
 import './Login.css';
 
@@ -7,6 +8,7 @@ interface LoginProps {
 }
 
 export function Login({ onLogin }: LoginProps) {
+  const { t } = useTranslation();
   const [apiKey, setApiKey] = useState('');
   const [showKey, setShowKey] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -15,14 +17,13 @@ export function Login({ onLogin }: LoginProps) {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!apiKey.trim()) {
-      setError('API key is required');
+      setError(t('login.apiKeyRequired'));
       return;
     }
     setIsLoading(true);
     setError('');
 
     try {
-      // Validate API key with backend
       const response = await fetch('/api/auth/validate', {
         method: 'POST',
         headers: {
@@ -35,10 +36,10 @@ export function Login({ onLogin }: LoginProps) {
         onLogin(apiKey);
       } else {
         const errorData = await response.json().catch(() => ({}));
-        setError(errorData.message || 'Invalid API key');
+        setError(errorData.message || t('login.invalidKey'));
       }
     } catch {
-      setError('Unable to connect to server. Please try again.');
+      setError(t('login.connectionError'));
     } finally {
       setIsLoading(false);
     }
@@ -50,19 +51,22 @@ export function Login({ onLogin }: LoginProps) {
         <div className="login-logo">
           <img src="/openwa_logo.webp" alt="OpenWA" className="logo-icon" />
           <span className="version-info">
-            v{__APP_VERSION__} · {new Date(__BUILD_TIME__).toLocaleDateString()}
+            {t('login.version', {
+              version: __APP_VERSION__,
+              date: new Date(__BUILD_TIME__).toLocaleDateString(),
+            })}
           </span>
         </div>
         <form onSubmit={handleSubmit} className="login-form">
           <div className="input-group">
-            <label htmlFor="apiKey">API Key</label>
+            <label htmlFor="apiKey">{t('login.apiKey')}</label>
             <div className="input-wrapper">
               <input
                 id="apiKey"
                 type={showKey ? 'text' : 'password'}
                 value={apiKey}
                 onChange={e => setApiKey(e.target.value)}
-                placeholder="Enter your API key"
+                placeholder={t('login.apiKeyPlaceholder')}
                 className={error ? 'error' : ''}
               />
               <button type="button" className="toggle-visibility" onClick={() => setShowKey(!showKey)}>
@@ -73,24 +77,24 @@ export function Login({ onLogin }: LoginProps) {
           </div>
 
           <button type="submit" className="connect-btn" disabled={isLoading}>
-            {isLoading ? 'Connecting...' : 'Connect'}
+            {isLoading ? t('login.connecting') : t('login.connect')}
           </button>
         </form>
 
         <p className="login-help">
-          Need help?{' '}
+          {t('login.help')}{' '}
           <a
             href="https://github.com/rmyndharis/OpenWA/blob/main/docs/01-project-overview.md"
             target="_blank"
             rel="noopener noreferrer"
           >
-            View Documentation
+            {t('login.viewDocs')}
           </a>
         </p>
       </div>
 
       <footer className="login-footer">
-        <span>Made with ❤️ by Yudhi Armyndharis and the OpenWA Community</span>
+        <span>{t('login.footer')}</span>
         <a
           href="https://github.com/rmyndharis/OpenWA"
           target="_blank"

--- a/dashboard/src/pages/Logs.tsx
+++ b/dashboard/src/pages/Logs.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Download, Search, Filter, Loader2, FileText } from 'lucide-react';
 import type { AuditLog } from '../services/api';
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
@@ -7,7 +8,8 @@ import { PageHeader } from '../components/PageHeader';
 import './Logs.css';
 
 export function Logs() {
-  useDocumentTitle('Audit Logs');
+  const { t } = useTranslation();
+  useDocumentTitle(t('logs.title'));
   const [searchQuery, setSearchQuery] = useState('');
   const [severityFilter, setSeverityFilter] = useState('all');
   const [page, setPage] = useState(1);
@@ -27,9 +29,7 @@ export function Logs() {
 
   const totalPages = Math.ceil(total / limit);
 
-  const formatTimestamp = (date: string) => {
-    return new Date(date).toLocaleString();
-  };
+  const formatTimestamp = (date: string) => new Date(date).toLocaleString();
 
   if (loading && logs.length === 0) {
     return (
@@ -45,12 +45,12 @@ export function Logs() {
   return (
     <div className="logs-page">
       <PageHeader
-        title="Audit Logs"
-        subtitle="Track and review all API actions and system events"
+        title={t('logs.title')}
+        subtitle={t('logs.subtitle')}
         actions={
           <button className="btn-secondary">
             <Download size={18} />
-            Export CSV
+            {t('logs.exportCsv')}
           </button>
         }
       />
@@ -60,7 +60,7 @@ export function Logs() {
           <Search size={18} />
           <input
             type="text"
-            placeholder="Search logs..."
+            placeholder={t('logs.searchPlaceholder')}
             value={searchQuery}
             onChange={e => setSearchQuery(e.target.value)}
           />
@@ -75,10 +75,10 @@ export function Logs() {
               setPage(1);
             }}
           >
-            <option value="all">All Severities</option>
-            <option value="info">Info</option>
-            <option value="warn">Warning</option>
-            <option value="error">Error</option>
+            <option value="all">{t('logs.severity.all')}</option>
+            <option value="info">{t('logs.severity.info')}</option>
+            <option value="warn">{t('logs.severity.warn')}</option>
+            <option value="error">{t('logs.severity.error')}</option>
           </select>
         </div>
       </div>
@@ -86,18 +86,18 @@ export function Logs() {
       <div className="logs-table-container">
         <div className="logs-table">
           <div className="table-row header">
-            <span>Timestamp</span>
-            <span>Action</span>
-            <span>Session</span>
-            <span>API Key</span>
-            <span>IP Address</span>
-            <span>Severity</span>
+            <span>{t('logs.columns.timestamp')}</span>
+            <span>{t('logs.columns.action')}</span>
+            <span>{t('logs.columns.session')}</span>
+            <span>{t('logs.columns.apiKey')}</span>
+            <span>{t('logs.columns.ip')}</span>
+            <span>{t('logs.columns.severity')}</span>
           </div>
           {filteredLogs.length === 0 ? (
             <div className="empty-table-state">
               <FileText size={48} strokeWidth={1} />
-              <h3>No logs found</h3>
-              <p>Audit logs will appear here as actions are performed</p>
+              <h3>{t('logs.empty.title')}</h3>
+              <p>{t('logs.empty.description')}</p>
             </div>
           ) : (
             filteredLogs.map(log => (
@@ -119,7 +119,7 @@ export function Logs() {
       {totalPages > 1 && (
         <div className="pagination">
           <button disabled={page === 1} onClick={() => setPage(p => p - 1)}>
-            Previous
+            {t('common.previous')}
           </button>
           <span className="page-numbers">
             {Array.from({ length: Math.min(totalPages, 5) }, (_, i) => i + 1).map(p => (
@@ -129,7 +129,7 @@ export function Logs() {
             ))}
           </span>
           <button disabled={page >= totalPages} onClick={() => setPage(p => p + 1)}>
-            Next
+            {t('common.next')}
           </button>
         </div>
       )}

--- a/dashboard/src/pages/MessageTester.tsx
+++ b/dashboard/src/pages/MessageTester.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Send, CheckCircle, XCircle, Loader2 } from 'lucide-react';
 import { messageApi } from '../services/api';
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
@@ -14,8 +15,11 @@ interface ApiResponse {
   error?: string;
 }
 
+const messageTypes = ['text', 'image', 'video', 'audio', 'document'] as const;
+
 export function MessageTester() {
-  useDocumentTitle('Message Tester');
+  const { t } = useTranslation();
+  useDocumentTitle(t('messageTester.title'));
   const { canWrite } = useRole();
   const { data: allSessions = [], isLoading: loadingSessions } = useSessionsQuery();
   const sessions = allSessions.filter(s => s.status === 'ready');
@@ -23,7 +27,7 @@ export function MessageTester() {
   const [recipient, setRecipient] = useState('');
   const [recipientType, setRecipientType] = useState<'personal' | 'group'>('personal');
   const [selectedGroup, setSelectedGroup] = useState('');
-  const [messageType, setMessageType] = useState<'text' | 'image' | 'video' | 'audio' | 'document'>('text');
+  const [messageType, setMessageType] = useState<typeof messageTypes[number]>('text');
   const [content, setContent] = useState('');
   const [mediaUrl, setMediaUrl] = useState('');
   const [isLoading, setIsLoading] = useState(false);
@@ -34,14 +38,12 @@ export function MessageTester() {
     recipientType === 'group',
   );
 
-  // Auto-select first session
   useEffect(() => {
     if (sessions.length > 0 && !session) {
       setSession(sessions[0].id);
     }
   }, [sessions, session]);
 
-  // Auto-select first group
   useEffect(() => {
     if (groups.length > 0 && !selectedGroup) {
       setSelectedGroup(groups[0].id);
@@ -52,13 +54,11 @@ export function MessageTester() {
   }, [groups, selectedGroup, recipientType]);
 
   const handleSend = async () => {
-    // For groups, use selectedGroup; for personal, use recipient
     const targetId = recipientType === 'group' ? selectedGroup : recipient;
     if (!session || !targetId) return;
     setIsLoading(true);
     setResponse(null);
 
-    // For personal, add @c.us suffix; for group, ID already has @g.us
     const chatId = recipientType === 'group' ? targetId : targetId.replace(/[^0-9]/g, '') + '@c.us';
 
     try {
@@ -75,7 +75,6 @@ export function MessageTester() {
         result = await messageApi.sendDocument(session, chatId, mediaUrl, content);
       }
 
-      // Infer success from having messageId - backend doesn't return success field
       setResponse({
         success: !!result.messageId,
         messageId: result.messageId,
@@ -85,7 +84,7 @@ export function MessageTester() {
       setResponse({
         success: false,
         timestamp: new Date().toISOString(),
-        error: err instanceof Error ? err.message : 'Failed to send message',
+        error: err instanceof Error ? err.message : t('messageTester.sendFailed'),
       });
     } finally {
       setIsLoading(false);
@@ -105,41 +104,41 @@ export function MessageTester() {
 
   return (
     <div className="message-tester">
-      <PageHeader title="Message Tester" subtitle="Send test messages through the API" />
+      <PageHeader title={t('messageTester.title')} subtitle={t('messageTester.subtitle')} />
 
       <div className="tester-panels">
         <div className="compose-panel">
-          <h2>Send Test Message</h2>
+          <h2>{t('messageTester.compose')}</h2>
 
           <div className="form-group">
-            <label>Session</label>
+            <label>{t('messageTester.session')}</label>
             <select value={session} onChange={e => setSession(e.target.value)}>
-              {sessions.length === 0 && <option value="">No ready sessions</option>}
+              {sessions.length === 0 && <option value="">{t('messageTester.noReadySessions')}</option>}
               {sessions.map(s => (
                 <option key={s.id} value={s.id}>
-                  {s.name} ({s.phone || 'No phone'})
+                  {s.name} ({s.phone || t('messageTester.sessionOptionPhoneNone')})
                 </option>
               ))}
             </select>
           </div>
 
           <div className="form-group">
-            <label>Recipient Type</label>
+            <label>{t('messageTester.recipientType')}</label>
             <div className="toggle-group">
               <button
                 className={recipientType === 'personal' ? 'active' : ''}
                 onClick={() => setRecipientType('personal')}
               >
-                Personal
+                {t('messageTester.personal')}
               </button>
               <button className={recipientType === 'group' ? 'active' : ''} onClick={() => setRecipientType('group')}>
-                Group
+                {t('messageTester.group')}
               </button>
             </div>
           </div>
 
           <div className="form-group">
-            <label>{recipientType === 'group' ? 'Select Group' : 'Recipient Phone Number'}</label>
+            <label>{recipientType === 'group' ? t('messageTester.selectGroup') : t('messageTester.recipientPhone')}</label>
             {recipientType === 'group' ? (
               <>
                 <select
@@ -147,15 +146,15 @@ export function MessageTester() {
                   onChange={e => setSelectedGroup(e.target.value)}
                   disabled={loadingGroups || groups.length === 0}
                 >
-                  {loadingGroups && <option value="">Loading groups...</option>}
-                  {!loadingGroups && groups.length === 0 && <option value="">No groups found</option>}
+                  {loadingGroups && <option value="">{t('messageTester.loadingGroups')}</option>}
+                  {!loadingGroups && groups.length === 0 && <option value="">{t('messageTester.noGroupsFound')}</option>}
                   {groups.map(g => (
                     <option key={g.id} value={g.id}>
                       {g.name}
                     </option>
                   ))}
                 </select>
-                <span className="hint">Select a group from your WhatsApp</span>
+                <span className="hint">{t('messageTester.selectGroupHint')}</span>
               </>
             ) : (
               <>
@@ -165,21 +164,21 @@ export function MessageTester() {
                   onChange={e => setRecipient(e.target.value)}
                   placeholder="+62812345678"
                 />
-                <span className="hint">Use international format without spaces</span>
+                <span className="hint">{t('messageTester.phoneHint')}</span>
               </>
             )}
           </div>
 
           <div className="form-group">
-            <label>Message Type</label>
+            <label>{t('messageTester.messageType')}</label>
             <div className="toggle-group">
-              {(['text', 'image', 'video', 'audio', 'document'] as const).map(type => (
+              {messageTypes.map(type => (
                 <button
                   key={type}
                   className={messageType === type ? 'active' : ''}
                   onClick={() => setMessageType(type)}
                 >
-                  {type.charAt(0).toUpperCase() + type.slice(1)}
+                  {t(`messageTester.types.${type}`)}
                 </button>
               ))}
             </div>
@@ -187,18 +186,18 @@ export function MessageTester() {
 
           {messageType === 'text' ? (
             <div className="form-group">
-              <label>Message Content</label>
+              <label>{t('messageTester.messageContent')}</label>
               <textarea
                 value={content}
                 onChange={e => setContent(e.target.value)}
-                placeholder="Enter your message here..."
+                placeholder={t('messageTester.messagePlaceholder')}
                 rows={5}
               />
             </div>
           ) : (
             <>
               <div className="form-group">
-                <label>Media URL</label>
+                <label>{t('messageTester.mediaUrl')}</label>
                 <input
                   type="text"
                   value={mediaUrl}
@@ -208,12 +207,14 @@ export function MessageTester() {
               </div>
               {messageType !== 'audio' && (
                 <div className="form-group">
-                  <label>{messageType === 'document' ? 'Filename' : 'Caption'} (optional)</label>
+                  <label>
+                    {messageType === 'document' ? t('messageTester.filename') : t('messageTester.caption')} ({t('common.optional')})
+                  </label>
                   <input
                     type="text"
                     value={content}
                     onChange={e => setContent(e.target.value)}
-                    placeholder={messageType === 'document' ? 'document.pdf' : 'Enter caption...'}
+                    placeholder={messageType === 'document' ? t('messageTester.filenamePlaceholder') : t('messageTester.captionPlaceholder')}
                   />
                 </div>
               )}
@@ -226,12 +227,12 @@ export function MessageTester() {
             disabled={!canWrite || isLoading || !session || (recipientType === 'group' ? !selectedGroup : !recipient)}
           >
             {isLoading ? <Loader2 className="animate-spin" size={18} /> : <Send size={18} />}
-            {isLoading ? 'Sending...' : canWrite ? 'Send Message' : 'View Only'}
+            {isLoading ? t('messageTester.sending') : canWrite ? t('messageTester.send') : t('messageTester.viewOnly')}
           </button>
         </div>
 
         <div className="response-panel">
-          <h2>API Response</h2>
+          <h2>{t('messageTester.responseTitle')}</h2>
 
           {response ? (
             <>
@@ -239,30 +240,30 @@ export function MessageTester() {
                 {response.success ? (
                   <>
                     <CheckCircle size={20} />
-                    <span>200 OK - Success</span>
+                    <span>{t('messageTester.successLabel')}</span>
                   </>
                 ) : (
                   <>
                     <XCircle size={20} />
-                    <span>400 - Failed</span>
+                    <span>{t('messageTester.failedLabel')}</span>
                   </>
                 )}
               </div>
 
               <div className="response-details">
                 <div className="detail-row">
-                  <span className="detail-label">Timestamp</span>
+                  <span className="detail-label">{t('messageTester.response.timestamp')}</span>
                   <span className="detail-value">{response.timestamp}</span>
                 </div>
                 {response.messageId && (
                   <div className="detail-row">
-                    <span className="detail-label">Message ID</span>
+                    <span className="detail-label">{t('messageTester.response.messageId')}</span>
                     <span className="detail-value mono">{response.messageId}</span>
                   </div>
                 )}
                 {response.error && (
                   <div className="detail-row">
-                    <span className="detail-label">Error</span>
+                    <span className="detail-label">{t('messageTester.response.error')}</span>
                     <span className="detail-value" style={{ color: '#DC2626' }}>
                       {response.error}
                     </span>
@@ -276,7 +277,7 @@ export function MessageTester() {
             </>
           ) : (
             <div className="response-empty">
-              <p>Send a message to see the API response</p>
+              <p>{t('messageTester.responseEmpty')}</p>
             </div>
           )}
         </div>

--- a/dashboard/src/pages/Plugins.tsx
+++ b/dashboard/src/pages/Plugins.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
 import {
   Puzzle,
@@ -48,7 +49,8 @@ interface EngineConfig {
 }
 
 export default function Plugins() {
-  useDocumentTitle('Plugins');
+  const { t } = useTranslation();
+  useDocumentTitle(t('plugins.title'));
   const toast = useToast();
   const queryClient = useQueryClient();
   const { data: plugins = [], isLoading: loadingPlugins, error: queryError } = usePluginsQuery();
@@ -60,7 +62,6 @@ export default function Plugins() {
   const error = queryError instanceof Error ? queryError.message : null;
   const [actionLoading, setActionLoading] = useState<string | null>(null);
 
-  // Config modal state
   const [showConfigModal, setShowConfigModal] = useState(false);
   const [configPlugin, setConfigPlugin] = useState<Plugin | null>(null);
   const [engineConfig, setEngineConfig] = useState<EngineConfig>({
@@ -87,7 +88,7 @@ export default function Plugins() {
       }
       refetchAll();
     } catch (err) {
-      toast.error('Plugin Error', err instanceof Error ? err.message : 'Failed to toggle plugin');
+      toast.error(t('plugins.toasts.errorTitle'), err instanceof Error ? err.message : t('plugins.toasts.errorDefault'));
     } finally {
       setActionLoading(null);
     }
@@ -98,12 +99,12 @@ export default function Plugins() {
     try {
       const result = await pluginsApi.healthCheck(pluginId);
       if (result.healthy) {
-        toast.success('Health Check Passed', result.message);
+        toast.success(t('plugins.toasts.healthOk'), result.message);
       } else {
-        toast.warning('Health Check Failed', result.message);
+        toast.warning(t('plugins.toasts.healthFail'), result.message);
       }
     } catch (err) {
-      toast.error('Health Check Error', err instanceof Error ? err.message : 'Unknown error');
+      toast.error(t('plugins.toasts.healthError'), err instanceof Error ? err.message : t('common.unknownError'));
     } finally {
       setActionLoading(null);
     }
@@ -117,11 +118,10 @@ export default function Plugins() {
   const handleSaveConfig = async () => {
     setSavingConfig(true);
     try {
-      // For now, show a success message - actual implementation would call API
-      toast.success('Configuration Saved', 'Server restart required to apply changes.');
+      toast.success(t('plugins.toasts.savedTitle'), t('plugins.toasts.savedDesc'));
       setShowConfigModal(false);
     } catch (err) {
-      toast.error('Save Failed', err instanceof Error ? err.message : 'Unknown error');
+      toast.error(t('plugins.toasts.saveFailed'), err instanceof Error ? err.message : t('common.unknownError'));
     } finally {
       setSavingConfig(false);
     }
@@ -143,17 +143,16 @@ export default function Plugins() {
   return (
     <div className="plugins-page">
       <PageHeader
-        title="Plugins"
-        subtitle="Manage engines, storage backends, and extensions"
+        title={t('plugins.title')}
+        subtitle={t('plugins.subtitle')}
         actions={
           <button className="btn-secondary" onClick={refetchAll}>
             <RefreshCw size={16} />
-            Refresh
+            {t('plugins.refresh')}
           </button>
         }
       />
 
-      {/* Error Banner */}
       {error && (
         <div className="error-banner">
           <AlertCircle size={20} />
@@ -161,7 +160,6 @@ export default function Plugins() {
         </div>
       )}
 
-      {/* Current Engine Card */}
       <div className="engine-card">
         <div className="engine-header">
           <div className="engine-info">
@@ -169,17 +167,16 @@ export default function Plugins() {
               <Cpu size={24} />
             </div>
             <div>
-              <h3 className="engine-title">Active WhatsApp Engine</h3>
+              <h3 className="engine-title">{t('plugins.engineCard')}</h3>
               <span className="engine-name">{currentEngine}</span>
             </div>
           </div>
-          <span className="status-badge connected">Running</span>
+          <span className="status-badge connected">{t('plugins.running')}</span>
         </div>
 
-        {/* Engine Features */}
         {activeEngine && activeEngine.features.length > 0 && (
           <div className="engine-features">
-            <p className="features-label">Supported Features:</p>
+            <p className="features-label">{t('plugins.supportedFeatures')}</p>
             <div className="features-list">
               {activeEngine.features.slice(0, 8).map(feature => (
                 <span key={feature} className="feature-tag">
@@ -187,14 +184,13 @@ export default function Plugins() {
                 </span>
               ))}
               {activeEngine.features.length > 8 && (
-                <span className="feature-more">+{activeEngine.features.length - 8} more</span>
+                <span className="feature-more">{t('plugins.more', { count: activeEngine.features.length - 8 })}</span>
               )}
             </div>
           </div>
         )}
       </div>
 
-      {/* Plugins Grid */}
       <div className="plugins-grid">
         {plugins.map(plugin => {
           const TypeIcon = pluginTypeIcons[plugin.type as PluginType] || Puzzle;
@@ -202,7 +198,6 @@ export default function Plugins() {
 
           return (
             <div key={plugin.id} className="plugin-card">
-              {/* Card Header */}
               <div className={`plugin-card-header type-${plugin.type}`}>
                 <div className="plugin-info">
                   <div className="plugin-icon-wrapper">
@@ -213,15 +208,12 @@ export default function Plugins() {
                     <span className="plugin-version">v{plugin.version}</span>
                   </div>
                 </div>
-                {plugin.builtIn && <span className="plugin-builtin-badge">Built-in</span>}
+                {plugin.builtIn && <span className="plugin-builtin-badge">{t('plugins.builtIn')}</span>}
               </div>
 
-              {/* Card Body */}
               <div className="plugin-card-body">
-                {/* Description */}
-                <p className="plugin-description">{plugin.description || 'No description available'}</p>
+                <p className="plugin-description">{plugin.description || t('plugins.noDescription')}</p>
 
-                {/* Status */}
                 <div className="plugin-status-row">
                   <div className="plugin-status">
                     <span className={`status-dot ${plugin.status}`} />
@@ -230,14 +222,12 @@ export default function Plugins() {
                   <span className="plugin-type-label">{plugin.type}</span>
                 </div>
 
-                {/* Error Display */}
                 {plugin.error && (
                   <div className="plugin-error">
                     <p className="plugin-error-text">{plugin.error}</p>
                   </div>
                 )}
 
-                {/* Provides */}
                 {plugin.provides && plugin.provides.length > 0 && (
                   <div className="plugin-provides">
                     {plugin.provides.map(item => (
@@ -248,9 +238,7 @@ export default function Plugins() {
                   </div>
                 )}
 
-                {/* Actions */}
                 <div className="plugin-actions">
-                  {/* Engine plugins: show Required if only engine, otherwise radio selection style */}
                   {plugin.type === 'engine' ? (
                     (() => {
                       const enginePlugins = plugins.filter(p => p.type === 'engine');
@@ -258,23 +246,20 @@ export default function Plugins() {
                       const isActive = plugin.status === 'enabled';
 
                       if (isOnlyEngine && isActive) {
-                        // Only engine available - cannot disable
                         return (
                           <span className="btn-required">
                             <CheckCircle size={16} />
-                            Required
+                            {t('plugins.required')}
                           </span>
                         );
                       } else if (isActive) {
-                        // Multiple engines, this one is active
                         return (
                           <span className="btn-active">
                             <CheckCircle size={16} />
-                            Active
+                            {t('plugins.active')}
                           </span>
                         );
                       } else {
-                        // Not active, can switch to this engine
                         return (
                           <button
                             onClick={() => handleToggle(plugin)}
@@ -286,7 +271,7 @@ export default function Plugins() {
                             ) : (
                               <>
                                 <Power size={16} />
-                                Activate
+                                {t('plugins.activate')}
                               </>
                             )}
                           </button>
@@ -294,7 +279,6 @@ export default function Plugins() {
                       }
                     })()
                   ) : (
-                    // Regular plugins: normal enable/disable
                     <button
                       onClick={() => handleToggle(plugin)}
                       disabled={isLoading}
@@ -305,12 +289,12 @@ export default function Plugins() {
                       ) : plugin.status === 'enabled' ? (
                         <>
                           <PowerOff size={16} />
-                          Disable
+                          {t('plugins.disable')}
                         </>
                       ) : (
                         <>
                           <Power size={16} />
-                          Enable
+                          {t('plugins.enable')}
                         </>
                       )}
                     </button>
@@ -320,12 +304,12 @@ export default function Plugins() {
                     onClick={() => handleHealthCheck(plugin.id)}
                     disabled={isLoading}
                     className="btn-action"
-                    title="Health Check"
+                    title={t('plugins.healthCheck')}
                   >
                     <CheckCircle size={16} />
                   </button>
 
-                  <button className="btn-action" title="Configure" onClick={() => handleOpenConfig(plugin)}>
+                  <button className="btn-action" title={t('plugins.configure')} onClick={() => handleOpenConfig(plugin)}>
                     <Settings size={16} />
                   </button>
                 </div>
@@ -335,21 +319,19 @@ export default function Plugins() {
         })}
       </div>
 
-      {/* Empty State */}
       {plugins.length === 0 && !loading && (
         <div className="empty-state">
           <Puzzle size={64} />
-          <h3>No Plugins Found</h3>
-          <p>Install plugins to extend OpenWA functionality</p>
+          <h3>{t('plugins.empty.title')}</h3>
+          <p>{t('plugins.empty.description')}</p>
         </div>
       )}
 
-      {/* Config Modal */}
       {showConfigModal && configPlugin && (
         <div className="modal-overlay" onClick={() => setShowConfigModal(false)}>
           <div className="modal config-modal" onClick={e => e.stopPropagation()}>
             <div className="modal-header">
-              <h2>Configure {configPlugin.name}</h2>
+              <h2>{t('plugins.config.title', { name: configPlugin.name })}</h2>
               <button className="btn-icon" onClick={() => setShowConfigModal(false)}>
                 <X size={20} />
               </button>
@@ -360,12 +342,12 @@ export default function Plugins() {
                 <>
                   <div className="config-info-banner">
                     <AlertCircle size={16} />
-                    <span>Changes require server restart to take effect</span>
+                    <span>{t('plugins.config.restartNotice')}</span>
                   </div>
 
                   <div className="config-form">
                     <div className="form-group">
-                      <label>Engine Type</label>
+                      <label>{t('plugins.config.engineType')}</label>
                       <select
                         value={engineConfig.type}
                         onChange={e => setEngineConfig({ ...engineConfig, type: e.target.value })}
@@ -376,8 +358,8 @@ export default function Plugins() {
 
                     <div className="form-group toggle-group">
                       <div className="toggle-info">
-                        <label>Headless Mode</label>
-                        <small>Run browser without visible UI (recommended for production)</small>
+                        <label>{t('plugins.config.headless')}</label>
+                        <small>{t('plugins.config.headlessDesc')}</small>
                       </div>
                       <label className="toggle-switch">
                         <input
@@ -390,7 +372,7 @@ export default function Plugins() {
                     </div>
 
                     <div className="form-group">
-                      <label>Session Data Path</label>
+                      <label>{t('plugins.config.sessionDataPath')}</label>
                       <input
                         type="text"
                         value={engineConfig.sessionDataPath}
@@ -399,7 +381,7 @@ export default function Plugins() {
                     </div>
 
                     <div className="form-group">
-                      <label>Browser Arguments</label>
+                      <label>{t('plugins.config.browserArgs')}</label>
                       <input
                         type="text"
                         value={engineConfig.browserArgs}
@@ -412,18 +394,18 @@ export default function Plugins() {
               ) : (
                 <div className="no-config">
                   <Settings size={48} style={{ opacity: 0.3 }} />
-                  <p>No configuration options available for this plugin</p>
+                  <p>{t('plugins.config.noOptions')}</p>
                 </div>
               )}
             </div>
 
             <div className="modal-footer">
               <button className="btn-secondary" onClick={() => setShowConfigModal(false)}>
-                Cancel
+                {t('common.cancel')}
               </button>
               {configPlugin.type === 'engine' && (
                 <button className="btn-primary" onClick={handleSaveConfig} disabled={savingConfig}>
-                  {savingConfig ? <Loader2 size={16} className="animate-spin" /> : 'Save Configuration'}
+                  {savingConfig ? <Loader2 size={16} className="animate-spin" /> : t('plugins.config.save')}
                 </button>
               )}
             </div>

--- a/dashboard/src/pages/Sessions.tsx
+++ b/dashboard/src/pages/Sessions.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
 import { Plus, QrCode, RefreshCw, Trash2, Eye, Loader2, Play, Square, X, Search, Filter } from 'lucide-react';
 import { sessionApi, type Session } from '../services/api';
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
@@ -9,7 +10,8 @@ import { PageHeader } from '../components/PageHeader';
 import './Sessions.css';
 
 export function Sessions() {
-  useDocumentTitle('Sessions');
+  const { t } = useTranslation();
+  useDocumentTitle(t('sessions.title'));
   const toast = useToast();
   const { canWrite } = useRole();
   const [sessions, setSessions] = useState<Session[]>([]);
@@ -24,22 +26,19 @@ export function Sessions() {
   const [selectedSession, setSelectedSession] = useState<Session | null>(null);
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
 
-  // WebSocket for real-time session updates
   useWebSocket({
     onSessionStatus: useCallback(
       (event: { sessionId: string; status: string }) => {
-        // Update session status in real-time
         setSessions(prev =>
           prev.map(s => (s.id === event.sessionId ? { ...s, status: event.status as Session['status'] } : s)),
         );
-        // Show toast for important status changes
         if (event.status === 'ready') {
-          toast.success('Session Ready', 'WhatsApp session is now connected');
+          toast.success(t('sessions.toasts.readyTitle'), t('sessions.toasts.readyDesc'));
         } else if (event.status === 'disconnected') {
-          toast.warning('Session Disconnected', 'WhatsApp session was disconnected');
+          toast.warning(t('sessions.toasts.disconnectedTitle'), t('sessions.toasts.disconnectedDesc'));
         }
       },
-      [toast],
+      [toast, t],
     ),
   });
 
@@ -49,7 +48,7 @@ export function Sessions() {
       const data = await sessionApi.list();
       setSessions(data);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load sessions');
+      setError(err instanceof Error ? err.message : t('sessions.create.errorDefault'));
     } finally {
       setLoading(false);
     }
@@ -57,9 +56,9 @@ export function Sessions() {
 
   useEffect(() => {
     fetchSessions();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Auto-refresh QR code every 5 seconds when modal is open
   const qrRefreshInterval = useRef<ReturnType<typeof setInterval> | null>(null);
   const currentSessionName = useRef<string>('');
 
@@ -67,14 +66,12 @@ export function Sessions() {
     try {
       const qr = await sessionApi.getQR(sessionId);
       setQrData({ sessionId, sessionName: currentSessionName.current, qrCode: qr.qrCode });
-      // Check if session became ready
       if (qr.status === 'ready') {
         setQrData(null);
         currentSessionName.current = '';
         fetchSessions();
       }
     } catch {
-      // QR not available or session already connected - stop polling
       setQrData(null);
       currentSessionName.current = '';
       fetchSessions();
@@ -83,17 +80,13 @@ export function Sessions() {
 
   useEffect(() => {
     if (qrData) {
-      // Preserve session name in ref for polling
       currentSessionName.current = qrData.sessionName;
-      // Start polling for QR updates
       qrRefreshInterval.current = setInterval(() => {
         fetchQR(qrData.sessionId);
       }, 5000);
     }
     return () => {
-      if (qrRefreshInterval.current) {
-        clearInterval(qrRefreshInterval.current);
-      }
+      if (qrRefreshInterval.current) clearInterval(qrRefreshInterval.current);
     };
   }, [qrData, fetchQR]);
 
@@ -105,11 +98,11 @@ export function Sessions() {
       setSessions([...sessions, newSession]);
       setNewSessionName('');
       setShowCreateModal(false);
-      toast.success('Session Created', `Session "${newSession.name}" created successfully`);
+      toast.success(t('sessions.create.successTitle'), t('sessions.create.successDesc', { name: newSession.name }));
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Failed to create session';
+      const msg = err instanceof Error ? err.message : t('sessions.create.errorDefault');
       setError(msg);
-      toast.error('Create Failed', msg);
+      toast.error(t('sessions.create.errorTitle'), msg);
     } finally {
       setCreating(false);
     }
@@ -120,21 +113,22 @@ export function Sessions() {
     try {
       await sessionApi.delete(id);
       setSessions(sessions.filter(s => s.id !== id));
-      toast.success('Session Deleted', session ? `Session "${session.name}" deleted` : 'Session deleted');
+      toast.success(
+        t('sessions.delete.successTitle'),
+        session ? t('sessions.delete.successDescNamed', { name: session.name }) : t('sessions.delete.successDescGeneric'),
+      );
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Failed to delete session';
+      const msg = err instanceof Error ? err.message : t('sessions.delete.errorDefault');
       console.error('Failed to delete:', err);
-      toast.error('Delete Failed', msg);
+      toast.error(t('sessions.delete.errorTitle'), msg);
     } finally {
       setDeleteConfirmId(null);
     }
   };
 
   const handleStart = async (id: string) => {
-    // Find session and check if it's already started
     const session = sessions.find(s => s.id === id);
     if (session && ['initializing', 'connecting', 'qr_ready'].includes(session.status)) {
-      // Session already started, just show QR
       handleShowQR(id);
       return;
     }
@@ -142,14 +136,11 @@ export function Sessions() {
     try {
       await sessionApi.start(id);
       setSessions(sessions.map(s => (s.id === id ? { ...s, status: 'connecting' } : s)));
-      // Refresh sessions and then fetch QR
       await fetchSessions();
       handleShowQR(id);
     } catch (err) {
       console.error('Failed to start:', err);
-      // Refresh sessions to get real status
       await fetchSessions();
-      // If error is "already started", try to show QR anyway
       if (err instanceof Error && err.message.includes('already started')) {
         handleShowQR(id);
       }
@@ -157,15 +148,14 @@ export function Sessions() {
   };
 
   const handleShowQR = async (id: string) => {
-    // Find session name
     const session = sessions.find(s => s.id === id);
-    const sessionName = session?.name || 'Unknown Session';
+    const sessionName = session?.name || '';
     try {
       const qr = await sessionApi.getQR(id);
       setQrData({ sessionId: id, sessionName, qrCode: qr.qrCode });
     } catch (err) {
       console.error('Failed to get QR:', err);
-      setError('QR code not available yet. Try again in a moment.');
+      setError(t('sessions.qr.unavailable'));
     }
   };
 
@@ -176,31 +166,19 @@ export function Sessions() {
       if (qrData?.sessionId === id) setQrData(null);
     } catch (err) {
       console.error('Failed to stop:', err);
-      // Refresh sessions to get real status
       fetchSessions();
     }
   };
 
   const formatLastActive = (date?: string) => {
-    if (!date) return 'Never';
+    if (!date) return t('common.never');
     const diff = Date.now() - new Date(date).getTime();
-    if (diff < 60000) return 'Just now';
-    if (diff < 3600000) return `${Math.floor(diff / 60000)} min ago`;
+    if (diff < 60000) return t('common.justNow');
+    if (diff < 3600000) return t('common.minAgo', { count: Math.floor(diff / 60000) });
     return new Date(date).toLocaleDateString();
   };
 
-  const formatStatus = (status: string) => {
-    const statusMap: Record<string, string> = {
-      created: 'New',
-      idle: 'Idle',
-      initializing: 'Starting...',
-      connecting: 'Connecting...',
-      qr_ready: 'Scan QR',
-      ready: 'Connected',
-      disconnected: 'Disconnected',
-    };
-    return statusMap[status] || status;
-  };
+  const formatStatus = (status: string) => t(`sessionStatus.${status}`, { defaultValue: status });
 
   const filteredSessions = sessions.filter(s => {
     const matchesSearch =
@@ -228,13 +206,13 @@ export function Sessions() {
   return (
     <div className="sessions-page">
       <PageHeader
-        title="Sessions"
-        subtitle="Manage your WhatsApp sessions and QR code connections"
+        title={t('sessions.title')}
+        subtitle={t('sessions.subtitle')}
         actions={
           canWrite && (
             <button className="btn-primary" onClick={() => setShowCreateModal(true)}>
               <Plus size={18} />
-              New Session
+              {t('sessions.newSession')}
             </button>
           )
         }
@@ -245,7 +223,7 @@ export function Sessions() {
           <Search size={18} />
           <input
             type="text"
-            placeholder="Search sessions..."
+            placeholder={t('sessions.searchPlaceholder')}
             value={searchQuery}
             onChange={e => setSearchQuery(e.target.value)}
           />
@@ -254,10 +232,10 @@ export function Sessions() {
         <div className="filter-group">
           <Filter size={16} />
           <select value={statusFilter} onChange={e => setStatusFilter(e.target.value)}>
-            <option value="all">All Status</option>
-            <option value="active">Active (Connected)</option>
-            <option value="inactive">Inactive</option>
-            <option value="connecting">Connecting</option>
+            <option value="all">{t('sessions.filter.all')}</option>
+            <option value="active">{t('sessions.filter.active')}</option>
+            <option value="inactive">{t('sessions.filter.inactive')}</option>
+            <option value="connecting">{t('sessions.filter.connecting')}</option>
           </select>
         </div>
       </div>
@@ -276,49 +254,46 @@ export function Sessions() {
         </div>
       )}
 
-      {/* Create Modal */}
       {showCreateModal && (
         <div className="modal-overlay" onClick={() => setShowCreateModal(false)}>
           <div className="modal" onClick={e => e.stopPropagation()}>
             <div className="modal-header">
-              <h2>Create New Session</h2>
+              <h2>{t('sessions.create.title')}</h2>
               <button className="btn-icon" onClick={() => setShowCreateModal(false)}>
                 <X size={20} />
               </button>
             </div>
             <div className="modal-body">
-              <label>Session Name</label>
+              <label>{t('sessions.create.label')}</label>
               <input
                 type="text"
-                placeholder="e.g., marketing-bot"
+                placeholder={t('sessions.create.placeholder')}
                 value={newSessionName}
                 onChange={e => {
-                  // Auto-convert to lowercase and replace spaces with hyphens
                   const value = e.target.value.toLowerCase().replace(/\s+/g, '-');
                   setNewSessionName(value);
                 }}
                 onKeyDown={e => e.key === 'Enter' && handleCreate()}
               />
               <p className="input-hint">
-                Use lowercase letters, numbers, and hyphens only. Example: <code>customer-support</code>,{' '}
-                <code>bot-1</code>
+                <Trans i18nKey="sessions.create.hint" components={{ code: <code /> }} />
               </p>
               {newSessionName && !/^[a-z0-9-]+$/.test(newSessionName) && (
-                <p className="input-error">Invalid characters. Only lowercase letters, numbers, and hyphens allowed.</p>
+                <p className="input-error">{t('sessions.create.invalidChars')}</p>
               )}
               {newSessionName && newSessionName.length > 50 && (
-                <p className="input-error">Name must be 50 characters or less ({newSessionName.length}/50).</p>
+                <p className="input-error">{t('sessions.create.tooLong', { length: newSessionName.length })}</p>
               )}
               {newSessionName &&
                 /^[a-z0-9-]+$/.test(newSessionName) &&
                 newSessionName.length <= 50 &&
                 sessions.some(s => s.name === newSessionName) && (
-                  <p className="input-error">Session with this name already exists.</p>
+                  <p className="input-error">{t('sessions.create.duplicate')}</p>
                 )}
             </div>
             <div className="modal-footer">
               <button className="btn-secondary" onClick={() => setShowCreateModal(false)}>
-                Cancel
+                {t('common.cancel')}
               </button>
               <button
                 className="btn-primary"
@@ -331,49 +306,42 @@ export function Sessions() {
                   sessions.some(s => s.name === newSessionName)
                 }
               >
-                {creating ? <Loader2 className="animate-spin" size={16} /> : 'Create'}
+                {creating ? <Loader2 className="animate-spin" size={16} /> : t('common.create')}
               </button>
             </div>
           </div>
         </div>
       )}
 
-      {/* QR Modal */}
       {qrData && (
         <div className="modal-overlay" onClick={() => setQrData(null)}>
           <div className="modal qr-modal" onClick={e => e.stopPropagation()}>
             <div className="modal-header">
               <div className="modal-title">
-                <h2>Scan QR Code</h2>
+                <h2>{t('sessions.qr.title')}</h2>
                 <span className="session-name">{qrData.sessionName}</span>
               </div>
-              <button className="btn-close" onClick={() => setQrData(null)} aria-label="Close">
+              <button className="btn-close" onClick={() => setQrData(null)} aria-label={t('common.close')}>
                 <X size={20} color="#64748b" />
               </button>
             </div>
             <div className="modal-body" style={{ textAlign: 'center' }}>
               {qrData.qrCode ? (
                 <>
-                  <img src={qrData.qrCode} alt="QR Code" style={{ maxWidth: '280px', borderRadius: '12px' }} />
+                  <img src={qrData.qrCode} alt="QR" style={{ maxWidth: '280px', borderRadius: '12px' }} />
                   <div className="qr-instructions">
-                    <p className="qr-step">
-                      <strong>1.</strong> Open WhatsApp on your phone
-                    </p>
-                    <p className="qr-step">
-                      <strong>2.</strong> Tap <strong>Menu</strong> → <strong>Linked Devices</strong>
-                    </p>
-                    <p className="qr-step">
-                      <strong>3.</strong> Tap <strong>Link a Device</strong> and scan this QR
-                    </p>
+                    <p className="qr-step"><Trans i18nKey="sessions.qr.step1" components={{ strong: <strong /> }} /></p>
+                    <p className="qr-step"><Trans i18nKey="sessions.qr.step2" components={{ strong: <strong /> }} /></p>
+                    <p className="qr-step"><Trans i18nKey="sessions.qr.step3" components={{ strong: <strong /> }} /></p>
                   </div>
                   <p className="qr-auto-refresh">
-                    <RefreshCw size={14} className="spin-slow" /> QR updates automatically every 5 seconds
+                    <RefreshCw size={14} className="spin-slow" /> {t('sessions.qr.autoRefresh')}
                   </p>
                 </>
               ) : (
                 <div style={{ padding: '2rem' }}>
                   <Loader2 className="animate-spin" size={48} />
-                  <p>Generating QR code...</p>
+                  <p>{t('sessions.qr.generating')}</p>
                 </div>
               )}
             </div>
@@ -381,12 +349,11 @@ export function Sessions() {
         </div>
       )}
 
-      {/* Session Detail Modal */}
       {selectedSession && (
         <div className="modal-overlay" onClick={() => setSelectedSession(null)}>
           <div className="modal" onClick={e => e.stopPropagation()}>
             <div className="modal-header">
-              <h2>Session Details</h2>
+              <h2>{t('sessions.details.title')}</h2>
               <button className="btn-icon" onClick={() => setSelectedSession(null)}>
                 <X size={20} />
               </button>
@@ -394,65 +361,67 @@ export function Sessions() {
             <div className="modal-body">
               <div className="detail-grid">
                 <div className="detail-item">
-                  <span className="detail-label">Name</span>
+                  <span className="detail-label">{t('sessions.details.name')}</span>
                   <span className="detail-value">{selectedSession.name}</span>
                 </div>
                 <div className="detail-item">
-                  <span className="detail-label">Status</span>
-                  <span className={`status-badge ${selectedSession.status}`}>{selectedSession.status}</span>
+                  <span className="detail-label">{t('sessions.details.status')}</span>
+                  <span className={`status-badge ${selectedSession.status}`}>{formatStatus(selectedSession.status)}</span>
                 </div>
                 <div className="detail-item">
-                  <span className="detail-label">Session ID</span>
+                  <span className="detail-label">{t('sessions.details.sessionId')}</span>
                   <span className="detail-value mono">{selectedSession.id}</span>
                 </div>
                 <div className="detail-item">
-                  <span className="detail-label">Phone Number</span>
-                  <span className="detail-value">{selectedSession.phone || 'Not connected'}</span>
+                  <span className="detail-label">{t('sessions.details.phone')}</span>
+                  <span className="detail-value">{selectedSession.phone || t('sessions.details.phoneNone')}</span>
                 </div>
                 <div className="detail-item">
-                  <span className="detail-label">Created</span>
+                  <span className="detail-label">{t('sessions.details.created')}</span>
                   <span className="detail-value">{new Date(selectedSession.createdAt).toLocaleString()}</span>
                 </div>
                 <div className="detail-item">
-                  <span className="detail-label">Last Active</span>
+                  <span className="detail-label">{t('sessions.details.lastActive')}</span>
                   <span className="detail-value">
-                    {selectedSession.lastActive ? new Date(selectedSession.lastActive).toLocaleString() : 'Never'}
+                    {selectedSession.lastActive ? new Date(selectedSession.lastActive).toLocaleString() : t('common.never')}
                   </span>
                 </div>
               </div>
             </div>
             <div className="modal-footer">
               <button className="btn-secondary" onClick={() => setSelectedSession(null)}>
-                Close
+                {t('common.close')}
               </button>
             </div>
           </div>
         </div>
       )}
 
-      {/* Delete Confirm Modal */}
       {deleteConfirmId && (
         <div className="modal-overlay" onClick={() => setDeleteConfirmId(null)}>
           <div className="modal confirm-modal" onClick={e => e.stopPropagation()}>
             <div className="modal-header">
-              <h2>Confirm Delete</h2>
+              <h2>{t('sessions.delete.title')}</h2>
               <button className="btn-icon" onClick={() => setDeleteConfirmId(null)}>
                 <X size={20} />
               </button>
             </div>
             <div className="modal-body">
               <p>
-                Are you sure you want to delete session{' '}
-                <strong>"{sessions.find(s => s.id === deleteConfirmId)?.name}"</strong>?
+                <Trans
+                  i18nKey="sessions.delete.message"
+                  values={{ name: sessions.find(s => s.id === deleteConfirmId)?.name }}
+                  components={{ strong: <strong /> }}
+                />
               </p>
-              <p className="text-muted">This action cannot be undone.</p>
+              <p className="text-muted">{t('sessions.delete.warning')}</p>
             </div>
             <div className="modal-footer">
               <button className="btn-secondary" onClick={() => setDeleteConfirmId(null)}>
-                Cancel
+                {t('common.cancel')}
               </button>
               <button className="btn-danger" onClick={() => handleDelete(deleteConfirmId)}>
-                Delete
+                {t('common.delete')}
               </button>
             </div>
           </div>
@@ -463,8 +432,8 @@ export function Sessions() {
         {filteredSessions.length === 0 ? (
           <div className="empty-state">
             <QrCode size={48} />
-            <h3>No sessions found</h3>
-            <p>Create a new session to get started</p>
+            <h3>{t('sessions.empty.title')}</h3>
+            <p>{t('sessions.empty.description')}</p>
           </div>
         ) : (
           filteredSessions.map(session => (
@@ -477,27 +446,27 @@ export function Sessions() {
               {session.status === 'initializing' || session.status === 'connecting' || session.status === 'qr_ready' ? (
                 <div className="qr-placeholder">
                   <QrCode size={80} className="qr-icon" />
-                  <p>{session.status === 'qr_ready' ? 'Scan QR code to connect' : 'Preparing QR code...'}</p>
+                  <p>{session.status === 'qr_ready' ? t('sessions.qr.scanToConnect') : t('sessions.qr.preparing')}</p>
                   <button
                     className="btn-sm"
                     onClick={() => handleShowQR(session.id)}
                     disabled={session.status !== 'qr_ready'}
                   >
-                    {session.status === 'qr_ready' ? 'Show QR' : 'Loading...'}
+                    {session.status === 'qr_ready' ? t('sessions.qr.showQr') : t('sessions.qr.loading')}
                   </button>
                 </div>
               ) : (
                 <div className="session-info">
                   <div className="info-row">
-                    <span className="info-label">Phone</span>
+                    <span className="info-label">{t('sessions.card.phone')}</span>
                     <span className="info-value">{session.phone || '—'}</span>
                   </div>
                   <div className="info-row">
-                    <span className="info-label">Session ID</span>
+                    <span className="info-label">{t('sessions.card.sessionId')}</span>
                     <span className="info-value mono">{session.id.substring(0, 12)}</span>
                   </div>
                   <div className="info-row">
-                    <span className="info-label">Last Active</span>
+                    <span className="info-label">{t('sessions.card.lastActive')}</span>
                     <span className="info-value">{formatLastActive(session.lastActive)}</span>
                   </div>
                 </div>
@@ -506,29 +475,29 @@ export function Sessions() {
               <div className="card-actions">
                 <button className="btn-action" onClick={() => setSelectedSession(session)}>
                   <Eye size={16} />
-                  View
+                  {t('sessions.actions.view')}
                 </button>
                 {canWrite &&
                 (session.status === 'created' || session.status === 'idle' || session.status === 'disconnected') ? (
                   <button className="btn-action" onClick={() => handleStart(session.id)}>
                     <Play size={16} />
-                    Start
+                    {t('sessions.actions.start')}
                   </button>
                 ) : canWrite && ['ready', 'initializing', 'connecting', 'qr_ready'].includes(session.status) ? (
                   <button className="btn-action" onClick={() => handleStop(session.id)}>
                     <Square size={16} />
-                    Stop
+                    {t('sessions.actions.stop')}
                   </button>
                 ) : canWrite ? (
                   <button className="btn-action" onClick={() => handleStart(session.id)}>
                     <RefreshCw size={16} />
-                    Reconnect
+                    {t('sessions.actions.reconnect')}
                   </button>
                 ) : null}
                 {canWrite && (
                   <button className="btn-action danger" onClick={() => setDeleteConfirmId(session.id)}>
                     <Trash2 size={16} />
-                    Delete
+                    {t('sessions.actions.delete')}
                   </button>
                 )}
               </div>

--- a/dashboard/src/pages/Webhooks.tsx
+++ b/dashboard/src/pages/Webhooks.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   Plus,
   Edit,
@@ -24,17 +25,18 @@ import {
 import { PageHeader } from '../components/PageHeader';
 import './Webhooks.css';
 
-const availableEvents = [
-  { name: 'message.received', description: 'When a message is received' },
-  { name: 'message.sent', description: 'When a message is sent' },
-  { name: 'session.connected', description: 'When a session connects' },
-  { name: 'session.disconnected', description: 'When a session disconnects' },
-  { name: 'session.qr', description: 'When QR code is generated' },
-  { name: '*', description: 'All events' },
-];
+const availableEventNames = [
+  'message.received',
+  'message.sent',
+  'session.connected',
+  'session.disconnected',
+  'session.qr',
+  '*',
+] as const;
 
 export function Webhooks() {
-  useDocumentTitle('Webhooks');
+  const { t } = useTranslation();
+  useDocumentTitle(t('webhooks.title'));
   const { canWrite } = useRole();
   const { data: webhooks = [], isLoading: loadingWebhooks } = useWebhooksQuery();
   const { data: sessions = [] } = useSessionsQuery();
@@ -50,6 +52,11 @@ export function Webhooks() {
   const [newWebhook, setNewWebhook] = useState({ url: '', events: ['message.received'], sessionId: '' });
   const [testingId, setTestingId] = useState<string | null>(null);
   const [toast, setToast] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+
+  const eventDescription = (name: string) => {
+    if (name === '*') return t('webhooks.eventDescriptions.all');
+    return t(`webhooks.eventDescriptions.${name}`, { defaultValue: name });
+  };
 
   useEffect(() => {
     if (toast) {
@@ -68,11 +75,13 @@ export function Webhooks() {
       });
       setShowCreateModal(false);
       setNewWebhook({ url: '', events: ['message.received'], sessionId: '' });
-      setToast({ type: 'success', message: 'Webhook created successfully' });
+      setToast({ type: 'success', message: t('webhooks.toasts.created') });
     } catch (err) {
       setToast({
         type: 'error',
-        message: `Failed to create webhook: ${err instanceof Error ? err.message : 'Unknown error'}`,
+        message: t('webhooks.toasts.createFailed', {
+          message: err instanceof Error ? err.message : t('common.unknownError'),
+        }),
       });
     }
   };
@@ -88,11 +97,13 @@ export function Webhooks() {
       await deleteMutation.mutateAsync({ sessionId: deleteTarget.sessionId, id: deleteTarget.id });
       setShowDeleteModal(false);
       setDeleteTarget(null);
-      setToast({ type: 'success', message: 'Webhook deleted successfully' });
+      setToast({ type: 'success', message: t('webhooks.toasts.deleted') });
     } catch (err) {
       setToast({
         type: 'error',
-        message: `Failed to delete webhook: ${err instanceof Error ? err.message : 'Unknown error'}`,
+        message: t('webhooks.toasts.deleteFailed', {
+          message: err instanceof Error ? err.message : t('common.unknownError'),
+        }),
       });
     }
   };
@@ -102,14 +113,19 @@ export function Webhooks() {
     try {
       const result = await webhookApi.test(sessionId, id);
       if (result.success) {
-        setToast({ type: 'success', message: `Webhook test successful! Status: ${result.statusCode}` });
+        setToast({ type: 'success', message: t('webhooks.toasts.testOk', { status: result.statusCode }) });
       } else {
-        setToast({ type: 'error', message: `Webhook test failed: ${result.error || `Status ${result.statusCode}`}` });
+        setToast({
+          type: 'error',
+          message: t('webhooks.toasts.testFailed', { message: result.error || `Status ${result.statusCode}` }),
+        });
       }
     } catch (err) {
       setToast({
         type: 'error',
-        message: `Failed to test webhook: ${err instanceof Error ? err.message : 'Unknown error'}`,
+        message: t('webhooks.toasts.testError', {
+          message: err instanceof Error ? err.message : t('common.unknownError'),
+        }),
       });
     } finally {
       setTestingId(null);
@@ -127,19 +143,17 @@ export function Webhooks() {
       await updateMutation.mutateAsync({
         sessionId: editWebhook.sessionId,
         id: editWebhook.id,
-        data: {
-          url: editWebhook.url,
-          events: editWebhook.events,
-          active: editWebhook.active,
-        },
+        data: { url: editWebhook.url, events: editWebhook.events, active: editWebhook.active },
       });
       setShowEditModal(false);
       setEditWebhook(null);
-      setToast({ type: 'success', message: 'Webhook updated successfully' });
+      setToast({ type: 'success', message: t('webhooks.toasts.updated') });
     } catch (err) {
       setToast({
         type: 'error',
-        message: `Failed to update webhook: ${err instanceof Error ? err.message : 'Unknown error'}`,
+        message: t('webhooks.toasts.updateFailed', {
+          message: err instanceof Error ? err.message : t('common.unknownError'),
+        }),
       });
     }
   };
@@ -174,7 +188,6 @@ export function Webhooks() {
 
   return (
     <div className="webhooks-page">
-      {/* Toast Notification */}
       {toast && (
         <div className={`toast ${toast.type}`}>
           {toast.type === 'success' ? <Check size={18} /> : <AlertTriangle size={18} />}
@@ -186,106 +199,104 @@ export function Webhooks() {
       )}
 
       <PageHeader
-        title="Webhooks"
-        subtitle="Configure HTTP callbacks for real-time event notifications"
+        title={t('webhooks.title')}
+        subtitle={t('webhooks.subtitle')}
         actions={
           canWrite && (
             <button className="btn-primary" onClick={() => setShowCreateModal(true)}>
               <Plus size={18} />
-              Add Webhook
+              {t('webhooks.addWebhook')}
             </button>
           )
         }
       />
 
-      {/* Create Modal */}
       {showCreateModal && (
         <div className="modal-overlay" onClick={() => setShowCreateModal(false)}>
           <div className="modal" onClick={e => e.stopPropagation()}>
             <div className="modal-header">
-              <h2>Create Webhook</h2>
+              <h2>{t('webhooks.createTitle')}</h2>
               <button className="btn-icon" onClick={() => setShowCreateModal(false)}>
                 <X size={20} />
               </button>
             </div>
             <div className="modal-body">
-              <label>Session</label>
+              <label>{t('webhooks.session')}</label>
               <select
                 value={newWebhook.sessionId}
                 onChange={e => setNewWebhook({ ...newWebhook, sessionId: e.target.value })}
               >
-                <option value="">Select session...</option>
+                <option value="">{t('webhooks.selectSession')}</option>
                 {sessions.map(s => (
                   <option key={s.id} value={s.id}>
                     {s.name}
                   </option>
                 ))}
               </select>
-              <label>URL</label>
+              <label>{t('common.url')}</label>
               <input
                 type="url"
                 placeholder="https://..."
                 value={newWebhook.url}
                 onChange={e => setNewWebhook({ ...newWebhook, url: e.target.value })}
               />
-              <label>Events</label>
+              <label>{t('webhooks.events')}</label>
               <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
-                {availableEvents.map(e => (
+                {availableEventNames.map(name => (
                   <button
-                    key={e.name}
+                    key={name}
                     type="button"
-                    className={`event-tag ${newWebhook.events.includes(e.name) ? 'selected' : ''}`}
-                    onClick={() => toggleNewEvent(e.name)}
+                    className={`event-tag ${newWebhook.events.includes(name) ? 'selected' : ''}`}
+                    onClick={() => toggleNewEvent(name)}
                   >
-                    {e.name}
+                    {name}
                   </button>
                 ))}
               </div>
             </div>
             <div className="modal-footer">
               <button className="btn-secondary" onClick={() => setShowCreateModal(false)}>
-                Cancel
+                {t('common.cancel')}
               </button>
               <button className="btn-primary" onClick={handleCreate}>
-                Create
+                {t('common.create')}
               </button>
             </div>
           </div>
         </div>
       )}
 
-      {/* Edit Modal */}
       {showEditModal && editWebhook && (
         <div className="modal-overlay" onClick={() => setShowEditModal(false)}>
           <div className="modal" onClick={e => e.stopPropagation()}>
             <div className="modal-header">
-              <h2>Edit Webhook</h2>
+              <h2>{t('webhooks.editTitle')}</h2>
               <button className="btn-icon" onClick={() => setShowEditModal(false)}>
                 <X size={20} />
               </button>
             </div>
             <div className="modal-body">
-              <label>URL</label>
+              <label>{t('common.url')}</label>
               <input
                 type="url"
                 value={editWebhook.url}
                 onChange={e => setEditWebhook({ ...editWebhook, url: e.target.value })}
               />
-              <label>Events</label>
+              <label>{t('webhooks.events')}</label>
               <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
-                {availableEvents.map(e => (
+                {availableEventNames.map(name => (
                   <button
-                    key={e.name}
+                    key={name}
                     type="button"
-                    className={`event-tag ${editWebhook.events.includes(e.name) ? 'selected' : ''}`}
-                    onClick={() => toggleEditEvent(e.name)}
+                    className={`event-tag ${editWebhook.events.includes(name) ? 'selected' : ''}`}
+                    onClick={() => toggleEditEvent(name)}
                   >
-                    {e.name}
+                    {name}
                   </button>
                 ))}
               </div>
               <div className="toggle-group">
-                <span className="toggle-label">Status</span>
+                <span className="toggle-label">{t('common.status')}</span>
                 <label className="toggle-switch">
                   <input
                     type="checkbox"
@@ -295,34 +306,33 @@ export function Webhooks() {
                   <span className="toggle-slider"></span>
                 </label>
                 <span className={`toggle-status ${editWebhook.active ? 'active' : 'inactive'}`}>
-                  {editWebhook.active ? 'Active' : 'Inactive'}
+                  {editWebhook.active ? t('common.active') : t('common.inactive')}
                 </span>
               </div>
             </div>
             <div className="modal-footer">
               <button className="btn-secondary" onClick={() => setShowEditModal(false)}>
-                Cancel
+                {t('common.cancel')}
               </button>
               <button className="btn-primary" onClick={handleEdit}>
-                Save Changes
+                {t('webhooks.saveChanges')}
               </button>
             </div>
           </div>
         </div>
       )}
 
-      {/* Delete Confirm Modal */}
       {showDeleteModal && deleteTarget && (
         <div className="modal-overlay" onClick={() => setShowDeleteModal(false)}>
           <div className="modal modal-sm" onClick={e => e.stopPropagation()}>
             <div className="modal-header">
-              <h2>Delete Webhook</h2>
+              <h2>{t('webhooks.deleteTitle')}</h2>
               <button className="btn-icon" onClick={() => setShowDeleteModal(false)}>
                 <X size={20} />
               </button>
             </div>
             <div className="modal-body">
-              <p>Are you sure you want to delete this webhook?</p>
+              <p>{t('webhooks.deleteConfirm')}</p>
               <code
                 style={{
                   display: 'block',
@@ -339,10 +349,10 @@ export function Webhooks() {
             </div>
             <div className="modal-footer">
               <button className="btn-secondary" onClick={() => setShowDeleteModal(false)}>
-                Cancel
+                {t('common.cancel')}
               </button>
               <button className="btn-danger" onClick={handleDelete}>
-                Delete
+                {t('common.delete')}
               </button>
             </div>
           </div>
@@ -353,17 +363,17 @@ export function Webhooks() {
         <div className="webhooks-table-container">
           <div className="webhooks-table">
             <div className="table-row header">
-              <span>URL</span>
-              <span>Events</span>
-              <span>Session</span>
-              <span>Status</span>
-              <span>Actions</span>
+              <span>{t('webhooks.columns.url')}</span>
+              <span>{t('webhooks.columns.events')}</span>
+              <span>{t('webhooks.columns.session')}</span>
+              <span>{t('webhooks.columns.status')}</span>
+              <span>{t('webhooks.columns.actions')}</span>
             </div>
             {webhooks.length === 0 ? (
               <div className="empty-table-state">
                 <WebhookIcon size={48} strokeWidth={1} />
-                <h3>No webhooks configured</h3>
-                <p>Add a webhook to receive real-time event notifications</p>
+                <h3>{t('webhooks.empty.title')}</h3>
+                <p>{t('webhooks.empty.description')}</p>
               </div>
             ) : (
               webhooks.map(webhook => (
@@ -384,13 +394,13 @@ export function Webhooks() {
                   </span>
                   <span>
                     <span className={`status-badge ${webhook.active ? 'active' : 'inactive'}`}>
-                      {webhook.active ? 'Active' : 'Inactive'}
+                      {webhook.active ? t('common.active') : t('common.inactive')}
                     </span>
                   </span>
                   <span className="actions-cell">
                     <button
                       className="icon-btn"
-                      title="Test"
+                      title={t('webhooks.actions.test')}
                       onClick={() => handleTest(webhook.sessionId, webhook.id)}
                       disabled={testingId === webhook.id}
                     >
@@ -398,12 +408,12 @@ export function Webhooks() {
                     </button>
                     {canWrite && (
                       <>
-                        <button className="icon-btn" title="Edit" onClick={() => openEdit(webhook)}>
+                        <button className="icon-btn" title={t('webhooks.actions.edit')} onClick={() => openEdit(webhook)}>
                           <Edit size={16} />
                         </button>
                         <button
                           className="icon-btn danger"
-                          title="Delete"
+                          title={t('webhooks.actions.delete')}
                           onClick={() => confirmDelete(webhook.sessionId, webhook.id, webhook.url)}
                         >
                           <Trash2 size={16} />
@@ -418,12 +428,12 @@ export function Webhooks() {
         </div>
 
         <div className="events-reference">
-          <h3>Available Events</h3>
+          <h3>{t('webhooks.available')}</h3>
           <div className="events-list">
-            {availableEvents.map(event => (
-              <div key={event.name} className="event-item">
-                <code>{event.name}</code>
-                <span>{event.description}</span>
+            {availableEventNames.map(name => (
+              <div key={name} className="event-item">
+                <code>{name}</code>
+                <span>{eventDescription(name)}</span>
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary

Adds full internationalization (i18n) to the dashboard with **English** and **Hebrew** locales, including **right-to-left (RTL)** layout support and an in-app **language switcher**.

## What's included

- **i18next stack**: `i18next`, `react-i18next`, and `i18next-browser-languagedetector`
- **New module**: `dashboard/src/i18n/` with `index.ts` config and `locales/{en,he}.json` covering every page, modal, toast, table column, button, and empty-state message
- **Language switcher**: globe icon in the sidebar footer; selection persists to `localStorage` (`openwa_language`); on first load the browser language is auto-detected
- **RTL support**: `document.documentElement.dir` / `.lang` are kept in sync with the active language. Scoped `[dir=\"rtl\"]` CSS overrides handle:
  - Sidebar border, collapse arrow, main content margin
  - Modal footer ordering (`flex-direction: row-reverse`)
  - Select caret position
  - Input text alignment
  - URL/email/tel inputs forced LTR
  - Toast slide-in side
  - `code`, `.mono`, `pre` stay LTR even inside RTL containers (so phone numbers, session IDs, and JSON render correctly)
- **Typography**: `Heebo` font loaded via Google Fonts for Hebrew, falling back to system Hebrew fonts
- **All 9 pages converted**: Login, Dashboard, Sessions, Webhooks, ApiKeys, MessageTester, Infrastructure, Plugins, Logs
- **Translation register**: professional/technical Hebrew (ktiv maleh, gender-neutral phrasing). Technical identifiers (Session, Webhook, API, QR, S3, Redis, PostgreSQL, MinIO, BullMQ, etc.) intentionally kept in English to match developer expectations and avoid awkward calques

## What's *not* changed

- No backend changes
- No API changes
- No database migrations
- No Docker / deployment changes
- English remains the default — existing users see no behavior change unless their browser is set to \`he-*\`

## Test plan

- [x] \`tsc -b\` passes with no errors
- [x] \`npm run build\` (vite) succeeds with no warnings
- [x] Hebrew strings present in production JS bundle (verified: דאשבורד, Sessions פעילים, התחברות, ניהול Sessions, הגדרות שרת, מפתחות API, בדיקת הודעות, תוספים, לוגים)
- [x] `[dir=rtl]` CSS rules present in compiled CSS bundle
- [x] Heebo @import present in compiled CSS
- [x] Dashboard loads and renders in EN (default)
- [x] Language switcher toggles to HE, document direction flips to RTL, sidebar and modals reflow correctly
- [x] Refreshing the page preserves the chosen language
- [x] All forms (Sessions create, Webhooks create/edit, API Key create, MessageTester) accept input correctly in both directions
- [ ] Reviewer: please verify Hebrew copy matches your preferred terminology - happy to iterate on phrasing
- [ ] Reviewer: consider whether `i18next-browser-languagedetector` first-load auto-detect is desired, or if EN-by-default-until-toggled is preferred

## Bundle size impact

Roughly +35 KB gzip from i18next + the two locale JSON files. Locales are bundled together (no async loading) to keep things simple; happy to switch to lazy-loaded namespaces if preferred.