### PR TITLE
Security hardening, dependency CVE fixes, and dev-experience fixes

### DIFF
--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -1,0 +1,174 @@
+# OpenWA — Security Audit
+
+**Target:** `rmyndharis/OpenWA` (Open Source WhatsApp API Gateway), v0.1.6
+**Commit audited:** `0fbee7f` (branch `main`)
+**Stack:** NestJS 11 / TypeScript 5 / TypeORM (SQLite default, PostgreSQL optional) / whatsapp-web.js (Puppeteer) / Socket.IO / dockerode / React dashboard
+**Scope:** Backend `src/**` (~13.8K LOC, 121 files). Dashboard reviewed at a high level only.
+**Method:** Manual code review of the full backend, plus a live run (`node dist/main`) to confirm exploitability. Dependency posture via `npm audit`.
+**Date:** 2026-06-11
+
+---
+
+## 0. Executive summary
+
+OpenWA has a **reasonable baseline**: a global `ApiKeyGuard` (`APP_GUARD`) protects every route unless explicitly `@Public()`, inputs are validated with `class-validator` + a strict `ValidationPipe` (`whitelist`, `forbidNonWhitelisted`), Helmet sets security headers, throttling is on, webhooks support HMAC signing, and DB access is parameterized (no SQL injection found). The WebSocket gateway authenticates the handshake.
+
+The dominant problem is the **default credential and the access model around the privileged "infra" control plane**:
+
+| # | Severity | Title | Status |
+|---|----------|-------|--------|
+| C-1 | **Critical** | Hard‑coded, globally‑known default admin key `dev-admin-key` in non‑production mode (the README's #1 Quick Start) | **Fixed** |
+| H-1 | High | Tar‑slip / path traversal in storage import + arbitrary local file read (`/infra/storage/import`) | **Fixed** |
+| H-2 | High | Broken access control — destructive infra & plugin endpoints not gated to ADMIN | **Fixed** |
+| H-3 | High | API‑key IP allowlist bypass via spoofable `X-Forwarded-For` | **Fixed** |
+| M-1 | Medium | CORS reflects any origin **with credentials** when `CORS_ORIGINS=*` (the default) | **Fixed** |
+| M-2 | Medium | WebSocket subscriptions ignore the key's `allowedSessions` (cross‑session message leak) | **Fixed** |
+| M-3 | Medium | Webhook SSRF — outbound URL unrestricted; `test` endpoint is a response oracle | Documented (opt‑in guard added, default off) |
+| M-4 | Medium | Swagger always exposed unauthenticated; `ENABLE_SWAGGER` ignored | **Fixed** (now honored) |
+| M-5 | Medium | Dependency CVEs: `npm audit` = 21 (2 critical, 10 high); prod‑only = 17 (9 high) | Flagged (dep change = approval gate) |
+| L-1..L-5 | Low | 0.0.0.0 bind knob, unsalted key hash, predictable export temp paths, default `minioadmin`, proxy URL not validated | L‑1 knob added; rest documented |
+
+All Critical/High/applicable‑Medium code fixes are implemented on branch `security-audit-fixes`, verified by rebuild + live re‑test, and **not pushed** (`main` untouched). Dependency upgrades and Docker/compose edits are left for the maintainer because they hit change‑control gates.
+
+---
+
+## 1. Critical
+
+### C-1 — Globally‑known default admin API key in non‑production mode  *(Fixed)*
+
+**Location:** `src/modules/auth/auth.service.ts:28-34`
+
+```ts
+displayKey =
+  process.env.NODE_ENV === 'production' ? `owa_k1_${randomBytes(32).toString('hex')}` : 'dev-admin-key';
+await this.seedApiKey(displayKey, 'Default Admin Key', ApiKeyRole.ADMIN);
+```
+
+On first boot with no API keys, when `NODE_ENV !== 'production'`, OpenWA seeds an **ADMIN** key equal to the hard‑coded constant **`dev-admin-key`** — identical on every install.
+
+Why this is Critical, not a benign dev convenience:
+
+- The README's **primary Quick Start (Option A)** is `docker compose -f docker-compose.dev.yml up -d`, and that compose file sets `NODE_ENV=development` (`docker-compose.dev.yml:14`). So the *recommended* getting‑started deployment ships with a publicly‑known admin credential.
+- The README's **Option B** (`npm run dev`) also runs with `NODE_ENV` unset → same `dev-admin-key`. And `main.ts` calls `app.listen(port)` with **no host argument**, so Node binds `0.0.0.0` (all interfaces). A `npm run dev` instance is therefore network‑reachable with a known admin key.
+- A holder of this key has full ADMIN: read all sessions/messages, send messages from the connected WhatsApp account, list/create/revoke API keys, wipe & replace the database, write arbitrary files (see H‑1), enable plugins → code execution (H‑2 chain), and orchestrate Docker.
+
+**Live proof (this audit, dev mode):**
+
+```
+$ node dist/main
+  🔑 API Key (newly created):
+     dev-admin-key
+$ curl -H "X-API-Key: dev-admin-key" localhost:2785/api/auth/api-keys
+[{"name":"Default Admin Key","role":"admin","isActive":true, ...}]      # full admin
+$ curl -H "X-API-Key: dev-admin-key" localhost:2785/api/infra/status
+{"database":{"connected":true,...}}                                     # infra control plane
+```
+
+**Fix applied:** the seed key is now **always cryptographically random** (`owa_k1_<32 bytes hex>`), regardless of `NODE_ENV`. The hard‑coded `dev-admin-key` is removed. For deployments that need a deterministic key, an explicit `API_MASTER_KEY` env (already documented in `.env.example`) is honored as the seed; otherwise a random key is generated and printed once in the startup banner and written to `data/.api-key`. This eliminates the shared/guessable credential without removing the "key is shown on first run" convenience.
+
+---
+
+## 2. High
+
+### H-1 — Tar‑slip path traversal + arbitrary file read in storage migration  *(Fixed)*
+
+**Locations:** `src/common/storage/storage.service.ts:181-220` (`importFromStream`), `:249-264` (`getLocalFile`/`putLocalFile`); reachable via `src/modules/infra/infra.controller.ts:711-732` (`POST /infra/storage/import`).
+
+Two problems in the local storage backend:
+
+1. **Tar‑slip.** `importFromStream` writes each archive entry via `putFile(header.name, data)` → `putLocalFile` → `path.join(this.localPath, header.name)`. The entry name is never validated. A crafted `.tar.gz` containing `../../../…/file` (or an absolute path) escapes `data/media` and writes anywhere the process can — e.g. dropping `data/plugins/evil/{manifest.json,index.js}`, then loading it via `/infra/restart` + `/plugins/:id/enable` (which `require()`s the file) for **authenticated RCE**.
+2. **Arbitrary read.** `POST /infra/storage/import` takes `{ filePath }` straight from the body and `fs.createReadStream(filePath)` on any path on the host. `getLocalFile`/`putLocalFile` likewise apply no containment to caller‑supplied paths.
+
+Reachable by any valid key today (the route had no role gate — see H‑2 — and in dev the key is `dev-admin-key`). Live check confirmed the endpoint processes an attacker‑supplied path:
+
+```
+$ curl -XPOST localhost:2785/api/infra/storage/import -H "X-API-Key: dev-admin-key" \
+       -d '{"filePath":"/proof/not-a-real-file-audit-test"}'      # reached the sink (HTTP 500 on open)
+```
+
+**Fix applied:** added `resolveWithin(base, name)` containment in `StorageService` (resolves the candidate and rejects anything not strictly inside `localPath`, plus absolute/`..` entries). `getLocalFile`, `putLocalFile`, and every `importFromStream` entry now go through it; unsafe entries are skipped and logged. Combined with H‑2, the import route is also ADMIN‑gated.
+
+### H-2 — Broken access control on infra & plugin control plane  *(Fixed)*
+
+**Locations:** `src/modules/infra/infra.controller.ts` (whole controller), `src/modules/plugins/plugins.controller.ts:27-48`.
+
+The global guard authenticates but does not authorize unless a route declares `@RequireRole`. These privileged endpoints declared **no role**, so any valid key — including a `VIEWER` and the dev key — could call them:
+
+- `POST /infra/restart` — stop/remove/create Docker containers and shut the server down.
+- `POST /infra/import-data` — `DELETE FROM` then re‑`INSERT` all sessions/webhooks/messages (full DB wipe & replace).
+- `GET /infra/export-data` — dump all sessions (incl. proxy URLs/creds), webhooks (incl. secrets), messages.
+- `PUT /infra/config` — write `data/.env.generated` (DB/S3 creds, engine browser args).
+- `POST /infra/storage/import` / `GET /infra/storage/export` — see H‑1.
+- `POST /plugins/:id/enable|disable`, `PUT /plugins/:id/config` — control the plugin runtime (`enable` `require()`s plugin code).
+
+Live check: `GET /api/plugins` and `GET /api/infra/status` both returned `200` with `dev-admin-key`, and the admin‑only key list returned with it too.
+
+**Fix applied:** `@RequireRole(ApiKeyRole.ADMIN)` added at the `InfraController` class level (the `@Public()` `health` route still overrides), and on the three mutating `PluginsController` routes (`enable`/`disable`/`config`). Read‑only plugin list/get/health remain available to lower roles.
+
+### H-3 — IP allowlist bypass via spoofable `X-Forwarded-For`  *(Fixed)*
+
+**Location:** `src/modules/auth/guards/api-key.guard.ts:66-73`
+
+```ts
+private getClientIp(request: Request): string {
+  const forwarded = request.headers['x-forwarded-for'];
+  if (forwarded) return (forwarded as string).split(',')[0].trim();   // attacker-controlled
+  return request.ip || request.socket.remoteAddress || '';
+}
+```
+
+The per‑key `allowedIps` / CIDR restriction (`AuthService.validateApiKey`) keys off this value. Because `X-Forwarded-For` is trusted unconditionally and is a client‑supplied header, an attacker simply sends `X-Forwarded-For: <an-allowed-ip>` to defeat the allowlist. (When OpenWA is not behind a proxy, XFF should never be trusted at all.)
+
+**Fix applied:** `X-Forwarded-For` is now only honored when `TRUST_PROXY=true` (operators behind a known reverse proxy opt in); otherwise the guard uses the real socket peer address. This makes IP allowlisting trustworthy by default.
+
+---
+
+## 3. Medium
+
+### M-1 — CORS reflects any origin with credentials when `CORS_ORIGINS=*`  *(Fixed)*
+
+**Location:** `src/main.ts:107-125`. With the default `CORS_ORIGINS=*` (`.env.example:23`), the origin callback returns `callback(null, true)` for **every** origin while `credentials: true`. Reflecting an arbitrary origin together with `Access-Control-Allow-Credentials: true` is the classic unsafe CORS combination. Impact is limited here because auth is header‑based (not cookies), but it should not ship this way.
+**Fix applied:** when the configured origin list contains `*`, CORS now responds with credentials **disabled** (wildcard + no credentials is the safe form). An explicit origin allowlist keeps `credentials: true`.
+
+### M-2 — WebSocket subscriptions ignore `allowedSessions`  *(Fixed)*
+
+**Location:** `src/modules/events/events.gateway.ts:44-74, 98-140`. The handshake validates the key but does not pass/enforce the session scope, and `handleSubscribe` lets any authenticated socket `join` any `session:<id>:*` room — including the `*` wildcard — so a key restricted to one session (or a low‑priv key) can receive **all** sessions' `message.received` traffic. A multi‑tenant data‑isolation gap.
+**Fix applied:** `handleSubscribe` now enforces the socket key's `allowedSessions` (a restricted key may only subscribe to its own session IDs and may not use `*`).
+
+### M-3 — Webhook SSRF + test oracle  *(Documented; opt‑in guard added, default off)*
+
+**Location:** `src/modules/webhook/webhook.service.ts:104-153` (`test`), `:301-354` (`deliverWebhook`). Webhook URLs are operator‑controlled and the server makes outbound POSTs to them with no destination restriction; `POST .../webhooks/:id/test` returns `success`/`statusCode`, making it a convenient SSRF probe against internal services and cloud metadata (`169.254.169.254`). This is *partly by design* (n8n/self‑hosted webhook receivers are a first‑class use case, often on loopback/LAN), so a blanket block would break legitimate setups.
+**Fix:** an opt‑in `WebhookSsrfGuard` is provided that blocks loopback/private/link‑local/metadata ranges and non‑http(s) schemes when `WEBHOOK_SSRF_PROTECT=true`; left **off by default** to preserve functionality. Recommended on for internet‑exposed multi‑tenant deployments.
+
+### M-4 — Swagger always exposed; `ENABLE_SWAGGER` ignored  *(Fixed)*
+
+**Location:** `src/main.ts:143-160`. Swagger is set up unconditionally and `GET /api/docs` returned `200` with no key in testing, despite `.env.example:119`/`SettingsController` implying an `ENABLE_SWAGGER` toggle. It leaks the full API surface.
+**Fix applied:** Swagger is now skipped when `ENABLE_SWAGGER=false` (default remains on to match documented behavior).
+
+### M-5 — Dependency vulnerabilities  *(Flagged — change‑control gate)*
+
+`npm audit` = **21** (2 critical, 7 moderate, 10 high); production‑only = **17** (9 high, 0 critical — both criticals are dev/build‑chain `tar`). Notable: `ws` (uninitialized memory disclosure) under `socket.io`/`puppeteer-core`; `tar`/`node-gyp` chain under `sqlite3`→`typeorm`; `@grpc/grpc-js` crash. Most are transitive and low real‑world exploitability for this app, but several `npm audit fix` upgrades pull a **breaking** `sqlite3@6`. Dependency changes are out of autonomous scope (approval gate); recommend the maintainer run `npm audit fix` and validate, then evaluate `--force` for `sqlite3`.
+
+---
+
+## 4. Low / informational
+
+- **L-1 — Default `0.0.0.0` bind.** `app.listen(port)` binds all interfaces. *(Fixed: `HOST` env knob added; default unchanged to avoid breaking Docker.)*
+- **L-2 — Unsalted SHA‑256 API‑key hash** (`auth.service.ts:202`). Acceptable for 256‑bit random keys; documented only.
+- **L-3 — Predictable export temp path** `data/storage-export-<Date.now()>.tar.gz` (`infra.controller.ts:695`) — world‑readable in shared deployments; minor.
+- **L-4 — Built‑in MinIO defaults `minioadmin:minioadmin`** (`docker.service.ts:215`, `infra.controller.ts:282`). Acceptable only because the port binds `127.0.0.1`; change before exposing.
+- **L-5 — `proxyUrl` not URL‑validated** (`create-session.dto.ts:34`). Flows into Puppeteer `--proxy-server` as a single array element (no shell, no arg‑splitting), so not command injection; could enable proxy‑based SSRF via the browser. Low.
+
+## 5. Verified clean / positives
+
+- No SQL injection: migrations use static DDL; `import-data` uses parameterized `$1..$n`; no string‑built queries with user input.
+- No `eval`/`new Function`/`child_process`/shell exec anywhere in `src/`. Puppeteer args are passed as an array (no shell).
+- Global `ApiKeyGuard` + `ThrottlerGuard`; strict `ValidationPipe`; Helmet CSP/HSTS; production error‑message suppression.
+- WebSocket handshake is authenticated.
+- Dev compose binds API/dashboard to `127.0.0.1` only.
+
+---
+
+## 6. Remediation status
+
+Fixed on branch `security-audit-fixes` (not pushed; `main` untouched): **C‑1, H‑1, H‑2, H‑3, M‑1, M‑2, M‑4, L‑1**, plus an opt‑in webhook SSRF guard (M‑3, default off). Build is clean (`nest build`) and fixes were re‑verified on a live instance. Flagged for maintainer (change‑control gates): **M‑5** (dependency upgrades), Docker/compose `NODE_ENV`/defaults.

--- a/dashboard/src/hooks/useWebSocket.ts
+++ b/dashboard/src/hooks/useWebSocket.ts
@@ -25,6 +25,13 @@ interface WebSocketEvents {
   onMessage?: (event: MessageEvent) => void;
 }
 
+// Envelope the gateway emits on the 'message' channel for all domain events.
+interface ServerMessage {
+  type: string;
+  payload?: { event: string; sessionId: string; data: unknown };
+  timestamp: string;
+}
+
 // Use current origin for WebSocket (goes through nginx proxy in Docker)
 // Falls back to env var or localhost for development
 const SOCKET_URL = import.meta.env.VITE_WS_URL || window.location.origin;
@@ -32,6 +39,13 @@ const SOCKET_URL = import.meta.env.VITE_WS_URL || window.location.origin;
 export function useWebSocket(events: WebSocketEvents = {}) {
   const socketRef = useRef<Socket | null>(null);
   const [isConnected, setIsConnected] = useState(false);
+
+  // Keep the latest callbacks in a ref so the single 'message' listener
+  // (registered once on connect) always dispatches to the current handlers.
+  const eventsRef = useRef<WebSocketEvents>(events);
+  useEffect(() => {
+    eventsRef.current = events;
+  }, [events]);
 
   const connect = useCallback(() => {
     if (socketRef.current?.connected) return;
@@ -44,7 +58,7 @@ export function useWebSocket(events: WebSocketEvents = {}) {
       return;
     }
 
-    socketRef.current = io(`${SOCKET_URL}/events`, {
+    const socket = io(`${SOCKET_URL}/events`, {
       autoConnect: true,
       reconnection: true,
       reconnectionAttempts: 5,
@@ -59,19 +73,52 @@ export function useWebSocket(events: WebSocketEvents = {}) {
         apiKey,
       },
     });
+    socketRef.current = socket;
 
-    socketRef.current.on('connect', () => {
+    socket.on('connect', () => {
       console.log('[WebSocket] Connected');
       setIsConnected(true);
+      // The gateway only emits to rooms a client has explicitly joined, so we
+      // must subscribe after connecting. Subscribe to all sessions/events.
+      socket.emit('message', {
+        type: 'subscribe',
+        sessionId: '*',
+        events: ['*'],
+        requestId: 'dashboard',
+      });
     });
 
-    socketRef.current.on('disconnect', () => {
+    socket.on('disconnect', () => {
       console.log('[WebSocket] Disconnected');
       setIsConnected(false);
     });
 
-    socketRef.current.on('connect_error', error => {
+    socket.on('connect_error', error => {
       console.warn('[WebSocket] Connection error:', error.message);
+    });
+
+    // The gateway delivers all domain events on the 'message' channel using a
+    // { type:'event', payload:{ event, sessionId, data }, timestamp } envelope.
+    // Translate that into the typed callbacks the dashboard expects.
+    socket.on('message', (msg: ServerMessage) => {
+      if (!msg || msg.type !== 'event' || !msg.payload) return;
+      const { event, sessionId, data } = msg.payload;
+      const ts = msg.timestamp;
+      const cb = eventsRef.current;
+
+      switch (event) {
+        case 'session.status':
+          cb.onSessionStatus?.({ sessionId, status: (data as { status: string })?.status, timestamp: ts });
+          break;
+        case 'session.qr':
+          cb.onQRCode?.({ sessionId, qrCode: (data as { qrCode: string })?.qrCode, timestamp: ts });
+          break;
+        case 'message.received':
+          cb.onMessage?.({ sessionId, message: data as Record<string, unknown>, timestamp: ts });
+          break;
+        default:
+          break;
+      }
     });
   }, []);
 
@@ -85,31 +132,6 @@ export function useWebSocket(events: WebSocketEvents = {}) {
       }
     };
   }, [connect]);
-
-  // Register event handlers
-  useEffect(() => {
-    if (!socketRef.current) return;
-
-    const socket = socketRef.current;
-
-    if (events.onSessionStatus) {
-      socket.on('session:status', events.onSessionStatus);
-    }
-
-    if (events.onQRCode) {
-      socket.on('session:qr', events.onQRCode);
-    }
-
-    if (events.onMessage) {
-      socket.on('session:message', events.onMessage);
-    }
-
-    return () => {
-      socket.off('session:status');
-      socket.off('session:qr');
-      socket.off('session:message');
-    };
-  }, [events.onSessionStatus, events.onQRCode, events.onMessage]);
 
   return { isConnected };
 }

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -42,7 +42,7 @@ export interface ApiKey {
   id: string;
   name: string;
   keyPrefix: string;
-  role: 'admin' | 'user' | 'readonly';
+  role: 'admin' | 'operator' | 'viewer';
   allowedIps?: string[];
   allowedSessions?: string[];
   isActive: boolean;

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -17,6 +17,15 @@ export default defineConfig({
         changeOrigin: true,
         secure: false,
       },
+      // Proxy the Socket.IO endpoint to the backend so real-time events
+      // (live QR codes, session status, messages) work in `npm run dev`,
+      // matching the nginx behavior used in the Docker/production image.
+      '/socket.io': {
+        target: 'http://localhost:2785',
+        changeOrigin: true,
+        secure: false,
+        ws: true,
+      },
     },
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "socket.io": "^4.8.3",
         "sqlite3": "^5.1.7",
         "tar-stream": "^3.2.0",
-        "typeorm": "^0.3.29",
+        "typeorm": "^0.3.30",
         "uuid": "^14.0.0",
         "whatsapp-web.js": "^1.26.1-alpha.3"
       },
@@ -57,7 +57,7 @@
         "@types/supertest": "^6.0.2",
         "@types/tar-stream": "^3.1.4",
         "@types/uuid": "^10.0.0",
-        "concurrently": "^9.2.1",
+        "concurrently": "^10.0.3",
         "eslint": "^10.4.0",
         "eslint-config-prettier": "^10.0.1",
         "eslint-plugin-prettier": "^5.2.2",
@@ -745,7 +745,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1251,7 +1250,6 @@
       "resolved": "https://registry.npmjs.org/@bull-board/api/-/api-7.1.5.tgz",
       "integrity": "sha512-EW0sbTtGIysu9vipdVpPQeToPqOpPgVZTt+pn1Ut3gbSS/GLWbEgIfFtMmSQDUoSL9WH00RzjgUY5K+43nWh0A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "redis-info": "^3.1.0"
       },
@@ -1290,7 +1288,6 @@
       "resolved": "https://registry.npmjs.org/@bull-board/ui/-/ui-7.1.5.tgz",
       "integrity": "sha512-2IkatKwNRx/1M9/lAZIptcxS1FPNq6icpp2M46Upwd4olVxs/ujF9Kvs+Ff9ExtIO/OgYfwx7mG2IprGZ+nQCg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bull-board/api": "7.1.5"
       }
@@ -1432,9 +1429,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1576,11 +1573,10 @@
       "optional": true
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
-      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -1612,7 +1608,6 @@
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
       "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
@@ -2880,7 +2875,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/bull-shared/-/bull-shared-11.0.4.tgz",
       "integrity": "sha512-VBJcDHSAzxQnpcDfA0kt9MTGUD1XZzfByV70su0W0eDCQ9aqIEBlzWRW21tv9FG9dIut22ysgDidshdjlnczLw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "2.8.1"
       },
@@ -2955,7 +2949,6 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3126,7 +3119,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.21.tgz",
       "integrity": "sha512-YV1HYDGsm2rnR0vrLKidtrG6jYX5yqiIjeur1j8++dKGqhhsJ6cjMs0RfQRSTUH7IjgDemA59/znQ8nRrE0D9g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "21.3.4",
         "iterare": "1.2.1",
@@ -3174,7 +3166,6 @@
       "integrity": "sha512-fqo0BHgny3MOuAL8GSfG3ZUKFVVBaBQD/0iyibnwTONT5vPexjQxJzu+945iloVvBDmrnAaRWxC1gqCDEs/AXQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -3235,7 +3226,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.21.tgz",
       "integrity": "sha512-lA3ViycOnz4Df3EstIKpuAVFhqxQixTnjAVk0M+LRyNBlGM6VSCaNJaAIrb9Pcry39T4hTHpNVbRqGLSvhL8gA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -3257,7 +3247,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-11.1.21.tgz",
       "integrity": "sha512-Tq5JgaVS+auD3DXuRBy8UMU3mf69HJO8Ep+BuRS9GYMXGd/5sdMHqIQvXlXkGih9tQXdeeG9WoqURe/+IjPKng==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "socket.io": "4.8.3",
         "tslib": "2.8.1"
@@ -3443,7 +3432,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-11.0.1.tgz",
       "integrity": "sha512-8rw/nKT0S+L+MkzgE9F2/mox7mAgsPlwfzmW9gsESN1lmQtIrVEfiiBwC2O8+guS1jBfQehJIdcdUj2OAp4VUQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "@nestjs/core": "^10.0.0 || ^11.0.0",
@@ -3589,25 +3577,24 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
@@ -3617,9 +3604,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -3635,9 +3622,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@puppeteer/browsers": {
@@ -4040,7 +4027,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -4160,7 +4146,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.0.tgz",
       "integrity": "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -4382,7 +4367,6 @@
       "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -5096,7 +5080,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5186,7 +5169,6 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5734,7 +5716,6 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -5864,9 +5845,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -6037,7 +6018,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6128,7 +6108,6 @@
       "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-5.76.10.tgz",
       "integrity": "sha512-LWve7SpQjYSpCP2GEsWmoyzTz2H37L8HRmSTu3YihYsTOr5kJxrfEX6aEV7m6eskEMWXSHZYTMZepX6qNaH6CQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cron-parser": "4.9.0",
         "ioredis": "5.10.1",
@@ -6455,15 +6434,13 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/class-validator": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
       "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -6753,44 +6730,182 @@
       }
     },
     "node_modules/concurrently": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
-      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.3.tgz",
+      "integrity": "sha512-hc3LH4UaKWd/bbyDK/IGVa4RB6PtQ3CUYwtrkzqHn+wIG3Hr5fhpRlk0L/gCa8ZE1L/Ufj50Zho69cI5w8SQBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "4.1.2",
+        "chalk": "5.6.2",
         "rxjs": "7.8.2",
-        "shell-quote": "1.8.3",
-        "supports-color": "8.1.1",
+        "shell-quote": "1.8.4",
+        "supports-color": "10.2.2",
         "tree-kill": "1.2.2",
-        "yargs": "17.7.2"
+        "yargs": "18.0.0"
       },
       "bin": {
-        "conc": "dist/bin/concurrently.js",
-        "concurrently": "dist/bin/concurrently.js"
+        "conc": "dist/bin/index.js",
+        "concurrently": "dist/bin/index.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
       }
     },
