### PR TITLE
fix(engine): add missing location data to incoming webhook messages

### DIFF
--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -155,6 +155,17 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
           isGroup: msg.from.endsWith('@g.us'),
         };
 
+        // Handle location
+        if (msg.type === 'location' && msg.location) {
+          incomingMessage.location = {
+            latitude: Number(msg.location.latitude),
+            longitude: Number(msg.location.longitude),
+            description: msg.location.description || undefined,
+            address: msg.location.address || undefined,
+            url: msg.location.url || undefined,
+          };
+        }
+
         // Handle media
         if (msg.hasMedia) {
           try {

--- a/src/engine/interfaces/whatsapp-engine.interface.ts
+++ b/src/engine/interfaces/whatsapp-engine.interface.ts
@@ -41,6 +41,13 @@ export interface IncomingMessage {
     id: string;
     body: string;
   };
+  location?: {
+    latitude: number;
+    longitude: number;
+    description?: string;
+    address?: string;
+    url?: string;
+  };
 }
 
 export interface Contact {


### PR DESCRIPTION
## Description
Location messages received via WhatsApp were not forwarding their latitude, longitude, and other metadata to the webhook. 

This update:
- Extends the `IncomingMessage` interface to include an optional `location` object.
- Modifies `WhatsAppWebJsAdapter` to properly parse and attach `msg.location` properties (latitude, longitude, description, address, url) to the payload.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] Lint passes
- [x] Self-reviewed

## Screenshots (if applicable)


## Related Issues
Closes #