### PR TITLE
fix(database): add UUID DEFAULT to id columns on Postgres

### DIFF
--- a/src/database/migrations/1779235200000-AddUuidDefaultsForPostgres.ts
+++ b/src/database/migrations/1779235200000-AddUuidDefaultsForPostgres.ts
@@ -1,0 +1,43 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds `gen_random_uuid()::varchar` DEFAULT to every `id` column on Postgres.
+ *
+ * Why this is needed:
+ *   The initial schema migration (1770108659848-AddMessageStatus) created the
+ *   `id` columns on Postgres as `varchar PRIMARY KEY NOT NULL` without a
+ *   DEFAULT. The TypeORM Postgres driver emits `INSERT ... VALUES (DEFAULT, ...)`
+ *   for `@PrimaryGeneratedColumn('uuid')` columns and expects the database to
+ *   supply the value. Without a column DEFAULT this fails with:
+ *     null value in column "id" of relation "<table>" violates not-null constraint
+ *
+ *   This migration is a no-op on SQLite (TypeORM generates the UUID in the
+ *   driver layer there, so no DB default is needed).
+ *
+ *   `gen_random_uuid()` is built into PostgreSQL 13+ — no extension required.
+ */
+export class AddUuidDefaultsForPostgres1779235200000 implements MigrationInterface {
+  name = 'AddUuidDefaultsForPostgres1779235200000';
+
+  private readonly tables = ['sessions', 'webhooks', 'messages', 'api_keys', 'audit_logs', 'message_batches'];
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    if (queryRunner.connection.options.type !== 'postgres') return;
+
+    for (const table of this.tables) {
+      const exists = await queryRunner.hasTable(table);
+      if (!exists) continue;
+      await queryRunner.query(`ALTER TABLE "${table}" ALTER COLUMN "id" SET DEFAULT gen_random_uuid()::varchar`);
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    if (queryRunner.connection.options.type !== 'postgres') return;
+
+    for (const table of this.tables) {
+      const exists = await queryRunner.hasTable(table);
+      if (!exists) continue;
+      await queryRunner.query(`ALTER TABLE "${table}" ALTER COLUMN "id" DROP DEFAULT`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fresh PostgreSQL installs cannot create any entity with a UUID primary key — every `POST /api/sessions`, `POST /api/api-keys`, etc. returns HTTP 500.

Authored by [Yosef Chai](https://github.com/yosef-chai).

## Reproduction

1. Bring up the stack with `DATABASE_TYPE=postgres` (e.g. `docker compose --profile full --profile postgres up -d`)
2. `POST /api/sessions { \"name\": \"test\" }` with a valid API key

Result:
```
QueryFailedError: null value in column \"id\" of relation \"sessions\" violates not-null constraint
INSERT INTO \"sessions\"(\"id\", \"name\", ...) VALUES (DEFAULT, $1, ...)
```

## Root cause

The initial schema migration ([`1770108659848-AddMessageStatus.ts`](https://github.com/rmyndharis/OpenWA/blob/main/src/database/migrations/1770108659848-AddMessageStatus.ts)) created `id` columns on Postgres as `varchar PRIMARY KEY NOT NULL` **without a DEFAULT**:

```sql
CREATE TABLE \"sessions\" (\"id\" varchar PRIMARY KEY NOT NULL, ...)
```

The TypeORM Postgres driver, seeing `@PrimaryGeneratedColumn('uuid')` mapped to a `varchar` column, emits `INSERT ... VALUES (DEFAULT, ...)` and relies on the database to generate the value. With no column default, Postgres rejects the insert.

Affected tables (all 6 created by that migration): `sessions`, `webhooks`, `messages`, `api_keys`, `audit_logs`, `message_batches`.

SQLite is **not** affected — TypeORM generates the UUID in the driver layer for SQLite.

## Fix

Add a new migration that runs:
```sql
ALTER TABLE <each_table> ALTER COLUMN id SET DEFAULT gen_random_uuid()::varchar;
```
on every affected table. `gen_random_uuid()` is built into PostgreSQL 13+ (no `pgcrypto` / `uuid-ossp` extension required, matching the project's `postgres:16-alpine` image).

The migration:
- Is a **no-op on SQLite** (guarded by `connection.options.type !== 'postgres'`)
- Is **idempotent on both up and down** (uses `hasTable` before each ALTER, so tables that don't yet exist are skipped — safe even if migration order shifts)
- Provides a working `down()` that drops the default

## Test plan

- [x] Patched running Postgres DB with the same ALTER statements
- [x] `POST /api/sessions { \"name\": \"test\" }` → HTTP 201 with valid UUID
- [x] `GET /api/sessions` → lists the new session
- [x] `DELETE /api/sessions/{uuid}` → HTTP 204
- [x] No errors in `docker logs openwa-api`
- [ ] Maintainer: verify on a fresh SQLite install that the no-op guard works (should be silent)
- [ ] Maintainer: optionally consider a separate, follow-up change to fix the column type itself (`uuid` instead of `varchar`) for a cleaner long-term schema. This PR intentionally chooses the minimal change to unblock existing users.

## Alternative considered

Modifying `1770108659848-AddMessageStatus.ts` directly to include the DEFAULT. Rejected because:
- It won't re-run on existing installs (migrations are versioned), so existing users would still be broken
- Changing a published migration is generally avoided