### PR TITLE
Fix Location constructor error

### DIFF
--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events';
-import { Client, LocalAuth, MessageMedia } from 'whatsapp-web.js';
+import { Client, LocalAuth, MessageMedia, Location as LocationMessage } from 'whatsapp-web.js';
 import * as qrcode from 'qrcode';
 import * as path from 'path';
 import {
@@ -385,8 +385,7 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
   async sendLocationMessage(chatId: string, location: LocationInput): Promise<MessageResult> {
     this.ensureReady();
     // Import Location class dynamically from whatsapp-web.js
-    const { Location } = await import('whatsapp-web.js');
-    const loc = new Location(location.latitude, location.longitude, {
+    const loc = new LocationMessage(location.latitude, location.longitude, {
       name: location.description || '',
       address: location.address || '',
     });


### PR DESCRIPTION
## Description
Fixes the error "Location is not a constructor" occurring when using whatsapp-web.js.

The issue was caused by incorrect import and usage of the Location class. The code now correctly imports Location as LocationMessage and uses it accordingly.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] Lint passes
- [x] Self-reviewed

## Screenshots (if applicable)

## Related Issues
No related issue