### PR TITLE
chore(release): v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.5] - 2026-06-16
+
+A patch release: pairing-code linking, a Chromium crash-dumps fix, and dark-mode native controls.
+
+### Added
+
+- **Pairing-code linking** — `POST /sessions/:id/pairing-code` returns an 8-character code so a
+  session can be linked via WhatsApp's "Link with phone number" instead of scanning the QR (useful
+  for single-device / mobile onboarding). The session must be started and not yet authenticated. (#252)
+
+### Fixed
+
+- Chromium is now given an explicit writable `--crash-dumps-dir` so its crashpad handler always
+  receives a `--database`, avoiding `chrome_crashpad_handler: --database is required` browser-launch
+  failures on some hardened/container hosts. (#254)
+- Dashboard native controls (select option popups, scrollbars) now follow the explicit app theme via
+  `color-scheme`, instead of only the OS preference. (#249)
+
 ## [0.2.4] - 2026-06-16
 
 A patch release: stop LAN dashboard logins from 500-ing, add a pin for the WhatsApp Web version

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/rmyndharis/OpenWA/actions/workflows/ci.yml"><img src="https://github.com/rmyndharis/OpenWA/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"/></a>
-  <img src="https://img.shields.io/badge/version-0.2.4-blue.svg" alt="Version"/>
+  <img src="https://img.shields.io/badge/version-0.2.5-blue.svg" alt="Version"/>
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"/>
   <img src="https://img.shields.io/badge/node-22_LTS-brightgreen.svg" alt="Node"/>
   <img src="https://img.shields.io/badge/NestJS-11.x-red.svg" alt="NestJS"/>

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashboard",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashboard",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
         "@tanstack/react-query": "^5.101.0",
         "@tanstack/react-table": "^8.21.3",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboard",
   "private": true,
-  "version": "0.2.4",
+  "version": "0.2.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/dashboard/src/App.css
+++ b/dashboard/src/App.css
@@ -21,6 +21,10 @@
 
 /* Dark Mode */
 [data-theme='dark'] {
+  /* Make native controls (select option popups, scrollbars, date pickers) follow the EXPLICIT
+     app theme, not just the OS preference — otherwise toggling dark while the OS is light left
+     native dropdowns rendered in the light scheme (#249). */
+  color-scheme: dark;
   --bg-light: #0f172a; /* Slate 900 */
   --bg-white: #1e293b; /* Slate 800 */
   --bg-card: #1e293b;
@@ -31,6 +35,11 @@
   --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.3);
   --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.3), 0 2px 4px -2px rgb(0 0 0 / 0.3);
   --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.4), 0 4px 6px -4px rgb(0 0 0 / 0.4);
+}
+
+/* Explicit light toggle: keep native controls light even if the OS prefers dark. */
+[data-theme='light'] {
+  color-scheme: light;
 }
 
 /* System preference dark mode */

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.2.4-blue.svg" alt="Version"/>
+  <img src="https://img.shields.io/badge/version-0.2.5-blue.svg" alt="Version"/>
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"/>
   <img src="https://img.shields.io/badge/node-22_LTS-brightgreen.svg" alt="Node"/>
   <img src="https://img.shields.io/badge/NestJS-11.x-red.svg" alt="NestJS"/>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openwa",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openwa",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwa",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API for WhatsApp",
   "author": "Yudhi Armyndharis & OpenWA Contributors",
   "private": true,

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -433,6 +433,18 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     return this.qrCode;
   }
 
+  /**
+   * Request an 8-char pairing code so the user can link via "Link with phone number" instead of
+   * scanning the QR. Must be called after the engine has started (the client is initialized and
+   * waiting to link); whatsapp-web.js throws if called before it is ready or after authentication.
+   */
+  async requestPairingCode(phoneNumber: string): Promise<string> {
+    if (!this.client) {
+      throw new EngineNotReadyError();
+    }
+    return this.client.requestPairingCode(phoneNumber);
+  }
+
   getPhoneNumber(): string | null {
     return this.phoneNumber;
   }

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'events';
 import { Client, LocalAuth, MessageMedia, MessageTypes } from 'whatsapp-web.js';
 import * as qrcode from 'qrcode';
 import * as path from 'path';
