### PR TITLE
Fix Location constructor import error using safe access

### DIFF
--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -385,7 +385,9 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
   async sendLocationMessage(chatId: string, location: LocationInput): Promise<MessageResult> {
     this.ensureReady();
     // Import Location class dynamically from whatsapp-web.js
-    const { Location } = await import('whatsapp-web.js');
+    const module = await import('whatsapp-web.js');
+    const Location = module.default.Location;
+
     const loc = new Location(location.latitude, location.longitude, {
       name: location.description || '',
       address: location.address || '',

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -386,7 +386,7 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     this.ensureReady();
     // Import Location class dynamically from whatsapp-web.js
     const module = await import('whatsapp-web.js');
-    const Location = module.default.Location;
+    const Location = module.Location || module.default?.Location;
 
     const loc = new Location(location.latitude, location.longitude, {
       name: location.description || '',


### PR DESCRIPTION
## Description

Fix for `Location is not a constructor` error when using dynamic import of `whatsapp-web.js`.
`Location` isndometimes nested under `default` depending on module resolution (ESM/CJS interop), causing runtime crashes.

Issue:

`Location` in undefined when using dynamic import:
`const { Location } = await import('whatsapp-web.js');`

This causes:

`TypeError: Location is not a constructor`

Cause:

Depending on the module resolution, `Location` is available unde `Default` instead of the top-level export.

Fix:

Use a safe access to support both cases:

```typescript
const module = await import("whatsapp-web.js");

const Location = module.Location || module.default?.Location
```


## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] Lint passes
- [x] Self-reviewed

## Screenshots (if applicable)
N/A

## Related Issues
N/A
