### PR TITLE
fix(dashboard): show QR loading state immediately and keep polling until ready

### DIFF
--- a/dashboard/src/pages/Sessions.tsx
+++ b/dashboard/src/pages/Sessions.tsx
@@ -75,7 +75,9 @@ export function Sessions() {
       // Keep qrData alive so the polling interval keeps retrying until the QR
       // is ready. Only stop polling if the session itself has failed.
       const currentSession = await sessionApi.get(sessionId).catch(() => null);
-      if (!currentSession || currentSession.status === 'failed' || currentSession.status === 'disconnected') {
+      const stillInitializing = currentSession &&
+        ['initializing', 'connecting', 'qr_ready'].includes(currentSession.status);
+      if (!stillInitializing) {
         setQrData(null);
         currentSessionName.current = '';
         fetchSessions();

--- a/dashboard/src/pages/Sessions.tsx
+++ b/dashboard/src/pages/Sessions.tsx
@@ -72,9 +72,14 @@ export function Sessions() {
         fetchSessions();
       }
     } catch {
-      setQrData(null);
-      currentSessionName.current = '';
-      fetchSessions();
+      // Keep qrData alive so the polling interval keeps retrying until the QR
+      // is ready. Only stop polling if the session itself has failed.
+      const currentSession = await sessionApi.get(sessionId).catch(() => null);
+      if (!currentSession || currentSession.status === 'failed' || currentSession.status === 'disconnected') {
+        setQrData(null);
+        currentSessionName.current = '';
+        fetchSessions();
+      }
     }
   }, []);
 
@@ -150,12 +155,17 @@ export function Sessions() {
   const handleShowQR = async (id: string) => {
     const session = sessions.find(s => s.id === id);
     const sessionName = session?.name || '';
+    // Show loading state immediately so the modal opens and polling starts
+    // even before Chromium has finished initializing.
+    setQrData({ sessionId: id, sessionName, qrCode: '' });
+    currentSessionName.current = sessionName;
     try {
       const qr = await sessionApi.getQR(id);
       setQrData({ sessionId: id, sessionName, qrCode: qr.qrCode });
     } catch (err) {
       console.error('Failed to get QR:', err);
-      setError(t('sessions.qr.unavailable'));
+      // Do not clear qrData here — keep the loading modal open so the
+      // polling interval (every 5 s) retries until the QR becomes available.
     }
   };
 


### PR DESCRIPTION
## Problem

When a session is in `Failed` or `disconnected` state and the user clicks **Reconnect**, Chromium takes a few seconds to initialize before the QR is available. During that window, `GET /api/sessions/:id/qr` returns a 404/error. The previous code caught that error, displayed a global banner _"QR code not available yet. Try again in a moment."_ and stopped — leaving the user unable to scan without clicking Reconnect again (and again).

## Root cause

`handleShowQR` only called `setQrData` on success. On error it fell through to `setError`, which meant `qrData` stayed `null` and the existing 5-second polling interval **never started**.

Additionally, `fetchQR` (called by the interval) cleared `qrData` on any error, killing the interval even for transient "not ready yet" responses.

## Fix

Two small changes in `dashboard/src/pages/Sessions.tsx`:

1. **`handleShowQR`** — sets `qrData` with an empty `qrCode` _before_ the fetch, so the modal opens immediately showing a loading spinner and the polling interval starts right away. A transient fetch error no longer clears the modal.

2. **`fetchQR`** — on error, checks the session status before clearing `qrData`. If the session is still initializing/connecting it keeps polling; it only stops when the session reaches a terminal state (`failed` / `disconnected`) or when the QR is successfully scanned (`status: ready`).

## Behaviour after fix

- User clicks Reconnect → modal opens instantly with loading spinner
- Every 5 s the interval retries `getQR`
- As soon as Chromium generates the QR it appears in the modal automatically
- If the session fails, the modal closes and the session list refreshes

No new dependencies. Single file changed.