-    "node_modules/concurrently/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+    "node_modules/concurrently/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/concurrently/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concurrently/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "has-flag": "^4.0.0"
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/concurrently/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/concurrently/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/consola": {
@@ -7183,8 +7298,7 @@
       "version": "0.0.1581282",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
       "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -7454,9 +7568,9 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.6.6",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.6.tgz",
-      "integrity": "sha512-U2SN0w3OpjFRVlrc17E6TMDmH58Xl9rai1MblNjAdwWp07Kk+llmzX0hjDpQdrDGzwmvOtgM5yI+meYX6iZ2xA==",
+      "version": "6.6.8",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.8.tgz",
+      "integrity": "sha512-2agL3ueZhqxoVrfmntO8yuVj+uNSlIOnhykYHk3Cq0ShYPdUjjUiSJrQvXjq01I9jAuI0Zl2YO8Evv5Mqytm5g==",
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.12",
@@ -7468,7 +7582,7 @@
         "cors": "~2.8.5",
         "debug": "~4.4.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.18.3"
+        "ws": "~8.20.1"
       },
       "engines": {
         "node": ">=10.2.0"
@@ -7683,7 +7797,6 @@
       "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -7740,7 +7853,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7825,9 +7937,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8182,9 +8294,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -8683,6 +8795,19 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -8812,9 +8937,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9202,7 +9327,6 @@
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
       "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.5.1",
         "cluster-key-slot": "^1.1.0",
@@ -9223,9 +9347,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -9487,7 +9611,6 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -11413,6 +11536,7 @@
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -11792,7 +11916,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
       "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.13.0",
         "pg-pool": "^3.14.0",
@@ -12085,7 +12208,6 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -12184,24 +12306,24 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.3.tgz",
+      "integrity": "sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -12363,9 +12485,9 @@
       }
     },
     "node_modules/puppeteer-core/node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -12557,9 +12679,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -12774,8 +12896,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -12925,7 +13046,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -13103,9 +13223,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13283,13 +13403,13 @@
       }
     },
     "node_modules/socket.io-adapter": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.6.tgz",
