### PR TITLE
feat: support API_MASTER_KEY env var for initial API key seed

### DIFF
--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -26,9 +26,11 @@ export class AuthService implements OnModuleInit {
     let isNewKey = false;
 
     if (count === 0) {
-      // Use predictable key in development, random key in production
-      displayKey =
-        process.env.NODE_ENV === 'production' ? `owa_k1_${randomBytes(32).toString('hex')}` : 'dev-admin-key';
+      // Use env var if set, otherwise auto-generate predictable key in development, random key in production
+      displayKey = process.env.API_MASTER_KEY
+        || (process.env.NODE_ENV === 'production' 
+          ? `owa_k1_${randomBytes(32).toString('hex')}` 
+          : 'dev-admin-key');
 
       await this.seedApiKey(displayKey, 'Default Admin Key', ApiKeyRole.ADMIN);
       isNewKey = true;


### PR DESCRIPTION
## Description
The API_MASTER_KEY env var is declared in docker-compose.yml and .env.example but never consumed by AuthService. When set, use it as the seed key instead of auto-generating a random one. Falls back to existing behavior when not set.

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Lint passes
- [X] Self-reviewed

## Screenshots (if applicable)

## Related Issues
Closes #
