### PR TITLE
fix: add @IsOptional() to media fields in BulkMessageContentDto and fix Swagger auth injection

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -146,6 +146,7 @@ async function bootstrap() {
     .setDescription('Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API')
     .setVersion('0.1.6')
     .addApiKey({ type: 'apiKey', name: 'X-API-Key', in: 'header' }, 'X-API-Key')
+    .addSecurityRequirements('X-API-Key')
     .addTag('sessions', 'WhatsApp session management')
     .addTag('messages', 'Send and manage messages')
     .addTag('webhooks', 'Webhook configuration')

--- a/src/modules/message/dto/bulk-message.dto.ts
+++ b/src/modules/message/dto/bulk-message.dto.ts
@@ -19,15 +19,19 @@ class BulkMessageContentDto {
   text?: string;
 
   @ApiPropertyOptional({ description: 'Image URL or base64' })
+  @IsOptional()
   image?: { url?: string; base64?: string; mimetype?: string };
 
   @ApiPropertyOptional({ description: 'Video URL or base64' })
+  @IsOptional()
   video?: { url?: string; base64?: string; mimetype?: string };
 
   @ApiPropertyOptional({ description: 'Audio URL or base64' })
+  @IsOptional()
   audio?: { url?: string; base64?: string; mimetype?: string };
 
   @ApiPropertyOptional({ description: 'Document URL or base64' })
+  @IsOptional()
   document?: { url?: string; base64?: string; mimetype?: string; filename?: string };
 
   @ApiPropertyOptional({ description: 'Caption for media messages' })


### PR DESCRIPTION
## Issues Fixed

### 1. send-bulk returning 400 on valid requests
`POST /api/sessions/:sessionId/messages/send-bulk` was returning 400 even with a
valid text-only payload:

```json
{
  "message": [
    "messages.0.content.property image should not exist",
    "messages.0.content.property video should not exist",
    "messages.0.content.property audio should not exist",
    "messages.0.content.property document should not exist"
  ],
  "error": "Bad Request",
  "statusCode": 400
}
```

**Root cause:** In `bulk-message.dto.ts`, the `image`, `video`, `audio`, and `document`
fields inside `BulkMessageContentDto` were decorated with `@ApiPropertyOptional` but
missing `@IsOptional()` from `class-validator`. Since `ValidationPipe` runs with
`whitelist: true` and `forbidNonWhitelisted: true`, any property without a
class-validator decorator is rejected — even when not present in the request.

**Fix:** Added `@IsOptional()` to the four affected fields in `BulkMessageContentDto`.

---

### 2. Swagger UI not injecting API key into requests
After authorizing with the API key in Swagger UI, the key was not being sent in
request headers — causing 401 errors on every endpoint when testing via Swagger.

**Root cause:** `main.ts` defined the API key scheme via `.addApiKey()` but never
applied it globally with `.addSecurityRequirements()`.

**Fix:** Added `.addSecurityRequirements('X-API-Key')` to the Swagger `DocumentBuilder`
config so the key is automatically injected into all requests after authorizing once.

---

## Testing
- Confirmed `send-bulk` with `type: text` returns `202` with batch status after fix
- Confirmed bulk messages are delivered successfully to all recipients
- Confirmed Swagger UI now correctly injects `X-API-Key` header after authorizing