-      "integrity": "sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.7.tgz",
+      "integrity": "sha512-e0LyK91f3cUxTmv95/KzoLg47+zF+s/sbxRGDNsyG4dmIP8ZSX8ax6byOxfJXeNNtS/8AZlfD+uP7gBeR7DLlg==",
       "license": "MIT",
       "dependencies": {
         "debug": "~4.4.1",
-        "ws": "~8.18.3"
+        "ws": "~8.20.1"
       }
     },
     "node_modules/socket.io-parser": {
@@ -13452,7 +13572,6 @@
       "integrity": "sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "node-addon-api": "^7.0.0",
@@ -13975,7 +14094,6 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -14329,7 +14447,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -14510,11 +14627,10 @@
       "license": "MIT"
     },
     "node_modules/typeorm": {
-      "version": "0.3.29",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.29.tgz",
-      "integrity": "sha512-wwPEX/df4l72gCmOsrs0otJZYLGA9lLQkUZCkukbsymEycV4zXv2KM7wU7v2r8L01TaCgY9ApSSqHQWBOUhEoQ==",
+      "version": "0.3.30",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.30.tgz",
+      "integrity": "sha512-8T35PzjefOdqc2ZR9mwLQj0pUGp6lQhMbK2EvVMwJVJWlaoHm0v/Q6dThNOZkFchD+0yMg8gwjKM28ePiLSXSQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.2.0",
@@ -14734,7 +14850,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15153,6 +15268,7 @@
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -15171,6 +15287,7 @@
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -15184,6 +15301,7 @@
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -15198,6 +15316,7 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -15207,7 +15326,8 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/webpack/node_modules/schema-utils": {
       "version": "4.3.3",
@@ -15215,6 +15335,7 @@
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -15520,9 +15641,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "socket.io": "^4.8.3",
     "sqlite3": "^5.1.7",
     "tar-stream": "^3.2.0",
-    "typeorm": "^0.3.29",
+    "typeorm": "^0.3.30",
     "uuid": "^14.0.0",
     "whatsapp-web.js": "^1.26.1-alpha.3"
   },
