### PR TITLE
chore(release): v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.3] - 2026-06-15
+
+A patch release: the dashboard now works when served over plain HTTP on a non-`localhost`
+origin (LAN/remote), plus a configurable dev-compose bind host.
 
 ### Fixed
 
@@ -16,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fallback; `execCommand('copy')` clipboard fallback). (#244)
 - The Infrastructure page's "View Bull Board" link no longer hardcodes `http://localhost:2785`;
   it opens the configured API origin, so it works on remote/LAN deployments.
+
+### Changed
+
+- The dev compose (`docker-compose.dev.yml`) bind host is now configurable via `BIND_HOST`
+  (default `127.0.0.1`); set `BIND_HOST=0.0.0.0` in `.env` to reach the dev stack from another
+  host (front it with a TLS proxy for anything public). Thanks @Stanley-blik (#245).
 
 ## [0.2.2] - 2026-06-15
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/rmyndharis/OpenWA/actions/workflows/ci.yml"><img src="https://github.com/rmyndharis/OpenWA/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"/></a>
-  <img src="https://img.shields.io/badge/version-0.2.2-blue.svg" alt="Version"/>
+  <img src="https://img.shields.io/badge/version-0.2.3-blue.svg" alt="Version"/>
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"/>
   <img src="https://img.shields.io/badge/node-22_LTS-brightgreen.svg" alt="Node"/>
   <img src="https://img.shields.io/badge/NestJS-11.x-red.svg" alt="NestJS"/>

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashboard",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashboard",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@tanstack/react-query": "^5.101.0",
         "@tanstack/react-table": "^8.21.3",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboard",
   "private": true,
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.2.2-blue.svg" alt="Version"/>
+  <img src="https://img.shields.io/badge/version-0.2.3-blue.svg" alt="Version"/>
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"/>
   <img src="https://img.shields.io/badge/node-22_LTS-brightgreen.svg" alt="Node"/>
   <img src="https://img.shields.io/badge/NestJS-11.x-red.svg" alt="NestJS"/>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openwa",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openwa",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwa",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API for WhatsApp",
   "author": "Yudhi Armyndharis & OpenWA Contributors",
   "private": true,


### PR DESCRIPTION
Patch release bundling the two dashboard/deployment fixes already merged to `main`:

- **#244** — dashboard works over plain HTTP on a non-`localhost` origin (LAN/remote): `crypto.randomUUID` + `navigator.clipboard` secure-context fallbacks, and the Bull Board link uses the API origin instead of hardcoded `localhost`.
- **#245** — dev compose bind host is configurable via `BIND_HOST` (default `127.0.0.1`). Thanks @Stanley-blik.

Version bump (0.2.2 → 0.2.3), CHANGELOG `[0.2.3]`, and README/docs badges. No breaking changes.