### PR TITLE
feat(swagger): add @ApiSecurity decorator to remaining controllers

### DIFF
--- a/src/modules/audit/audit.controller.ts
+++ b/src/modules/audit/audit.controller.ts
@@ -1,9 +1,10 @@
 import { Controller, Get, Query } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiQuery } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiQuery, ApiSecurity } from '@nestjs/swagger';
 import { AuditService, AuditQueryOptions } from './audit.service';
 import { AuditLog, AuditAction, AuditSeverity } from './entities/audit-log.entity';
 
 @ApiTags('audit')
+@ApiSecurity('X-API-Key')
 @Controller('audit')
 export class AuditController {
   constructor(private readonly auditService: AuditService) {}

--- a/src/modules/auth/auth-validate.controller.ts
+++ b/src/modules/auth/auth-validate.controller.ts
@@ -1,9 +1,10 @@
 import { Controller, Post, Headers, HttpCode, HttpStatus } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiHeader } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiHeader, ApiSecurity } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { createLogger } from '../../common/services/logger.service';
 
 @ApiTags('auth')
+@ApiSecurity('X-API-Key')
 @Controller('auth')
 export class AuthValidateController {
   private readonly logger = createLogger('AuthValidateController');

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,11 +1,12 @@
 import { Controller, Get, Post, Put, Delete, Body, Param, HttpCode, HttpStatus } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiSecurity } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { CreateApiKeyDto, UpdateApiKeyDto, ApiKeyResponseDto, ApiKeyCreatedResponseDto } from './dto';
 import { RequireRole } from './decorators/auth.decorators';
 import { ApiKeyRole } from './entities/api-key.entity';
 
 @ApiTags('auth')
+@ApiSecurity('X-API-Key')
 @Controller('auth/api-keys')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}

--- a/src/modules/catalog/catalog.controller.ts
+++ b/src/modules/catalog/catalog.controller.ts
@@ -1,9 +1,10 @@
 import { Controller, Get, Post, Param, Body, Query } from '@nestjs/common';
-import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiSecurity } from '@nestjs/swagger';
 import { CatalogService } from './catalog.service';
 import { SendProductDto, SendCatalogDto, ProductQueryDto } from './dto/send-product.dto';
 
 @ApiTags('Catalog')
+@ApiSecurity('X-API-Key')
 @Controller('sessions/:sessionId')
 export class CatalogController {
   constructor(private readonly catalogService: CatalogService) {}

--- a/src/modules/channel/channel.controller.ts
+++ b/src/modules/channel/channel.controller.ts
@@ -1,9 +1,10 @@
 import { Controller, Get, Post, Delete, Param, Body, Query } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBody, ApiQuery } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBody, ApiQuery, ApiSecurity } from '@nestjs/swagger';
 import { ChannelService } from './channel.service';
 import { SubscribeChannelDto } from './dto/subscribe-channel.dto';
 
 @ApiTags('channels')
+@ApiSecurity('X-API-Key')
 @Controller('sessions/:sessionId/channels')
 export class ChannelController {
   constructor(private readonly channelService: ChannelService) {}

--- a/src/modules/contact/contact.controller.ts
+++ b/src/modules/contact/contact.controller.ts
@@ -1,8 +1,9 @@
 import { Controller, Get, Post, Delete, Param, HttpCode, HttpStatus } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiSecurity } from '@nestjs/swagger';
 import { ContactService } from './contact.service';
 
 @ApiTags('contacts')
+@ApiSecurity('X-API-Key')
 @Controller('sessions/:sessionId/contacts')
 export class ContactController {
   constructor(private readonly contactService: ContactService) {}

--- a/src/modules/group/group.controller.ts
+++ b/src/modules/group/group.controller.ts
@@ -1,9 +1,10 @@
 import { Controller, Get, Post, Put, Delete, Param, Body, HttpCode, HttpStatus } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBody } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBody, ApiSecurity } from '@nestjs/swagger';
 import { GroupService } from './group.service';
 import { CreateGroupDto, ParticipantsDto, GroupSubjectDto, GroupDescriptionDto } from './dto/group.dto';
 
 @ApiTags('groups')
+@ApiSecurity('X-API-Key')
 @Controller('sessions/:sessionId/groups')
 export class GroupController {
   constructor(private readonly groupService: GroupService) {}

--- a/src/modules/infra/infra.controller.ts
+++ b/src/modules/infra/infra.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Put, Post, Body, BadRequestException } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiBody } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiBody, ApiSecurity } from '@nestjs/swagger';
 import { ConfigService } from '@nestjs/config';
 import { DataSource } from 'typeorm';
 import { InjectDataSource } from '@nestjs/typeorm';
@@ -165,6 +165,7 @@ interface SavedConfigResponse {
 }
 
 @ApiTags('infrastructure')
+@ApiSecurity('X-API-Key')
 @Controller('infra')
 export class InfraController {
   private readonly logger = createLogger('InfraController');

--- a/src/modules/label/label.controller.ts
+++ b/src/modules/label/label.controller.ts
@@ -1,9 +1,10 @@
 import { Controller, Get, Post, Delete, Param, Body } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBody } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBody, ApiSecurity } from '@nestjs/swagger';
 import { LabelService } from './label.service';
 import { AddLabelDto } from './dto/add-label.dto';
 
 @ApiTags('labels')
+@ApiSecurity('X-API-Key')
 @Controller('sessions/:sessionId/labels')
 export class LabelController {
   constructor(private readonly labelService: LabelService) {}

--- a/src/modules/message/message.controller.ts
+++ b/src/modules/message/message.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Post, Get, Param, Body, Query, HttpCode, HttpStatus } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiQuery } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiQuery, ApiSecurity } from '@nestjs/swagger';
 import { MessageService } from './message.service';
 import { BulkMessageService } from './bulk-message.service';
 import { SendTextMessageDto, SendMediaMessageDto, MessageResponseDto } from './dto';
