### PR TITLE
fix(dashboard): work over plain HTTP / non-localhost origins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Dashboard now works over plain HTTP on a non-`localhost` origin.** Toast notifications and
+  the API-key copy button used secure-context-only browser APIs (`crypto.randomUUID`,
+  `navigator.clipboard`) that are unavailable over HTTP on a LAN IP — so creating a session
+  threw `crypto.randomUUID is not a function`. Both now degrade gracefully (non-crypto id
+  fallback; `execCommand('copy')` clipboard fallback). (#244)
+
 ## [0.2.2] - 2026-06-15
 
 A security-hardening and reliability release. It tightens defaults (SSRF protection on,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `navigator.clipboard`) that are unavailable over HTTP on a LAN IP — so creating a session
   threw `crypto.randomUUID is not a function`. Both now degrade gracefully (non-crypto id
   fallback; `execCommand('copy')` clipboard fallback). (#244)
+- The Infrastructure page's "View Bull Board" link no longer hardcodes `http://localhost:2785`;
+  it opens the configured API origin, so it works on remote/LAN deployments.
 
 ## [0.2.2] - 2026-06-15
 

--- a/dashboard/src/components/Toast.tsx
+++ b/dashboard/src/components/Toast.tsx
@@ -45,7 +45,10 @@ export function ToastProvider({ children }: ToastProviderProps) {
 
   const addToast = useCallback(
     (toast: Omit<Toast, 'id'>) => {
-      const id = crypto.randomUUID();
+      // crypto.randomUUID() is only defined in a secure context (HTTPS / localhost). Over plain
+      // HTTP on a LAN IP it is undefined, which previously threw "crypto.randomUUID is not a
+      // function" on every toast — fall back to a non-crypto id (a toast key needs no strength).
+      const id = crypto.randomUUID?.() ?? `t-${Date.now()}-${Math.random().toString(36).slice(2)}`;
       const newToast = { ...toast, id };
       setToasts(prev => [...prev, newToast]);
 

--- a/dashboard/src/pages/ApiKeys.tsx
+++ b/dashboard/src/pages/ApiKeys.tsx
@@ -97,9 +97,33 @@ export function ApiKeys() {
   };
 
   const copyToClipboard = (text: string, id: string) => {
-    navigator.clipboard.writeText(text);
-    setCopied(id);
-    setTimeout(() => setCopied(null), 2000);
+    // The async Clipboard API is only available in a secure context (HTTPS / localhost). Over
+    // plain HTTP on a LAN IP `navigator.clipboard` is undefined, so fall back to a hidden
+    // textarea + execCommand('copy') instead of throwing.
+    const copied = (() => {
+      if (navigator.clipboard?.writeText) {
+        void navigator.clipboard.writeText(text);
+        return true;
+      }
+      try {
+        const ta = document.createElement('textarea');
+        ta.value = text;
+        ta.setAttribute('readonly', '');
+        ta.style.position = 'fixed';
+        ta.style.opacity = '0';
+        document.body.appendChild(ta);
+        ta.select();
+        const ok = document.execCommand('copy');
+        document.body.removeChild(ta);
+        return ok;
+      } catch {
+        return false;
+      }
+    })();
+    if (copied) {
+      setCopied(id);
+      setTimeout(() => setCopied(null), 2000);
+    }
   };
 
   const columns = useMemo(

--- a/dashboard/src/pages/Infrastructure.tsx
+++ b/dashboard/src/pages/Infrastructure.tsx
@@ -13,7 +13,7 @@ import {
   Webhook,
   Gauge,
 } from 'lucide-react';
-import { infraApi } from '../services/api';
+import { infraApi, API_BASE_URL } from '../services/api';
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { useInfraStatusQuery, useInfraConfigQuery } from '../hooks/queries';
 import { PageHeader } from '../components/PageHeader';
@@ -814,7 +814,7 @@ export function Infrastructure() {
                     </button>
                     <button
                       className="btn-outline"
-                      onClick={() => window.open('http://localhost:2785/api/admin/queues', '_blank')}
+                      onClick={() => window.open(`${API_BASE_URL}/admin/queues`, '_blank')}
                     >
                       <ExternalLink size={16} />
                       {t('infrastructure.redis.viewBullMq')}


### PR DESCRIPTION
## Problem

When the dashboard is served over **plain HTTP on a non-`localhost` origin** (e.g. a LAN IP / remote VPS at `http://192.168.x.x:2886`), creating a session throws **`crypto.randomUUID is not a function`** and the UI breaks. (#244)

## Root cause

The browser only exposes some Web APIs in a **secure context** (HTTPS or `localhost`). Over plain HTTP on a LAN IP those are `undefined`:

- `crypto.randomUUID()` — used for toast IDs in `Toast.tsx` (present since v0.1.0; latent until accessed over HTTP-LAN).
- `navigator.clipboard` — used to copy a freshly created API key in `ApiKeys.tsx`.

Separately, the Infrastructure page's "View Bull Board" link hardcoded `http://localhost:2785`, which points at the **user's own machine** on a remote/LAN deploy.

## Fixes

- **Toast IDs**: `crypto.randomUUID?.() ?? \`t-${Date.now()}-${Math.random()...}\`` — a toast key needs no cryptographic strength.
- **API-key copy**: try `navigator.clipboard?.writeText`, else fall back to a hidden-textarea `execCommand('copy')`.
- **Bull Board link**: open the configured API origin (`API_BASE_URL`) instead of hardcoded `localhost:2785`.

## Notes

- These degrade gracefully; no behavior change on `localhost`/HTTPS.
- For any **public** exposure, HTTPS is still recommended — the `X-API-Key` travels in cleartext over plain HTTP.

## Verification

- `dashboard`: lint 0 errors, build ✓.

Closes #244.