### PR TITLE
ci: publish multi-arch Docker images for amd64 + arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   NODE_VERSION: '22'
+  DOCKER_PLATFORMS: linux/amd64,linux/arm64
 
 jobs:
   lint:
@@ -118,6 +119,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -143,7 +147,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.DOCKER_PLATFORMS }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   NODE_VERSION: '22'
+  DOCKER_PLATFORMS: linux/amd64,linux/arm64
 
 permissions:
   contents: write
@@ -81,6 +82,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -106,7 +110,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.DOCKER_PLATFORMS }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ docker compose --profile full up -d
 >
 > - Development (`docker-compose.dev.yml`): SQLite, local storage, both API & Dashboard included
 > - Production (`docker-compose.yml`): Configurable database, profiles for optional services
+>
+> Official GHCR images are published as multi-arch manifests for:
+> - `linux/amd64`
+> - `linux/arm64`
 
 ## 🔌 Ports
 

--- a/docs/10-devops-infrastructure.md
+++ b/docs/10-devops-infrastructure.md
@@ -296,6 +296,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
## Summary
This PR enables official multi-arch image publishing so OpenWA tags can be pulled natively on both x64 and ARM64 hosts.

Closes #164

## Changes
- Add `platforms: linux/amd64,linux/arm64` to Docker build/push in CI workflow
- Add `platforms: linux/amd64,linux/arm64` to Docker build/push in release workflow
- Document supported image architectures in README
- Align DevOps guide CI snippet with the workflow changes

## Why
ARM64 environments (Apple Silicon and ARM VPS) need official multi-arch manifests for seamless image pulls using the same tag.

## Scope
This change only updates image build/publish configuration and related documentation; no runtime behavior changes.

## Validation
- Workflow syntax updated in existing docker/build-push-action steps only
- No changes to application code paths