+import * as os from 'os';
 import {
   IWhatsAppEngine,
   EngineStatus,
@@ -161,6 +162,14 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
         '--no-zygote',
         '--disable-gpu',
       ];
+
+      // Give Chromium an explicit, writable crash-dumps dir so its crashpad handler always gets a
+      // --database. On some hardened/container hosts Chromium otherwise fails to launch with
+      // "chrome_crashpad_handler: --database is required" (#254/#242). Skipped if the operator
+      // already supplied their own --crash-dumps-dir via PUPPETEER_ARGS.
+      if (!puppeteerArgs.some(a => a.startsWith('--crash-dumps-dir'))) {
+        puppeteerArgs.push(`--crash-dumps-dir=${path.join(os.tmpdir(), 'openwa-crashpad')}`);
+      }
 
       // Add proxy configuration if provided
       if (this.config.proxy) {

--- a/src/engine/interfaces/whatsapp-engine.interface.ts
+++ b/src/engine/interfaces/whatsapp-engine.interface.ts
@@ -282,6 +282,8 @@ export interface IWhatsAppEngine {
   // Status
   getStatus(): EngineStatus;
   getQRCode(): string | null;
+  /** Request an 8-char pairing code to link via phone number instead of scanning the QR. */
+  requestPairingCode(phoneNumber: string): Promise<string>;
   getPhoneNumber(): string | null;
   getPushName(): string | null;
 

--- a/src/modules/session/dto/index.ts
+++ b/src/modules/session/dto/index.ts
@@ -1,3 +1,4 @@
 export * from './create-session.dto';
 export * from './session-response.dto';
 export * from './mark-chat-read.dto';
+export * from './request-pairing-code.dto';

--- a/src/modules/session/dto/request-pairing-code.dto.spec.ts
+++ b/src/modules/session/dto/request-pairing-code.dto.spec.ts
@@ -1,0 +1,19 @@
+import { validateSync } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { RequestPairingCodeDto } from './request-pairing-code.dto';
+
+const errorCount = (phoneNumber: unknown): number =>
+  validateSync(plainToInstance(RequestPairingCodeDto, { phoneNumber })).length;
+
+describe('RequestPairingCodeDto (#252)', () => {
+  it.each(['628123456789', '12025550123', '447911123456'])('accepts a digits-only number: %s', n => {
+    expect(errorCount(n)).toBe(0);
+  });
+
+  it.each(['', '+628123456789', '628 123 456', '628-123-456', 'abc123', '12345', '0123456789012345'])(
+    'rejects a malformed number: %s',
+    n => {
+      expect(errorCount(n)).toBeGreaterThan(0);
+    },
+  );
+});

--- a/src/modules/session/dto/request-pairing-code.dto.ts
+++ b/src/modules/session/dto/request-pairing-code.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, Matches } from 'class-validator';
+
+export class RequestPairingCodeDto {
+  @ApiProperty({
+    description: 'Phone number to link, digits only in international format (country code + number).',
+    example: '628123456789',
+  })
+  @IsString()
+  @IsNotEmpty()
+  // Digits only (no +, spaces, or dashes); 6–15 digits covers E.164.
+  @Matches(/^[0-9]{6,15}$/, {
+    message: 'phoneNumber must be digits only in international format (country code + number), e.g. 628123456789',
+  })
+  phoneNumber: string;
+}
+
+export class PairingCodeResponseDto {
+  @ApiProperty({ description: 'The 8-character pairing code to enter in WhatsApp.', example: 'ABCD1234' })
+  pairingCode: string;
+
+  @ApiProperty({ description: 'Current session status.', example: 'qr_ready' })
+  status: string;
+}

--- a/src/modules/session/session.controller.ts
+++ b/src/modules/session/session.controller.ts
@@ -1,7 +1,14 @@
 import { Controller, Get, Post, Delete, Param, Body, HttpCode, HttpStatus } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
 import { SessionService } from './session.service';
-import { CreateSessionDto, SessionResponseDto, QRCodeResponseDto, MarkChatReadDto } from './dto';
+import {
+  CreateSessionDto,
+  SessionResponseDto,
+  QRCodeResponseDto,
+  MarkChatReadDto,
+  RequestPairingCodeDto,
+  PairingCodeResponseDto,
+} from './dto';
 import { Session } from './entities/session.entity';
 import { ChatSummary } from '../../engine/interfaces/whatsapp-engine.interface';
 import { AuditService } from '../audit/audit.service';
@@ -154,6 +161,20 @@ export class SessionController {
       sessionId: id,
     });
     return qrCode;
