### PR TITLE
chore(release): v0.2.1 — dashboard split-origin fix (#91) + TS 6.0 (#140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-06-15
+
+A patch release.
+
+### Fixed
+
+- **Dashboard:** The API client now honors `VITE_API_URL` for split-origin deployments.
+  It reads `VITE_API_URL` (the API origin) and appends `/api` instead of always calling the
+  same-origin `/api`; the same-origin default is unchanged. This fixes the dashboard
+  failing with "Invalid API Key" when it is hosted on a different origin than the API.
+  Thanks @jairo315-bit (#91).
+
+### Dependencies
+
+- **Dashboard:** Bump the TypeScript dev dependency from 5.9.3 to 6.0.3 (#140).
+
 ## [0.2.0] - 2026-06-15
 
 A major feature- and security-focused release. Adds six dashboard languages and a

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.2.0-blue.svg" alt="Version"/>
+  <img src="https://img.shields.io/badge/version-0.2.1-blue.svg" alt="Version"/>
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"/>
   <img src="https://img.shields.io/badge/node-22_LTS-brightgreen.svg" alt="Node"/>
   <img src="https://img.shields.io/badge/NestJS-11.x-red.svg" alt="NestJS"/>

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashboard",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashboard",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@tanstack/react-query": "^5.101.0",
         "@tanstack/react-table": "^8.21.3",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboard",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.2.0-blue.svg" alt="Version"/>
+  <img src="https://img.shields.io/badge/version-0.2.1-blue.svg" alt="Version"/>
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"/>
   <img src="https://img.shields.io/badge/node-22_LTS-brightgreen.svg" alt="Node"/>
   <img src="https://img.shields.io/badge/NestJS-11.x-red.svg" alt="NestJS"/>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openwa",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openwa",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwa",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API for WhatsApp",
   "author": "Yudhi Armyndharis & OpenWA Contributors",
   "private": true,

--- a/src/config/swagger.config.ts
+++ b/src/config/swagger.config.ts
@@ -14,7 +14,7 @@ export function createSwaggerConfig(): Omit<OpenAPIObject, 'paths'> {
     new DocumentBuilder()
       .setTitle('OpenWA API')
       .setDescription('Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API')
-      .setVersion('0.2.0')
+      .setVersion('0.2.1')
       .addApiKey({ type: 'apiKey', name: 'X-API-Key', in: 'header' }, API_KEY_SECURITY_SCHEME)
       // Apply the scheme globally so Swagger UI sends the key with every request
       // (mirrors the global ApiKeyGuard). Without this, "Authorize" is cosmetic.


### PR DESCRIPTION
Patch release bundling the two changes that landed on `main` after v0.2.0:
- **fix(dashboard):** honor `VITE_API_URL` for split-origin deployments (#91)
- **chore(deps-dev):** TypeScript 5.9.3 → 6.0.3 in /dashboard (#140)

Version stamped 0.2.1 across package.json + package-lock (backend & dashboard), README/docs badges, and the Swagger API version; CHANGELOG [0.2.1] added. Backend + dashboard builds verified.