### PR TITLE
fix: add @IsOptional() to BulkMessageContentDto media fields

### DIFF
--- a/src/modules/message/dto/bulk-message.dto.ts
+++ b/src/modules/message/dto/bulk-message.dto.ts
@@ -19,15 +19,19 @@ class BulkMessageContentDto {
   text?: string;
 
   @ApiPropertyOptional({ description: 'Image URL or base64' })
+  @IsOptional()
   image?: { url?: string; base64?: string; mimetype?: string };
 
   @ApiPropertyOptional({ description: 'Video URL or base64' })
+  @IsOptional()
   video?: { url?: string; base64?: string; mimetype?: string };
 
   @ApiPropertyOptional({ description: 'Audio URL or base64' })
+  @IsOptional()
   audio?: { url?: string; base64?: string; mimetype?: string };
 
   @ApiPropertyOptional({ description: 'Document URL or base64' })
+  @IsOptional()
   document?: { url?: string; base64?: string; mimetype?: string; filename?: string };
 
   @ApiPropertyOptional({ description: 'Caption for media messages' })


### PR DESCRIPTION
## Problem

The `send-bulk` endpoint always returns 400 Bad Request for text messages, even with a valid request body.

When `class-transformer` instantiates `BulkMessageContentDto` via `@Type()`, it adds `image`, `video`, `audio`, and `document` as `undefined` properties on the object. Since the global `ValidationPipe` is configured with `forbidNonWhitelisted: true`, these properties are rejected because they lack class-validator decorators.

## Fix

Added `@IsOptional()` to `image`, `video`, `audio`, and `document` fields in `BulkMessageContentDto` so they are recognized as whitelisted optional properties.

## Testing

Verified that `POST /api/sessions/:sessionId/messages/send-bulk` with a text message payload now returns 202 and the message is delivered successfully.