### PR TITLE
feat(messages): add GET chat history endpoint with optional media

### DIFF
--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -774,6 +774,42 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
 
   // ========== Gap Quick Wins Implementation ==========
 
+  async getChatHistory(chatId: string, limit: number = 50, includeMedia: boolean = false): Promise<IncomingMessage[]> {
+    this.ensureReady();
+    const chat = await this.client!.getChatById(chatId);
+    const messages = await chat.fetchMessages({ limit });
+    const results: IncomingMessage[] = [];
+    for (const msg of messages) {
+      const out: IncomingMessage = {
+        id: msg.id._serialized,
+        from: msg.from,
+        to: msg.to,
+        chatId,
+        body: msg.body,
+        type: msg.type,
+        timestamp: msg.timestamp,
+        fromMe: msg.fromMe,
+        isGroup: chatId.endsWith('@g.us'),
+      };
+      if (includeMedia && msg.hasMedia) {
+        try {
+          const media = await msg.downloadMedia();
+          if (media) {
+            out.media = {
+              mimetype: media.mimetype,
+              filename: media.filename || undefined,
+              data: media.data,
+            };
+          }
+        } catch (error) {
+          this.logger.warn(`Failed to download media for ${msg.id._serialized}: ${String(error)}`);
+        }
+      }
+      results.push(out);
+    }
+    return results;
+  }
+
   // Delete Message
   async deleteMessage(chatId: string, messageId: string, forEveryone: boolean = true): Promise<void> {
     this.ensureReady();

--- a/src/engine/interfaces/whatsapp-engine.interface.ts
+++ b/src/engine/interfaces/whatsapp-engine.interface.ts
@@ -259,6 +259,7 @@ export interface IWhatsAppEngine {
 
   // Message Operations
   deleteMessage(chatId: string, messageId: string, forEveryone?: boolean): Promise<void>;
+  getChatHistory(chatId: string, limit?: number, includeMedia?: boolean): Promise<IncomingMessage[]>;
 
   // Contact Extended Operations
   getProfilePicture(contactId: string): Promise<string | null>;

--- a/src/modules/message/message.controller.ts
+++ b/src/modules/message/message.controller.ts
@@ -240,6 +240,37 @@ export class MessageController {
     return { success: true };
   }
 
+  @Get(':chatId/history')
+  @ApiOperation({
+    summary: 'Fetch chat history live from WhatsApp',
+    description:
+      'Reads messages directly from the WhatsApp client for the given chat, bypassing the local DB. ' +
+      'Useful for retrieving messages that arrived before the gateway was started.',
+  })
+  @ApiParam({ name: 'sessionId', description: 'Session ID' })
+  @ApiParam({ name: 'chatId', description: 'Chat ID (e.g. 1234567890@c.us or groupId@g.us)' })
+  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Max messages to return (default 50)' })
+  @ApiQuery({
+    name: 'includeMedia',
+    required: false,
+    type: Boolean,
+    description: 'When true, downloads media (base64) for messages that have it. Slower; default false.',
+  })
+  @ApiResponse({ status: 200, description: 'Chat history (most recent messages)' })
+  async getChatHistory(
+    @Param('sessionId') sessionId: string,
+    @Param('chatId') chatId: string,
+    @Query('limit') limit?: string,
+    @Query('includeMedia') includeMedia?: string,
+  ) {
+    return this.messageService.getChatHistory(
+      sessionId,
+      chatId,
+      limit ? parseInt(limit, 10) : undefined,
+      includeMedia === 'true' || includeMedia === '1',
+    );
+  }
+
   @Get(':chatId/:messageId/reactions')
   @ApiOperation({ summary: 'Get reactions for a specific message' })
   @ApiParam({ name: 'sessionId', description: 'Session ID' })

--- a/src/modules/message/message.service.spec.ts
+++ b/src/modules/message/message.service.spec.ts
@@ -24,6 +24,7 @@ function createMockEngine() {
     reactToMessage: jest.fn().mockResolvedValue(undefined),
     getMessageReactions: jest.fn().mockResolvedValue([]),
     deleteMessage: jest.fn().mockResolvedValue(undefined),
+    getChatHistory: jest.fn().mockResolvedValue([]),
   };
 }
 
@@ -342,6 +343,30 @@ describe('MessageService', () => {
       });
 
       expect(mockEngine.reactToMessage).toHaveBeenCalledWith('test@c.us', 'wa-msg-1', '👍');
+    });
+  });
+
+  describe('getChatHistory', () => {
+    it('should call engine.getChatHistory with default limit and includeMedia=false', async () => {
+      await service.getChatHistory('sess-1', 'test@c.us');
+      expect(mockEngine.getChatHistory).toHaveBeenCalledWith('test@c.us', 50, false);
+    });
+
+    it('should pass through custom limit', async () => {
+      await service.getChatHistory('sess-1', 'test@c.us', 10);
+      expect(mockEngine.getChatHistory).toHaveBeenCalledWith('test@c.us', 10, false);
+    });
+
+    it('should pass through includeMedia flag', async () => {
+      await service.getChatHistory('sess-1', 'test@c.us', 5, true);
+      expect(mockEngine.getChatHistory).toHaveBeenCalledWith('test@c.us', 5, true);
+    });
+
+    it('should return engine result', async () => {
+      const fake = [{ id: 'm1', body: 'hi', from: 'a', to: 'b', chatId: 'test@c.us' }];
+      mockEngine.getChatHistory.mockResolvedValueOnce(fake);
+      const result = await service.getChatHistory('sess-1', 'test@c.us');
+      expect(result).toBe(fake);
     });
   });
 

