### PR TITLE
docs(auth): document API key endpoints

### DIFF
--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -25,6 +25,84 @@ X-API-Key: your-api-key
 X-Request-ID: optional-tracking-id (recommended)
 ```
 
+### API Key Management
+
+OpenWA creates an initial admin API key on first run. The key is printed in the
+startup logs and written to:
+
+- `data/.api-key` for local development
+- `/app/data/.api-key` inside the API container for Docker deployments
+
+Local development uses `dev-admin-key` when no keys exist; production creates a
+random `owa_k1_...` admin key. Use that admin key to create scoped keys for
+integrations. The full generated key is returned only once in the `apiKey`
+field of the create response.
+
+#### Create API Key
+
+```http
+POST /api/auth/api-keys
+```
+
+**Required role:** `admin`
+
+**Request Body:**
+```json
+{
+  "name": "Production Bot",
+  "role": "operator",
+  "allowedIps": ["192.168.1.10", "10.0.0.0/8"],
+  "allowedSessions": ["session-uuid-1"],
+  "expiresAt": "2027-12-31T23:59:59Z"
+}
+```
+
+Only `name` is required. `role` defaults to `operator`; valid roles are
+`admin`, `operator`, and `viewer`.
+
+**Example:**
+```bash
+curl -X POST http://localhost:2785/api/auth/api-keys \
+  -H "X-API-Key: $ADMIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "n8n Integration",
+    "role": "operator"
+  }'
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": {
+    "id": "2a8f41e3-3b9a-4a1d-b6d0-b9910df8f0be",
+    "name": "n8n Integration",
+    "keyPrefix": "owa_k1_abcd",
+    "role": "operator",
+    "isActive": true,
+    "usageCount": 0,
+    "createdAt": "2026-02-02T10:30:00.000Z",
+    "apiKey": "owa_k1_abcd1234..."
+  },
+  "meta": {
+    "timestamp": "2026-02-02T10:30:00.000Z"
+  }
+}
+```
+
+#### API Key Endpoints
+
+| Method | Endpoint | Description | Required role |
+|--------|----------|-------------|---------------|
+| `GET` | `/api/auth/api-keys` | List API keys | `admin` |
+| `POST` | `/api/auth/api-keys` | Create an API key | `admin` |
+| `GET` | `/api/auth/api-keys/:id` | Get API key details | `admin` |
+| `PUT` | `/api/auth/api-keys/:id` | Update API key metadata, role, IPs, sessions, or expiry | `admin` |
+| `DELETE` | `/api/auth/api-keys/:id` | Delete an API key | `admin` |
+| `POST` | `/api/auth/api-keys/:id/revoke` | Revoke an API key by setting it inactive | `admin` |
+| `POST` | `/api/auth/validate` | Validate the key in `X-API-Key` | Any key |
+
 ## 6.2 Response Format
 
 ### Success Response

--- a/docs/07-api-collection.md
+++ b/docs/07-api-collection.md
@@ -1031,13 +1031,19 @@ curl -X POST \
 
 ## 07.8 API Keys API
 
-### GET /api/api-keys
+All API key management endpoints require an admin API key in `X-API-Key`.
+OpenWA creates the initial admin key on first run, prints it in the startup
+logs, and writes it to `data/.api-key` (or `/app/data/.api-key` inside the API
+container). Local development uses `dev-admin-key` when no keys exist;
+production creates a random `owa_k1_...` admin key.
+
+### GET /api/auth/api-keys
 
 List API keys.
 
 ```bash
 curl -H "X-API-Key: $API_KEY" \
-  http://localhost:2785/api/api-keys
+  http://localhost:2785/api/auth/api-keys
 ```
 
 **Response:**
@@ -1046,13 +1052,15 @@ curl -H "X-API-Key: $API_KEY" \
   "success": true,
   "data": [
     {
-      "id": "key_123",
+      "id": "2a8f41e3-3b9a-4a1d-b6d0-b9910df8f0be",
       "name": "Production Key",
-      "prefix": "owa_prod_***",
-      "permissions": ["*"],
-      "sessionAccess": ["*"],
-      "rateLimit": 1000,
-      "lastUsed": "2026-02-02T10:30:00Z",
+      "keyPrefix": "owa_k1_abcd",
+      "role": "operator",
+      "allowedIps": ["192.168.1.10"],
+      "allowedSessions": ["session-uuid-1"],
+      "isActive": true,
+      "lastUsedAt": "2026-02-02T10:30:00Z",
+      "usageCount": 12,
       "expiresAt": null,
       "createdAt": "2026-01-01T00:00:00Z"
     }
@@ -1060,38 +1068,28 @@ curl -H "X-API-Key: $API_KEY" \
 }
 ```
 
