### PR TITLE
fix(dashboard): honor VITE_API_URL for split-origin deployments (#91)

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -78,10 +78,16 @@ dashboard/
 
 ## 🔗 API Connection
 
-The dashboard connects to the OpenWA API backend. Configure the API URL in environment variables:
+By default the dashboard calls the API on the **same origin** it is served from (the
+single-container setup), so no configuration is needed.
+
+For a **split-origin** deployment (dashboard hosted separately from the API), set the API
+**origin** at build time — the `/api` prefix is appended automatically:
 
 ```bash
 VITE_API_URL=http://localhost:2785
+# real-time events (WebSocket) origin; defaults to the page origin
+VITE_WS_URL=http://localhost:2785
 ```
 
 ## 📄 License

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -1,7 +1,14 @@
 // API Service Layer for OpenWA Dashboard
 // Centralized API client with TypeScript types
 
-const API_BASE_URL = '/api';
+// Resolve the API base URL. By default this is the same-origin relative path '/api',
+// correct when the dashboard and API are served from the same origin (the default
+// single-container setup). For a split-origin deployment (dashboard hosted separately
+// from the API), set VITE_API_URL at build time to the API ORIGIN — e.g.
+// `VITE_API_URL=https://gateway.example.com` — and the '/api' prefix is appended here.
+// Previously VITE_API_URL was documented but never read, so the dashboard always called
+// same-origin '/api' and a split deployment failed with "Invalid API Key" (#91).
+const API_BASE_URL = `${(import.meta.env.VITE_API_URL ?? '').replace(/\/+$/, '')}/api`;
 
 // =============================================================================
 // Types


### PR DESCRIPTION
## Problem
The dashboard README documents `VITE_API_URL` to point the UI at a separately-hosted API, but `dashboard/src/services/api.ts` ignored it and always called the same-origin `/api`. In a **split-origin** deployment (dashboard hosted apart from the API), requests hit the dashboard's own server → **"Invalid API Key"** on login. (#91)

## Fix
- `api.ts` reads `import.meta.env.VITE_API_URL` (the API **origin**) and appends `/api`.
- When unset, falls back to the same-origin relative `/api` — **default single-container setup is unchanged** (verified: `/api` is still inlined in the build when the var is absent).
- README clarified (VITE_API_URL optional, origin-only, `/api` appended) + documents `VITE_WS_URL` alongside.

## Verification
- `npm --prefix dashboard run build` (tsc -b + vite) passes; default `/api` confirmed inlined.

Closes #91.