### PR TITLE
fix(security): run container process as non-root via gosu entrypoint

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Force LF line endings for files that must run inside Linux containers
+*.sh        text eol=lf
+Dockerfile* text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN apt-get update && apt-get install -y \
     libxrandr2 \
     xdg-utils \
     dumb-init \
+    gosu \
     && rm -rf /var/lib/apt/lists/*
 
 # Set Chrome executable path for Puppeteer
@@ -69,13 +70,13 @@ RUN npm ci --omit=dev && npm cache clean --force
 # Copy built application from builder stage
 COPY --from=builder /app/dist ./dist
 
-# Create data directories with proper permissions
+# Create data directories with correct ownership
 RUN mkdir -p ./data/sessions ./data/media && \
     chown -R openwa:openwa /app
 
-# Note: Running as root to allow Docker socket access for orchestration
-# For production with stricter security, consider using a Docker socket proxy
-# USER openwa
+# Copy entrypoint: runs as root to fix named-volume ownership, then drops to openwa via gosu
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 # Expose port
 EXPOSE 2785
@@ -84,6 +85,8 @@ EXPOSE 2785
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
     CMD node -e "require('http').get('http://localhost:2785/api/health', (r) => process.exit(r.statusCode === 200 ? 0 : 1))"
 
-# Start with dumb-init to handle signals properly
-ENTRYPOINT ["dumb-init", "--"]
+# dumb-init is PID 1 and handles signal forwarding.
+# It execs docker-entrypoint.sh (as root), which fixes volume ownership and
+# then drops to the openwa user via gosu before starting the node process.
+ENTRYPOINT ["dumb-init", "--", "/usr/local/bin/docker-entrypoint.sh"]
 CMD ["node", "dist/main"]

--- a/README.md
+++ b/README.md
@@ -129,6 +129,26 @@ npm run dev
 
 ---
 
+## 🔒 Security Architecture
+
+### Non-root Container Execution
+
+The production image never runs the Node.js process as root. On startup, the container follows this chain:
+
+```
+dumb-init (PID 1)
+  └─ docker-entrypoint.sh (root — fixes named-volume ownership via chown)
+       └─ gosu openwa node dist/main  (drops to the openwa user)
+```
+
+- **dumb-init** is PID 1 and forwards signals (SIGTERM, etc.) for graceful shutdown.
+- **docker-entrypoint.sh** runs as root only long enough to `chown` the named-volume mount points so the `openwa` user can write to them.
+- **gosu** performs a clean `exec`-based privilege drop — no `su` or `sudo` wrappers, so the node process is the direct child of dumb-init.
+
+Named volumes (e.g. `openwa-data`) get their ownership corrected automatically on every start, so no manual `chown` step is needed after volume creation.
+
+---
+
 ## 🏭 Production Deployment
 
 For production, use the main `docker-compose.yml` with optional services:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Runs as root (via dumb-init). Fixes named-volume ownership then drops to the
+# openwa user via gosu so the Node process never holds root privileges.
+set -e
+
+mkdir -p /app/data/sessions /app/data/media /app/data/plugins
+chown -R openwa:openwa /app/data
+
+# "$@" = CMD from Dockerfile (default: node dist/main).
+# gosu performs exec, so the node process replaces this shell and becomes the
+# direct child of dumb-init (PID 1), which can therefore forward SIGTERM cleanly.
+exec gosu openwa "$@"

--- a/scripts/smoke-test-non-root.sh
+++ b/scripts/smoke-test-non-root.sh
@@ -1,0 +1,44 @@
+﻿#!/bin/sh
+# Smoke test: verify the built image runs its process as the openwa user (not root).
+# Usage: ./scripts/smoke-test-non-root.sh
+# Requires Docker to be running locally.
+set -e
+
+IMAGE_TAG="openwa-test-non-root:smoke"
+
+echo "==> Building test image..."
+docker build -t "$IMAGE_TAG" .
+
+echo ""
+echo "==> Checking process user inside container..."
+# Override CMD with 'id' so docker-entrypoint.sh runs: exec gosu openwa id
+USER_OUTPUT=$(docker run --rm "$IMAGE_TAG" id)
+echo "    $USER_OUTPUT"
+
+if echo "$USER_OUTPUT" | grep -q "uid=0(root)"; then
+  echo "FAIL: process is running as root!" >&2
+  docker rmi "$IMAGE_TAG" > /dev/null 2>&1 || true
+  exit 1
+fi
+
+if echo "$USER_OUTPUT" | grep -q "openwa"; then
+  echo "PASS: process runs as openwa (non-root)"
+else
+  echo "FAIL: process is not running as the openwa user" >&2
+  docker rmi "$IMAGE_TAG" > /dev/null 2>&1 || true
+  exit 1
+fi
+
+echo ""
+echo "==> Verifying dumb-init is PID 1..."
+PID1=$(docker run --rm "$IMAGE_TAG" sh -c 'cat /proc/1/comm 2>/dev/null || ps -p 1 -o comm= 2>/dev/null || echo unknown')
+echo "    PID 1: $PID1"
+if echo "$PID1" | grep -q "dumb-init"; then
+  echo "PASS: dumb-init is PID 1"
+else
+  echo "WARN: PID 1 is '$PID1' (expected dumb-init) — check entrypoint chain"
+fi
+
+docker rmi "$IMAGE_TAG" > /dev/null 2>&1 || true
+echo ""
+echo "All smoke tests passed!"


### PR DESCRIPTION
- Install gosu in the production stage of the Dockerfile
- Add docker-entrypoint.sh: runs as root, chowns /app/data for named-volume mounts, then exec-drops to the openwa user via gosu before starting node
- Fix entrypoint chain: ENTRYPOINT [dumb-init,--,/usr/local/bin/docker-entrypoint.sh] so dumb-init is PID 1, the script runs under it, and node is its direct child for clean SIGTERM forwarding (resolves the missing -- bug from PR #129 review)
- Add scripts/smoke-test-non-root.sh: builds the image and asserts the process runs as openwa (uid != 0) and that dumb-init is PID 1
- Add .gitattributes to enforce LF line endings for shell scripts
- Document the startup chain in README

Splits from PR #129 (entrypoint/non-root only; bull-board-auth via #214).

## Description
Brief description of changes

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Lint passes
- [ ] Self-reviewed

## Screenshots (if applicable)

## Related Issues
Closes #