--- a/src/modules/message/message.service.ts
+++ b/src/modules/message/message.service.ts
@@ -456,6 +456,16 @@ export class MessageService {
     return engine.getMessageReactions(chatId, messageId);
   }
 
+  /**
+   * Fetch chat history live from WhatsApp (bypasses local DB).
+   * Returns the most recent `limit` messages for the given chat.
+   * When `includeMedia` is true, downloads media (base64) for messages that have it.
+   */
+  async getChatHistory(sessionId: string, chatId: string, limit = 50, includeMedia = false) {
+    const engine = this.getEngine(sessionId);
+    return engine.getChatHistory(chatId, limit, includeMedia);
+  }
+
   // ========== Delete Message ==========
 
   async deleteMessage(


### PR DESCRIPTION
## Description
Adds a new endpoint to fetch chat history live from the WhatsApp client, bypassing the gateway's local DB. The current `GET /messages` only returns messages persisted since the gateway started, so historical context for any given chat is unreachable through the API today.

`GET /api/sessions/:sessionId/messages/:chatId/history?limit=50&includeMedia=false`

- `limit` (default 50): max messages to return
- `includeMedia` (default false): when true, downloads media (base64) for messages that have it. Skipped by default to keep payloads small.

## Implementation
- Add `getChatHistory(chatId, limit?, includeMedia?)` to `IWhatsAppEngine`
- Implement in `whatsapp-web-js.adapter.ts` via `chat.fetchMessages({ limit })`
- Wire through `MessageService` and `MessageController`
- Unit tests added (default limit, custom limit, includeMedia pass-through)

## Type of Change
- [x] New feature

## Checklist
- [x] Tests added/updated (3 new tests, 26 total in message.service.spec.ts)
- [x] Lint passes (eslint clean on modified files)
- [x] Format passes (prettier check clean)
- [x] Build passes (nest build clean)
- [x] Self-reviewed
- [ ] Documentation updated (no README/docs change needed; Swagger annotations cover it)

## Testing
Tested locally against a live session:
- Fetched a real chat with `?limit=60` and got the full 60-message history.
- Fetched same chat with `?includeMedia=true` and got base64 for 2 image messages (successfully decoded).