### PR TITLE
feat: auto-start authenticated sessions on server boot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@ NODE_ENV=production
 API_PORT=2785
 LOG_LEVEL=info                      # error | warn | info | debug
 
+# Auto-start previously authenticated sessions on server boot
+AUTO_START_SESSIONS=false
+
 # Domain Configuration
 DOMAIN=localhost
 DASHBOARD_PORT=2886

--- a/.env.minimal
+++ b/.env.minimal
@@ -4,6 +4,9 @@
 # This is a minimal configuration for development
 # and single-session personal bots using SQLite.
 
+# Auto-start previously authenticated sessions on server boot
+AUTO_START_SESSIONS=false
+
 # Server
 PORT=2785
 NODE_ENV=development

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -393,4 +393,67 @@ describe('SessionService', () => {
       expect(service.getActiveCount()).toBe(0);
     });
   });
+
+  // ── onApplicationBootstrap (auto-start) ───────────────────────────
+  describe('onApplicationBootstrap', () => {
+    const originalFlag = process.env.AUTO_START_SESSIONS;
+
+    afterEach(() => {
+      if (originalFlag === undefined) delete process.env.AUTO_START_SESSIONS;
+      else process.env.AUTO_START_SESSIONS = originalFlag;
+    });
+
+    it('does nothing when AUTO_START_SESSIONS is not enabled', async () => {
+      delete process.env.AUTO_START_SESSIONS;
+      const startSpy = jest.spyOn(service, 'start').mockResolvedValue(undefined as never);
+
+      await service.onApplicationBootstrap();
+
+      expect(repository.find).not.toHaveBeenCalled();
+      expect(startSpy).not.toHaveBeenCalled();
+    });
+
+    it('starts no engine when there are no previously-authenticated sessions', async () => {
+      process.env.AUTO_START_SESSIONS = 'true';
+      (repository.find as jest.Mock).mockResolvedValue([]);
+      const startSpy = jest.spyOn(service, 'start').mockResolvedValue(undefined as never);
+
+      await service.onApplicationBootstrap();
+
+      expect(startSpy).not.toHaveBeenCalled();
+    });
+
+    it('auto-starts every previously-authenticated session', async () => {
+      process.env.AUTO_START_SESSIONS = 'true';
+      (repository.find as jest.Mock).mockResolvedValue([
+        { id: 'a', name: 'A' },
+        { id: 'b', name: 'B' },
+      ]);
+      jest.spyOn(service as unknown as { delay: () => Promise<void> }, 'delay').mockResolvedValue(undefined);
+      const startSpy = jest.spyOn(service, 'start').mockResolvedValue(undefined as never);
+
+      await service.onApplicationBootstrap();
+
+      expect(startSpy).toHaveBeenCalledTimes(2);
+      expect(startSpy).toHaveBeenCalledWith('a');
+      expect(startSpy).toHaveBeenCalledWith('b');
+    });
+
+    it('keeps starting the remaining sessions when one fails', async () => {
+      process.env.AUTO_START_SESSIONS = 'true';
+      (repository.find as jest.Mock).mockResolvedValue([
+        { id: 'a', name: 'A' },
+        { id: 'b', name: 'B' },
+      ]);
+      jest.spyOn(service as unknown as { delay: () => Promise<void> }, 'delay').mockResolvedValue(undefined);
+      const startSpy = jest
+        .spyOn(service, 'start')
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce(undefined as never);
+
+      await service.onApplicationBootstrap();
+
+      expect(startSpy).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -5,9 +5,10 @@ import {
   BadRequestException,
   OnModuleDestroy,
   OnModuleInit,
+  OnApplicationBootstrap,
 } from '@nestjs/common';
 import { InjectRepository, InjectDataSource } from '@nestjs/typeorm';
-import { Repository, In, DataSource } from 'typeorm';
+import { Repository, In, Not, IsNull, DataSource } from 'typeorm';
 import { Session, SessionStatus } from './entities/session.entity';
 import { CreateSessionDto } from './dto';
 import { EngineFactory } from '../../engine/engine.factory';
@@ -25,7 +26,7 @@ interface ReconnectState {
 }
 
 @Injectable()
-export class SessionService implements OnModuleDestroy, OnModuleInit {
+export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicationBootstrap {
   private readonly logger = createLogger('SessionService');
 
   // In-memory map of active engine instances
@@ -67,6 +68,38 @@ export class SessionService implements OnModuleDestroy, OnModuleInit {
         action: 'startup_reset',
         affected: result.affected,
       });
+    }
+  }
+
+  async onApplicationBootstrap(): Promise<void> {
+    if (process.env.AUTO_START_SESSIONS !== 'true') return;
+
+    const sessions = await this.sessionRepository.find({
+      where: { phone: Not(IsNull()), status: SessionStatus.DISCONNECTED },
+    });
+
+    if (sessions.length === 0) return;
+
+    this.logger.log(`Auto-starting ${sessions.length} previously authenticated session(s)`, {
+      action: 'auto_start',
+      count: sessions.length,
+    });
+
+    for (const session of sessions) {
+      try {
+        await this.start(session.id);
+        this.logger.log(`Auto-started session: ${session.name}`, {
+          sessionId: session.id,
+          action: 'auto_start_success',
+        });
+      } catch (error: unknown) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        this.logger.error(`Auto-start failed for session: ${session.name}`, errorMessage, {
+          sessionId: session.id,
+          action: 'auto_start_failed',
+        });
+      }
+      await this.delay(2000);
     }
   }
 
@@ -536,5 +569,9 @@ export class SessionService implements OnModuleDestroy, OnModuleInit {
    */
   isActive(id: string): boolean {
     return this.engines.has(id);
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
   }
 }

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -85,7 +85,8 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
       count: sessions.length,
     });
 
