### PR TITLE
docs: add community health files (CoC, Contributing, Security, issue templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,88 @@
+name: Bug report
+description: Report a problem with OpenWA
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug! Please fill in the details below — the
+        version, deployment, and logs make a huge difference for triage.
+
+        ⚠️ **Do not report security vulnerabilities here.** See
+        [SECURITY.md](https://github.com/rmyndharis/OpenWA/blob/main/SECURITY.md).
+  - type: checkboxes
+    attributes:
+      label: Pre-flight
+      options:
+        - label: I searched existing issues and this isn't a duplicate
+          required: true
+        - label: I'm on the latest released version (or noted my version below)
+          required: true
+  - type: input
+    id: version
+    attributes:
+      label: OpenWA version
+      description: e.g. 0.2.1 (shown on the dashboard Login screen) or a commit SHA
+      placeholder: "0.2.1"
+    validations:
+      required: true
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment
+      options:
+        - Docker Compose
+        - Docker (manual run)
+        - Bare metal (npm)
+        - Other (describe below)
+    validations:
+      required: true
+  - type: dropdown
+    id: database
+    attributes:
+      label: Database
+      options:
+        - SQLite (default)
+        - PostgreSQL
+    validations:
+      required: true
+  - type: input
+    id: engine
+    attributes:
+      label: WhatsApp engine
+      description: The default is whatsapp-web.js; note the version if you changed it.
+      value: "whatsapp-web.js"
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and its impact.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Exact steps (including the API call or dashboard action) to reproduce.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Server/container logs around the failure (redact API keys & secrets).
+      render: shell
+  - type: textarea
+    id: context
+    attributes:
+      label: Environment / additional context
+      description: OS, Node version, reverse proxy, anything else relevant.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📚 Documentation
+    url: https://github.com/rmyndharis/OpenWA/tree/main/docs
+    about: Setup, API specification, and operational guides.
+  - name: 🔒 Report a security vulnerability
+    url: https://github.com/rmyndharis/OpenWA/security/advisories/new
+    about: Please report vulnerabilities privately — not as a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature request
+description: Suggest an idea or improvement for OpenWA
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! Please describe the problem first — that helps us find
+        the best solution, which isn't always the one initially imagined.
+  - type: checkboxes
+    attributes:
+      label: Pre-flight
+      options:
+        - label: I searched existing issues and this isn't already requested
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do, and what's getting in the way today?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like to see? API shape, dashboard behavior, config, etc.
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope
+      description: A quick reality check on engine capabilities.
+      options:
+        - label: >-
+            I understand some features are limited by the underlying WhatsApp engine
+            (e.g. interactive Buttons/List messages are not supported on whatsapp-web.js).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,36 @@
+# Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and maintainers pledge to make participation in the OpenWA
+community a welcoming, respectful, and inclusive experience for everyone, regardless of
+background or identity.
+
+## Our standards
+
+We expect everyone in the community to act professionally and considerately:
+
+- Be welcoming, patient, and respectful in all interactions.
+- Assume good intent; give and accept constructive feedback gracefully.
+- Focus on what is best for the community and the project.
+
+Conduct that a reasonable person would find inappropriate in a professional setting is
+not acceptable and may result in moderation action.
+
+## Adoption
+
+This project adopts the **Contributor Covenant, version 2.1**. The complete text —
+including the detailed standards, enforcement guidelines, and scope — is published at:
+
+- <https://www.contributor-covenant.org/version/2/1/code_of_conduct/>
+
+## Enforcement
+
+Concerns about a community member's conduct may be reported privately to the project
+maintainer at **yudhi@rmyndharis.com**. All reports will be reviewed and investigated
+promptly and fairly, and the reporter's privacy will be respected.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing to OpenWA
+
+Thanks for your interest in improving OpenWA! This guide covers how to get set up, the
+conventions we follow, and how to get a change merged. Contributions of all sizes are
+welcome — bug fixes, features, docs, and tests.
+
+## Project layout
+
+OpenWA is a NestJS (backend) + React/Vite (dashboard) project:
+
+- `src/` — the NestJS API. Feature modules under `src/modules/` (session, message,
+  webhook, queue, audit, settings, infra, …), the WhatsApp engine abstraction under
+  `src/engine/`, and shared utilities under `src/common/`.
+- `dashboard/` — the React dashboard.
+- `docs/` — architecture, API specification, and operational docs.
+
+See `docs/03-system-architecture.md` for the bigger picture.
+
+## Getting started
+
+OpenWA targets **Node.js 22+**.
+
+```bash
+# backend
+npm install
+cp .env.example .env        # adjust as needed
+npm run start:dev           # hot-reload, default port 2785
+
+# dashboard (separate terminal)
+cd dashboard && npm install && npm run dev
+```
+
+Default storage is SQLite, so no external services are required to run locally.
+
+## Before opening a pull request
+
+Please make sure these pass locally:
+
+```bash
+npm run build               # NestJS build (tsc)
+npm test                    # unit tests (Jest)
+npm run lint                # ESLint
+npm run format              # Prettier
+npm --prefix dashboard run build   # dashboard type-check + build
+```
+
+- Add or update tests for behavior changes — specs are colocated as `*.spec.ts`.
+- Keep each PR focused on one logical change; it makes review (and credit) much easier.
+- Update `docs/` and the `CHANGELOG.md` `[Unreleased]` section when your change is
+  user-visible. (Maintainers own version stamping and release cutting.)
+
+## Conventions
+
+- **Commits:** [Conventional Commits](https://www.conventionalcommits.org/) —
+  `feat(...)`, `fix(...)`, `docs(...)`, `chore(...)`, etc.
+- **Style:** single quotes, 2-space indentation, 120-column width, semicolons — all
+  enforced by Prettier + ESLint. Run `npm run format` before committing.
+- **Types:** explicit types, avoid `any`.
+- **Requests:** validate request bodies with DTOs + `class-validator`.
+- **Errors & logging:** throw NestJS HTTP exceptions; use the project `LoggerService`
+  (`createLogger`) rather than `console.*`.
+- **Database:** changes to the persisted (data) schema need a TypeORM migration under
+  `src/database/migrations/`.
+
+## Scope notes (please read before large PRs)
+
+- The default engine is **whatsapp-web.js**. Some capabilities are engine-limited — for
+  example, interactive **Buttons / List** messages are not supported on whatsapp-web.js,
+  so PRs adding them won't function against the default engine.
+- The **REST API is the public contract**. Please avoid changing response shapes or
+  status codes without opening an issue to discuss first.
+- For substantial architectural changes (new frameworks, large rewrites), please open an
+  issue to align on the approach before investing the work.
+
+## Reporting issues
+
+Use the **Bug report** or **Feature request** issue templates — the structured fields
+(version, deployment, engine, logs, reproduction) make triage much faster. For security
+vulnerabilities, see [`SECURITY.md`](SECURITY.md) — please do **not** open a public issue.
+
+## Code of conduct
+
+This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md). By participating,
+you're expected to uphold it.
+
+## License
+
+By contributing, you agree that your contributions are licensed under the project's
+[MIT License](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,50 @@
+# Security Policy
+
+OpenWA is a self-hosted WhatsApp API gateway. It handles API-key authentication,
+WhatsApp session credentials, message data, and — optionally — access to the Docker
+socket. Security matters here, and we appreciate responsible disclosure.
+
+## Supported versions
+
+Security fixes land on the latest minor release. Please upgrade older deployments.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.2.x   | :white_check_mark: |
+| < 0.2   | :x:                |
+
+## Reporting a vulnerability
+
+**Please do not open a public issue, discussion, or PR for a security vulnerability.**
+
+Report it privately through either channel:
+
+- **GitHub Security Advisories** (preferred) — open a private report at
+  <https://github.com/rmyndharis/OpenWA/security/advisories/new>
+- **Email** — yudhi@rmyndharis.com
+
+Please include, where possible:
+
+- A description of the issue and its impact
+- Steps to reproduce or a proof of concept
+- Affected version(s) and deployment details (Docker / bare metal, database, engine)
+
+### What to expect
+
+- An acknowledgement, typically within a few days
+- An assessment, and — where applicable — a coordinated fix and release
+- Credit in the advisory / release notes, unless you'd prefer to remain anonymous
+
+## Hardening notes for operators
+
+OpenWA already ships several hardening measures: API-key auth with roles
+(ADMIN / OPERATOR / VIEWER), optional outbound webhook SSRF protection, a production
+CORS policy (wildcard origins refused in production), request body-size limits, a
+least-privilege Docker socket-proxy with a non-root container, and path-containment
+checks on storage import/export.
+
+When exposing OpenWA, please review the security-relevant configuration documented in
+the README and `docs/` — in particular `CORS_ORIGINS`, `ALLOW_DEV_API_KEY`,
+`ENABLE_SWAGGER`, `WEBHOOK_SSRF_PROTECT`, `BODY_SIZE_LIMIT`, and the Docker proxy setup.
+Never expose the dashboard/API to the public internet with the development API key
+enabled.


### PR DESCRIPTION
Completes the GitHub **Community Standards** checklist (was 4/8 → now 8/8), tailored to OpenWA rather than boilerplate.

- **SECURITY.md** — supported versions, private vulnerability reporting (GitHub Advisories + email), operator hardening notes
- **CONTRIBUTING.md** — project layout, dev setup, the build/test/lint gate, conventions, and scope notes (engine limits, REST contract)
- **.github/ISSUE_TEMPLATE/** — structured Bug report + Feature request forms (the version/deployment/engine/logs fields that make triage easy) + config routing security to private advisories
- **CODE_OF_CONDUCT.md** — adopts the Contributor Covenant v2.1

Docs-only, additive, no code impact.