+  }
+
+  @Post(':id/pairing-code')
+  @RequireRole(ApiKeyRole.OPERATOR)
+  @ApiOperation({ summary: 'Request an 8-char pairing code to link via phone number (alternative to QR)' })
+  @ApiParam({ name: 'id', description: 'Session ID' })
+  @ApiResponse({ status: 201, description: 'Pairing code generated', type: PairingCodeResponseDto })
+  @ApiResponse({ status: 400, description: 'Session not started or already authenticated' })
+  @ApiResponse({ status: 404, description: 'Session not found' })
+  async requestPairingCode(
+    @Param('id') id: string,
+    @Body() dto: RequestPairingCodeDto,
+  ): Promise<PairingCodeResponseDto> {
+    return this.sessionService.requestPairingCode(id, dto.phoneNumber);
   }
 
   @Get(':id/groups')

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -743,6 +743,25 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
     };
   }
 
+  /**
+   * Request an 8-char pairing code (link via phone number) as an alternative to scanning the QR.
+   * The session must be started but not yet authenticated.
+   */
+  async requestPairingCode(id: string, phoneNumber: string): Promise<{ pairingCode: string; status: SessionStatus }> {
+    const session = await this.findOne(id);
+    const engine = this.engines.get(id);
+
+    if (!engine) {
+      throw new BadRequestException('Session is not started. Call POST /sessions/:id/start first.');
+    }
+    if (session.status === SessionStatus.READY) {
+      throw new BadRequestException('Session is already authenticated, no pairing needed');
+    }
+
+    const pairingCode = await engine.requestPairingCode(phoneNumber);
+    return { pairingCode, status: session.status };
+  }
+
   getEngine(id: string): IWhatsAppEngine | undefined {
     return this.engines.get(id);
   }


### PR DESCRIPTION
Patch release bundling three triaged items.

### Added
- **Pairing-code linking** — `POST /sessions/:id/pairing-code` returns an 8-char code to link via WhatsApp's "Link with phone number" instead of the QR (single-device / mobile onboarding). Closes #252. *(Backend API; a dashboard toggle is a planned fast-follow.)*

### Fixed
- Chromium gets an explicit writable `--crash-dumps-dir` so crashpad always has a `--database`, targeting `chrome_crashpad_handler: --database is required` launch failures on hardened/container hosts. `Refs #254` — **best-effort**: verified Chromium still launches under the read-only compose, but I couldn't reproduce the reporter's exact failure, so it's pending their confirmation.
- Dashboard native controls (select popups, scrollbars) follow the explicit app theme via `color-scheme`. `Refs #249` — the custom sidebar dropdown was verified correct in dark mode (Playwright); this fixes a plausible native-control mismatch, pending reporter confirmation.

### Verification
Backend: lint 0 · **429 tests** · build ✓. Dashboard: lint 0 · build ✓. #254 read-only Docker smoke ✓ (Chromium launches, flag applied).

> #254 and #249 are intentionally `Refs` (not `Closes`) — kept open until the reporters confirm.