### PR TITLE
feat(groups): expose linkedParentJID for community sub-groups

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install dependencies
-RUN npm ci
+RUN npm ci --legacy-peer-deps
 
 # Copy source code
 COPY . .

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -30,6 +30,7 @@ import {
 import { createLogger } from '../../common/services/logger.service';
 import {
   GroupChat,
+  GroupMetadataRaw,
   MessageWithReactions,
   BusinessClient,
   WwjsChannelData,
@@ -48,6 +49,26 @@ export interface WhatsAppWebJsConfig {
     url: string;
     type: 'http' | 'https' | 'socks4' | 'socks5';
   };
+}
+
+/**
+ * Extracts the JID of the parent community a group is linked to, if any.
+ * The field name has varied across whatsapp-web.js/WA Web versions, so
+ * known candidates are checked in order.
+ */
+function extractLinkedParentJID(groupMetadata?: GroupMetadataRaw): string | null {
+  const candidate =
+    groupMetadata?.parentGroup ?? groupMetadata?.linkedParentGroup ?? groupMetadata?.linkedParent ?? null;
+
+  if (!candidate) {
+    return null;
+  }
+
+  if (typeof candidate === 'string') {
+    return candidate;
+  }
+
+  return candidate._serialized ?? null;
 }
 
 export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngine {
@@ -376,6 +397,7 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
         isAdmin: groupChat.participants?.some(
           p => p.isAdmin && p.id._serialized === this.client?.info?.wid?._serialized,
         ),
+        linkedParentJID: extractLinkedParentJID(groupChat.groupMetadata),
       };
     });
   }
@@ -503,6 +525,7 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
         participants,
         isReadOnly: Boolean(groupChat.isReadOnly),
         isAnnounce: Boolean(groupChat.isAnnounce),
+        linkedParentJID: extractLinkedParentJID(groupChat.groupMetadata),
       };
     } catch (error) {
       this.logger.warn(`Failed to get group: ${groupId}`, String(error));

--- a/src/engine/interfaces/whatsapp-engine.interface.ts
+++ b/src/engine/interfaces/whatsapp-engine.interface.ts
@@ -58,6 +58,8 @@ export interface Group {
   name: string;
   participantsCount?: number;
   isAdmin?: boolean;
+  /** JID of the parent community this group is linked to, or null if standalone. */
+  linkedParentJID?: string | null;
 }
 
 export interface GroupParticipant {
@@ -77,6 +79,8 @@ export interface GroupInfo {
   participants: GroupParticipant[];
   isReadOnly?: boolean;
   isAnnounce?: boolean;
+  /** JID of the parent community this group is linked to, or null if standalone. */
+  linkedParentJID?: string | null;
 }
 
 export interface ContactCard {

--- a/src/engine/types/whatsapp-web-js.types.ts
+++ b/src/engine/types/whatsapp-web-js.types.ts
@@ -5,6 +5,25 @@
 import { Chat, Client, Message } from 'whatsapp-web.js';
 
 /**
+ * A WhatsApp ID (Wid) as serialized by whatsapp-web.js, e.g. `{ _serialized: '120363xxx@g.us' }`.
+ */
+export interface SerializedWid {
+  _serialized?: string;
+}
+
+/**
+ * Raw group metadata as returned by `chat.groupMetadata.serialize()`.
+ * The field that links a community sub-group to its parent community has
+ * varied across whatsapp-web.js/WA Web versions, so multiple known
+ * candidates are declared here defensively.
+ */
+export interface GroupMetadataRaw {
+  parentGroup?: SerializedWid | string | null;
+  linkedParentGroup?: SerializedWid | string | null;
+  linkedParent?: SerializedWid | string | null;
+}
+
+/**
  * WhatsApp Group Chat with group-specific properties and methods.
  */
 export interface GroupChat extends Omit<Chat, 'isReadOnly' | 'getLabels'> {
@@ -19,6 +38,7 @@ export interface GroupChat extends Omit<Chat, 'isReadOnly' | 'getLabels'> {
   createdAt?: number;
   isReadOnly?: boolean;
   isAnnounce?: boolean;
+  groupMetadata?: GroupMetadataRaw;
   addParticipants(ids: string[]): Promise<void>;
   removeParticipants(ids: string[]): Promise<void>;
   promoteParticipants(ids: string[]): Promise<void>;


### PR DESCRIPTION
  ## Summary

  - Adds a `linkedParentJID` field to the group response objects returned by:
    - `GET /api/sessions/{sessionId}/groups`
    - `GET /api/sessions/{sessionId}/groups/{groupId}`
  - For groups that belong to a WhatsApp Community, this field contains the
    parent community's JID (e.g. `120363416871560789@g.us`). For standalone
    groups it is `null`.
  - This mirrors the `LinkedParentJID` field already exposed by WAHA, allowing
    clients to filter community sub-groups with
    `groups.filter(g => g.linkedParentJID === communityJID)`.

  ## Implementation details

  - `Group` and `GroupInfo` (in `src/engine/interfaces/whatsapp-engine.interface.ts`)
    now declare `linkedParentJID?: string | null`.
  - `src/engine/types/whatsapp-web-js.types.ts` adds `SerializedWid` and
    `GroupMetadataRaw` types, and exposes `groupMetadata` on `GroupChat`.
  - `src/engine/adapters/whatsapp-web-js.adapter.ts` adds a small
    `extractLinkedParentJID()` helper that reads the parent-community JID from
    the raw `groupMetadata` object. Since the exact field name has varied across
    whatsapp-web.js / WA Web versions, it checks several known candidates
    (`parentGroup`, `linkedParentGroup`, `linkedParent`) and falls back to `null`
    if none are present.
  - Both `getGroups()` and `getGroupInfo()` now populate `linkedParentJID`.

  ## Other fix included

  - `dashboard/Dockerfile`: `npm ci` → `npm ci --legacy-peer-deps`. The dashboard
    build currently fails out of the box because `@vitejs/plugin-react@5.1.4`
    declares a peer dependency on `vite@^4 || ^5 || ^6 || ^7`, while
    `package.json` pins `vite@^8.0.13`, causing `npm ci` to fail with
    `ERESOLVE`. This flag unblocks the Docker build without changing the
    dependency versions.

  ## Testing

  - `npm run build` (NestJS) compiles successfully with the new types.
  - Dashboard Docker image builds successfully with the `--legacy-peer-deps` fix.

  ## Behavior

  | Group type            | `linkedParentJID`                  |
  |------------------------|-------------------------------------|
  | Community sub-group    | `"120363416871560789@g.us"`         |
  | Standalone group        | `null`                              |