-### POST /api/api-keys
+### POST /api/auth/api-keys
 
 Create API key.
 
 ```bash
-curl -X POST http://localhost:2785/api/api-keys \
+curl -X POST http://localhost:2785/api/auth/api-keys \
   -H "X-API-Key: $API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "Integration Key",
-    "permissions": ["sessions:read", "messages:write"],
-    "sessionAccess": ["default"],
-    "rateLimit": 100,
+    "role": "operator",
+    "allowedIps": ["192.168.1.10"],
+    "allowedSessions": ["default"],
     "expiresAt": "2027-01-01T00:00:00Z"
   }'
 ```
 
-**Permissions:**
+**Roles:**
 ```
-*                    - All permissions
-sessions:read        - Read session info
-sessions:write       - Create/delete sessions
-messages:read        - Read messages
-messages:write       - Send messages
-contacts:read        - Read contacts
-contacts:write       - Block/unblock contacts
-groups:read          - Read group info
-groups:write         - Manage groups
-webhooks:read        - Read webhooks
-webhooks:write       - Manage webhooks
-api-keys:read        - Read API keys
-api-keys:write       - Manage API keys
+admin     - Full access, including API key management
+operator  - Operational API access for integrations
+viewer    - Read-only API access where supported
 ```
 
 **Response:**
@@ -1099,28 +1097,65 @@ api-keys:write       - Manage API keys
 {
   "success": true,
   "data": {
-    "id": "key_456",
+    "id": "4d0564f1-5fb7-4e4a-baae-4cb0d154e861",
     "name": "Integration Key",
-    "key": "owa_abc123xyz789...",
-    "permissions": ["sessions:read", "messages:write"],
-    "sessionAccess": ["default"],
-    "rateLimit": 100,
+    "keyPrefix": "owa_k1_efgh",
+    "role": "operator",
+    "allowedIps": ["192.168.1.10"],
+    "allowedSessions": ["default"],
+    "isActive": true,
+    "usageCount": 0,
     "expiresAt": "2027-01-01T00:00:00Z",
-    "createdAt": "2026-02-02T10:30:00Z"
+    "createdAt": "2026-02-02T10:30:00Z",
+    "apiKey": "owa_k1_efgh5678..."
   }
 }
 ```
 
-**Note:** The full `key` is only shown once at creation.
+**Note:** The full `apiKey` is only shown once at creation.
 
-### DELETE /api/api-keys/:id
+### PUT /api/auth/api-keys/:id
 
-Revoke API key.
+Update API key metadata, role, IP allowlist, session allowlist, or expiry.
+
+```bash
+curl -X PUT http://localhost:2785/api/auth/api-keys/4d0564f1-5fb7-4e4a-baae-4cb0d154e861 \
+  -H "X-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Integration Key - Production",
+    "role": "operator"
+  }'
+```
+
+### POST /api/auth/api-keys/:id/revoke
+
+Revoke API key without deleting its record.
+
+```bash
+curl -X POST \
+  -H "X-API-Key: $API_KEY" \
+  http://localhost:2785/api/auth/api-keys/4d0564f1-5fb7-4e4a-baae-4cb0d154e861/revoke
+```
+
+### DELETE /api/auth/api-keys/:id
+
+Delete API key.
 
 ```bash
 curl -X DELETE \
   -H "X-API-Key: $API_KEY" \
-  http://localhost:2785/api/api-keys/key_456
+  http://localhost:2785/api/auth/api-keys/4d0564f1-5fb7-4e4a-baae-4cb0d154e861
+```
+
+### POST /api/auth/validate
+
+Validate the API key provided in the `X-API-Key` header.
+
+```bash
+curl -X POST \
+  -H "X-API-Key: $API_KEY" \
+  http://localhost:2785/api/auth/validate
 ```
 
 ## 07.9 Postman Collection

--- a/docs/README.md
+++ b/docs/README.md
@@ -104,8 +104,13 @@ Access:
 OpenWA seeds a default API key on first run and writes it to:
 
 - `data/.api-key` (development)
+- `/app/data/.api-key` inside the API container when using Docker
 
-You can also create new keys via the API (see [API Specification](./06-api-specification.md)).
+The startup logs also print the initial key. Local development uses
+`dev-admin-key` when no keys exist; production creates a random `owa_k1_...`
+admin key. Use an admin key to create additional keys with
+`POST /api/auth/api-keys` (see
+[API Specification](./06-api-specification.md#api-key-management)).
 
 ## API Example
 


### PR DESCRIPTION
## Description
Documents how to find the initial admin API key and how to create/manage API keys through the actual `/api/auth/api-keys` endpoints.

Also updates the API collection examples that still referenced the old `/api/api-keys` path and permission-style payload fields.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist
- [ ] Tests added/updated
- [x] Documentation updated
- [ ] Lint passes
- [x] Self-reviewed

## Screenshots (if applicable)
N/A

## Related Issues
Refs #110