### PR TITLE
 addSecurityRequirements header while using swagger

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -146,6 +146,7 @@ async function bootstrap() {
     .setDescription('Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API')
     .setVersion('0.1.6')
     .addApiKey({ type: 'apiKey', name: 'X-API-Key', in: 'header' }, 'X-API-Key')
+    .addSecurityRequirements('X-API-Key')
     .addTag('sessions', 'WhatsApp session management')
     .addTag('messages', 'Send and manage messages')
     .addTag('webhooks', 'Webhook configuration')


### PR DESCRIPTION
## Description
Fix Swagger/OpenAPI security configuration so API key entered in Swagger UI is actually sent as `X-API-Key` in request headers for protected endpoints.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] Lint passes
- [x] Self-reviewed

## Screenshots (if applicable)

## Related Issues
Closes #173 
