### PR TITLE
chore(docker): upgrade Node.js version and include .npmrc in Dockerfiles

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 
 WORKDIR /app
 
-# Copy package files
-COPY package*.json ./
+# .npmrc (legacy-peer-deps) must be present before npm ci — matches local dev
+COPY package*.json .npmrc ./
 
 # Install dependencies
 RUN npm ci

--- a/dashboard/Dockerfile.traefik
+++ b/dashboard/Dockerfile.traefik
@@ -1,9 +1,10 @@
 # Dashboard with lightweight static file server for Traefik
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 
 WORKDIR /app
 
-COPY package*.json ./
+# .npmrc (legacy-peer-deps) must be present before npm ci — matches local dev
+COPY package*.json .npmrc ./
 RUN npm ci
 
 COPY . .


### PR DESCRIPTION
Updated the base image in both Dockerfiles from node:20-alpine to node:22-alpine. Added .npmrc to the COPY command to ensure legacy-peer-deps are handled correctly during npm installation.
