### PR TITLE
chore(release): v0.2.4

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,6 +65,13 @@ PUPPETEER_ARGS=--no-sandbox,--disable-setuid-sandbox,--disable-dev-shm-usage,--d
 # Required in the Docker image and on hosts without a bundled browser (e.g. Alpine/ARM).
 # PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 
+# Pin the WhatsApp Web client version. If sessions get stuck at "authenticating" and never
+# reach "ready" (a whatsapp-web.js version-sync hang), set this to a known-good version from
+# https://github.com/wppconnect-team/wa-version (browse the html/ folder). Leave unset (or
+# "latest") to let whatsapp-web.js auto-select. WWEBJS_WEB_VERSION_REMOTE_PATH overrides the
+# URL template (use {version} as the placeholder) if you self-host the version HTML.
+# WWEBJS_WEB_VERSION=2.3000.1023204257
+
 # Observability — Prometheus scrape endpoint at GET /api/metrics.
 # Disabled by default; set a token to enable. Scrapers must send `Authorization: Bearer <token>`.
 # METRICS_TOKEN=change-me-to-a-long-random-string

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.4] - 2026-06-16
+
+A patch release: stop LAN dashboard logins from 500-ing, add a pin for the WhatsApp Web version
+(works around sessions stuck at "authenticating"), and harden the data-export stream.
+
+### Added
+
+- **Pinnable WhatsApp Web version** via `WWEBJS_WEB_VERSION`. whatsapp-web.js 1.34.x can hang at
+  `authenticating` (the post-link sync never completes) when the auto-selected WA-Web version is
+  incompatible; set a known-good version (browse
+  [wppconnect-team/wa-version](https://github.com/wppconnect-team/wa-version)) to pin it.
+  Opt-in — unset keeps the default auto-version behavior. (#251)
 
 ### Fixed
 
+- **Dashboard login over LAN no longer returns 500.** A disallowed CORS origin threw inside the
+  cors callback, surfacing as an Internal Server Error; it now denies without throwing — so the
+  bundled (same-origin) dashboard works on a LAN/remote host out of the box, while a genuine
+  cross-origin dashboard still needs its origin in `CORS_ORIGINS`. (#250)
 - Data-export stream now surfaces archive-level errors (gzip/finalize) on the response stream
   instead of an unhandled rejection or a silently truncated download. (#248)
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/rmyndharis/OpenWA/actions/workflows/ci.yml"><img src="https://github.com/rmyndharis/OpenWA/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"/></a>
-  <img src="https://img.shields.io/badge/version-0.2.3-blue.svg" alt="Version"/>
+  <img src="https://img.shields.io/badge/version-0.2.4-blue.svg" alt="Version"/>
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"/>
   <img src="https://img.shields.io/badge/node-22_LTS-brightgreen.svg" alt="Node"/>
   <img src="https://img.shields.io/badge/NestJS-11.x-red.svg" alt="NestJS"/>

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashboard",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashboard",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
         "@tanstack/react-query": "^5.101.0",
         "@tanstack/react-table": "^8.21.3",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboard",
   "private": true,
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.2.3-blue.svg" alt="Version"/>
+  <img src="https://img.shields.io/badge/version-0.2.4-blue.svg" alt="Version"/>
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"/>
   <img src="https://img.shields.io/badge/node-22_LTS-brightgreen.svg" alt="Node"/>
   <img src="https://img.shields.io/badge/NestJS-11.x-red.svg" alt="NestJS"/>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openwa",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openwa",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwa",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API for WhatsApp",
   "author": "Yudhi Armyndharis & OpenWA Contributors",
   "private": true,

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -1,5 +1,10 @@
 import { MessageMedia } from 'whatsapp-web.js';
-import { WhatsAppWebJsAdapter, extractLinkedParentJID, loadRemoteMedia } from './whatsapp-web-js.adapter';
+import {
+  WhatsAppWebJsAdapter,
+  extractLinkedParentJID,
+  loadRemoteMedia,
+  resolveWebVersionPin,
+} from './whatsapp-web-js.adapter';
 import { EngineNotReadyError } from '../../common/errors/engine-not-ready.error';
 import { SsrfBlockedError } from '../../common/security/ssrf-guard';
 
@@ -100,5 +105,42 @@ describe('WhatsAppWebJsAdapter readiness guard (#100)', () => {
 
   it('carries HTTP 409 so NestJS returns "session not connected" (not 500) without a custom filter', () => {
     expect(new EngineNotReadyError().getStatus()).toBe(409);
+  });
+});
+
+describe('resolveWebVersionPin (#251 — opt-in WA-Web version pin)', () => {
+  const orig = { v: process.env.WWEBJS_WEB_VERSION, p: process.env.WWEBJS_WEB_VERSION_REMOTE_PATH };
+  afterEach(() => {
+    if (orig.v === undefined) delete process.env.WWEBJS_WEB_VERSION;
+    else process.env.WWEBJS_WEB_VERSION = orig.v;
+    if (orig.p === undefined) delete process.env.WWEBJS_WEB_VERSION_REMOTE_PATH;
+    else process.env.WWEBJS_WEB_VERSION_REMOTE_PATH = orig.p;
+  });
+
+  it('returns undefined (default auto-version) when unset / "latest" / "off"', () => {
+    delete process.env.WWEBJS_WEB_VERSION;
+    expect(resolveWebVersionPin()).toBeUndefined();
+    process.env.WWEBJS_WEB_VERSION = 'latest';
+    expect(resolveWebVersionPin()).toBeUndefined();
+    process.env.WWEBJS_WEB_VERSION = 'off';
+    expect(resolveWebVersionPin()).toBeUndefined();
+  });
+
+  it('pins a remote webVersionCache from the version when set', () => {
+    delete process.env.WWEBJS_WEB_VERSION_REMOTE_PATH;
+    process.env.WWEBJS_WEB_VERSION = '2.3000.1023204257';
+    expect(resolveWebVersionPin()).toEqual({
+      webVersion: '2.3000.1023204257',
+      webVersionCache: {
+        type: 'remote',
+        remotePath: 'https://raw.githubusercontent.com/wppconnect-team/wa-version/main/html/2.3000.1023204257.html',
+      },
+    });
+  });
+
+  it('honors a custom WWEBJS_WEB_VERSION_REMOTE_PATH template ({version} placeholder)', () => {
+    process.env.WWEBJS_WEB_VERSION = '2.9999.0';
+    process.env.WWEBJS_WEB_VERSION_REMOTE_PATH = 'https://cdn.example.com/wa/{version}.html';
+    expect(resolveWebVersionPin()?.webVersionCache.remotePath).toBe('https://cdn.example.com/wa/2.9999.0.html');
   });
 });

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -89,6 +89,30 @@ export interface WhatsAppWebJsConfig {
 }
 
 /**
+ * Optional pin for the WhatsApp Web client version. whatsapp-web.js 1.34.x can get stuck at
+ * "authenticating" (the post-link sync never completes) when the auto-fetched WA-Web version is
+ * incompatible (#251). Set WWEBJS_WEB_VERSION to a known-good version string (browse
+ * https://github.com/wppconnect-team/wa-version) to pin it; WWEBJS_WEB_VERSION_REMOTE_PATH
+ * overrides the URL template (use `{version}` as the placeholder) if you self-host the HTML.
+ * Unset (or `latest`/`off`) keeps whatsapp-web.js's default auto-version behavior.
+ */
+export function resolveWebVersionPin():
+  | { webVersion: string; webVersionCache: { type: 'remote'; remotePath: string } }
+  | undefined {
+  const version = process.env.WWEBJS_WEB_VERSION?.trim();
+  if (!version || version.toLowerCase() === 'off' || version.toLowerCase() === 'latest') {
+    return undefined;
+  }
+  const template =
+    process.env.WWEBJS_WEB_VERSION_REMOTE_PATH?.trim() ||
+    'https://raw.githubusercontent.com/wppconnect-team/wa-version/main/html/{version}.html';
+  return {
+    webVersion: version,
+    webVersionCache: { type: 'remote', remotePath: template.replace('{version}', version) },
+  };
+}
+
+/**
  * Extracts the JID of the parent community a group is linked to, if any.
  * The field name has varied across whatsapp-web.js/WA Web versions, so
  * known candidates are checked in order.
@@ -146,6 +170,13 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
         );
       }
 
+      // Pin the WA-Web version when configured (fixes the 1.34.x "stuck at authenticating"
+      // hang on some setups, #251). Opt-in: unset leaves whatsapp-web.js to auto-select.
+      const versionPin = resolveWebVersionPin();
+      if (versionPin) {
+        this.logger.log(`Pinning WhatsApp Web version ${versionPin.webVersion}`);
+      }
+
       this.client = new Client({
         authStrategy: new LocalAuth({
           clientId: this.config.sessionId,
@@ -158,6 +189,7 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
           // whatsapp-web.js fall back to Puppeteer's bundled Chromium.
           ...(this.config.puppeteer?.executablePath ? { executablePath: this.config.puppeteer.executablePath } : {}),
         },
+        ...(versionPin ?? {}),
       });
 
       this.setupEventHandlers();

--- a/src/main.ts
+++ b/src/main.ts
@@ -154,7 +154,12 @@ async function bootstrap() {
       if (corsPolicy.allowAnyOrigin || corsPolicy.origins.includes(origin)) {
         callback(null, true);
       } else {
-        callback(new Error('Not allowed by CORS'));
+        // Deny WITHOUT throwing. Throwing here surfaced as a 500 Internal Server Error (#250).
+        // Returning false simply omits the CORS headers: the browser blocks a true cross-origin
+        // request itself (correct), while same-origin requests — e.g. the bundled dashboard served
+        // through the proxy, which the browser never subjects to CORS — keep working. A genuine
+        // cross-origin dashboard still needs its origin in CORS_ORIGINS.
+        callback(null, false);
       }
     },
     credentials: corsPolicy.credentials,


### PR DESCRIPTION
Patch release.

### Added
- **`WWEBJS_WEB_VERSION`** — pin the WhatsApp Web client version to work around whatsapp-web.js 1.34.x sessions hanging at `authenticating` (#251). **Opt-in** (unset = unchanged auto-version); operators set a known-good version from [wppconnect-team/wa-version](https://github.com/wppconnect-team/wa-version). 3 unit tests.

### Fixed
- **LAN dashboard login no longer 500s** — a disallowed CORS origin threw → Internal Server Error; now denies without throwing, so the bundled same-origin dashboard works on a LAN/remote host out of the box. Closes #250.
- Data-export stream surfaces archive errors instead of an unhandled rejection / silent truncation (#248, already on main).

### Notes
- **#251 is shipped as an opt-in knob, not an auto-fix** — a verified-good *default* version needs a live WhatsApp scan-to-`ready` to confirm. Keeping #251 open until then. `Refs #251`.
- **#249** (dark-mode language dropdown) is **deferred** — the obvious theme vars are correct, so it needs reproduction before a fix (no speculative CSS).

### Verification
Backend: lint 0 · **419 tests** · build ✓. Dashboard: build ✓.