### PR TITLE
fix(security): isolate Docker socket access via docker-socket-proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,20 @@ npm run dev
 
 ---
 
+## 🔒 Security Architecture
+
+### Docker Socket Proxy
+
+The production stack never exposes `/var/run/docker.sock` directly to the application container. Instead, a dedicated `docker-proxy` sidecar (based on [`tecnativa/docker-socket-proxy`](https://github.com/Tecnativa/docker-socket-proxy)) acts as the sole gateway to the Docker daemon:
+
+```
+openwa-api  ──TCP 2375──▶  docker-proxy  ──unix──▶  /var/run/docker.sock
+```
+
+Only the operations needed for container orchestration are enabled (`CONTAINERS`, `IMAGES`, `VOLUMES`, `INFO`, `PING`, `POST`, `DELETE`). The application connects via the `DOCKER_HOST=tcp://docker-proxy:2375` environment variable, which `DockerService` detects automatically.
+
+---
+
 ## 🏭 Production Deployment
 
 For production, use the main `docker-compose.yml` with optional services:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,26 @@
 # Smart Orchestration with Profiles
 
 services:
+  # ===== CORE: Docker Socket Proxy (sole container with /var/run/docker.sock access) =====
+  docker-proxy:
+    image: tecnativa/docker-socket-proxy
+    container_name: openwa-docker-proxy
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      CONTAINERS: 1
+      IMAGES: 1
+      VOLUMES: 1
+      INFO: 1
+      PING: 1
+      POST: 1
+      DELETE: 1
+      # Everything else is denied by default (AUTH, SECRETS, NETWORKS, PLUGINS, SWARM, TASKS, SERVICES, CONFIGS, NODES, DISTRIBUTIONS)
+    labels:
+      - 'com.openwa.service=docker-proxy'
+      - 'com.openwa.core=true'
+
   # ===== CORE: Traefik Reverse Proxy =====
   traefik:
     image: traefik:v3.0
@@ -70,11 +90,14 @@ services:
       - PLUGINS_DIR=/app/data/plugins
       # Security
       - API_MASTER_KEY=${API_MASTER_KEY:-}
+      # Docker socket proxy (openwa-api never touches /var/run/docker.sock directly)
+      - DOCKER_HOST=tcp://docker-proxy:2375
     volumes:
       - openwa-data:/app/data
-      - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./docker-compose.yml:/app/docker-compose.yml:ro
     depends_on:
+      docker-proxy:
+        condition: service_started
       postgres:
         condition: service_healthy
         required: false

--- a/scripts/smoke-test-docker-proxy.sh
+++ b/scripts/smoke-test-docker-proxy.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# Smoke test: verify openwa-api can list containers via docker-socket-proxy.
+# Run this after `docker compose up -d` with the stack fully started.
+# Usage: ./scripts/smoke-test-docker-proxy.sh [API_KEY]
+set -e
+
+API_KEY="${1:-}"
+BASE_URL="${BASE_URL:-http://localhost:2785}"
+
+if [ -z "$API_KEY" ]; then
+  echo "Usage: $0 <admin-api-key>" >&2
+  exit 1
+fi
+
+echo "==> Checking openwa-api health..."
+STATUS=$(curl -sf -o /dev/null -w "%{http_code}" "$BASE_URL/api/health")
+if [ "$STATUS" != "200" ]; then
+  echo "FAIL: /api/health returned HTTP $STATUS (expected 200)" >&2
+  exit 1
+fi
+echo "PASS: API health OK"
+
+echo ""
+echo "==> Verifying Docker proxy connectivity via infrastructure status..."
+RESPONSE=$(curl -sf \
+  -H "X-API-Key: $API_KEY" \
+  "$BASE_URL/api/infra/status")
+
+echo "Response: $RESPONSE"
+
+# The key check: docker availability flag from DockerService.isDockerAvailable()
+# If the proxy is unreachable, the service logs a warning and sets isAvailable=false.
+# We indirectly validate this by confirming the API responds without error.
+echo ""
+echo "==> Verifying docker-proxy container is running..."
+PROXY_STATE=$(docker inspect --format='{{.State.Status}}' openwa-docker-proxy 2>/dev/null || echo "not_found")
+if [ "$PROXY_STATE" != "running" ]; then
+  echo "FAIL: openwa-docker-proxy is not running (state: $PROXY_STATE)" >&2
+  exit 1
+fi
+echo "PASS: openwa-docker-proxy is running"
+
+echo ""
+echo "==> Verifying openwa-api socket mount is gone..."
+SOCKET_MOUNT=$(docker inspect openwa-api --format='{{range .Mounts}}{{.Source}}{{"\n"}}{{end}}' 2>/dev/null | grep "docker.sock" || true)
+if [ -n "$SOCKET_MOUNT" ]; then
+  echo "FAIL: openwa-api still has a docker.sock mount: $SOCKET_MOUNT" >&2
+  exit 1
+fi
+echo "PASS: openwa-api has no direct docker.sock mount"
+
+echo ""
+echo "All smoke tests passed!"

--- a/src/modules/docker/docker.service.spec.ts
+++ b/src/modules/docker/docker.service.spec.ts
@@ -1,0 +1,44 @@
+import { DockerService } from './docker.service';
+
+// Prevent actual Docker connections on module init during tests
+jest.mock('dockerode');
+
+describe('DockerService.buildDockerOptions', () => {
+  let service: DockerService;
+  const originalDockerHost = process.env.DOCKER_HOST;
+
+  beforeEach(() => {
+    service = new DockerService();
+  });
+
+  afterEach(() => {
+    if (originalDockerHost === undefined) {
+      delete process.env.DOCKER_HOST;
+    } else {
+      process.env.DOCKER_HOST = originalDockerHost;
+    }
+  });
+
+  it('returns TCP options when DOCKER_HOST is set to tcp://host:port', () => {
+    process.env.DOCKER_HOST = 'tcp://docker-proxy:2375';
+    expect(service.buildDockerOptions()).toEqual({
+      host: 'docker-proxy',
+      port: 2375,
+      protocol: 'http',
+    });
+  });
+
+  it('falls back to unix socket when DOCKER_HOST is not set', () => {
+    delete process.env.DOCKER_HOST;
+    expect(service.buildDockerOptions()).toEqual({
+      socketPath: '/var/run/docker.sock',
+    });
+  });
+
+  it('falls back to unix socket for unsupported DOCKER_HOST schemes', () => {
+    process.env.DOCKER_HOST = 'unix:///run/docker.sock';
+    expect(service.buildDockerOptions()).toEqual({
+      socketPath: '/var/run/docker.sock',
+    });
+  });
+});

--- a/src/modules/docker/docker.service.ts
+++ b/src/modules/docker/docker.service.ts
@@ -71,17 +71,29 @@ export class DockerService implements OnModuleInit {
 
   private async initializeDocker(): Promise<void> {
     try {
-      this.docker = new Docker({ socketPath: '/var/run/docker.sock' });
+      this.docker = new Docker(this.buildDockerOptions());
       await this.docker.ping();
       this.isAvailable = true;
       this.logger.log('Docker API connected successfully');
     } catch (error) {
       this.logger.warn(
-        'Docker socket not available. Container orchestration disabled.',
+        'Docker not available. Container orchestration disabled.',
         error instanceof Error ? error.message : error,
       );
       this.isAvailable = false;
     }
+  }
+
+  // Visible for testing
+  buildDockerOptions(): Docker.DockerOptions {
+    const dockerHost = process.env.DOCKER_HOST;
+    if (dockerHost) {
+      const match = /^tcp:\/\/([^:]+):(\d+)$/.exec(dockerHost);
+      if (match) {
+        return { host: match[1], port: parseInt(match[2], 10), protocol: 'http' };
+      }
+    }
+    return { socketPath: '/var/run/docker.sock' };
   }
 
   /**


### PR DESCRIPTION
- Add tecnativa/docker-socket-proxy as the sole container with /var/run/docker.sock access; openwa-api connects via TCP instead
- Remove direct socket mount from openwa-api; add DOCKER_HOST env var and depends_on: docker-proxy to docker-compose.yml
- Fix DockerService.initializeDocker() to read DOCKER_HOST (tcp://host:port) instead of hardcoding the unix socket path
- Add unit tests for buildDockerOptions() covering tcp, socket, and unsupported-scheme fallback cases
- Add scripts/smoke-test-docker-proxy.sh for post-deploy integration check
- Document the proxy network topology in README

Splits from PR #129 (docker-proxy only; bull-board-auth via #214).

## Description
Brief description of changes

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Lint passes
- [ ] Self-reviewed

## Screenshots (if applicable)

## Related Issues
Closes #
