### PR TITLE
fix(message): allow bulk message media content properties

### DIFF
--- a/src/modules/message/dto/bulk-message.dto.ts
+++ b/src/modules/message/dto/bulk-message.dto.ts
@@ -19,15 +19,19 @@ class BulkMessageContentDto {
   text?: string;
 
   @ApiPropertyOptional({ description: 'Image URL or base64' })
+  @IsOptional()
   image?: { url?: string; base64?: string; mimetype?: string };
 
   @ApiPropertyOptional({ description: 'Video URL or base64' })
+  @IsOptional()
   video?: { url?: string; base64?: string; mimetype?: string };
 
   @ApiPropertyOptional({ description: 'Audio URL or base64' })
+  @IsOptional()
   audio?: { url?: string; base64?: string; mimetype?: string };
 
   @ApiPropertyOptional({ description: 'Document URL or base64' })
+  @IsOptional()
   document?: { url?: string; base64?: string; mimetype?: string; filename?: string };
 
   @ApiPropertyOptional({ description: 'Caption for media messages' })


### PR DESCRIPTION
## Problem
Every `POST /sessions/:id/messages/send-bulk` request was rejected with:
```
messages.0.content.property image should not exist
messages.0.content.property video should not exist
messages.0.content.property audio should not exist
messages.0.content.property document should not exist
```
even for plain **text** batches that never included any media key.

## Cause
`BulkMessageContentDto` declares `image` / `video` / `audio` / `document` with only `@ApiPropertyOptional()` and **no class-validator decorator**. The global `ValidationPipe` runs with `forbidNonWhitelisted: true`, so class-validator treats those undecorated fields as non-whitelisted and rejects the nested `content` object.

## Fix
Add `@IsOptional()` to the four media properties so they become whitelisted optional fields. Text and media bulk sends now validate correctly.

## Test
Verified locally against a connected session: text bulk batch returns `status=completed, sent=1, failed=0` and the message is delivered.

?? Generated with [Claude Code](https://claude.com/claude-code)