### PR TITLE
chore(release): v0.1.8 — managed-path SSL toggle, version, changelog

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,8 @@ DATABASE_USERNAME=openwa
 DATABASE_PASSWORD=your-secure-password
 DATABASE_SYNCHRONIZE=false          # WARNING: Set false in production!
 DATABASE_LOGGING=false
+DATABASE_SSL=false                   # Set true for managed Postgres (Supabase, Heroku, Render, Railway)
+DATABASE_SSL_REJECT_UNAUTHORIZED=true # Set false to allow self-signed certs (only when DATABASE_SSL=true)
 
 # =============================================================================
 # REDIS / QUEUE (Phase 2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8] - 2026-06-13
+
+A bug-fix patch release for self-hosted PostgreSQL (TLS/SSL) deployments and
+webhook delivery deduplication. Backward compatible; defaults are unchanged.
+
+### Added
+
+- **Dashboard / Setup:** The Infrastructure screen now exposes a **Verify SSL Certificate** toggle (`DATABASE_SSL_REJECT_UNAUTHORIZED`), shown when SSL is enabled, so managed-Postgres TLS can be configured end-to-end from the UI without hand-editing `.env`. Defaults to verifying certificates; turn it off only for managed Postgres with self-signed certs (Supabase, Heroku, Render, Railway).
+
+### Fixed
+
+- **Database:** The runtime PostgreSQL TypeORM connection now honors `DATABASE_SSL` and `DATABASE_SSL_REJECT_UNAUTHORIZED`. Previously SSL was wired only into the migration CLI, so `DATABASE_SSL=true` was silently ignored on the live connection. Defaults are unchanged (`ssl: false`), so existing deployments are unaffected. Thanks @farrasyakila (#205, closes #204).
+- **Webhooks:** Fixed idempotency-key generation for `message.received`, `message.sent`, `message.ack`, and `message.revoked`. The dispatched payload is an `IncomingMessage` carrying `id` (not `messageId`), but the resolver short-circuited on a truthy `'unknown'` fallback and never read `id`, so every incoming-message webhook was keyed `msg_unknown` — collapsing all messages into one deduplication bucket for consumers relying on the `X-OpenWA-Idempotency-Key` header. The resolver now uses `id ?? messageId`, with regression tests for the id-only and both-present payload shapes. Thanks @Singh1106 (#179).
+- **Dashboard:** The Login screen now derives the displayed version from `package.json` at build time instead of a hard-coded literal, so it always reflects the installed release rather than a stale placeholder (closes #88).
+
 ## [0.1.7] - 2026-06-13
 
 A security- and stability-focused patch release. Hardens the API surface,

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.1.7-blue.svg" alt="Version"/>
+  <img src="https://img.shields.io/badge/version-0.1.8-blue.svg" alt="Version"/>
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"/>
   <img src="https://img.shields.io/badge/node-22_LTS-brightgreen.svg" alt="Node"/>
   <img src="https://img.shields.io/badge/NestJS-11.x-red.svg" alt="NestJS"/>

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboard",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/dashboard/src/i18n/locales/en.json
+++ b/dashboard/src/i18n/locales/en.json
@@ -401,6 +401,8 @@
       "poolSize": "Pool Size",
       "ssl": "SSL Connection",
       "sslDesc": "Enable TLS/SSL for secure database connections",
+      "sslRejectUnauthorized": "Verify SSL Certificate",
+      "sslRejectUnauthorizedDesc": "Reject self-signed or invalid certificates. Turn off for managed Postgres with self-signed certs (Supabase, Heroku, Render, Railway).",
       "migrationsTitle": "Database Migrations",
       "migrationsStatus": "Schema is auto-synchronized with TypeORM",
       "migrationsHint": "Migrations are managed automatically. Use CLI for manual migrations."

--- a/dashboard/src/i18n/locales/he.json
+++ b/dashboard/src/i18n/locales/he.json
@@ -401,6 +401,8 @@
       "poolSize": "גודל Pool",
       "ssl": "חיבור SSL",
       "sslDesc": "הפעלת TLS/SSL לחיבור מאובטח למסד הנתונים",
+      "sslRejectUnauthorized": "אימות תעודת SSL",
+      "sslRejectUnauthorizedDesc": "דחיית תעודות בחתימה עצמית או לא תקפות. כבה עבור Postgres מנוהל עם תעודות בחתימה עצמית (Supabase, Heroku, Render, Railway).",
       "migrationsTitle": "Migrations של מסד הנתונים",
       "migrationsStatus": "הסכמה מסונכרנת אוטומטית עם TypeORM",
       "migrationsHint": "ה-Migrations מנוהלים אוטומטית. ניתן להשתמש ב-CLI ל-Migrations ידניים."

--- a/dashboard/src/pages/Infrastructure.tsx
+++ b/dashboard/src/pages/Infrastructure.tsx
@@ -35,6 +35,7 @@ interface DatabaseConfig {
   database: string;
   poolSize: number;
   sslEnabled: boolean;
+  sslRejectUnauthorized: boolean;
 }
 
 interface RedisConfig {
@@ -103,6 +104,7 @@ export function Infrastructure() {
     database: 'openwa',
     poolSize: 10,
     sslEnabled: false,
+    sslRejectUnauthorized: true,
   });
 
   const [redisConfig, setRedisConfig] = useState<RedisConfig>({
@@ -565,6 +567,22 @@ export function Infrastructure() {
                       <span className="toggle-slider"></span>
                     </label>
                   </div>
+                  {dbConfig.sslEnabled && (
+                    <div className="toggle-row">
+                      <div className="toggle-info">
+                        <span>{t('infrastructure.database.sslRejectUnauthorized')}</span>
+                        <small>{t('infrastructure.database.sslRejectUnauthorizedDesc')}</small>
+                      </div>
+                      <label className="toggle-switch">
+                        <input
+                          type="checkbox"
+                          checked={dbConfig.sslRejectUnauthorized}
+                          onChange={e => updateDbConfig('sslRejectUnauthorized', e.target.checked)}
+                        />
+                        <span className="toggle-slider"></span>
+                      </label>
+                    </div>
+                  )}
                 </div>
               )}
             </>

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -107,6 +107,7 @@ export interface SaveConfigPayload {
     database?: string;
     poolSize?: number;
     sslEnabled?: boolean;
+    sslRejectUnauthorized?: boolean;
   };
   redis?: {
     enabled?: boolean;

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -1,12 +1,22 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+
+// Single source of truth for the version shown in the dashboard: read it from
+// package.json at build time so the Login screen always reflects the actual
+// release (bumped via `npm version`), instead of a hard-coded literal that
+// silently drifts. APP_VERSION env still overrides if explicitly provided.
+const { version: pkgVersion } = JSON.parse(readFileSync(resolve(process.cwd(), 'package.json'), 'utf-8')) as {
+  version: string;
+};
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   appType: 'spa', // Enable SPA fallback for client-side routing
   define: {
-    __APP_VERSION__: JSON.stringify(process.env.APP_VERSION || '0.2.1'),
+    __APP_VERSION__: JSON.stringify(process.env.APP_VERSION || pkgVersion),
     __BUILD_TIME__: JSON.stringify(new Date().toISOString()),
   },
   server: {

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,9 +16,9 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.1.7-blue.svg" alt="Version"/>
+  <img src="https://img.shields.io/badge/version-0.1.8-blue.svg" alt="Version"/>
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"/>
-  <img src="https://img.shields.io/badge/node-20_LTS-brightgreen.svg" alt="Node"/>
+  <img src="https://img.shields.io/badge/node-22_LTS-brightgreen.svg" alt="Node"/>
   <img src="https://img.shields.io/badge/NestJS-11.x-red.svg" alt="NestJS"/>
   <img src="https://img.shields.io/badge/docker-ready-blue.svg" alt="Docker"/>
   <img src="https://img.shields.io/badge/TypeScript-5.x-3178C6.svg" alt="TypeScript"/>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwa",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API for WhatsApp",
   "author": "Yudhi Armyndharis & OpenWA Contributors",
   "private": true,

--- a/src/config/swagger.config.ts
+++ b/src/config/swagger.config.ts
@@ -14,7 +14,7 @@ export function createSwaggerConfig(): Omit<OpenAPIObject, 'paths'> {
     new DocumentBuilder()
       .setTitle('OpenWA API')
       .setDescription('Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API')
-      .setVersion('0.1.7')
+      .setVersion('0.1.8')
       .addApiKey({ type: 'apiKey', name: 'X-API-Key', in: 'header' }, API_KEY_SECURITY_SCHEME)
       // Apply the scheme globally so Swagger UI sends the key with every request
       // (mirrors the global ApiKeyGuard). Without this, "Authorize" is cosmetic.

--- a/src/modules/infra/infra.controller.spec.ts
+++ b/src/modules/infra/infra.controller.spec.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import { Reflector } from '@nestjs/core';
 import { BadRequestException } from '@nestjs/common';
 
@@ -5,6 +6,13 @@ import { BadRequestException } from '@nestjs/common';
 // v8, which is ESM-only and cannot be parsed by ts-jest. The controller logic
 // under test never touches archiver, so a lightweight stub is sufficient.
 jest.mock('archiver', () => ({ default: jest.fn() }));
+
+// saveConfig writes the generated env via fs.writeFileSync; mock only that call so
+// the tests can assert the produced content without touching the filesystem.
+jest.mock('fs', () => {
+  const actual = jest.requireActual<typeof import('fs')>('fs');
+  return { ...actual, writeFileSync: jest.fn() };
+});
 
 import { InfraController } from './infra.controller';
 import { REQUIRED_ROLE_KEY } from '../auth/decorators/auth.decorators';
@@ -61,5 +69,41 @@ describe('InfraController.importStorage filePath validation (Vuln 3)', () => {
       BadRequestException,
     );
     expect(storage.importFromStream).not.toHaveBeenCalled();
+  });
+});
+
+describe('InfraController.saveConfig SSL reject-unauthorized', () => {
+  function writtenEnv(config: unknown): string {
+    const spy = jest.spyOn(fs, 'writeFileSync').mockImplementation(() => undefined);
+    const controller = new InfraController(
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+    );
+    controller.saveConfig(config as never);
+    const content = spy.mock.calls[0][1] as string;
+    spy.mockRestore();
+    return content;
+  }
+
+  it('writes DATABASE_SSL_REJECT_UNAUTHORIZED=false for self-signed managed Postgres', () => {
+    const env = writtenEnv({ database: { type: 'postgres', sslEnabled: true, sslRejectUnauthorized: false } });
+    expect(env).toContain('DATABASE_SSL=true');
+    expect(env).toContain('DATABASE_SSL_REJECT_UNAUTHORIZED=false');
+  });
+
+  it('defaults DATABASE_SSL_REJECT_UNAUTHORIZED=true when SSL is enabled without an explicit flag', () => {
+    const env = writtenEnv({ database: { type: 'postgres', sslEnabled: true } });
+    expect(env).toContain('DATABASE_SSL_REJECT_UNAUTHORIZED=true');
+  });
+
+  it('omits DATABASE_SSL_REJECT_UNAUTHORIZED when SSL is disabled', () => {
+    const env = writtenEnv({ database: { type: 'postgres', sslEnabled: false } });
+    expect(env).not.toContain('DATABASE_SSL_REJECT_UNAUTHORIZED');
   });
 });

--- a/src/modules/infra/infra.controller.ts
+++ b/src/modules/infra/infra.controller.ts
@@ -38,6 +38,7 @@ interface SaveConfigDto {
     database?: string;
     poolSize?: number;
     sslEnabled?: boolean;
+    sslRejectUnauthorized?: boolean;
   };
   redis?: {
     enabled?: boolean;
@@ -245,6 +246,13 @@ export class InfraController {
           }
           envLines.push(`DATABASE_POOL_SIZE=${config.database.poolSize || 10}`);
           envLines.push(`DATABASE_SSL=${config.database.sslEnabled ? 'true' : 'false'}`);
+          if (config.database.sslEnabled) {
+            // Default to certificate verification; only relax it when the operator opts out
+            // (managed Postgres with self-signed certs: Supabase, Heroku, Render, Railway).
+            envLines.push(
+              `DATABASE_SSL_REJECT_UNAUTHORIZED=${config.database.sslRejectUnauthorized === false ? 'false' : 'true'}`,
+            );
+          }
         }
         envLines.push('');
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,6 @@
     "target": "ES2023",
     "sourceMap": true,
     "outDir": "./dist",
-    "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": true,


### PR DESCRIPTION
Release-prep for **v0.1.8**, on top of the merged bundle (#205 Postgres SSL, #179 webhook idempotency).

## Included
- **feat(infra):** expose `DATABASE_SSL_REJECT_UNAUTHORIZED` end-to-end (SaveConfigDto + env writer + dashboard API type + Infrastructure SSL toggle + en/he i18n) so managed-Postgres self-signed certs are configurable from the UI.
- **docs(env):** document `DATABASE_SSL` / `DATABASE_SSL_REJECT_UNAUTHORIZED` in `.env.example`.
- **fix(dashboard):** derive the Login version from `package.json` at build time (self-updating) instead of a hard-coded literal. Closes #88.
- **chore(tsconfig):** drop the unused `baseUrl` to clear the TS 7.0 deprecation.
- **chore:** bump to 0.1.8 (package.json, dashboard, swagger, README/docs badges; fix stale node-20 badge), CHANGELOG `[0.1.8]`.

Verified: backend build + 158 tests + lint, dashboard build + lint, version baked `0.1.8`, i18n parity.

Closes #88