### PR TITLE
fix(storage): handle archive errors in the data-export stream

### DIFF
--- a/src/common/storage/storage.service.ts
+++ b/src/common/storage/storage.service.ts
@@ -162,6 +162,13 @@ export class StorageService {
       gzipOptions: { level: 6 },
     });
 
+    // Surface archive-level failures (gzip/finalize) on the returned stream instead of
+    // letting them become an unhandled rejection or a silently truncated download.
+    archive.on('error', (err: Error) => {
+      this.logger.error('Export archive failed', String(err));
+      output.destroy(err);
+    });
+
     archive.pipe(output);
 
     // Add files to archive
@@ -174,7 +181,9 @@ export class StorageService {
       }
     }
 
-    void archive.finalize();
+    // finalize() rejections also emit via the 'error' handler above; catch the promise so it
+    // never surfaces as an unhandled rejection.
+    archive.finalize().catch(() => undefined);
     return output;
   }
 


### PR DESCRIPTION
## Problem

`StorageService.createExportStream()` (the admin data-export / backup feature) did `void archive.finalize()` and had **no `archive.on('error', …)` handler**. The per-file `getFile()` failures are caught, but an *archive-level* error (gzip / finalize) would become an **unhandled promise rejection** or a **silently truncated download** with no error surfaced to the client.

## Fix

- Add `archive.on('error', …)` → log + `output.destroy(err)` so the failure surfaces on the returned stream.
- `archive.finalize().catch(() => undefined)` so a finalize rejection can't become an unhandled rejection (it also routes through the `error` handler).

No behavior change on the success path. Niche (rare error path of the export feature), found during the runtime-deployment review.

## Verification
- `npm run build` ✓ · lint 0 · `storage.service.spec` 4/4.