@@ -17,6 +17,7 @@ import { RequireRole } from '../auth/decorators/auth.decorators';
 import { ApiKeyRole } from '../auth/entities/api-key.entity';
 
 @ApiTags('messages')
+@ApiSecurity('X-API-Key')
 @Controller('sessions/:sessionId/messages')
 export class MessageController {
   constructor(

--- a/src/modules/plugins/plugins.controller.ts
+++ b/src/modules/plugins/plugins.controller.ts
@@ -1,11 +1,12 @@
 import { Controller, Get, Post, Put, Param, Body, HttpCode, HttpStatus } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiSecurity } from '@nestjs/swagger';
 import { PluginsService } from './plugins.service';
 import { PluginDto, PluginConfigDto } from './dto/plugin.dto';
 import { RequireRole } from '../auth/decorators/auth.decorators';
 import { ApiKeyRole } from '../auth/entities/api-key.entity';
 
 @ApiTags('plugins')
+@ApiSecurity('X-API-Key')
 @Controller('plugins')
 export class PluginsController {
   constructor(private readonly pluginsService: PluginsService) {}

--- a/src/modules/session/session.controller.ts
+++ b/src/modules/session/session.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Post, Delete, Param, Body, HttpCode, HttpStatus } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiSecurity } from '@nestjs/swagger';
 import { SessionService } from './session.service';
 import {
   CreateSessionDto,
@@ -17,6 +17,7 @@ import { RequireRole } from '../auth/decorators/auth.decorators';
 import { ApiKeyRole } from '../auth/entities/api-key.entity';
 
 @ApiTags('sessions')
+@ApiSecurity('X-API-Key')
 @Controller('sessions')
 export class SessionController {
   constructor(

--- a/src/modules/settings/settings.controller.ts
+++ b/src/modules/settings/settings.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Put, Body } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiSecurity } from '@nestjs/swagger';
 import { ConfigService } from '@nestjs/config';
 import { RequireRole } from '../auth/decorators/auth.decorators';
 import { ApiKeyRole } from '../auth/entities/api-key.entity';
@@ -24,6 +24,7 @@ interface Settings {
 }
 
 @ApiTags('settings')
+@ApiSecurity('X-API-Key')
 @Controller('settings')
 export class SettingsController {
   private settings: Settings;

--- a/src/modules/stats/stats.controller.ts
+++ b/src/modules/stats/stats.controller.ts
@@ -1,9 +1,10 @@
 import { Controller, Get, Param, Query } from '@nestjs/common';
-import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiSecurity } from '@nestjs/swagger';
 import { StatsService } from './stats.service';
 import { StatsQueryDto } from './dto/stats-query.dto';
 
 @ApiTags('Statistics')
+@ApiSecurity('X-API-Key')
 @Controller('stats')
 export class StatsController {
   constructor(private readonly statsService: StatsService) {}

--- a/src/modules/status/status.controller.ts
+++ b/src/modules/status/status.controller.ts
@@ -1,10 +1,11 @@
 import { Controller, Get, Post, Delete, Param, Body } from '@nestjs/common';
-import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiSecurity } from '@nestjs/swagger';
 import { StatusService } from './status.service';
 import { SendTextStatusDto } from './dto/send-text-status.dto';
 import { SendImageStatusDto, SendVideoStatusDto } from './dto/send-media-status.dto';
 
 @ApiTags('Status')
+@ApiSecurity('X-API-Key')
 @Controller('sessions/:sessionId/status')
 export class StatusController {
   constructor(private readonly statusService: StatusService) {}

--- a/src/modules/webhook/webhook.controller.ts
+++ b/src/modules/webhook/webhook.controller.ts
@@ -1,11 +1,12 @@
 import { Controller, Get, Post, Put, Delete, Param, Body, HttpCode, HttpStatus } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiSecurity } from '@nestjs/swagger';
 import { WebhookService } from './webhook.service';
 import { CreateWebhookDto, UpdateWebhookDto, WebhookResponseDto } from './dto';
 import { RequireRole } from '../auth/decorators/auth.decorators';
 import { ApiKeyRole } from '../auth/entities/api-key.entity';
 
 @ApiTags('webhooks')
+@ApiSecurity('X-API-Key')
 @Controller('sessions/:sessionId/webhooks')
 export class WebhookController {
   constructor(private readonly webhookService: WebhookService) {}

--- a/src/modules/webhook/webhooks-list.controller.ts
+++ b/src/modules/webhook/webhooks-list.controller.ts
@@ -1,11 +1,12 @@
 import { Controller, Get } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiSecurity } from '@nestjs/swagger';
 import { WebhookService } from './webhook.service';
 import { WebhookResponseDto } from './dto';
 import { RequireRole } from '../auth/decorators/auth.decorators';
 import { ApiKeyRole } from '../auth/entities/api-key.entity';
 
 @ApiTags('webhooks')
+@ApiSecurity('X-API-Key')
 @Controller('webhooks')
 export class WebhooksListController {
   constructor(private readonly webhookService: WebhookService) {}


### PR DESCRIPTION
## Description
The Swagger docs at `/api/docs` were unusable — every protected endpoint returned `401 Unauthorized` because the `X-API-Key` header was not being attached to requests. Two controllers (`/infra` and `/auth/validate`) were missing the `@ApiSecurity('X-API-Key')` decorator, which meant Swagger had no way to know these endpoints required authentication. Without it, Swagger does not include the header and all requests from the docs fail.

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] Lint passes
- [X] Self-reviewed

## Screenshots (if applicable)

## Related Issues
Closes #