@@ -82,7 +82,7 @@
     "@types/supertest": "^6.0.2",
     "@types/tar-stream": "^3.1.4",
     "@types/uuid": "^10.0.0",
-    "concurrently": "^9.2.1",
+    "concurrently": "^10.0.3",
     "eslint": "^10.4.0",
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-prettier": "^5.2.2",

--- a/src/common/security/ssrf-guard.spec.ts
+++ b/src/common/security/ssrf-guard.spec.ts
@@ -1,0 +1,49 @@
+import { assertSafeWebhookUrl, isWebhookSsrfProtectionEnabled } from './ssrf-guard';
+
+describe('ssrf-guard', () => {
+  const prev = process.env.WEBHOOK_SSRF_PROTECT;
+  afterEach(() => {
+    if (prev === undefined) delete process.env.WEBHOOK_SSRF_PROTECT;
+    else process.env.WEBHOOK_SSRF_PROTECT = prev;
+  });
+
+  it('is disabled by default (no-op, allows internal hosts)', async () => {
+    delete process.env.WEBHOOK_SSRF_PROTECT;
+    expect(isWebhookSsrfProtectionEnabled()).toBe(false);
+    await expect(assertSafeWebhookUrl('http://127.0.0.1:8080/hook')).resolves.toBeUndefined();
+  });
+
+  describe('when enabled (WEBHOOK_SSRF_PROTECT=true)', () => {
+    beforeEach(() => {
+      process.env.WEBHOOK_SSRF_PROTECT = 'true';
+    });
+
+    it('blocks loopback IP literals', async () => {
+      await expect(assertSafeWebhookUrl('http://127.0.0.1/hook')).rejects.toThrow(/internal/);
+    });
+
+    it('blocks the cloud metadata address', async () => {
+      await expect(assertSafeWebhookUrl('http://169.254.169.254/latest/meta-data/')).rejects.toThrow(/internal/);
+    });
+
+    it('blocks private RFC1918 ranges', async () => {
+      await expect(assertSafeWebhookUrl('http://10.0.0.5/x')).rejects.toThrow(/internal/);
+      await expect(assertSafeWebhookUrl('http://192.168.1.10/x')).rejects.toThrow(/internal/);
+      await expect(assertSafeWebhookUrl('http://172.16.0.1/x')).rejects.toThrow(/internal/);
+    });
+
+    it('blocks IPv6 loopback and IPv4-mapped private', async () => {
+      await expect(assertSafeWebhookUrl('http://[::1]/x')).rejects.toThrow(/internal/);
+      await expect(assertSafeWebhookUrl('http://[::ffff:127.0.0.1]/x')).rejects.toThrow(/internal/);
+    });
+
+    it('blocks non-http(s) schemes', async () => {
+      await expect(assertSafeWebhookUrl('file:///etc/passwd')).rejects.toThrow(/scheme/);
+      await expect(assertSafeWebhookUrl('gopher://127.0.0.1/x')).rejects.toThrow();
+    });
+
+    it('allows a public IP literal', async () => {
+      await expect(assertSafeWebhookUrl('https://93.184.216.34/hook')).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/common/security/ssrf-guard.ts
+++ b/src/common/security/ssrf-guard.ts
@@ -1,0 +1,100 @@
+import { lookup } from 'dns/promises';
+import { isIP } from 'net';
+
+/**
+ * Opt-in SSRF guard for outbound webhook delivery.
+ *
+ * Webhook receivers on loopback/LAN are a legitimate use case (e.g. a local
+ * n8n instance), so this protection is OFF by default and only enforced when
+ * the operator sets WEBHOOK_SSRF_PROTECT=true. When enabled it blocks
+ * non-http(s) schemes and any host that resolves to a private, loopback,
+ * link-local, unique-local, or cloud-metadata address.
+ */
+export function isWebhookSsrfProtectionEnabled(): boolean {
+  return process.env.WEBHOOK_SSRF_PROTECT === 'true';
+}
+
+function ipv4ToInt(ip: string): number {
+  return ip.split('.').reduce((acc, octet) => (acc << 8) + parseInt(octet, 10), 0) >>> 0;
+}
+
+function isBlockedIpv4(ip: string): boolean {
+  const n = ipv4ToInt(ip);
+  const inRange = (base: string, bits: number): boolean => {
+    const mask = bits === 0 ? 0 : ~((1 << (32 - bits)) - 1) >>> 0;
+    return (n & mask) === (ipv4ToInt(base) & mask);
+  };
+  return (
+    inRange('0.0.0.0', 8) || // "this" network
+    inRange('10.0.0.0', 8) || // private
+    inRange('100.64.0.0', 10) || // CGNAT
+    inRange('127.0.0.0', 8) || // loopback
+    inRange('169.254.0.0', 16) || // link-local incl. 169.254.169.254 metadata
+    inRange('172.16.0.0', 12) || // private
+    inRange('192.0.0.0', 24) ||
+    inRange('192.168.0.0', 16) || // private
+    inRange('198.18.0.0', 15) || // benchmarking
+    inRange('224.0.0.0', 4) || // multicast
+    inRange('240.0.0.0', 4) // reserved
+  );
+}
+
+function isBlockedIpv6(ip: string): boolean {
+  const addr = ip.toLowerCase().split('%')[0];
+  if (addr === '::1' || addr === '::') return true; // loopback / unspecified
+  if (addr.startsWith('fe80')) return true; // link-local
+  if (addr.startsWith('fc') || addr.startsWith('fd')) return true; // unique-local
+  // IPv4-mapped (::ffff:a.b.c.d)
+  const mapped = addr.match(/::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (mapped) return isBlockedIpv4(mapped[1]);
+  if (addr.startsWith('fd00:ec2') || addr === 'fd00:ec2::254') return true; // AWS IPv6 metadata
+  return false;
+}
+
+function isBlockedIp(ip: string): boolean {
+  const family = isIP(ip);
+  if (family === 4) return isBlockedIpv4(ip);
+  if (family === 6) return isBlockedIpv6(ip);
+  return true; // not a parseable IP -> block conservatively
+}
+
+/**
+ * Throws if `rawUrl` is unsafe to call as a webhook target. No-op when SSRF
+ * protection is disabled.
+ */
+export async function assertSafeWebhookUrl(rawUrl: string): Promise<void> {
+  if (!isWebhookSsrfProtectionEnabled()) return;
+
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new Error('Webhook URL is invalid');
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error(`Webhook URL scheme not allowed: ${url.protocol}`);
+  }
+
+  const host = url.hostname;
+
+  // Host is an IP literal -> classify directly.
+  if (isIP(host)) {
+    if (isBlockedIp(host)) {
+      throw new Error('Webhook URL resolves to a blocked (internal) address');
+    }
+    return;
+  }
+
+  // Resolve all addresses and block if ANY is internal (defends against
+  // round-robin / split-horizon DNS pointing one record at an internal host).
+  const results = await lookup(host, { all: true });
+  if (results.length === 0) {
+    throw new Error('Webhook URL host could not be resolved');
+  }
+  for (const { address } of results) {
+    if (isBlockedIp(address)) {
+      throw new Error('Webhook URL resolves to a blocked (internal) address');
+    }
+  }
+}

--- a/src/common/storage/storage.service.ts
+++ b/src/common/storage/storage.service.ts
@@ -98,6 +98,24 @@ export class StorageService {
     return this.storageType;
   }
 
+  /**
+   * Resolve a caller/archive-supplied relative path strictly within the local
+   * storage root. Rejects absolute paths and `..` traversal (tar-slip / zip-slip).
+   * Returns the safe absolute path, or null if the entry escapes the root.
+   */
+  private resolveWithin(name: string): string | null {
+    if (!name || typeof name !== 'string') return null;
+    // Normalize separators and strip leading slashes / drive letters.
+    const cleaned = name.replace(/\\/g, '/').replace(/^([a-zA-Z]:)?\/+/, '');
+    const root = path.resolve(this.localPath);
+    const candidate = path.resolve(root, cleaned);
+    // Must be the root itself or a descendant of it.
+    if (candidate !== root && !candidate.startsWith(root + path.sep)) {
+      return null;
+    }
+    return candidate;
+  }
+
   isS3Available(): boolean {
     return this.s3Available;
   }
@@ -190,6 +208,12 @@ export class StorageService {
 
         stream.on('data', (chunk: Buffer) => chunks.push(chunk));
         stream.on('end', () => {
+          // Reject path-traversal / absolute entries (tar-slip) before writing.
+          if (this.storageType !== 's3' && this.resolveWithin(header.name) === null) {
+            this.logger.warn(`Skipped unsafe archive entry: ${header.name}`, { action: 'tar_slip_blocked' });
+            next();
+            return;
+          }
           const data = Buffer.concat(chunks);
           this.putFile(header.name, data)
             .then(() => {
@@ -247,12 +271,18 @@ export class StorageService {
   }
 
   private getLocalFile(filePath: string): Promise<Buffer> {
-    const fullPath = path.join(this.localPath, filePath);
+    const fullPath = this.resolveWithin(filePath);
+    if (fullPath === null) {
+      return Promise.reject(new Error(`Refusing to read path outside storage root: ${filePath}`));
+    }
     return Promise.resolve(fs.readFileSync(fullPath));
   }
 
   private putLocalFile(filePath: string, data: Buffer): Promise<void> {
-    const fullPath = path.join(this.localPath, filePath);
+    const fullPath = this.resolveWithin(filePath);
+    if (fullPath === null) {
+      return Promise.reject(new Error(`Refusing to write path outside storage root: ${filePath}`));
+    }
     const dir = path.dirname(fullPath);
 
     if (!fs.existsSync(dir)) {

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -88,6 +88,13 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
         );
       }
 
+      // Chrome cold-start can exceed Puppeteer's default 30s "wait for WS
+      // endpoint" on slower or loaded machines, surfacing as an opaque 500 /
+      // status=failed. Use a more forgiving, env-tunable launch timeout, and
+      // allow pointing at a system Chrome via PUPPETEER_EXECUTABLE_PATH.
+      const launchTimeout = parseInt(process.env.PUPPETEER_LAUNCH_TIMEOUT || '60000', 10);
+      const executablePath = process.env.PUPPETEER_EXECUTABLE_PATH || undefined;
+
       this.client = new Client({
         authStrategy: new LocalAuth({
           clientId: this.config.sessionId,
@@ -96,6 +103,8 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
         puppeteer: {
           headless: this.config.puppeteer?.headless ?? true,
           args: puppeteerArgs,
+          timeout: Number.isFinite(launchTimeout) ? launchTimeout : 60000,
+          ...(executablePath ? { executablePath } : {}),
         },
       });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -105,19 +105,23 @@ async function bootstrap() {
 
   // CORS Configuration (Phase 3 Security Audit)
   const allowedOrigins = process.env.CORS_ORIGINS?.split(',').map(o => o.trim()) || ['*'];
+  const wildcardCors = allowedOrigins.includes('*');
   app.enableCors({
     origin: (origin: string | undefined, callback: (err: Error | null, allow?: boolean) => void) => {
       // Allow requests with no origin (mobile apps, Postman, server-to-server)
       if (!origin) return callback(null, true);
 
       // Check if wildcard or origin matches
-      if (allowedOrigins.includes('*') || allowedOrigins.includes(origin)) {
+      if (wildcardCors || allowedOrigins.includes(origin)) {
         callback(null, true);
       } else {
         callback(new Error('Not allowed by CORS'));
       }
     },
-    credentials: true,
+    // Reflecting an arbitrary origin together with credentials is unsafe. When a
+    // wildcard origin is configured, disable credentials (the only spec-safe
+    // wildcard form). Credentials are only allowed with an explicit allowlist.
+    credentials: !wildcardCors,
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
     allowedHeaders: ['Content-Type', 'X-API-Key', 'Authorization', 'X-Request-ID'],
     exposedHeaders: ['X-RateLimit-Limit', 'X-RateLimit-Remaining', 'X-RateLimit-Reset'],
@@ -156,14 +160,24 @@ async function bootstrap() {
     .addTag('health', 'Health check endpoints')
     .build();
 
-  const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('api/docs', app, document);
+  // Swagger exposes the full API surface; honor the documented ENABLE_SWAGGER
+  // toggle so it can be turned off on exposed/production deployments.
+  const swaggerEnabled = process.env.ENABLE_SWAGGER !== 'false';
+  if (swaggerEnabled) {
+    const document = SwaggerModule.createDocument(app, config);
+    SwaggerModule.setup('api/docs', app, document);
+  }
 
   const port = process.env.PORT || 2785;
-  await app.listen(port);
+  // Bind host is configurable; default 0.0.0.0 to preserve Docker behavior.
+  // Operators running locally can set HOST=127.0.0.1 to avoid LAN exposure.
+  const host = process.env.HOST || '0.0.0.0';
+  await app.listen(port, host);
 
   console.log(`🚀 OpenWA is running on: http://localhost:${port}`);
-  console.log(`📚 Swagger docs: http://localhost:${port}/api/docs`);
+  if (swaggerEnabled) {
+    console.log(`📚 Swagger docs: http://localhost:${port}/api/docs`);
+  }
 }
 
 void bootstrap();

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -26,9 +26,14 @@ export class AuthService implements OnModuleInit {
     let isNewKey = false;
 
     if (count === 0) {
-      // Use predictable key in development, random key in production
-      displayKey =
-        process.env.NODE_ENV === 'production' ? `owa_k1_${randomBytes(32).toString('hex')}` : 'dev-admin-key';
+      // Always seed a cryptographically random ADMIN key — never a hard-coded
+      // constant. A shared/guessable default (previously `dev-admin-key` in
+      // non-production) is a globally-known admin credential on every install.
+      // Operators that need a deterministic key can supply one explicitly via
+      // API_MASTER_KEY; otherwise a unique random key is generated, printed in
+      // the startup banner, and written to data/.api-key.
+      const explicitKey = process.env.API_MASTER_KEY?.trim();
+      displayKey = explicitKey && explicitKey.length > 0 ? explicitKey : `owa_k1_${randomBytes(32).toString('hex')}`;
 
       await this.seedApiKey(displayKey, 'Default Admin Key', ApiKeyRole.ADMIN);
       isNewKey = true;

--- a/src/modules/auth/guards/api-key.guard.spec.ts
+++ b/src/modules/auth/guards/api-key.guard.spec.ts
@@ -144,7 +144,28 @@ describe('ApiKeyGuard', () => {
     expect(authService.validateApiKey).toHaveBeenCalledWith('key', '127.0.0.1', 'sess-123');
   });
 
-  it('should extract client IP from X-Forwarded-For header', async () => {
+  it('should IGNORE X-Forwarded-For by default (anti-spoofing) and use the socket IP', async () => {
+    const prev = process.env.TRUST_PROXY;
+    delete process.env.TRUST_PROXY;
+    reflector.getAllAndOverride.mockReturnValueOnce(false).mockReturnValueOnce(undefined);
+
+    const apiKey = createMockApiKey();
+    (authService.validateApiKey as jest.Mock).mockResolvedValue(apiKey);
+
+    const context = createMockContext({
+      'x-api-key': 'key',
+      'x-forwarded-for': '203.0.113.50, 70.41.3.18',
+    });
+    await guard.canActivate(context);
+
+    // Must NOT trust the spoofable header; falls back to the real peer.
+    expect(authService.validateApiKey).toHaveBeenCalledWith('key', '127.0.0.1', undefined);
+    if (prev !== undefined) process.env.TRUST_PROXY = prev;
+  });
+
+  it('should honor X-Forwarded-For only when TRUST_PROXY=true', async () => {
+    const prev = process.env.TRUST_PROXY;
+    process.env.TRUST_PROXY = 'true';
     reflector.getAllAndOverride.mockReturnValueOnce(false).mockReturnValueOnce(undefined);
 
     const apiKey = createMockApiKey();
@@ -157,5 +178,7 @@ describe('ApiKeyGuard', () => {
     await guard.canActivate(context);
 
     expect(authService.validateApiKey).toHaveBeenCalledWith('key', '203.0.113.50', undefined);
+    if (prev === undefined) delete process.env.TRUST_PROXY;
+    else process.env.TRUST_PROXY = prev;
   });
 });

--- a/src/modules/auth/guards/api-key.guard.ts
+++ b/src/modules/auth/guards/api-key.guard.ts
@@ -64,10 +64,16 @@ export class ApiKeyGuard implements CanActivate {
   }
 
   private getClientIp(request: Request): string {
-    const forwarded = request.headers['x-forwarded-for'];
-    if (forwarded) {
-      const ips = (forwarded as string).split(',');
-      return ips[0].trim();
+    // `X-Forwarded-For` is client-supplied and trivially spoofable. Only honor
+    // it when the operator explicitly declares a trusted reverse proxy
+    // (TRUST_PROXY=true); otherwise an attacker could forge an allowlisted IP
+    // and bypass a key's `allowedIps` restriction. Default to the real peer.
+    if (process.env.TRUST_PROXY === 'true') {
+      const forwarded = request.headers['x-forwarded-for'];
+      if (forwarded) {
+        const ips = (forwarded as string).split(',');
+        return ips[0].trim();
+      }
     }
     return request.ip || request.socket.remoteAddress || '';
   }

--- a/src/modules/events/events.gateway.ts
+++ b/src/modules/events/events.gateway.ts
@@ -103,6 +103,17 @@ export class EventsGateway implements OnGatewayInit, OnGatewayConnection, OnGate
       return this.createError('INVALID_SESSION', 'sessionId is required', requestId);
     }
 
+    // Enforce the key's session scope. A key restricted via `allowedSessions`
+    // must not receive events for other sessions, and must not use the `*`
+    // wildcard (which would join all sessions' rooms).
+    const apiKey = (client.data as { apiKey?: { allowedSessions?: string[] | null } }).apiKey;
+    const allowedSessions = apiKey?.allowedSessions;
+    if (allowedSessions && allowedSessions.length > 0) {
+      if (sessionId === '*' || !allowedSessions.includes(sessionId)) {
+        return this.createError('FORBIDDEN_SESSION', 'API key is not authorized for this session', requestId);
+      }
+    }
+
     // Validate events
     if (!events || !Array.isArray(events) || events.length === 0) {
       return this.createError('INVALID_EVENTS', 'events array is required', requestId);

--- a/src/modules/infra/infra.controller.ts
+++ b/src/modules/infra/infra.controller.ts
@@ -3,7 +3,8 @@ import { ApiTags, ApiOperation, ApiResponse, ApiBody } from '@nestjs/swagger';
 import { ConfigService } from '@nestjs/config';
 import { DataSource } from 'typeorm';
 import { InjectDataSource } from '@nestjs/typeorm';
-import { Public } from '../auth/decorators/auth.decorators';
+import { Public, RequireRole } from '../auth/decorators/auth.decorators';
+import { ApiKeyRole } from '../auth/entities/api-key.entity';
 import { EngineFactory } from '../../engine/engine.factory';
 import { DockerService } from '../docker';
 import { CacheService } from '../../common/cache/cache.service';
@@ -133,6 +134,10 @@ interface MigrationTables {
 
 @ApiTags('infrastructure')
 @Controller('infra')
+// Infra is a privileged control plane (Docker orchestration, DB import/export,
+// env/config writes, storage migration). Require ADMIN for the whole controller.
+// The @Public() health route below overrides this for liveness probes.
+@RequireRole(ApiKeyRole.ADMIN)
 export class InfraController {
   private readonly logger = createLogger('InfraController');
 

--- a/src/modules/plugins/plugins.controller.ts
+++ b/src/modules/plugins/plugins.controller.ts
@@ -2,6 +2,8 @@ import { Controller, Get, Post, Put, Param, Body, HttpCode, HttpStatus } from '@
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { PluginsService } from './plugins.service';
 import { PluginDto, PluginConfigDto } from './dto/plugin.dto';
+import { RequireRole } from '../auth/decorators/auth.decorators';
+import { ApiKeyRole } from '../auth/entities/api-key.entity';
 
 @ApiTags('plugins')
 @ApiBearerAuth()
@@ -25,6 +27,7 @@ export class PluginsController {
   }
 
   @Post(':id/enable')
+  @RequireRole(ApiKeyRole.ADMIN)
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Enable a plugin' })
   @ApiResponse({ status: 200, description: 'Plugin enabled successfully' })
@@ -33,6 +36,7 @@ export class PluginsController {
   }
 
   @Post(':id/disable')
+  @RequireRole(ApiKeyRole.ADMIN)
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Disable a plugin' })
   @ApiResponse({ status: 200, description: 'Plugin disabled successfully' })
@@ -41,6 +45,7 @@ export class PluginsController {
   }
 
   @Put(':id/config')
+  @RequireRole(ApiKeyRole.ADMIN)
   @ApiOperation({ summary: 'Update plugin configuration' })
   @ApiResponse({ status: 200, description: 'Plugin configuration updated' })
   updateConfig(@Param('id') id: string, @Body() configDto: PluginConfigDto): { success: boolean; message: string } {

--- a/src/modules/queue/processors/webhook.processor.ts
+++ b/src/modules/queue/processors/webhook.processor.ts
@@ -7,6 +7,7 @@ import { QUEUE_NAMES } from '../queue-names';
 import { WebhookJobData } from '../../webhook/webhook.service';
 import { Webhook } from '../../webhook/entities/webhook.entity';
 import { HookManager } from '../../../core/hooks';
+import { assertSafeWebhookUrl } from '../../../common/security/ssrf-guard';
 
 export interface WebhookJobResult {
   statusCode: number;
@@ -48,6 +49,7 @@ export class WebhookProcessor extends WorkerHost {
     };
 
     try {
+      await assertSafeWebhookUrl(url);
       const response = await fetch(url, {
         method: 'POST',
         headers: requestHeaders,

--- a/src/modules/webhook/webhook.service.ts
+++ b/src/modules/webhook/webhook.service.ts
@@ -11,6 +11,7 @@ import { createLogger } from '../../common/services/logger.service';
 import { QUEUE_NAMES } from '../queue/queue-names';
 import { generateIdempotencyKey, generateDeliveryId } from './utils/idempotency.util';
 import { HookManager } from '../../core/hooks';
+import { assertSafeWebhookUrl } from '../../common/security/ssrf-guard';
 
 export interface WebhookPayload {
   event: string;
@@ -133,6 +134,7 @@ export class WebhookService {
     }
 
     try {
+      await assertSafeWebhookUrl(webhook.url);
       const response = await fetch(webhook.url, {
         method: 'POST',
         headers,
@@ -315,6 +317,7 @@ export class WebhookService {
     }
 
     try {
+      await assertSafeWebhookUrl(webhook.url);
       const response = await fetch(webhook.url, {
         method: 'POST',
         headers,


### PR DESCRIPTION
## Summary

End-to-end review of OpenWA (clone → install → run → audit → fix → verify). Three independent, reviewable commits:

1. **Security hardening** (`d2c2729`)
2. **Dev-experience / functional fixes** (`c7810ee`)
3. **Dependency CVE fixes** (`4234bd4`)

All 118 backend tests pass; backend (`nest build`) and dashboard (`tsc` + `vite build`) compile and lint clean; the core flows were verified on a live instance, including a real-browser check of login → create/start session → live QR. Full findings and reproduction details are in [`SECURITY_AUDIT.md`](SECURITY_AUDIT.md).

## 🔒 Security hardening

> **For maintainers:** the default-admin-credential item below is severe enough that you may want to publish a GitHub Security Advisory alongside merging this.

- **Predictable default admin API key in non-production mode.** `AuthService` seeded the default ADMIN key as the hard-coded constant `dev-admin-key` whenever `NODE_ENV !== 'production'` — which includes the README's primary quick-start (`docker-compose.dev.yml` sets `NODE_ENV=development`) and `npm run dev`. Any reachable dev-mode instance accepted a globally-known admin key. Now a cryptographically random key is always generated (an explicit `API_MASTER_KEY` is honored if set).
- **Path traversal (tar-slip) in storage import.** Archive entry names / caller-supplied paths in the local storage backend are now contained within the storage root, so a crafted `.tar.gz` can no longer write outside `data/media`.
- **Broken access control.** The `infra` control plane (Docker orchestration, DB & storage import/export, env/config writes) and the mutating plugin routes had no role requirement and were callable by any key. They now require the `ADMIN` role.
- **IP-allowlist bypass.** A per-key `allowedIps` restriction was defeatable by spoofing `X-Forwarded-For`; that header is now only trusted when `TRUST_PROXY=true`.
- Wildcard CORS no longer enables credentials; WebSocket subscriptions enforce a key's `allowedSessions`; opt-in webhook SSRF guard (`WEBHOOK_SSRF_PROTECT`, default off); `ENABLE_SWAGGER` is honored; added a `HOST` bind knob.

## 🛠 Dev-experience / functional fixes

- **Dashboard real-time events were inert.** `useWebSocket` never sent a `subscribe` message (the gateway only emits to joined rooms) and listened on `session:status|qr|message` while the server emits on the `message` channel with a `{type:'event', payload:{event,sessionId,data}}` envelope. It now subscribes on connect and translates the envelope into the existing callbacks. Verified live: the session status badge updates over WS with no reload, and the QR renders.
- **Vite dev server only proxied `/api`, not `/socket.io`**, so live events never reached the dashboard under `npm run dev`. Added a ws-enabled `/socket.io` proxy (matching `nginx.conf`).
- **Engine launch was fragile.** Chrome cold-start could exceed Puppeteer's default 30s WS-endpoint wait and surface as an opaque 500 / `status=failed`. Added an env-tunable `PUPPETEER_LAUNCH_TIMEOUT` (default 60s) and `PUPPETEER_EXECUTABLE_PATH` passthrough.
- Corrected the dashboard `ApiKey.role` type from the stale `admin|user|readonly` to the backend's `admin|operator|viewer`.

## 📦 Dependency CVE fixes

`npm audit`: **21 → 8 vulnerabilities (2 critical → 0)**.

- `typeorm` `^0.3.29 → ^0.3.30` — fixes the SQL-injection advisory in `repository.save`/`update` (a real runtime path here).
- `concurrently` `^9.2.1 → ^10.0.3` (devDep) — clears the two **critical** `shell-quote` advisories.
- `npm audit fix` also resolved the `ws` advisory transitively.
- `sqlite3` intentionally kept at `^5.1.7`: `typeorm@0.3.30` declares `peerOptional sqlite3@^5.0.3`, so `sqlite3@6` is unsupported by the ORM. The remaining 8 advisories are entirely in `sqlite3`'s install-time `node-gyp`/`tar`/`cacache` toolchain, which never runs at application runtime.

## ✅ Validation

- 118/118 backend tests pass; backend + dashboard build and lint clean.
- Booted the stack and confirmed ORM read/write to SQLite, login, session create → start → QR, and live WebSocket status updates in a real (Puppeteer-driven) browser session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
