### PR TITLE
fix(session): persist message_ack so delivery/read status is tracked

### DIFF
--- a/src/modules/session/session.module.ts
+++ b/src/modules/session/session.module.ts
@@ -1,12 +1,13 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Session } from './entities/session.entity';
+import { Message } from '../message/entities/message.entity';
 import { SessionService } from './session.service';
 import { SessionController } from './session.controller';
 import { WebhookModule } from '../webhook/webhook.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Session], 'data'), forwardRef(() => WebhookModule)],
+  imports: [TypeOrmModule.forFeature([Session, Message], 'data'), forwardRef(() => WebhookModule)],
   controllers: [SessionController],
   providers: [SessionService],
   exports: [SessionService],

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -9,6 +9,7 @@ import {
 import { InjectRepository, InjectDataSource } from '@nestjs/typeorm';
 import { Repository, In, DataSource } from 'typeorm';
 import { Session, SessionStatus } from './entities/session.entity';
+import { Message, MessageStatus } from '../message/entities/message.entity';
 import { CreateSessionDto } from './dto';
 import { EngineFactory } from '../../engine/engine.factory';
 import { IWhatsAppEngine, EngineStatus } from '../../engine/interfaces/whatsapp-engine.interface';
@@ -37,6 +38,8 @@ export class SessionService implements OnModuleDestroy, OnModuleInit {
   constructor(
     @InjectRepository(Session, 'data')
     private readonly sessionRepository: Repository<Session>,
+    @InjectRepository(Message, 'data')
+    private readonly messageRepository: Repository<Message>,
     @InjectDataSource('data')
     private readonly dataSource: DataSource,
     private readonly engineFactory: EngineFactory,
@@ -312,6 +315,10 @@ export class SessionService implements OnModuleDestroy, OnModuleInit {
             this.eventsGateway.emitMessage(id, finalMessage);
           });
       },
+      onMessageAck: (waMessageId: string, ack: number): void => {
+        // Persist WhatsApp delivery/read receipts so message status reflects reality
+        void this.handleMessageAck(id, waMessageId, ack);
+      },
       onDisconnected: (reason: string): void => {
         this.logger.warn(`Session disconnected: ${reason}`, {
           sessionId: id,
@@ -351,6 +358,63 @@ export class SessionService implements OnModuleDestroy, OnModuleInit {
     });
 
     await this.updateStatus(id, SessionStatus.INITIALIZING);
+  }
+
+  /**
+   * Map a whatsapp-web.js message ACK level to our MessageStatus.
+   * Ack levels: -1 error, 0 pending, 1 server (sent), 2 device (delivered), 3 read, 4 played.
+   */
+  private static readonly ACK_STATUS: Record<number, MessageStatus> = {
+    [-1]: MessageStatus.FAILED,
+    0: MessageStatus.PENDING,
+    1: MessageStatus.SENT,
+    2: MessageStatus.DELIVERED,
+    3: MessageStatus.READ,
+    4: MessageStatus.READ,
+  };
+
+  private static statusRank(status: MessageStatus): number {
+    switch (status) {
+      case MessageStatus.PENDING:
+        return 0;
+      case MessageStatus.SENT:
+        return 1;
+      case MessageStatus.DELIVERED:
+        return 2;
+      case MessageStatus.READ:
+        return 3;
+      default:
+        return -1; // FAILED or unknown
+    }
+  }
+
+  /**
+   * Persist a WhatsApp delivery/read receipt for an outgoing message.
+   * Updates the stored message status, never downgrading (except an explicit failure).
+   */
+  private async handleMessageAck(sessionId: string, waMessageId: string, ack: number): Promise<void> {
+    const newStatus = SessionService.ACK_STATUS[ack];
+    if (!newStatus) return;
+    try {
+      const message = await this.messageRepository.findOne({ where: { sessionId, waMessageId } });
+      if (!message) return; // ack for a message we didn't record (e.g. incoming) - ignore
+      if (
+        newStatus !== MessageStatus.FAILED &&
+        SessionService.statusRank(newStatus) <= SessionService.statusRank(message.status)
+      ) {
+        return; // don't downgrade (e.g. a late 'delivered' arriving after 'read')
+      }
+      message.status = newStatus;
+      await this.messageRepository.save(message);
+      this.logger.debug(`Message ack ${waMessageId} -> ${newStatus}`, {
+        sessionId,
+        action: 'message_ack',
+        ack,
+        status: newStatus,
+      });
+    } catch (error) {
+      this.logger.warn(`Failed to update message ack for ${waMessageId}: ${String(error)}`);
+    }
   }
 
   private scheduleReconnect(id: string, session: Session): void {


### PR DESCRIPTION
## Problem

The whatsapp-web.js engine emits `message_ack` events, and the adapter (`whatsapp-web-js.adapter.ts`) already forwards them through the `onMessageAck` engine callback. But `SessionService` never implemented `onMessageAck`, so every delivery/read receipt was silently dropped.

As a result, an outgoing message's `status` is set to `sent` at send time and **never updated**. `MessageStatus.DELIVERED` and `MessageStatus.READ` exist in the enum but were never written — so the message history and dashboard could never reflect real delivery state (every message appears stuck at `sent` forever, even after it's delivered and read).

## Fix

Implement the `onMessageAck` callback in `SessionService`:

- Map whatsapp-web.js ack levels to `MessageStatus`: `-1 → failed`, `1 → sent`, `2 → delivered`, `3`/`4 → read`.
- Look up the stored message by `(sessionId, waMessageId)` and update its `status`.
- Never downgrade an already-higher status (e.g. a late `delivered` arriving after `read`).
- Ignore acks for messages that aren't tracked (e.g. incoming).

`SessionModule` now registers the `Message` repository so the service can persist updates. It injects the **repository**, not `MessageService`, so there's no new circular dependency.

## Validation

Built and run locally. An outgoing message now advances `sent → delivered → read` in `GET /sessions/:id/messages`, instead of remaining `sent` indefinitely.

## Notes

- No schema/migration change — the `DELIVERED`/`READ` enum values already existed.
- Stats counts are unaffected; they key off `direction`, not `status`.
