### PR TITLE
fix(dashboard): downgrade Vite to v6.2.6 to resolve peer dependency conflict

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install dependencies
-RUN npm ci
+RUN npm install
 
 # Copy source code
 COPY . .

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -33,6 +33,6 @@
     "globals": "^17.6.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.59.3",
-    "vite": "^8.0.13"
+    "vite": "^6.2.6"
   }
 }


### PR DESCRIPTION
## Problem

docker compose -f docker-compose.dev.yml up -d fails during the dashboard service build with an ERESOLVE peer dependency conflict.

Error:
npm error While resolving: @vitejs/plugin-react@5.1.4
npm error Found: vite@8.0.13
npm error Could not resolve dependency:
npm error peer vite@"^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" from @vitejs/plugin-react@5.1.4

@vitejs/plugin-react@5.1.4 does not support Vite 8, causing npm ci to abort.

## Solution

- Downgrade vite from ^8.0.13 to ^6.2.6 (compatible with @vitejs/plugin-react@5.1.4)
- Switch dashboard/Dockerfile from RUN npm ci to RUN npm install to regenerate the lock file cleanly after deleting the stale package-lock.json

## Changes

- dashboard/package.json: "vite": "^8.0.13" -> "vite": "^6.2.6"
- dashboard/Dockerfile: RUN npm ci -> RUN npm install

## Verification

- docker compose -f docker-compose.dev.yml up -d --build now completes successfully
- Dashboard loads correctly at http://localhost:2886

## Related

Fixes #123