### PR TITLE
fix(database): add SSL support for runtime PostgreSQL TypeORM connection

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -86,16 +86,11 @@ if (process.env.QUEUE_ENABLED === 'true') {
             password: configService.get<string>('dataDatabase.password'),
             database: 'openwa',
 
-            ssl:
-              configService.get<boolean>('dataDatabase.ssl', false)
-                ? {
-                    rejectUnauthorized:
-                      configService.get<boolean>(
-                        'dataDatabase.sslRejectUnauthorized',
-                        false,
-                      ),
-                  }
-                : false,
+            ssl: configService.get<boolean>('dataDatabase.ssl', false)
+              ? {
+                  rejectUnauthorized: configService.get<boolean>('dataDatabase.sslRejectUnauthorized', false),
+                }
+              : false,
 
             // Never auto-sync Postgres in production; rely on migrations.
             synchronize: configService.get<boolean>('dataDatabase.synchronize', false),

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -85,6 +85,18 @@ if (process.env.QUEUE_ENABLED === 'true') {
             username: configService.get<string>('dataDatabase.username'),
             password: configService.get<string>('dataDatabase.password'),
             database: 'openwa',
+
+            ssl:
+              configService.get<boolean>('dataDatabase.ssl', false)
+                ? {
+                    rejectUnauthorized:
+                      configService.get<boolean>(
+                        'dataDatabase.sslRejectUnauthorized',
+                        false,
+                      ),
+                  }
+                : false,
+
             // Never auto-sync Postgres in production; rely on migrations.
             synchronize: configService.get<boolean>('dataDatabase.synchronize', false),
             migrationsRun: true,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -88,7 +88,7 @@ if (process.env.QUEUE_ENABLED === 'true') {
 
             ssl: configService.get<boolean>('dataDatabase.ssl', false)
               ? {
-                  rejectUnauthorized: configService.get<boolean>('dataDatabase.sslRejectUnauthorized', false),
+                  rejectUnauthorized: configService.get<boolean>('dataDatabase.sslRejectUnauthorized', true),
                 }
               : false,
 


### PR DESCRIPTION
## Description
fix for https://github.com/rmyndharis/OpenWA/issues/204
This change adds SSL configuration support to the runtime PostgreSQL TypeORM connection in AppModule.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Lint passes
- [x] Self-reviewed


