### PR TITLE
fix(engine): sender author + contact in incoming webhook payload; interactive-message + community-integration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Built on a **pluggable architecture**, OpenWA lets you swap database engines (SQ
 | 🔹 **Multi-Session Ready**    | Run multiple WhatsApp sessions concurrently on one instance  |
 | 🐳 **Docker Native**          | Production-ready with zero configuration                     |
 | 🔗 **n8n Integration**        | Community nodes for workflow automation                      |
+| 🧩 **Community Adapters**     | Third-party integrations (e.g. ioBroker) — see [docs](./docs/23-community-integrations.md) |
 
 ---
 

--- a/docs/07-api-collection.md
+++ b/docs/07-api-collection.md
@@ -435,40 +435,16 @@ curl -X POST http://localhost:2785/api/sessions/default/messages \
 }
 ```
 
-**Request Body - Buttons (Interactive):**
-```json
-{
-  "phone": "628123456789@c.us",
-  "type": "buttons",
-  "body": "Please choose an option:",
-  "buttons": [
-    { "id": "btn1", "text": "Option 1" },
-    { "id": "btn2", "text": "Option 2" },
-    { "id": "btn3", "text": "Option 3" }
-  ],
-  "footer": "Powered by OpenWA"
-}
-```
+**Interactive messages (Buttons / List): not supported**
 
-**Request Body - List (Interactive):**
-```json
-{
-  "phone": "628123456789@c.us",
-  "type": "list",
-  "body": "Please select from the menu:",
-  "buttonText": "View Menu",
-  "sections": [
-    {
-      "title": "Category 1",
-      "rows": [
-        { "id": "item1", "title": "Item 1", "description": "Description 1" },
-        { "id": "item2", "title": "Item 2", "description": "Description 2" }
-      ]
-    }
-  ],
-  "footer": "Powered by OpenWA"
-}
-```
+> ⚠️ **Buttons and List (interactive) messages are not available** through OpenWA's
+> whatsapp-web.js engine. WhatsApp stopped honoring the interactive-message payload
+> for unofficial web clients around 2021–2022 — the `Buttons` / `List` classes still
+> exist in the library, but messages built with them are **silently dropped and never
+> delivered** to recipients. OpenWA therefore does not expose `type: "buttons"` or
+> `type: "list"` endpoints; sending interactive messages requires the official
+> WhatsApp Business Cloud API. (The earlier examples here were speculative and never
+> implemented — see #158.)
 
 **Response:**
 ```json

