### PR TITLE
fix: replace generic Error with proper NestJS HTTP exceptions in controllers

### DIFF
--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -10,7 +10,7 @@ const API_BASE_URL = '/api';
 export interface Session {
   id: string;
   name: string;
-  status: 'created' | 'idle' | 'initializing' | 'connecting' | 'qr_ready' | 'ready' | 'disconnected';
+  status: 'created' | 'idle' | 'initializing' | 'connecting' | 'qr_ready' | 'ready' | 'disconnected' | 'failed';
   phone?: string;
   pushName?: string;
   lastActive?: string;

--- a/src/modules/channel/channel.controller.ts
+++ b/src/modules/channel/channel.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Delete, Param, Body, Query } from '@nestjs/common';
+import { Controller, Get, Post, Delete, Param, Body, Query, BadRequestException, NotFoundException } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBody, ApiQuery } from '@nestjs/swagger';
 import { SessionService } from '../session/session.service';
 
@@ -10,7 +10,7 @@ export class ChannelController {
   private getEngine(sessionId: string) {
     const engine = this.sessionService.getEngine(sessionId);
     if (!engine) {
-      throw new Error('Session is not started');
+      throw new BadRequestException('Session is not started');
     }
     return engine;
   }
@@ -41,7 +41,7 @@ export class ChannelController {
     const engine = this.getEngine(sessionId);
     const channel = await engine.getChannelById(channelId);
     if (!channel) {
-      throw new Error(`Channel ${channelId} not found`);
+      throw new NotFoundException(`Channel ${channelId} not found`);
     }
     return channel;
   }

--- a/src/modules/contact/contact.controller.ts
+++ b/src/modules/contact/contact.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Delete, Param, HttpCode, HttpStatus } from '@nestjs/common';
+import { Controller, Get, Post, Delete, Param, HttpCode, HttpStatus, BadRequestException, NotFoundException } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
 import { SessionService } from '../session/session.service';
 
