### PR TITLE
fix(docker): bind dev ports to 0.0.0.0 for remote access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,12 @@ LOG_LEVEL=info                      # error | warn | info | debug
 DOMAIN=localhost
 DASHBOARD_PORT=2886
 
+# Host interface the dev compose binds the API/dashboard ports to. Defaults to 127.0.0.1
+# (localhost only). Set to 0.0.0.0 to reach the dev stack from another machine (e.g. a remote
+# VPS) — put a TLS reverse proxy in front for anything internet-facing (the API key is sent in
+# cleartext over plain HTTP).
+# BIND_HOST=0.0.0.0
+
 # Public URLs (for startup banner and external access)
 # BASE_URL=https://api.yourdomain.com
 # DASHBOARD_URL=https://dashboard.yourdomain.com

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,7 +9,8 @@ services:
       dockerfile: Dockerfile
     container_name: openwa-api
     ports:
-      - '0.0.0.0:2785:2785'
+      # Bind to localhost by default; set BIND_HOST=0.0.0.0 in .env to reach it from another host.
+      - '${BIND_HOST:-127.0.0.1}:2785:2785'
     environment:
       - NODE_ENV=development
       - PORT=2785
@@ -48,7 +49,7 @@ services:
       dockerfile: Dockerfile
     container_name: openwa-dashboard
     ports:
-      - '0.0.0.0:2886:80'
+      - '${BIND_HOST:-127.0.0.1}:2886:80'
     depends_on:
       openwa:
         condition: service_healthy

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,7 +9,7 @@ services:
       dockerfile: Dockerfile
     container_name: openwa-api
     ports:
-      - '127.0.0.1:2785:2785'
+      - '0.0.0.0:2785:2785'
     environment:
       - NODE_ENV=development
       - PORT=2785
@@ -48,7 +48,7 @@ services:
       dockerfile: Dockerfile
     container_name: openwa-dashboard
     ports:
-      - '127.0.0.1:2886:80'
+      - '0.0.0.0:2886:80'
     depends_on:
       openwa:
         condition: service_healthy


### PR DESCRIPTION
## Problem

The dev compose file binds both the API (2785) and dashboard (2886) to `127.0.0.1`, which prevents access from external hosts. This makes it impossible to use the dashboard when running OpenWA on a remote VPS/server.

## Solution

Changed port bindings from `127.0.0.1:PORT:PORT` to `0.0.0.0:PORT:PORT` in `docker-compose.dev.yml` so the services are accessible externally during development.

The production compose (`docker-compose.yml`) is unchanged — this only affects the dev environment.

## Testing

- Deployed on a remote VPS
- Confirmed dashboard accessible at `http://<vps-ip>:2886`
- Confirmed API accessible at `http://<vps-ip>:2785/api`