### PR TITLE
chore(deps): bump lucide-react from 0.575.0 to 1.16.0 in /dashboard

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -12,7 +12,7 @@
         "@tanstack/react-table": "^8.21.3",
         "i18next": "^26.2.0",
         "i18next-browser-languagedetector": "^8.2.1",
-        "lucide-react": "^0.575.0",
+        "lucide-react": "^1.16.0",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "react-i18next": "^17.0.8",
@@ -2379,9 +2379,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.575.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.575.0.tgz",
-      "integrity": "sha512-VuXgKZrk0uiDlWjGGXmKV6MSk9Yy4l10qgVvzGn2AWBx1Ylt0iBexKOAoA6I7JO3m+M9oeovJd3yYENfkUbOeg==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.16.0.tgz",
+      "integrity": "sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -14,7 +14,7 @@
     "@tanstack/react-table": "^8.21.3",
     "i18next": "^26.2.0",
     "i18next-browser-languagedetector": "^8.2.1",
-    "lucide-react": "^0.575.0",
+    "lucide-react": "^1.16.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-i18next": "^17.0.8",

--- a/dashboard/src/components/GithubIcon.tsx
+++ b/dashboard/src/components/GithubIcon.tsx
@@ -1,0 +1,23 @@
+/**
+ * GitHub brand mark — inlined because lucide-react v1 removed all brand icons.
+ * Filled path + `fill="currentColor"` so it inherits color from CSS like the
+ * lucide icon it replaced. Decorative (`aria-hidden`); label the parent link.
+ */
+interface GithubIconProps {
+  size?: number;
+}
+
+export function GithubIcon({ size = 24 }: GithubIconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+    </svg>
+  );
+}

--- a/dashboard/src/pages/Login.tsx
+++ b/dashboard/src/pages/Login.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Eye, EyeOff, Github } from 'lucide-react';
+import { Eye, EyeOff } from 'lucide-react';
+import { GithubIcon } from '../components/GithubIcon';
 import './Login.css';
 
 interface LoginProps {
@@ -100,8 +101,9 @@ export function Login({ onLogin }: LoginProps) {
           target="_blank"
           rel="noopener noreferrer"
           className="github-link"
+          aria-label="GitHub"
         >
-          <Github size={18} />
+          <GithubIcon size={18} />
         </a>
       </footer>
     </div>


### PR DESCRIPTION
## Summary

Bumps `lucide-react` 0.575.0 → 1.16.0 in `/dashboard`. Supersedes #73.

## Breaking change in v1

lucide-react v1 removed all brand icons, including `Github`. Across the 13 dashboard files importing lucide-react, only one symbol broke: `Github` in `Login.tsx`.

## Fix

- New `dashboard/src/components/GithubIcon.tsx` — inline SVG of the official GitHub mark. Filled path with `fill="currentColor"` so it inherits color from CSS exactly like the stroke-based lucide icon it replaced (no CSS changes needed).
- `Login.tsx` — swap `<Github>` for `<GithubIcon>`, and add `aria-label="GitHub"` to the footer link (it previously had no accessible name).

## Verification

- `npm run build` (tsc + vite) — passes, zero errors.
- `npm run lint` — zero errors (3 pre-existing warnings in unrelated files).
- Ran the dashboard dev server and checked the Login page in a browser: the GitHub icon renders correctly, inheriting `--text-muted` normally and `--primary` on hover.