--- a/docs/23-community-integrations.md
+++ b/docs/23-community-integrations.md
@@ -1,0 +1,15 @@
+# Community Integrations
+
+Third-party integrations and adapters built by the community on top of OpenWA's REST API.
+
+> ⚠️ **These projects are community-maintained and are not affiliated with or endorsed by OpenWA.**
+> They may lag behind OpenWA API changes. Verify compatibility and review the source before using
+> them in production.
+
+| Integration | Platform | Source | Notes |
+| --- | --- | --- | --- |
+| **ioBroker.openwa** | [ioBroker](https://www.iobroker.net/) (home / IoT automation) | [ThorstenBoettler/ioBroker.openwa](https://github.com/ThorstenBoettler/ioBroker.openwa) · [npm](https://www.npmjs.com/package/iobroker.openwa) | Send text / image / video / audio / document messages to chats and groups through OpenWA's REST API, with Blockly blocks. Early stage. |
+
+Maintain an integration built on OpenWA and want it listed here? Open a PR adding a row (or an issue), including the repository link and a one-line description.
+
+For the first-party n8n nodes, see [n8n Integration](./22-n8n-integration.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,7 @@
 | 20  | [Community Guidelines](./20-community-guidelines.md)             | Contribution and governance                       |
 | 21  | [Glossary](./21-glossary.md)                                     | Terms and definitions                             |
 | 22  | [n8n Integration](./22-n8n-integration.md)                       | n8n community nodes for OpenWA                    |
+| 23  | [Community Integrations](./23-community-integrations.md)         | Third-party adapters built on the OpenWA API      |
 
 ## Quick Start
 

--- a/src/engine/adapters/message-mapper.spec.ts
+++ b/src/engine/adapters/message-mapper.spec.ts
@@ -1,0 +1,40 @@
+import { buildIncomingMessageBase, RawMessageFields } from './message-mapper';
+
+describe('buildIncomingMessageBase', () => {
+  const base: RawMessageFields = {
+    id: { _serialized: 'MSG1' },
+    from: '123@c.us',
+    to: 'me@c.us',
+    body: 'hi',
+    type: 'chat',
+    timestamp: 1700000000,
+    fromMe: false,
+  };
+
+  it('maps the core fields and flags 1:1 chats as non-group', () => {
+    const r = buildIncomingMessageBase(base);
+    expect(r.id).toBe('MSG1');
+    expect(r.chatId).toBe('123@c.us');
+    expect(r.isGroup).toBe(false);
+    expect(r.author).toBeUndefined();
+    expect(r.contact).toBeUndefined();
+  });
+
+  it('includes author and pushName for a group message', () => {
+    const r = buildIncomingMessageBase({
+      ...base,
+      from: 'group-1@g.us',
+      author: '456@c.us',
+      _data: { notifyName: 'Alice' },
+    });
+    expect(r.isGroup).toBe(true);
+    expect(r.author).toBe('456@c.us');
+    expect(r.contact).toEqual({ pushName: 'Alice' });
+  });
+
+  it('omits contact when no push name is present', () => {
+    const r = buildIncomingMessageBase({ ...base, author: '789@c.us' });
+    expect(r.author).toBe('789@c.us');
+    expect(r.contact).toBeUndefined();
+  });
+});

--- a/src/engine/adapters/message-mapper.ts
+++ b/src/engine/adapters/message-mapper.ts
@@ -1,0 +1,52 @@
+import { IncomingMessage } from '../interfaces/whatsapp-engine.interface';
+
+/**
+ * The subset of whatsapp-web.js `Message` fields we read synchronously to build
+ * the base of an {@link IncomingMessage}. Declared explicitly so the mapping is
+ * unit-testable without constructing a full wwebjs `Message`.
+ */
+export interface RawMessageFields {
+  id: { _serialized: string };
+  from: string;
+  to: string;
+  body: string;
+  type: string;
+  timestamp: number;
+  fromMe: boolean;
+  /** Set on group messages: the participant WID that actually sent the message. */
+  author?: string;
+  /** Raw wwebjs payload; `notifyName` carries the sender's push name without an extra lookup. */
+  _data?: { notifyName?: string };
+}
+
+/**
+ * Build the synchronous base of an IncomingMessage from a raw wwebjs message.
+ * Async enrichment (media, quoted message, saved-contact name) is layered on by
+ * the adapter; this covers the fields available without an await.
+ */
+export function buildIncomingMessageBase(msg: RawMessageFields): IncomingMessage {
+  const incoming: IncomingMessage = {
+    id: msg.id._serialized,
+    from: msg.from,
+    to: msg.to,
+    chatId: msg.from,
+    body: msg.body,
+    type: msg.type,
+    timestamp: msg.timestamp,
+    fromMe: msg.fromMe,
+    isGroup: msg.from.endsWith('@g.us'),
+  };
+
+  // In a group, `from` is the group JID, so `author` is the only way to know the real sender.
+  if (msg.author) {
+    incoming.author = msg.author;
+  }
+
+  // Push name is available synchronously on the raw payload — no contact lookup needed.
+  const pushName = msg._data?.notifyName;
+  if (pushName) {
+    incoming.contact = { pushName };
+  }
+
+  return incoming;
+}

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -35,6 +35,7 @@ import {
   WwjsChannelData,
   GroupCreateResult,
 } from '../types/whatsapp-web-js.types';
+import { buildIncomingMessageBase } from './message-mapper';
 
 export interface WhatsAppWebJsConfig {
   sessionId: string;
@@ -143,17 +144,21 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     this.client.on('message', async msg => {
       try {
-        const incomingMessage: IncomingMessage = {
-          id: msg.id._serialized,
-          from: msg.from,
-          to: msg.to,
-          chatId: msg.from,
-          body: msg.body,
-          type: msg.type,
-          timestamp: msg.timestamp,
-          fromMe: msg.fromMe,
-          isGroup: msg.from.endsWith('@g.us'),
-        };
+        const incomingMessage: IncomingMessage = buildIncomingMessageBase(msg);
+
+        // Enrich the sender contact with the saved name (best-effort, from the WhatsApp Web cache).
+        // `author`/`from` resolve to the actual sender for group and 1:1 messages respectively.
+        try {
+          const contact = await msg.getContact();
+          if (contact?.name || contact?.pushname) {
+            incomingMessage.contact = {
+              name: contact.name || incomingMessage.contact?.name,
+              pushName: contact.pushname || incomingMessage.contact?.pushName,
+            };
+          }
+        } catch (error) {
+          this.logger.error('Error getting message contact', String(error));
+        }
 
         // Handle location
         if (msg.type === MessageTypes.LOCATION && msg.location) {

--- a/src/engine/interfaces/whatsapp-engine.interface.ts
+++ b/src/engine/interfaces/whatsapp-engine.interface.ts
@@ -32,6 +32,13 @@ export interface IncomingMessage {
   timestamp: number;
   fromMe: boolean;
   isGroup: boolean;
+  /** For group messages, the WID of the participant who actually sent it (`from` is the group JID there). */
+  author?: string;
+  /** Sender display info, best-effort from the WhatsApp Web contact cache. */
+  contact?: {
+    name?: string;
+    pushName?: string;
+  };
   media?: {
     mimetype: string;
     filename?: string;


### PR DESCRIPTION
Bundles one small additive bug fix and two doc corrections from the issue sweep.

## fix(engine): `author` + `contact` on `message.received` (Closes #146)
The dispatched `IncomingMessage` was missing the group sender's identity and display name. Now includes:
- **`author`** — the participant WID that actually sent a group message (`from` is the group JID, so this was the only missing way to know the sender).
- **`contact`** `{ name, pushName }` — best-effort from the WhatsApp Web cache (push name read synchronously from the raw payload; saved name enriched via `getContact()`).

Extracted a unit-tested `buildIncomingMessageBase` helper (3 new tests). Additive and back-compatible — no existing field changed.

## docs(api): interactive messages marked unsupported (Closes #158)
`docs/07-api-collection.md` showed speculative `type: "buttons"` / `type: "list"` examples for an endpoint that never existed. whatsapp-web.js's `Buttons`/`List` classes are silently dropped by WhatsApp for unofficial clients (since ~2021–2022), so these can't be honestly offered. Replaced the examples with a clear "not supported" note.

## docs: community integrations (Closes #134)
Added `docs/23-community-integrations.md` listing the community **ioBroker** adapter (with a community-maintained / not-endorsed caveat) + index rows in `docs/README.md` and `README.md`.

Verified: backend build + lint + 161 tests green.