### PR TITLE
fix(dashboard): proxy API in Traefik image

### DIFF
--- a/dashboard/Dockerfile.traefik
+++ b/dashboard/Dockerfile.traefik
@@ -15,12 +15,32 @@ FROM nginx:alpine
 # Copy built static files
 COPY --from=builder /app/dist /usr/share/nginx/html
 
-# Simple nginx config for SPA (Traefik handles routing)
+# Simple nginx config for SPA (Traefik handles public routing).
+# Keep API/WebSocket requests same-origin so the dashboard also works when
+# users bring their own external reverse proxy.
 RUN echo 'server { \
     listen 80; \
     server_name localhost; \
     root /usr/share/nginx/html; \
     index index.html; \
+    location /api/ { \
+        proxy_pass http://openwa-api:2785; \
+        proxy_http_version 1.1; \
+        proxy_set_header Host $host; \
+        proxy_set_header X-Real-IP $remote_addr; \
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; \
+        proxy_set_header X-Forwarded-Proto $scheme; \
+    } \
+    location /socket.io/ { \
+        proxy_pass http://openwa-api:2785; \
+        proxy_http_version 1.1; \
+        proxy_set_header Upgrade $http_upgrade; \
+        proxy_set_header Connection "upgrade"; \
+        proxy_set_header Host $host; \
+        proxy_set_header X-Real-IP $remote_addr; \
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; \
+        proxy_set_header X-Forwarded-Proto $scheme; \
+    } \
     location / { \
         try_files $uri $uri/ /index.html; \
     } \


### PR DESCRIPTION
## Description
Adds same-origin proxying for dashboard API and Socket.IO traffic in the Traefik dashboard image.

`dashboard/Dockerfile.traefik` previously generated an nginx config that only served the SPA. The dashboard calls `/api/...` from the browser, so deployments behind an external reverse proxy would send API validation requests back to the dashboard container and show Invalid API Key even when the key was valid.

This forwards:
- `/api/` to `openwa-api:2785`
- `/socket.io/` to `openwa-api:2785`

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Lint passes
- [x] Self-reviewed

## Screenshots (if applicable)
N/A

## Related Issues
Closes #116

## Testing
- `git diff --check`
- Docker build not run locally: Docker CLI is not available in this environment.
