### PR TITLE
feat(dashboard): add Chinese translations

### DIFF
--- a/dashboard/src/components/Layout.css
+++ b/dashboard/src/components/Layout.css
@@ -195,6 +195,64 @@
   color: var(--text-primary);
 }
 
+.language-menu {
+  position: relative;
+}
+
+.language-menu .theme-toggle-btn {
+  width: 100%;
+}
+
+.language-menu-list {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: calc(100% + 0.35rem);
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 160px;
+  padding: 0.3rem;
+  background: var(--bg-white);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.16);
+  z-index: 120;
+}
+
+.language-menu-item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-height: 34px;
+  padding: 0.45rem 0.6rem;
+  color: var(--text-secondary);
+  background: transparent;
+  border: 0;
+  border-radius: calc(var(--radius) - 2px);
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.language-menu-item:hover {
+  background: var(--bg-light);
+  color: var(--text-primary);
+}
+
+.language-menu-item.active {
+  background: rgba(37, 211, 102, 0.1);
+  color: var(--primary);
+}
+
+.sidebar.collapsed .language-menu-list {
+  right: auto;
+  left: calc(100% + 0.5rem);
+  bottom: 0;
+}
+
 .logout-btn {
   display: flex;
   align-items: center;
@@ -350,6 +408,15 @@
 
 [dir="rtl"] .collapse-toggle svg {
   transform: scaleX(-1);
+}
+
+[dir="rtl"] .language-menu-item {
+  text-align: right;
+}
+
+[dir="rtl"] .sidebar.collapsed .language-menu-list {
+  right: calc(100% + 0.5rem);
+  left: auto;
 }
 
 [dir="rtl"] .main-content {

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { NavLink, Outlet } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
@@ -22,7 +22,7 @@ import {
 } from 'lucide-react';
 import { useTheme } from '../hooks/useTheme';
 import { type UserRole } from '../hooks/useRole';
-import { supportedLanguages, type SupportedLanguage } from '../i18n';
+import { languageOptions, resolveSupportedLanguage, type SupportedLanguage } from '../i18n';
 import './Layout.css';
 
 interface LayoutProps {
@@ -54,6 +54,8 @@ export function Layout({ onLogout, userRole }: LayoutProps) {
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [isMobileOpen, setIsMobileOpen] = useState(false);
   const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
+  const [isLanguageMenuOpen, setIsLanguageMenuOpen] = useState(false);
+  const languageMenuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const handleResize = () => {
@@ -76,16 +78,35 @@ export function Layout({ onLogout, userRole }: LayoutProps) {
     };
   }, [isMobileOpen]);
 
+  useEffect(() => {
+    if (!isLanguageMenuOpen) return;
+
+    const closeOnOutsideClick = (event: MouseEvent) => {
+      if (!languageMenuRef.current?.contains(event.target as Node)) {
+        setIsLanguageMenuOpen(false);
+      }
+    };
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setIsLanguageMenuOpen(false);
+    };
+
+    document.addEventListener('mousedown', closeOnOutsideClick);
+    document.addEventListener('keydown', closeOnEscape);
+    return () => {
+      document.removeEventListener('mousedown', closeOnOutsideClick);
+      document.removeEventListener('keydown', closeOnEscape);
+    };
+  }, [isLanguageMenuOpen]);
+
   const toggleCollapse = () => setIsCollapsed(!isCollapsed);
   const toggleMobile = () => setIsMobileOpen(!isMobileOpen);
 
-  const currentLang = (i18n.resolvedLanguage || i18n.language || 'en').split('-')[0] as SupportedLanguage;
-  const cycleLanguage = () => {
-    const idx = supportedLanguages.indexOf(currentLang);
-    const next = supportedLanguages[(idx + 1) % supportedLanguages.length];
-    void i18n.changeLanguage(next);
+  const currentLang = resolveSupportedLanguage(i18n.resolvedLanguage || i18n.language);
+  const languageLabel = languageOptions.find(option => option.value === currentLang)?.compactLabel ?? 'EN';
+  const changeLanguage = (language: SupportedLanguage) => {
+    setIsLanguageMenuOpen(false);
+    void i18n.changeLanguage(language);
   };
-  const languageLabel = currentLang === 'he' ? 'עברית' : 'EN';
   const isRtl = currentLang === 'he';
 
   return (
@@ -151,15 +172,34 @@ export function Layout({ onLogout, userRole }: LayoutProps) {
         </nav>
 
         <div className="sidebar-footer">
-          <button
-            className="theme-toggle-btn"
-            onClick={cycleLanguage}
-            title={t('common.language')}
-            aria-label={t('common.language')}
-          >
-            <Languages size={18} />
-            {!isCollapsed && <span>{languageLabel}</span>}
-          </button>
+          <div className="language-menu" ref={languageMenuRef}>
+            <button
+              className="theme-toggle-btn"
+              onClick={() => setIsLanguageMenuOpen(open => !open)}
+              title={t('common.language')}
+              aria-label={t('common.language')}
+              aria-haspopup="menu"
+              aria-expanded={isLanguageMenuOpen}
+            >
+              <Languages size={18} />
+              {!isCollapsed && <span>{languageLabel}</span>}
+            </button>
+            {isLanguageMenuOpen && (
+              <div className="language-menu-list" role="menu" aria-label={t('common.language')}>
+                {languageOptions.map(option => (
+                  <button
+                    key={option.value}
+                    className={`language-menu-item ${option.value === currentLang ? 'active' : ''}`}
+                    onClick={() => changeLanguage(option.value)}
+                    role="menuitemradio"
+                    aria-checked={option.value === currentLang}
+                  >
+                    <span>{option.label}</span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
           <button
             className="theme-toggle-btn"
             onClick={toggleTheme}

--- a/dashboard/src/i18n/index.ts
+++ b/dashboard/src/i18n/index.ts
@@ -3,11 +3,36 @@ import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import en from './locales/en.json';
 import he from './locales/he.json';
+import zhCN from './locales/zh-CN.json';
+import zhHK from './locales/zh-HK.json';
 
-export const supportedLanguages = ['en', 'he'] as const;
+export const supportedLanguages = ['en', 'he', 'zh-CN', 'zh-HK'] as const;
 export type SupportedLanguage = (typeof supportedLanguages)[number];
 
 export const rtlLanguages: SupportedLanguage[] = ['he'];
+
+export const languageOptions: Array<{ value: SupportedLanguage; label: string; compactLabel: string }> = [
+  { value: 'en', label: 'English', compactLabel: 'EN' },
+  { value: 'he', label: 'עברית', compactLabel: 'עברית' },
+  { value: 'zh-CN', label: '简体中文', compactLabel: '简中' },
+  { value: 'zh-HK', label: '繁體中文', compactLabel: '繁中' },
+];
+
+export function resolveSupportedLanguage(lang?: string): SupportedLanguage {
+  const value = lang || 'en';
+  const exact = supportedLanguages.find(supported => supported.toLowerCase() === value.toLowerCase());
+  if (exact) return exact;
+
+  const parts = value.toLowerCase().split('-');
+  const base = parts[0];
+  if (base === 'zh') {
+    const subtags = new Set(parts.slice(1));
+    if (subtags.has('hant') || subtags.has('hk') || subtags.has('mo') || subtags.has('tw')) return 'zh-HK';
+    return 'zh-CN';
+  }
+
+  return supportedLanguages.find(supported => supported === base) ?? 'en';
+}
 
 void i18n
   .use(LanguageDetector)
@@ -16,24 +41,27 @@ void i18n
     resources: {
       en: { translation: en },
       he: { translation: he },
+      'zh-CN': { translation: zhCN },
+      'zh-HK': { translation: zhHK },
     },
     fallbackLng: 'en',
     supportedLngs: supportedLanguages as unknown as string[],
-    nonExplicitSupportedLngs: true,
+    nonExplicitSupportedLngs: false,
     interpolation: { escapeValue: false },
     detection: {
       order: ['localStorage', 'navigator'],
       lookupLocalStorage: 'openwa_language',
       caches: ['localStorage'],
+      convertDetectedLanguage: (lang: string) => resolveSupportedLanguage(lang),
     },
     react: { useSuspense: false },
   });
 
 function applyDirection(lang: string) {
-  const base = (lang || 'en').split('-')[0] as SupportedLanguage;
-  const dir = rtlLanguages.includes(base) ? 'rtl' : 'ltr';
+  const resolved = resolveSupportedLanguage(lang);
+  const dir = rtlLanguages.includes(resolved) ? 'rtl' : 'ltr';
   if (typeof document !== 'undefined') {
-    document.documentElement.lang = base;
+    document.documentElement.lang = resolved;
     document.documentElement.dir = dir;
   }
 }

--- a/dashboard/src/i18n/locales/zh-CN.json
+++ b/dashboard/src/i18n/locales/zh-CN.json
@@ -1,0 +1,512 @@
+{
+  "common": {
+    "appName": "OpenWA",
+    "appSubtitle": "WhatsApp API",
+    "loading": "正在加载...",
+    "save": "保存",
+    "cancel": "取消",
+    "delete": "删除",
+    "edit": "编辑",
+    "create": "创建",
+    "close": "关闭",
+    "submit": "提交",
+    "confirm": "确认",
+    "search": "搜索",
+    "filter": "筛选",
+    "actions": "操作",
+    "status": "状态",
+    "name": "名称",
+    "role": "角色",
+    "type": "类型",
+    "url": "URL",
+    "port": "端口",
+    "host": "主机",
+    "username": "用户名",
+    "password": "密码",
+    "active": "活跃",
+    "inactive": "非活跃",
+    "enabled": "已启用",
+    "disabled": "已禁用",
+    "connected": "已连接",
+    "disconnected": "已断开",
+    "never": "从未",
+    "justNow": "刚刚",
+    "minAgo": "{{count}} 分钟前",
+    "hoursAgo": "{{count}} 小时前",
+    "optional": "可选",
+    "language": "语言",
+    "english": "English",
+    "hebrew": "עברית",
+    "back": "返回",
+    "next": "下一步",
+    "previous": "上一步",
+    "expand": "展开",
+    "collapse": "收起",
+    "logout": "退出登录",
+    "refresh": "刷新",
+    "errorGeneric": "发生错误",
+    "unknownError": "未知错误"
+  },
+  "theme": {
+    "light": "浅色",
+    "dark": "深色",
+    "system": "跟随系统",
+    "label": "主题：{{value}}"
+  },
+  "nav": {
+    "dashboard": "仪表盘",
+    "sessions": "会话",
+    "webhooks": "Webhooks",
+    "apiKeys": "API 密钥",
+    "messageTester": "消息测试器",
+    "infrastructure": "基础设施",
+    "plugins": "插件",
+    "logs": "日志"
+  },
+  "errorBoundary": {
+    "title": "出了点问题",
+    "description": "仪表盘遇到意外错误。",
+    "reload": "重新加载仪表盘"
+  },
+  "login": {
+    "apiKey": "API 密钥",
+    "apiKeyPlaceholder": "输入你的 API 密钥",
+    "apiKeyRequired": "必须输入 API 密钥",
+    "connect": "连接",
+    "connecting": "正在连接...",
+    "invalidKey": "API 密钥无效",
+    "connectionError": "无法连接到服务器。请重试。",
+    "help": "需要帮助？",
+    "viewDocs": "查看文档",
+    "footer": "由 Yudhi Armyndharis 和 OpenWA 社区用 ❤️ 打造",
+    "version": "v{{version}} · {{date}}"
+  },
+  "dashboard": {
+    "title": "仪表盘",
+    "subtitle": "查看你的 WhatsApp 会话和活动概览",
+    "stats": {
+      "activeSessions": "活跃会话",
+      "messagesToday": "今日消息",
+      "webhooksConfigured": "已配置 Webhook",
+      "apiCalls": "API 调用（24 小时）"
+    },
+    "sessionsOverview": "会话概览",
+    "showingSessions": "显示 {{shown}} / {{total}} 个会话",
+    "columns": {
+      "sessionId": "会话 ID",
+      "phone": "电话号码",
+      "status": "状态",
+      "lastActive": "上次活跃",
+      "actions": "操作"
+    },
+    "noSessions": "未找到会话。创建一个即可开始。",
+    "view": "查看",
+    "disconnect": "断开连接",
+    "errorPrefix": "错误：{{message}}",
+    "loadError": "加载数据失败"
+  },
+  "sessionStatus": {
+    "created": "新建",
+    "idle": "空闲",
+    "initializing": "正在启动...",
+    "connecting": "正在连接...",
+    "qr_ready": "扫描 QR",
+    "ready": "已连接",
+    "disconnected": "已断开"
+  },
+  "sessions": {
+    "title": "会话",
+    "subtitle": "管理你的 WhatsApp 会话和 QR 码连接",
+    "newSession": "新建会话",
+    "searchPlaceholder": "搜索会话...",
+    "filter": {
+      "all": "所有状态",
+      "active": "活跃（已连接）",
+      "inactive": "非活跃",
+      "connecting": "正在连接"
+    },
+    "empty": {
+      "title": "未找到会话",
+      "description": "创建新会话即可开始"
+    },
+    "create": {
+      "title": "创建新会话",
+      "label": "会话名称",
+      "placeholder": "例如：marketing-bot",
+      "hint": "只能使用小写字母、数字和连字符。例如：<code>customer-support</code>、<code>bot-1</code>",
+      "invalidChars": "字符无效。只能使用小写字母、数字和连字符。",
+      "tooLong": "名称长度不能超过 50 个字符（{{length}}/50）。",
+      "duplicate": "已存在同名会话。",
+      "successTitle": "会话已创建",
+      "successDesc": "会话 \"{{name}}\" 已成功创建",
+      "errorTitle": "创建失败",
+      "errorDefault": "创建会话失败"
+    },
+    "delete": {
+      "title": "确认删除",
+      "message": "确定要删除会话 <strong>\"{{name}}\"</strong> 吗？",
+      "warning": "此操作无法撤销。",
+      "successTitle": "会话已删除",
+      "successDescNamed": "会话 \"{{name}}\" 已删除",
+      "successDescGeneric": "会话已删除",
+      "errorTitle": "删除失败",
+      "errorDefault": "删除会话失败"
+    },
+    "qr": {
+      "title": "扫描 QR 码",
+      "step1": "<strong>1.</strong> 在手机上打开 WhatsApp",
+      "step2": "<strong>2.</strong> 点击<strong>菜单</strong> → <strong>已关联设备</strong>",
+      "step3": "<strong>3.</strong> 点击<strong>关联设备</strong>并扫描此 QR",
+      "autoRefresh": "QR 每 5 秒自动更新一次",
+      "generating": "正在生成 QR 码...",
+      "unavailable": "QR 码暂不可用。请稍后重试。",
+      "preparing": "正在准备 QR 码...",
+      "showQr": "显示 QR",
+      "loading": "正在加载...",
+      "scanToConnect": "扫描 QR 码以连接"
+    },
+    "details": {
+      "title": "会话详情",
+      "name": "名称",
+      "status": "状态",
+      "sessionId": "会话 ID",
+      "phone": "电话号码",
+      "phoneNone": "未连接",
+      "created": "创建时间",
+      "lastActive": "上次活跃"
+    },
+    "actions": {
+      "view": "查看",
+      "start": "启动",
+      "stop": "停止",
+      "reconnect": "重新连接",
+      "delete": "删除"
+    },
+    "toasts": {
+      "readyTitle": "会话就绪",
+      "readyDesc": "WhatsApp 会话现已连接",
+      "disconnectedTitle": "会话已断开",
+      "disconnectedDesc": "WhatsApp 会话已断开连接"
+    },
+    "card": {
+      "phone": "电话",
+      "sessionId": "会话 ID",
+      "lastActive": "上次活跃"
+    }
+  },
+  "webhooks": {
+    "title": "Webhooks",
+    "subtitle": "配置用于实时事件通知的 HTTP 回调",
+    "addWebhook": "添加 Webhook",
+    "createTitle": "创建 Webhook",
+    "editTitle": "编辑 Webhook",
+    "deleteTitle": "删除 Webhook",
+    "deleteConfirm": "确定要删除此 webhook 吗？",
+    "selectSession": "选择会话...",
+    "session": "会话",
+    "events": "事件",
+    "available": "可用事件",
+    "saveChanges": "保存更改",
+    "columns": {
+      "url": "URL",
+      "events": "事件",
+      "session": "会话",
+      "status": "状态",
+      "actions": "操作"
+    },
+    "empty": {
+      "title": "尚未配置 Webhook",
+      "description": "添加 Webhook 以接收实时事件通知"
+    },
+    "toasts": {
+      "created": "Webhook 创建成功",
+      "createFailed": "创建 Webhook 失败：{{message}}",
+      "deleted": "Webhook 删除成功",
+      "deleteFailed": "删除 Webhook 失败：{{message}}",
+      "updated": "Webhook 更新成功",
+      "updateFailed": "更新 Webhook 失败：{{message}}",
+      "testOk": "Webhook 测试成功！状态：{{status}}",
+      "testFailed": "Webhook 测试失败：{{message}}",
+      "testError": "测试 Webhook 失败：{{message}}"
+    },
+    "actions": {
+      "test": "测试",
+      "edit": "编辑",
+      "delete": "删除"
+    },
+    "eventDescriptions": {
+      "message.received": "收到消息时",
+      "message.sent": "发送消息时",
+      "session.connected": "会话连接时",
+      "session.disconnected": "会话断开时",
+      "session.qr": "生成 QR 码时",
+      "all": "所有事件"
+    }
+  },
+  "apiKeys": {
+    "title": "API 密钥",
+    "subtitle": "管理用于认证和访问控制的 API 密钥",
+    "createBtn": "创建 API 密钥",
+    "modalTitle": "创建 API 密钥",
+    "createdTitle": "API 密钥已创建",
+    "createdHint": "请立即复制此密钥。之后将无法再次查看。",
+    "namePlaceholder": "例如：Production Key",
+    "rolesTitle": "角色参考",
+    "roles": {
+      "admin": "管理员",
+      "operator": "操作员",
+      "viewer": "查看者"
+    },
+    "roleDescriptions": {
+      "admin": "可完全访问所有资源",
+      "operator": "会话和消息管理",
+      "viewer": "只读访问"
+    },
+    "columns": {
+      "name": "名称",
+      "key": "密钥",
+      "role": "角色",
+      "status": "状态",
+      "lastUsed": "上次使用",
+      "actions": "操作"
+    },
+    "statuses": {
+      "active": "活跃",
+      "revoked": "已撤销"
+    },
+    "empty": {
+      "title": "尚未创建 API 密钥",
+      "description": "创建 API 密钥以认证你的请求"
+    },
+    "confirm": {
+      "deleteTitle": "删除 API 密钥",
+      "revokeTitle": "撤销 API 密钥",
+      "deleteMessage": "确定要永久删除 <strong>{{name}}</strong> 吗？此操作无法撤销。",
+      "revokeMessage": "确定要撤销 <strong>{{name}}</strong> 吗？它将不再可用。",
+      "delete": "删除",
+      "revoke": "撤销"
+    },
+    "actions": {
+      "copy": "复制",
+      "revoke": "撤销",
+      "delete": "删除"
+    }
+  },
+  "logs": {
+    "title": "审计日志",
+    "subtitle": "跟踪并查看所有 API 操作和系统事件",
+    "exportCsv": "导出 CSV",
+    "searchPlaceholder": "搜索日志...",
+    "severity": {
+      "all": "所有严重级别",
+      "info": "信息",
+      "warn": "警告",
+      "error": "错误"
+    },
+    "columns": {
+      "timestamp": "时间戳",
+      "action": "操作",
+      "session": "会话",
+      "apiKey": "API 密钥",
+      "ip": "IP 地址",
+      "severity": "严重级别"
+    },
+    "empty": {
+      "title": "未找到日志",
+      "description": "执行操作后，审计日志将显示在这里"
+    }
+  },
+  "messageTester": {
+    "title": "消息测试器",
+    "subtitle": "通过 API 发送测试消息",
+    "compose": "发送测试消息",
+    "responseTitle": "API 响应",
+    "session": "会话",
+    "noReadySessions": "没有就绪的会话",
+    "sessionOptionPhoneNone": "无电话",
+    "recipientType": "接收方类型",
+    "personal": "个人",
+    "group": "群组",
+    "selectGroup": "选择群组",
+    "recipientPhone": "接收方电话号码",
+    "loadingGroups": "正在加载群组...",
+    "noGroupsFound": "未找到群组",
+    "selectGroupHint": "从你的 WhatsApp 中选择一个群组",
+    "phoneHint": "使用无空格的国际格式",
+    "messageType": "消息类型",
+    "types": {
+      "text": "文本",
+      "image": "图片",
+      "video": "视频",
+      "audio": "音频",
+      "document": "文档"
+    },
+    "messageContent": "消息内容",
+    "messagePlaceholder": "在此输入你的消息...",
+    "mediaUrl": "媒体 URL",
+    "caption": "说明文字",
+    "filename": "文件名",
+    "captionPlaceholder": "输入说明文字...",
+    "filenamePlaceholder": "document.pdf",
+    "send": "发送消息",
+    "sending": "正在发送...",
+    "viewOnly": "仅查看",
+    "responseEmpty": "发送消息后即可查看 API 响应",
+    "successLabel": "200 OK - 成功",
+    "failedLabel": "400 - 失败",
+    "response": {
+      "timestamp": "时间戳",
+      "messageId": "消息 ID",
+      "error": "错误"
+    },
+    "sendFailed": "发送消息失败"
+  },
+  "infrastructure": {
+    "title": "基础设施",
+    "subtitle": "配置服务器、数据库、缓存、存储和引擎设置",
+    "saveConfig": "保存配置",
+    "saving": "正在保存...",
+    "server": {
+      "title": "服务器配置",
+      "production": "生产",
+      "development": "开发",
+      "environment": "环境",
+      "domain": "域名",
+      "apiPort": "API 端口",
+      "dashboardPort": "仪表盘端口",
+      "corsOrigins": "CORS 来源",
+      "corsPlaceholder": "* 或用逗号分隔的来源",
+      "publicApiUrl": "公共 API URL（可选）",
+      "publicDashboardUrl": "公共仪表盘 URL（可选）"
+    },
+    "webhook": {
+      "title": "Webhook 和速率限制",
+      "settings": "Webhook 设置",
+      "timeout": "超时（毫秒）",
+      "maxRetries": "最大重试次数",
+      "retryDelay": "重试延迟（毫秒）",
+      "rateLimit": "速率限制",
+      "window": "时间窗口（秒）",
+      "maxReq": "每个窗口最大请求数"
+    },
+    "database": {
+      "title": "数据库配置",
+      "sqlite": "SQLite",
+      "sqliteDesc": "本地文件型数据库",
+      "postgres": "PostgreSQL",
+      "postgresDesc": "适用于生产的数据库",
+      "useBuiltIn": "使用内置 PostgreSQL 容器",
+      "builtInDesc": "OpenWA 将为你管理 PostgreSQL 容器",
+      "dbName": "数据库名称",
+      "poolSize": "连接池大小",
+      "ssl": "SSL 连接",
+      "sslDesc": "启用 TLS/SSL 以保障数据库连接安全",
+      "migrationsTitle": "数据库迁移",
+      "migrationsStatus": "架构会通过 TypeORM 自动同步",
+      "migrationsHint": "迁移会自动管理。手动迁移请使用 CLI。"
+    },
+    "redis": {
+      "title": "Redis",
+      "enable": "启用 Redis",
+      "enableDesc": "缓存、会话存储和 BullMQ 队列需要 Redis",
+      "useBuiltIn": "使用内置 Redis 容器",
+      "builtInDesc": "OpenWA 将为你管理 Redis 容器",
+      "queueTitle": "启用 BullMQ 队列系统",
+      "queueDesc": "使用消息队列可靠地投递消息和 Webhook",
+      "statsTitle": "队列统计",
+      "messageQueue": "消息队列",
+      "webhookQueue": "Webhook 队列",
+      "pending": "待处理",
+      "completed": "已完成",
+      "failed": "失败",
+      "clearFailed": "清除失败任务",
+      "viewBullMq": "查看 Bull MQ 仪表盘",
+      "disabledTitle": "Redis 已禁用",
+      "disabledDesc": "启用 Redis 以使用缓存、会话存储和 BullMQ 消息队列。",
+      "passwordOptional": "（可选）"
+    },
+    "storage": {
+      "title": "存储配置",
+      "local": "本地文件系统",
+      "localDesc": "在本地存储媒体文件",
+      "s3": "Amazon S3",
+      "s3Desc": "云存储（兼容 S3）",
+      "useBuiltIn": "使用内置 MinIO 容器",
+      "builtInDesc": "OpenWA 将为你管理 MinIO（兼容 S3）容器",
+      "storagePath": "存储路径",
+      "bucket": "存储桶名称",
+      "region": "区域",
+      "accessKey": "访问密钥",
+      "secretKey": "秘密密钥",
+      "endpoint": "自定义端点（可选）",
+      "endpointHint": "适用于 MinIO 或其他兼容 S3 的服务"
+    },
+    "statusLabels": {
+      "connected": "已连接",
+      "disconnected": "已断开",
+      "disabled": "已禁用"
+    },
+    "restart": {
+      "idleTitle": "⚙️ 配置已保存",
+      "restartingTitle": "🔄 正在重启服务器...",
+      "waitingTitle": "⏳ 请稍候...",
+      "successTitle": "✅ 服务器就绪",
+      "errorTitle": "❌ 重启失败",
+      "idleDesc": "配置已保存到 <code>.env.generated</code>。<br/>需要重启服务器才能应用更改。",
+      "later": "稍后重启",
+      "now": "立即重启",
+      "restartingMsg": "服务器正在重启... {{count}} 秒",
+      "checking": "正在检查服务器状态...",
+      "dontClose": "请不要关闭此窗口",
+      "successMsg": "服务器已恢复在线！页面将自动重新加载。",
+      "errorMsg": "服务器在 30 秒后仍无响应。请检查 Docker 日志并手动重启。",
+      "reload": "重新加载页面"
+    },
+    "toasts": {
+      "saveFailed": "保存失败"
+    }
+  },
+  "plugins": {
+    "title": "插件",
+    "subtitle": "管理引擎、存储后端和扩展",
+    "refresh": "刷新",
+    "engineCard": "当前 WhatsApp 引擎",
+    "running": "运行中",
+    "supportedFeatures": "支持的功能：",
+    "more": "+{{count}} 更多",
+    "builtIn": "内置",
+    "noDescription": "没有可用描述",
+    "required": "必需",
+    "active": "活跃",
+    "activate": "激活",
+    "enable": "启用",
+    "disable": "禁用",
+    "healthCheck": "健康检查",
+    "configure": "配置",
+    "empty": {
+      "title": "未找到插件",
+      "description": "安装插件以扩展 OpenWA 功能"
+    },
+    "config": {
+      "title": "配置 {{name}}",
+      "restartNotice": "更改需要重启服务器后才会生效",
+      "engineType": "引擎类型",
+      "headless": "无头模式",
+      "headlessDesc": "运行不显示界面的浏览器（推荐用于生产环境）",
+      "sessionDataPath": "会话数据路径",
+      "browserArgs": "浏览器参数",
+      "noOptions": "此插件没有可用配置项",
+      "save": "保存配置"
+    },
+    "toasts": {
+      "errorTitle": "插件错误",
+      "errorDefault": "切换插件失败",
+      "healthOk": "健康检查通过",
+      "healthFail": "健康检查失败",
+      "healthError": "健康检查出错",
+      "savedTitle": "配置已保存",
+      "savedDesc": "需要重启服务器以应用更改。",
+      "saveFailed": "保存失败"
+    }
+  }
+}

--- a/dashboard/src/i18n/locales/zh-HK.json
+++ b/dashboard/src/i18n/locales/zh-HK.json
@@ -1,0 +1,512 @@
+{
+  "common": {
+    "appName": "OpenWA",
+    "appSubtitle": "WhatsApp API",
+    "loading": "正在載入...",
+    "save": "儲存",
+    "cancel": "取消",
+    "delete": "刪除",
+    "edit": "編輯",
+    "create": "建立",
+    "close": "關閉",
+    "submit": "提交",
+    "confirm": "確認",
+    "search": "搜尋",
+    "filter": "篩選",
+    "actions": "操作",
+    "status": "狀態",
+    "name": "名稱",
+    "role": "角色",
+    "type": "類型",
+    "url": "URL",
+    "port": "連接埠",
+    "host": "主機",
+    "username": "用戶名稱",
+    "password": "密碼",
+    "active": "活躍",
+    "inactive": "非活躍",
+    "enabled": "已啟用",
+    "disabled": "已停用",
+    "connected": "已連線",
+    "disconnected": "已中斷連線",
+    "never": "從未",
+    "justNow": "剛剛",
+    "minAgo": "{{count}} 分鐘前",
+    "hoursAgo": "{{count}} 小時前",
+    "optional": "選填",
+    "language": "語言",
+    "english": "English",
+    "hebrew": "עברית",
+    "back": "返回",
+    "next": "下一步",
+    "previous": "上一步",
+    "expand": "展開",
+    "collapse": "收合",
+    "logout": "登出",
+    "refresh": "重新整理",
+    "errorGeneric": "發生錯誤",
+    "unknownError": "未知錯誤"
+  },
+  "theme": {
+    "light": "淺色",
+    "dark": "深色",
+    "system": "跟隨系統",
+    "label": "主題：{{value}}"
+  },
+  "nav": {
+    "dashboard": "控制面板",
+    "sessions": "工作階段",
+    "webhooks": "Webhooks",
+    "apiKeys": "API 金鑰",
+    "messageTester": "訊息測試器",
+    "infrastructure": "基礎架構",
+    "plugins": "外掛",
+    "logs": "記錄"
+  },
+  "errorBoundary": {
+    "title": "發生問題",
+    "description": "控制面板遇到未預期的錯誤。",
+    "reload": "重新載入控制面板"
+  },
+  "login": {
+    "apiKey": "API 金鑰",
+    "apiKeyPlaceholder": "輸入你的 API 金鑰",
+    "apiKeyRequired": "必須輸入 API 金鑰",
+    "connect": "連線",
+    "connecting": "正在連線...",
+    "invalidKey": "API 金鑰無效",
+    "connectionError": "無法連線到伺服器。請再試一次。",
+    "help": "需要協助？",
+    "viewDocs": "查看文件",
+    "footer": "由 Yudhi Armyndharis 及 OpenWA 社群用 ❤️ 打造",
+    "version": "v{{version}} · {{date}}"
+  },
+  "dashboard": {
+    "title": "控制面板",
+    "subtitle": "查看你的 WhatsApp 工作階段及活動概覽",
+    "stats": {
+      "activeSessions": "活躍工作階段",
+      "messagesToday": "今日訊息",
+      "webhooksConfigured": "已設定 Webhook",
+      "apiCalls": "API 呼叫（24 小時）"
+    },
+    "sessionsOverview": "工作階段概覽",
+    "showingSessions": "顯示 {{shown}} / {{total}} 個工作階段",
+    "columns": {
+      "sessionId": "工作階段 ID",
+      "phone": "電話號碼",
+      "status": "狀態",
+      "lastActive": "上次活躍",
+      "actions": "操作"
+    },
+    "noSessions": "找不到工作階段。建立一個即可開始。",
+    "view": "查看",
+    "disconnect": "中斷連線",
+    "errorPrefix": "錯誤：{{message}}",
+    "loadError": "載入資料失敗"
+  },
+  "sessionStatus": {
+    "created": "新增",
+    "idle": "閒置",
+    "initializing": "正在啟動...",
+    "connecting": "正在連線...",
+    "qr_ready": "掃描 QR",
+    "ready": "已連線",
+    "disconnected": "已中斷連線"
+  },
+  "sessions": {
+    "title": "工作階段",
+    "subtitle": "管理你的 WhatsApp 工作階段及 QR 碼連線",
+    "newSession": "新增工作階段",
+    "searchPlaceholder": "搜尋工作階段...",
+    "filter": {
+      "all": "所有狀態",
+      "active": "活躍（已連線）",
+      "inactive": "非活躍",
+      "connecting": "正在連線"
+    },
+    "empty": {
+      "title": "找不到工作階段",
+      "description": "建立新工作階段即可開始"
+    },
+    "create": {
+      "title": "建立新工作階段",
+      "label": "工作階段名稱",
+      "placeholder": "例如：marketing-bot",
+      "hint": "只可使用小寫字母、數字及連字號。例如：<code>customer-support</code>、<code>bot-1</code>",
+      "invalidChars": "字元無效。只可使用小寫字母、數字及連字號。",
+      "tooLong": "名稱不可超過 50 個字元（{{length}}/50）。",
+      "duplicate": "已存在同名工作階段。",
+      "successTitle": "工作階段已建立",
+      "successDesc": "工作階段 \"{{name}}\" 已成功建立",
+      "errorTitle": "建立失敗",
+      "errorDefault": "建立工作階段失敗"
+    },
+    "delete": {
+      "title": "確認刪除",
+      "message": "確定要刪除工作階段 <strong>\"{{name}}\"</strong> 嗎？",
+      "warning": "此操作無法復原。",
+      "successTitle": "工作階段已刪除",
+      "successDescNamed": "工作階段 \"{{name}}\" 已刪除",
+      "successDescGeneric": "工作階段已刪除",
+      "errorTitle": "刪除失敗",
+      "errorDefault": "刪除工作階段失敗"
+    },
+    "qr": {
+      "title": "掃描 QR 碼",
+      "step1": "<strong>1.</strong> 在手機上開啟 WhatsApp",
+      "step2": "<strong>2.</strong> 點按<strong>選單</strong> → <strong>已連結裝置</strong>",
+      "step3": "<strong>3.</strong> 點按<strong>連結裝置</strong>並掃描此 QR",
+      "autoRefresh": "QR 每 5 秒自動更新一次",
+      "generating": "正在產生 QR 碼...",
+      "unavailable": "QR 碼暫時未能使用。請稍後再試。",
+      "preparing": "正在準備 QR 碼...",
+      "showQr": "顯示 QR",
+      "loading": "正在載入...",
+      "scanToConnect": "掃描 QR 碼以連線"
+    },
+    "details": {
+      "title": "工作階段詳情",
+      "name": "名稱",
+      "status": "狀態",
+      "sessionId": "工作階段 ID",
+      "phone": "電話號碼",
+      "phoneNone": "未連線",
+      "created": "建立時間",
+      "lastActive": "上次活躍"
+    },
+    "actions": {
+      "view": "查看",
+      "start": "啟動",
+      "stop": "停止",
+      "reconnect": "重新連線",
+      "delete": "刪除"
+    },
+    "toasts": {
+      "readyTitle": "工作階段就緒",
+      "readyDesc": "WhatsApp 工作階段現已連線",
+      "disconnectedTitle": "工作階段已中斷連線",
+      "disconnectedDesc": "WhatsApp 工作階段已中斷連線"
+    },
+    "card": {
+      "phone": "電話",
+      "sessionId": "工作階段 ID",
+      "lastActive": "上次活躍"
+    }
+  },
+  "webhooks": {
+    "title": "Webhooks",
+    "subtitle": "設定用於即時事件通知的 HTTP 回呼",
+    "addWebhook": "新增 Webhook",
+    "createTitle": "建立 Webhook",
+    "editTitle": "編輯 Webhook",
+    "deleteTitle": "刪除 Webhook",
+    "deleteConfirm": "確定要刪除此 webhook 嗎？",
+    "selectSession": "選擇工作階段...",
+    "session": "工作階段",
+    "events": "事件",
+    "available": "可用事件",
+    "saveChanges": "儲存變更",
+    "columns": {
+      "url": "URL",
+      "events": "事件",
+      "session": "工作階段",
+      "status": "狀態",
+      "actions": "操作"
+    },
+    "empty": {
+      "title": "尚未設定 Webhook",
+      "description": "新增 Webhook 以接收即時事件通知"
+    },
+    "toasts": {
+      "created": "Webhook 建立成功",
+      "createFailed": "建立 Webhook 失敗：{{message}}",
+      "deleted": "Webhook 刪除成功",
+      "deleteFailed": "刪除 Webhook 失敗：{{message}}",
+      "updated": "Webhook 更新成功",
+      "updateFailed": "更新 Webhook 失敗：{{message}}",
+      "testOk": "Webhook 測試成功！狀態：{{status}}",
+      "testFailed": "Webhook 測試失敗：{{message}}",
+      "testError": "測試 Webhook 失敗：{{message}}"
+    },
+    "actions": {
+      "test": "測試",
+      "edit": "編輯",
+      "delete": "刪除"
+    },
+    "eventDescriptions": {
+      "message.received": "收到訊息時",
+      "message.sent": "傳送訊息時",
+      "session.connected": "工作階段連線時",
+      "session.disconnected": "工作階段中斷連線時",
+      "session.qr": "產生 QR 碼時",
+      "all": "所有事件"
+    }
+  },
+  "apiKeys": {
+    "title": "API 金鑰",
+    "subtitle": "管理用於認證及存取控制的 API 金鑰",
+    "createBtn": "建立 API 金鑰",
+    "modalTitle": "建立 API 金鑰",
+    "createdTitle": "API 金鑰已建立",
+    "createdHint": "請立即複製此金鑰。之後將無法再次查看。",
+    "namePlaceholder": "例如：Production Key",
+    "rolesTitle": "角色參考",
+    "roles": {
+      "admin": "管理員",
+      "operator": "操作員",
+      "viewer": "檢視者"
+    },
+    "roleDescriptions": {
+      "admin": "可完整存取所有資源",
+      "operator": "工作階段及訊息管理",
+      "viewer": "唯讀存取"
+    },
+    "columns": {
+      "name": "名稱",
+      "key": "金鑰",
+      "role": "角色",
+      "status": "狀態",
+      "lastUsed": "上次使用",
+      "actions": "操作"
+    },
+    "statuses": {
+      "active": "活躍",
+      "revoked": "已撤銷"
+    },
+    "empty": {
+      "title": "尚未建立 API 金鑰",
+      "description": "建立 API 金鑰以認證你的請求"
+    },
+    "confirm": {
+      "deleteTitle": "刪除 API 金鑰",
+      "revokeTitle": "撤銷 API 金鑰",
+      "deleteMessage": "確定要永久刪除 <strong>{{name}}</strong> 嗎？此操作無法復原。",
+      "revokeMessage": "確定要撤銷 <strong>{{name}}</strong> 嗎？它將無法再使用。",
+      "delete": "刪除",
+      "revoke": "撤銷"
+    },
+    "actions": {
+      "copy": "複製",
+      "revoke": "撤銷",
+      "delete": "刪除"
+    }
+  },
+  "logs": {
+    "title": "審計記錄",
+    "subtitle": "追蹤及查看所有 API 操作和系統事件",
+    "exportCsv": "匯出 CSV",
+    "searchPlaceholder": "搜尋記錄...",
+    "severity": {
+      "all": "所有嚴重程度",
+      "info": "資訊",
+      "warn": "警告",
+      "error": "錯誤"
+    },
+    "columns": {
+      "timestamp": "時間戳記",
+      "action": "操作",
+      "session": "工作階段",
+      "apiKey": "API 金鑰",
+      "ip": "IP 位址",
+      "severity": "嚴重程度"
+    },
+    "empty": {
+      "title": "找不到記錄",
+      "description": "執行操作後，審計記錄會顯示在這裡"
+    }
+  },
+  "messageTester": {
+    "title": "訊息測試器",
+    "subtitle": "透過 API 傳送測試訊息",
+    "compose": "傳送測試訊息",
+    "responseTitle": "API 回應",
+    "session": "工作階段",
+    "noReadySessions": "沒有就緒的工作階段",
+    "sessionOptionPhoneNone": "沒有電話",
+    "recipientType": "接收者類型",
+    "personal": "個人",
+    "group": "群組",
+    "selectGroup": "選擇群組",
+    "recipientPhone": "接收者電話號碼",
+    "loadingGroups": "正在載入群組...",
+    "noGroupsFound": "找不到群組",
+    "selectGroupHint": "從你的 WhatsApp 選擇一個群組",
+    "phoneHint": "使用不含空格的國際格式",
+    "messageType": "訊息類型",
+    "types": {
+      "text": "文字",
+      "image": "圖片",
+      "video": "影片",
+      "audio": "音訊",
+      "document": "文件"
+    },
+    "messageContent": "訊息內容",
+    "messagePlaceholder": "在此輸入你的訊息...",
+    "mediaUrl": "媒體 URL",
+    "caption": "說明文字",
+    "filename": "檔案名稱",
+    "captionPlaceholder": "輸入說明文字...",
+    "filenamePlaceholder": "document.pdf",
+    "send": "傳送訊息",
+    "sending": "正在傳送...",
+    "viewOnly": "僅檢視",
+    "responseEmpty": "傳送訊息後即可查看 API 回應",
+    "successLabel": "200 OK - 成功",
+    "failedLabel": "400 - 失敗",
+    "response": {
+      "timestamp": "時間戳記",
+      "messageId": "訊息 ID",
+      "error": "錯誤"
+    },
+    "sendFailed": "傳送訊息失敗"
+  },
+  "infrastructure": {
+    "title": "基礎架構",
+    "subtitle": "設定伺服器、資料庫、快取、儲存空間和引擎設定",
+    "saveConfig": "儲存設定",
+    "saving": "正在儲存...",
+    "server": {
+      "title": "伺服器設定",
+      "production": "生產",
+      "development": "開發",
+      "environment": "環境",
+      "domain": "網域",
+      "apiPort": "API 連接埠",
+      "dashboardPort": "控制面板連接埠",
+      "corsOrigins": "CORS 來源",
+      "corsPlaceholder": "* 或以逗號分隔的來源",
+      "publicApiUrl": "公開 API URL（選填）",
+      "publicDashboardUrl": "公開控制面板 URL（選填）"
+    },
+    "webhook": {
+      "title": "Webhook 及速率限制",
+      "settings": "Webhook 設定",
+      "timeout": "逾時（毫秒）",
+      "maxRetries": "最大重試次數",
+      "retryDelay": "重試延遲（毫秒）",
+      "rateLimit": "速率限制",
+      "window": "時間視窗（秒）",
+      "maxReq": "每個視窗最大請求數"
+    },
+    "database": {
+      "title": "資料庫設定",
+      "sqlite": "SQLite",
+      "sqliteDesc": "本機檔案型資料庫",
+      "postgres": "PostgreSQL",
+      "postgresDesc": "適用於生產環境的資料庫",
+      "useBuiltIn": "使用內置 PostgreSQL 容器",
+      "builtInDesc": "OpenWA 會為你管理 PostgreSQL 容器",
+      "dbName": "資料庫名稱",
+      "poolSize": "連線池大小",
+      "ssl": "SSL 連線",
+      "sslDesc": "啟用 TLS/SSL 以保障資料庫連線安全",
+      "migrationsTitle": "資料庫遷移",
+      "migrationsStatus": "結構會透過 TypeORM 自動同步",
+      "migrationsHint": "遷移會自動管理。手動遷移請使用 CLI。"
+    },
+    "redis": {
+      "title": "Redis",
+      "enable": "啟用 Redis",
+      "enableDesc": "快取、工作階段儲存及 BullMQ 佇列需要 Redis",
+      "useBuiltIn": "使用內置 Redis 容器",
+      "builtInDesc": "OpenWA 會為你管理 Redis 容器",
+      "queueTitle": "啟用 BullMQ 佇列系統",
+      "queueDesc": "使用訊息佇列可靠地傳遞訊息和 Webhook",
+      "statsTitle": "佇列統計",
+      "messageQueue": "訊息佇列",
+      "webhookQueue": "Webhook 佇列",
+      "pending": "待處理",
+      "completed": "已完成",
+      "failed": "失敗",
+      "clearFailed": "清除失敗任務",
+      "viewBullMq": "查看 Bull MQ 控制面板",
+      "disabledTitle": "Redis 已停用",
+      "disabledDesc": "啟用 Redis 以使用快取、工作階段儲存及 BullMQ 訊息佇列。",
+      "passwordOptional": "（選填）"
+    },
+    "storage": {
+      "title": "儲存空間設定",
+      "local": "本機檔案系統",
+      "localDesc": "在本機儲存媒體檔案",
+      "s3": "Amazon S3",
+      "s3Desc": "雲端儲存空間（兼容 S3）",
+      "useBuiltIn": "使用內置 MinIO 容器",
+      "builtInDesc": "OpenWA 會為你管理 MinIO（兼容 S3）容器",
+      "storagePath": "儲存路徑",
+      "bucket": "儲存桶名稱",
+      "region": "區域",
+      "accessKey": "存取金鑰",
+      "secretKey": "秘密金鑰",
+      "endpoint": "自訂端點（選填）",
+      "endpointHint": "適用於 MinIO 或其他兼容 S3 的服務"
+    },
+    "statusLabels": {
+      "connected": "已連線",
+      "disconnected": "已中斷連線",
+      "disabled": "已停用"
+    },
+    "restart": {
+      "idleTitle": "⚙️ 設定已儲存",
+      "restartingTitle": "🔄 正在重新啟動伺服器...",
+      "waitingTitle": "⏳ 請稍候...",
+      "successTitle": "✅ 伺服器就緒",
+      "errorTitle": "❌ 重新啟動失敗",
+      "idleDesc": "設定已儲存到 <code>.env.generated</code>。<br/>需要重新啟動伺服器才能套用變更。",
+      "later": "稍後重新啟動",
+      "now": "立即重新啟動",
+      "restartingMsg": "伺服器正在重新啟動... {{count}} 秒",
+      "checking": "正在檢查伺服器狀態...",
+      "dontClose": "請不要關閉此視窗",
+      "successMsg": "伺服器已重新上線！頁面將自動重新載入。",
+      "errorMsg": "伺服器在 30 秒後仍未回應。請檢查 Docker 記錄並手動重新啟動。",
+      "reload": "重新載入頁面"
+    },
+    "toasts": {
+      "saveFailed": "儲存失敗"
+    }
+  },
+  "plugins": {
+    "title": "外掛",
+    "subtitle": "管理引擎、儲存後端和擴充功能",
+    "refresh": "重新整理",
+    "engineCard": "目前 WhatsApp 引擎",
+    "running": "執行中",
+    "supportedFeatures": "支援功能：",
+    "more": "+{{count}} 更多",
+    "builtIn": "內置",
+    "noDescription": "沒有可用描述",
+    "required": "必需",
+    "active": "活躍",
+    "activate": "啟用",
+    "enable": "啟用",
+    "disable": "停用",
+    "healthCheck": "健康檢查",
+    "configure": "設定",
+    "empty": {
+      "title": "找不到外掛",
+      "description": "安裝外掛以擴展 OpenWA 功能"
+    },
+    "config": {
+      "title": "設定 {{name}}",
+      "restartNotice": "變更需要重新啟動伺服器後才會生效",
+      "engineType": "引擎類型",
+      "headless": "無頭模式",
+      "headlessDesc": "執行不顯示介面的瀏覽器（建議用於生產環境）",
+      "sessionDataPath": "工作階段資料路徑",
+      "browserArgs": "瀏覽器參數",
+      "noOptions": "此外掛沒有可用設定選項",
+      "save": "儲存設定"
+    },
+    "toasts": {
+      "errorTitle": "外掛錯誤",
+      "errorDefault": "切換外掛失敗",
+      "healthOk": "健康檢查通過",
+      "healthFail": "健康檢查失敗",
+      "healthError": "健康檢查錯誤",
+      "savedTitle": "設定已儲存",
+      "savedDesc": "需要重新啟動伺服器以套用變更。",
+      "saveFailed": "儲存失敗"
+    }
+  }
+}

--- a/dashboard/src/pages/Login.css
+++ b/dashboard/src/pages/Login.css
@@ -45,6 +45,39 @@
   font-weight: 500;
 }
 
+.login-language {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  width: 100%;
+  margin-bottom: 1.5rem;
+  padding: 0.65rem 0.8rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-secondary);
+  background: var(--bg-white);
+}
+
+.login-language svg {
+  flex-shrink: 0;
+}
+
+.login-language select {
+  flex: 1;
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  color: var(--text-primary);
+  background: transparent;
+  font: inherit;
+  cursor: pointer;
+}
+
+.login-language:focus-within {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(37, 211, 102, 0.1);
+}
+
 .login-title {
   font-size: 1.75rem;
   font-weight: 600;
@@ -59,6 +92,10 @@
 
 .login-form {
   text-align: left;
+}
+
+[dir="rtl"] .login-form {
+  text-align: right;
 }
 
 .input-group {

--- a/dashboard/src/pages/Login.tsx
+++ b/dashboard/src/pages/Login.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Eye, EyeOff } from 'lucide-react';
+import { Eye, EyeOff, Languages } from 'lucide-react';
 import { GithubIcon } from '../components/GithubIcon';
+import { languageOptions, resolveSupportedLanguage, type SupportedLanguage } from '../i18n';
 import './Login.css';
 
 interface LoginProps {
@@ -9,11 +10,16 @@ interface LoginProps {
 }
 
 export function Login({ onLogin }: LoginProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [apiKey, setApiKey] = useState('');
   const [showKey, setShowKey] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
+  const currentLang = resolveSupportedLanguage(i18n.resolvedLanguage || i18n.language);
+
+  const changeLanguage = (language: SupportedLanguage) => {
+    void i18n.changeLanguage(language);
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -58,6 +64,22 @@ export function Login({ onLogin }: LoginProps) {
             })}
           </span>
         </div>
+
+        <div className="login-language">
+          <Languages size={18} />
+          <select
+            value={currentLang}
+            onChange={event => changeLanguage(event.target.value as SupportedLanguage)}
+            aria-label={t('common.language')}
+          >
+            {languageOptions.map(option => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
         <form onSubmit={handleSubmit} className="login-form">
           <div className="input-group">
             <label htmlFor="apiKey">{t('login.apiKey')}</label>


### PR DESCRIPTION
## Description
Adds Simplified Chinese (`zh-CN`) and Hong Kong Traditional Chinese (`zh-HK`) translations for the dashboard. Also updates the language selector from a two-language cycle button to a four-language selector, and adds language selection to the login form before authentication.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] Lint passes
- [x] Self-reviewed

## Screenshots (if applicable)
<img width="315" height="489" alt="Screenshot 2026-05-28 at 9 31 53" src="https://github.com/user-attachments/assets/706939fc-8a38-4fc1-85e0-2cee02428310" />
<img width="667" height="789" alt="Screenshot 2026-05-28 at 9 31 44" src="https://github.com/user-attachments/assets/4826bc66-ab34-44c2-95b7-24495b41d1ea" />
