### PR TITLE
fix(session): accept @lid JID when marking chats as read (#issue)

### DIFF
--- a/src/modules/session/dto/mark-chat-read.dto.spec.ts
+++ b/src/modules/session/dto/mark-chat-read.dto.spec.ts
@@ -1,0 +1,18 @@
+import { validateSync } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { MarkChatReadDto } from './mark-chat-read.dto';
+
+const errorCount = (chatId: unknown): number => validateSync(plainToInstance(MarkChatReadDto, { chatId })).length;
+
+describe('MarkChatReadDto chatId validation', () => {
+  it.each(['1234567890@c.us', '1234567890-123@g.us', '1234567890@lid'])('accepts a valid JID: %s', chatId => {
+    expect(errorCount(chatId)).toBe(0);
+  });
+
+  it.each(['', 'not-a-jid', 'abc@c.us', '1234567890@s.whatsapp.net', '1234567890@lid.us'])(
+    'rejects an invalid chatId: %s',
+    chatId => {
+      expect(errorCount(chatId)).toBeGreaterThan(0);
+    },
+  );
+});

--- a/src/modules/session/dto/mark-chat-read.dto.ts
+++ b/src/modules/session/dto/mark-chat-read.dto.ts
@@ -3,14 +3,15 @@ import { IsNotEmpty, IsString, Matches } from 'class-validator';
 
 export class MarkChatReadDto {
   @ApiProperty({
-    description: 'WhatsApp chat ID to mark as read (e.g., 1234567890@c.us or 1234567890-123@g.us)',
+    description: 'WhatsApp chat ID to mark as read (e.g., 1234567890@c.us, 1234567890-123@g.us, or 1234567890@lid)',
     example: '1234567890@c.us',
   })
   @IsString()
   @IsNotEmpty()
   // Reject malformed IDs early with a clear 400 instead of a silent no-op at the engine layer.
-  @Matches(/^[0-9-]+@[cg]\.us$/, {
-    message: 'chatId must be a valid WhatsApp JID (e.g. 1234567890@c.us or 1234567890-123@g.us)',
+  // @lid is the privacy "Linked ID" address newer WhatsApp assigns to some 1:1 contacts.
+  @Matches(/^[0-9-]+@(?:[cg]\.us|lid)$/, {
+    message: 'chatId must be a valid WhatsApp JID (e.g. 1234567890@c.us, 1234567890-123@g.us, or 1234567890@lid)',
   })
   chatId: string;
 }


### PR DESCRIPTION
## Description
  Marking a personal DM as read returned a 400: `chatId must be a valid WhatsApp JID`.
  Newer WhatsApp assigns some 1:1 contacts a privacy `@lid` ("Linked ID") address instead
  of `@c.us`, but the `MarkChatReadDto` regex (`/^[0-9-]+@[cg]\.us$/`) only accepted
  `@c.us` and `@g.us`, so those DMs were rejected at the DTO layer. Groups (`@g.us`) were
  unaffected. Widened the regex to also accept `@lid`; the engine already handles `@lid`
  via `getChatById(...).sendSeen()`, so no other change was needed.

  ## Type of Change
  - [x] Bug fix
  - [ ] New feature
  - [ ] Breaking change
  - [ ] Documentation update

  ## Checklist
  - [ ] Tests added/updated
  - [ ] Documentation updated
  - [ ] Lint passes
  - [x] Self-reviewed

  ## Screenshots (if applicable)
  N/A — backend validation fix.

  ## Related Issues
  Closes #