### PR TITLE
fix(webhook-received): adjust idempotency key generation

### DIFF
--- a/src/modules/webhook/utils/idempotency.util.spec.ts
+++ b/src/modules/webhook/utils/idempotency.util.spec.ts
@@ -12,6 +12,22 @@ describe('Idempotency Utils', () => {
       expect(key).toBe('ack_ABC123_3');
     });
 
+    it('should use the IncomingMessage `id` field for message.received (the real dispatch shape)', () => {
+      // session.service dispatches the IncomingMessage object, which carries `id`, not `messageId`.
+      const key = generateIdempotencyKey('message.received', { id: 'ABC123' });
+      expect(key).toBe('msg_ABC123');
+    });
+
+    it('should prefer `id` over a legacy `messageId` when both are present for message.received', () => {
+      const key = generateIdempotencyKey('message.received', { id: 'REAL', messageId: 'LEGACY' });
+      expect(key).toBe('msg_REAL');
+    });
+
+    it('should use the `id` field for message.ack (the real dispatch shape)', () => {
+      const key = generateIdempotencyKey('message.ack', { id: 'ABC123', ack: 3 });
+      expect(key).toBe('ack_ABC123_3');
+    });
+
     it('should generate key for session.status', () => {
       const key = generateIdempotencyKey('session.status', {
         sessionId: 'sess_1',

--- a/src/modules/webhook/utils/idempotency.util.spec.ts
+++ b/src/modules/webhook/utils/idempotency.util.spec.ts
@@ -28,6 +28,11 @@ describe('Idempotency Utils', () => {
       expect(key).toBe('ack_ABC123_3');
     });
 
+    it('should use the `id` field for message.revoked (the real dispatch shape)', () => {
+      const key = generateIdempotencyKey('message.revoked', { id: 'ABC123' });
+      expect(key).toBe('rev_ABC123');
+    });
+
     it('should generate key for session.status', () => {
       const key = generateIdempotencyKey('session.status', {
         sessionId: 'sess_1',

--- a/src/modules/webhook/utils/idempotency.util.ts
+++ b/src/modules/webhook/utils/idempotency.util.ts
@@ -32,12 +32,12 @@ export function generateIdempotencyKey(event: string, data: Record<string, unkno
   switch (event) {
     case 'message.received':
     case 'message.sent':
-      // Message ID is unique per message
-      return `msg_${toStr(data.messageId) || toStr(data.id)}`;
+      // Message ID is unique per message — check 'id' first (IncomingMessage), then 'messageId'
+      return `msg_${toStr(data.id) || toStr(data.messageId)}`;
 
     case 'message.ack':
       // Message ID + ack status together are unique
-      return `ack_${toStr(data.messageId)}_${toStr(data.ack, '0')}`;
+      return `ack_${toStr(data.id) || toStr(data.messageId)}_${toStr(data.ack, '0')}`;
 
     case 'message.revoked':
       return `rev_${toStr(data.messageId)}`;

--- a/src/modules/webhook/utils/idempotency.util.ts
+++ b/src/modules/webhook/utils/idempotency.util.ts
@@ -42,7 +42,7 @@ export function generateIdempotencyKey(event: string, data: Record<string, unkno
       return `ack_${toStr(data.id ?? data.messageId)}_${toStr(data.ack, '0')}`;
 
     case 'message.revoked':
-      return `rev_${toStr(data.messageId)}`;
+      return `rev_${toStr(data.id ?? data.messageId)}`;
 
     case 'session.status':
       // Session + status combo (same status emitted once per transition)

--- a/src/modules/webhook/utils/idempotency.util.ts
+++ b/src/modules/webhook/utils/idempotency.util.ts
@@ -32,12 +32,14 @@ export function generateIdempotencyKey(event: string, data: Record<string, unkno
   switch (event) {
     case 'message.received':
     case 'message.sent':
-      // Message ID is unique per message — check 'id' first (IncomingMessage), then 'messageId'
-      return `msg_${toStr(data.id) || toStr(data.messageId)}`;
+      // Dispatched payload is an IncomingMessage, which carries `id`; fall back to a legacy `messageId`.
+      // Resolve the value before toStr() — toStr() returns a truthy 'unknown' fallback, so chaining with
+      // `||` would short-circuit before reaching the second field.
+      return `msg_${toStr(data.id ?? data.messageId)}`;
 
     case 'message.ack':
       // Message ID + ack status together are unique
-      return `ack_${toStr(data.id) || toStr(data.messageId)}_${toStr(data.ack, '0')}`;
+      return `ack_${toStr(data.id ?? data.messageId)}_${toStr(data.ack, '0')}`;
 
     case 'message.revoked':
       return `rev_${toStr(data.messageId)}`;


### PR DESCRIPTION
Flip the message idempotency-key resolution to prefer `data.id` over `data.messageId` (the dispatched payload is an `IncomingMessage` carrying `id`), applied to `message.received` / `message.sent` / `message.ack` / `message.revoked`, with regression tests for the real `id`-shape payload.

## Description

`generateIdempotencyKey` resolved the message id with `toStr(data.messageId) || toStr(data.id)`. Because `toStr()` returns the truthy string `'unknown'` for a missing field, the `||` never fell through to `data.id` — so every dispatched message webhook was keyed `msg_unknown`, collapsing all messages into one bucket for consumers that deduplicate on the `X-OpenWA-Idempotency-Key` header. Resolved with nullish coalescing (`id ?? messageId`) before stringifying.

## Type of Change
- [x] Bug fix

## Checklist
- [x] Tests added/updated
- [ ] Documentation updated
- [x] Lint passes
- [x] Self-reviewed

## Related Issues

Refs #168. **Note:** this fixes the idempotency-key collapse only. It does **not**
resolve #168 on its own — self-messages (`fromMe: true`) not firing a webhook is a
separate root cause (the engine listens to the `message` event, not `message_create`)
and remains tracked under #168 for v0.2.0. This PR is intentionally **not** auto-closing #168.
