### PR TITLE
feat(groups): expose linkedParentJID for community sub-groups

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install dependencies
-RUN npm ci
+RUN npm ci --legacy-peer-deps
 
 # Copy source code
 COPY . .

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -388,18 +388,44 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     // Filter only group chats
     const groups = chats.filter(chat => chat.isGroup);
 
-    return groups.map(g => {
-      const groupChat = g as unknown as GroupChat;
-      return {
-        id: g.id._serialized,
-        name: g.name,
-        participantsCount: groupChat.participants?.length,
-        isAdmin: groupChat.participants?.some(
-          p => p.isAdmin && p.id._serialized === this.client?.info?.wid?._serialized,
-        ),
-        linkedParentJID: extractLinkedParentJID(groupChat.groupMetadata),
-      };
-    });
+    return Promise.all(
+      groups.map(async g => {
+        const groupChat = g as unknown as GroupChat;
+        return {
+          id: g.id._serialized,
+          name: g.name,
+          participantsCount: groupChat.participants?.length,
+          isAdmin: groupChat.participants?.some(
+            p => p.isAdmin && p.id._serialized === this.client?.info?.wid?._serialized,
+          ),
+          linkedParentJID: await this.resolveLinkedParentJID(g.id._serialized, groupChat.groupMetadata),
+        };
+      }),
+    );
+  }
+
+  /**
+   * `client.getChats()` does not always populate `groupMetadata` for groups
+   * that haven't been loaded into the WhatsApp Web store yet, so the
+   * `linkedParentJID` would always come back null for them. When that happens,
+   * fall back to `getChatById`, which reliably loads the full group metadata.
+   */
+  private async resolveLinkedParentJID(
+    groupId: string,
+    groupMetadata?: GroupMetadataRaw,
+  ): Promise<string | null> {
+    const linkedParentJID = extractLinkedParentJID(groupMetadata);
+    if (linkedParentJID !== null) {
+      return linkedParentJID;
+    }
+
+    try {
+      const chat = await this.client!.getChatById(groupId);
+      return extractLinkedParentJID((chat as unknown as GroupChat).groupMetadata);
+    } catch (error) {
+      this.logger.warn(`Failed to resolve linkedParentJID for group: ${groupId}`, String(error));
+      return null;
+    }
   }
 
   // ============= Phase 3: Extended Messaging =============

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -30,6 +30,7 @@ import {
 import { createLogger } from '../../common/services/logger.service';
 import {
   GroupChat,
+  GroupMetadataRaw,
   MessageWithReactions,
   BusinessClient,
   WwjsChannelData,
@@ -48,6 +49,26 @@ export interface WhatsAppWebJsConfig {
     url: string;
     type: 'http' | 'https' | 'socks4' | 'socks5';
   };
+}
+
+/**
+ * Extracts the JID of the parent community a group is linked to, if any.
+ * The field name has varied across whatsapp-web.js/WA Web versions, so
+ * known candidates are checked in order.
+ */
+function extractLinkedParentJID(groupMetadata?: GroupMetadataRaw): string | null {
+  const candidate =
+    groupMetadata?.parentGroup ?? groupMetadata?.linkedParentGroup ?? groupMetadata?.linkedParent ?? null;
+
+  if (!candidate) {
+    return null;
+  }
+
+  if (typeof candidate === 'string') {
+    return candidate;
+  }
+
+  return candidate._serialized ?? null;
 }
 
 export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngine {
@@ -376,6 +397,7 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
         isAdmin: groupChat.participants?.some(
           p => p.isAdmin && p.id._serialized === this.client?.info?.wid?._serialized,
         ),
+        linkedParentJID: extractLinkedParentJID(groupChat.groupMetadata),
       };
     });
   }
@@ -503,6 +525,7 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
         participants,
         isReadOnly: Boolean(groupChat.isReadOnly),
         isAnnounce: Boolean(groupChat.isAnnounce),