@@ -19,7 +19,7 @@ export class ContactController {
   async findAll(@Param('sessionId') sessionId: string) {
     const engine = this.sessionService.getEngine(sessionId);
     if (!engine) {
-      throw new Error('Session is not started');
+      throw new BadRequestException('Session is not started');
     }
     return engine.getContacts();
   }
@@ -36,11 +36,11 @@ export class ContactController {
   async findOne(@Param('sessionId') sessionId: string, @Param('contactId') contactId: string) {
     const engine = this.sessionService.getEngine(sessionId);
     if (!engine) {
-      throw new Error('Session is not started');
+      throw new BadRequestException('Session is not started');
     }
     const contact = await engine.getContactById(contactId);
     if (!contact) {
-      throw new Error(`Contact ${contactId} not found`);
+      throw new NotFoundException(`Contact ${contactId} not found`);
     }
     return contact;
   }
@@ -56,7 +56,7 @@ export class ContactController {
   async checkNumber(@Param('sessionId') sessionId: string, @Param('number') number: string) {
     const engine = this.sessionService.getEngine(sessionId);
     if (!engine) {
-      throw new Error('Session is not started');
+      throw new BadRequestException('Session is not started');
     }
     const exists = await engine.checkNumberExists(number);
     return {
@@ -79,7 +79,7 @@ export class ContactController {
   async getProfilePicture(@Param('sessionId') sessionId: string, @Param('contactId') contactId: string) {
     const engine = this.sessionService.getEngine(sessionId);
     if (!engine) {
-      throw new Error('Session is not started');
+      throw new BadRequestException('Session is not started');
     }
     const url = await engine.getProfilePicture(contactId);
     return { url };
@@ -97,7 +97,7 @@ export class ContactController {
   async blockContact(@Param('sessionId') sessionId: string, @Param('contactId') contactId: string) {
     const engine = this.sessionService.getEngine(sessionId);
     if (!engine) {
-      throw new Error('Session is not started');
+      throw new BadRequestException('Session is not started');
     }
     await engine.blockContact(contactId);
     return { success: true, message: 'Contact blocked' };
@@ -114,7 +114,7 @@ export class ContactController {
   async unblockContact(@Param('sessionId') sessionId: string, @Param('contactId') contactId: string) {
     const engine = this.sessionService.getEngine(sessionId);
     if (!engine) {
-      throw new Error('Session is not started');
+      throw new BadRequestException('Session is not started');
     }
     await engine.unblockContact(contactId);
     return { success: true, message: 'Contact unblocked' };

--- a/src/modules/group/group.controller.ts
+++ b/src/modules/group/group.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Put, Delete, Param, Body, HttpCode, HttpStatus } from '@nestjs/common';
+import { Controller, Get, Post, Put, Delete, Param, Body, HttpCode, HttpStatus, BadRequestException, NotFoundException } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBody } from '@nestjs/swagger';
 import { SessionService } from '../session/session.service';
 
@@ -44,7 +44,7 @@ export class GroupController {
     const engine = this.getEngine(sessionId);
     const group = await engine.getGroupInfo(groupId);
     if (!group) {
-      throw new Error(`Group ${groupId} not found`);
+      throw new NotFoundException(`Group ${groupId} not found`);
     }
     return group;
   }
@@ -205,7 +205,7 @@ export class GroupController {
   private getEngine(sessionId: string) {
     const engine = this.sessionService.getEngine(sessionId);
     if (!engine) {
-      throw new Error('Session is not started');
+      throw new BadRequestException('Session is not started');
     }
     return engine;
   }

--- a/src/modules/label/label.controller.ts
+++ b/src/modules/label/label.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Delete, Param, Body } from '@nestjs/common';
+import { Controller, Get, Post, Delete, Param, Body, BadRequestException, NotFoundException } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBody } from '@nestjs/swagger';
 import { SessionService } from '../session/session.service';
 
@@ -10,7 +10,7 @@ export class LabelController {
   private getEngine(sessionId: string) {
     const engine = this.sessionService.getEngine(sessionId);
     if (!engine) {
-      throw new Error('Session is not started');
+      throw new BadRequestException('Session is not started');
     }
     return engine;
   }
@@ -42,7 +42,7 @@ export class LabelController {
     const engine = this.getEngine(sessionId);
     const label = await engine.getLabelById(labelId);
     if (!label) {
-      throw new Error(`Label ${labelId} not found`);
+      throw new NotFoundException(`Label ${labelId} not found`);
     }
     return label;
   }


### PR DESCRIPTION
## Summary

Multiple controllers (`channel`, `contact`, `group`, `label`) throw generic JavaScript `Error` instead of NestJS HTTP exceptions (`BadRequestException`, `NotFoundException`). This causes **500 Internal Server Error** responses instead of the correct **400/404** status codes that are already documented in the Swagger API specs.

## Problem

When a session is not started (e.g., after a phone disconnects per #100), calling any endpoint on these controllers returns:

```json
{
  \"statusCode\": 500,
  \"message\": \"Internal server error\"
}
```

Instead of the expected:

```json
{
  \"statusCode\": 400,
  \"message\": \"Session is not started\"
}
```

Similarly, when a resource (channel, contact, group, label) is not found, the API returns 500 instead of 404.

This is inconsistent with:\n- The Swagger `@ApiResponse` decorators that document 400/404 responses\n- Other controllers/services in the codebase that correctly use NestJS exceptions (e.g., `session.service.ts`, `status.service.ts`, `webhook.service.ts`)

## Changes

### Backend (4 controllers)

| File | Fix |\n|------|-----|\n| `src/modules/channel/channel.controller.ts` | `throw new Error(...)` → `BadRequestException` / `NotFoundException` |\n| `src/modules/contact/contact.controller.ts` | `throw new Error(...)` → `BadRequestException` / `NotFoundException` |\n| `src/modules/group/group.controller.ts` | `throw new Error(...)` → `BadRequestException` / `NotFoundException` |\n| `src/modules/label/label.controller.ts` | `throw new Error(...)` → `BadRequestException` / `NotFoundException` |\n\n### Dashboard\n\n| File | Fix |\n|------|-----|\n| `dashboard/src/services/api.ts` | Added missing `'failed'` to `Session.status` union type to match backend `SessionStatus` enum |\n\n## Related Issues\n\n- Partially addresses #100 — after a session disconnects from the phone, API calls now return proper 400 responses instead of 500\n\n## Testing\n\n- No existing unit tests for these controllers to break\n- Changes are minimal and mechanical (import swap + class swap)\n- Consistent with patterns already used in `status.service.ts`, `webhook.service.ts`, `session.service.ts`"}