-    for (const session of sessions) {
+    for (let i = 0; i < sessions.length; i++) {
+      const session = sessions[i];
       try {
         await this.start(session.id);
         this.logger.log(`Auto-started session: ${session.name}`, {
@@ -99,7 +100,10 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
           action: 'auto_start_failed',
         });
       }
-      await this.delay(2000);
+      // Throttle between sequential Chromium launches; no need to wait after the last one.
+      if (i < sessions.length - 1) {
+        await this.delay(2000);
+      }
     }
   }
 


### PR DESCRIPTION
## Problema

Al reiniciar el servidor, todas las sesiones quedaban en estado `disconnected`. Había que entrar al dashboard y hacer clic en "Start" manualmente en cada sesión.

## Solución

Se agregó un nuevo hook `onApplicationBootstrap` en `SessionService` (se ejecuta después de que toda la app está inicializada) que:

1. Si `AUTO_START_SESSIONS=true` (opt-in), busca en BD sesiones que ya estaban autenticadas antes del reinicio (`phone != null`)
2. Las inicia una por una (`start()`) con 2s de delay entre cada una para evitar saturación de recursos (~500MB por sesión con Puppeteer)
3. Cada sesión tiene su propio try/catch — una falla no afecta a las demás
4. Usa el mismo flujo `start() → initializeEngine()` del dashboard, y whatsapp-web.js con LocalAuth restaura la sesión sin escanear QR de nuevo

## Archivos modificados

- **`src/modules/session/session.service.ts`**: Agrega `OnApplicationBootstrap`, nuevo método `onApplicationBootstrap()` con auto-start, helper `delay()`, importa `Not`, `IsNull` de typeorm
- **`.env.example`** / **`.env.minimal`**: Nueva variable `AUTO_START_SESSIONS=false` (opt-in)

## Related Issues
Closes #218
Refs #125 (partial — addresses the container-restart-persistence symptom of that umbrella issue, not the QR-generation case)