+        linkedParentJID: extractLinkedParentJID(groupChat.groupMetadata),
       };
     } catch (error) {
       this.logger.warn(`Failed to get group: ${groupId}`, String(error));

--- a/src/engine/interfaces/whatsapp-engine.interface.ts
+++ b/src/engine/interfaces/whatsapp-engine.interface.ts
@@ -58,6 +58,8 @@ export interface Group {
   name: string;
   participantsCount?: number;
   isAdmin?: boolean;
+  /** JID of the parent community this group is linked to, or null if standalone. */
+  linkedParentJID?: string | null;
 }
 
 export interface GroupParticipant {
@@ -77,6 +79,8 @@ export interface GroupInfo {
   participants: GroupParticipant[];
   isReadOnly?: boolean;
   isAnnounce?: boolean;
+  /** JID of the parent community this group is linked to, or null if standalone. */
+  linkedParentJID?: string | null;
 }
 
 export interface ContactCard {

--- a/src/engine/types/whatsapp-web-js.types.ts
+++ b/src/engine/types/whatsapp-web-js.types.ts
@@ -5,6 +5,25 @@
 import { Chat, Client, Message } from 'whatsapp-web.js';
 
 /**
+ * A WhatsApp ID (Wid) as serialized by whatsapp-web.js, e.g. `{ _serialized: '120363xxx@g.us' }`.
+ */
+export interface SerializedWid {
+  _serialized?: string;
+}
+
+/**
+ * Raw group metadata as returned by `chat.groupMetadata.serialize()`.
+ * The field that links a community sub-group to its parent community has
+ * varied across whatsapp-web.js/WA Web versions, so multiple known
+ * candidates are declared here defensively.
+ */
+export interface GroupMetadataRaw {
+  parentGroup?: SerializedWid | string | null;
+  linkedParentGroup?: SerializedWid | string | null;
+  linkedParent?: SerializedWid | string | null;
+}
+
+/**
  * WhatsApp Group Chat with group-specific properties and methods.
  */
 export interface GroupChat extends Omit<Chat, 'isReadOnly' | 'getLabels'> {
@@ -19,6 +38,7 @@ export interface GroupChat extends Omit<Chat, 'isReadOnly' | 'getLabels'> {
   createdAt?: number;
   isReadOnly?: boolean;
   isAnnounce?: boolean;
+  groupMetadata?: GroupMetadataRaw;
   addParticipants(ids: string[]): Promise<void>;
   removeParticipants(ids: string[]): Promise<void>;
   promoteParticipants(ids: string[]): Promise<void>;

--- a/src/modules/session/session.controller.ts
+++ b/src/modules/session/session.controller.ts
@@ -162,7 +162,7 @@ export class SessionController {
   })
   @ApiResponse({ status: 400, description: 'Session not ready' })
   @ApiResponse({ status: 404, description: 'Session not found' })
-  async getGroups(@Param('id') id: string): Promise<{ id: string; name: string }[]> {
+  async getGroups(@Param('id') id: string): Promise<{ id: string; name: string; linkedParentJID?: string | null }[]> {
     return this.sessionService.getGroups(id);
   }
 

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -464,7 +464,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit {
     return this.engines.get(id);
   }
 
-  async getGroups(id: string): Promise<{ id: string; name: string }[]> {
+  async getGroups(id: string): Promise<{ id: string; name: string; linkedParentJID?: string | null }[]> {
     await this.findOne(id); // Verify session exists
     const engine = this.engines.get(id);
 
@@ -476,6 +476,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit {
     return groups.map(g => ({
       id: g.id,
       name: g.name,
+      linkedParentJID: g.linkedParentJID,
     }));
   }
 


### PR DESCRIPTION
## Summary

  Adds a `linkedParentJID` field to the group endpoints so API consumers can tell whether a group is a sub-group of a WhatsApp Community, and which community it belongs to.
  
  - `GET /api/sessions/{sessionId}/groups`
  - `GET /api/sessions/{sessionId}/groups/{groupId}`
  
  Both endpoints now return:
  
```json
  {
    "id": "126663421933678702@g.us",
    "name": "Groupe Name",
    "linkedParentJID": "120363416871160700@g.us"
  }
```

  For standalone groups (not part of a community), `linkedParentJID` is `null`.
  
  ## Changes

  - **`src/engine/types/whatsapp-web-js.types.ts`**: added `SerializedWid` and `GroupMetadataRaw` types, and a `groupMetadata` field on `GroupChat`. The underlying field name
  for the parent community link has varied across whatsapp-web.js / WA Web versions, so multiple known candidates (`parentGroup`, `linkedParentGroup`, `linkedParent`) are
  declared and checked.
  - **`src/engine/interfaces/whatsapp-engine.interface.ts`**: added optional `linkedParentJID?: string | null` to the `Group` and `GroupInfo` interfaces.
  - **`src/engine/adapters/whatsapp-web-js.adapter.ts`**:
      - Added `extractLinkedParentJID()` helper that reads the parent community JID from `groupMetadata`, handling the different field-name candidates and serialized WID shapes.
      - `getGroupInfo()` now populates `linkedParentJID` from `chat.groupMetadata`.
      - `getGroups()` now also populates `linkedParentJID`. Since `client.getChats()` doesn't always have `groupMetadata` populated for groups that haven't been loaded into the
  WhatsApp Web store yet, `getGroups()` falls back to `getChatById()` (which reliably loads full group metadata) when it's missing from the chat list.
  - **`src/modules/session/session.service.ts` / `session.controller.ts`**: `GET /api/sessions/{id}/groups` is actually served by `SessionController` (it takes priority over
  `GroupController` for this route), and `SessionService.getGroups()` was mapping the engine result down to `{ id, name }`, silently dropping any extra fields. Updated the
  mapping and return types to include `linkedParentJID` so the list endpoint is consistent with the single-group endpoint.
  - **`dashboard/Dockerfile`**: `npm ci` → `npm ci --legacy-peer-deps` to fix an `ERESOLVE` conflict between `@vitejs/plugin-react@5.1.4` and `vite@8.0.13` that currently breaks
  the dashboard Docker build.
  
  ## Testing

  - Built and deployed both the API and dashboard images via Docker.
  - Verified `GET /api/sessions/{id}/groups` returns `linkedParentJID` with the correct community JID for sub-groups and `null` for standalone groups, matching `GET
  /api/sessions/{id}/groups/{groupId}`.