### PR TITLE
bugfix docker compose build error

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -26,7 +26,7 @@
     "@types/node": "^25.9.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^5.1.4",
+    "@vitejs/plugin-react": "^6.0.2",
     "eslint": "^10.4.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.1",


### PR DESCRIPTION
Fixed the Docker Compose build error. The issue was a peer dependency conflict in `dashboard/package.json`: `@vitejs/plugin-react@^5.1.4` only supports `vite@^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0`, but the project uses `vite@^8.0.13`. Upgraded `@vitejs/plugin-react` from `^5.1.4` to `^6.0.2`, which supports `vite@^8.0.0`.
