### PR TITLE
chore(release): v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.6] - 2026-06-16
+
+A patch release: stop Chromium from failing to launch on hardened `read_only` containers, and make the
+Login language selector legible in dark mode.
+
+### Fixed
+
+- Chromium no longer hard-crashes at launch (`Trace/breakpoint trap` / `chrome_crashpad_handler:
+  --database is required`) on hardened `read_only` containers. Chromium resolves its home dir from the
+  passwd entry and ignores `$HOME`, so the home-less `openwa` user pointed it at a nonexistent
+  `/home/openwa`. It is now given writable, pre-created `XDG_CONFIG_HOME`/`XDG_CACHE_HOME` dirs (created
+  by the entrypoint, owned by `openwa`). This supersedes the ineffective `--crash-dumps-dir` approach
+  from 0.2.5, which is a confirmed no-op for the crashpad database on Debian/Ubuntu system Chromium. (#254)
+- The Login screen's language `<select>` option popup is now legible in dark mode. The login route never
+  sets `data-theme`, so it relied solely on the `prefers-color-scheme` media block, which set dark colors
+  but left `color-scheme` ambiguous — rendering the native popup light with light text. (#249)
+
 ## [0.2.5] - 2026-06-16
 
 A patch release: pairing-code linking, a Chromium crash-dumps fix, and dark-mode native controls.

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,12 +75,16 @@ COPY --from=builder /app/dist ./dist
 RUN mkdir -p ./data/sessions ./data/media && \
     chown -R openwa:openwa /app
 
-# The non-root openwa user has no home of its own (created with `useradd -r`, no -m), so $HOME
-# defaults to "/", which is not writable. Newer Chromium spawns chrome_crashpad_handler, which
-# needs a writable HOME-derived crash-dump dir or the browser fails to launch ("--database is
-# required"). Point HOME at the openwa-owned data dir so the engine starts under `docker run`,
-# Kubernetes, etc. (compose overrides this with HOME=/tmp on its read-only rootfs). See #242.
+# The non-root openwa user has no home of its own (`useradd -r`, no -m). Chromium resolves the home
+# dir from the passwd entry via glib's getpwuid() — it IGNORES $HOME — so it tries to read/write
+# /home/openwa, which does not exist. On hardened/read-only hosts that makes the browser HARD-CRASH
+# at launch (SIGTRAP/int3, logged as "chrome_crashpad_handler: --database is required"). The robust
+# fix is to point Chromium's config + cache at writable, pre-created dirs via XDG_* (honored directly,
+# bypassing the passwd lookup); docker-entrypoint.sh creates them owned by openwa. On a read_only
+# rootfs these live on the tmpfs /tmp. HOME is kept for any other HOME-relative tooling. See #254/#242.
 ENV HOME=/app/data
+ENV XDG_CONFIG_HOME=/tmp/.config
+ENV XDG_CACHE_HOME=/tmp/.cache
 
 # Copy entrypoint: runs as root to fix named-volume ownership, then drops to openwa via gosu
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/rmyndharis/OpenWA/actions/workflows/ci.yml"><img src="https://github.com/rmyndharis/OpenWA/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"/></a>
-  <img src="https://img.shields.io/badge/version-0.2.5-blue.svg" alt="Version"/>
+  <img src="https://img.shields.io/badge/version-0.2.6-blue.svg" alt="Version"/>
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"/>
   <img src="https://img.shields.io/badge/node-22_LTS-brightgreen.svg" alt="Node"/>
   <img src="https://img.shields.io/badge/NestJS-11.x-red.svg" alt="NestJS"/>

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashboard",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashboard",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "dependencies": {
         "@tanstack/react-query": "^5.101.0",
         "@tanstack/react-table": "^8.21.3",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboard",
   "private": true,
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/dashboard/src/App.css
+++ b/dashboard/src/App.css
@@ -45,6 +45,10 @@
 /* System preference dark mode */
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme='light']) {
+    /* Match native controls (e.g. the Login page <select> option popup) to the dark theme.
+       The Login screen never sets data-theme, so it relies solely on this block — without an
+       explicit color-scheme the popup rendered light, leaving the light option text illegible (#249). */
+    color-scheme: dark;
     --bg-light: #0f172a;
     --bg-white: #1e293b;
     --bg-card: #1e293b;

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -38,6 +38,10 @@ services:
       - NODE_ENV=development
       - PORT=2785
       - HOME=/tmp
+      # Chromium reads its home from the passwd entry (no /home/openwa), so it needs writable, existing
+      # config/cache dirs on the tmpfs or it hard-crashes at launch; the entrypoint pre-creates them. (#254)
+      - XDG_CONFIG_HOME=/tmp/.config
+      - XDG_CACHE_HOME=/tmp/.cache
       - DATABASE_TYPE=sqlite
       - DATABASE_NAME=/app/data/openwa.sqlite
       - DATABASE_SYNCHRONIZE=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,11 @@ services:
       - NODE_ENV=${NODE_ENV:-production}
       # Writable HOME on tmpfs so Chromium's HOME-relative writes don't hit the read_only rootfs
       - HOME=/tmp
+      # Chromium resolves its home from the passwd entry (no /home/openwa), ignoring $HOME, so without
+      # writable, existing config/cache dirs it hard-crashes at launch on the read_only rootfs. Pin XDG
+      # to the tmpfs; the entrypoint pre-creates these owned by openwa. (#254)
+      - XDG_CONFIG_HOME=/tmp/.config
+      - XDG_CACHE_HOME=/tmp/.cache
       - PORT=2785
       - LOG_LEVEL=${LOG_LEVEL:-info}
       # Database

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,6 +6,18 @@ set -e
 mkdir -p /app/data/sessions /app/data/media /app/data/plugins
 chown -R openwa:openwa /app/data
 
+# Chromium resolves its home from the passwd entry (no /home/openwa exists), so it hard-crashes at
+# launch unless its config/cache dirs exist and are writable. XDG_CONFIG_HOME/XDG_CACHE_HOME (set in
+# the image) point here; create them owned by openwa. On a read_only rootfs these live on tmpfs /tmp,
+# which is mounted fresh each start — so they must be (re)created at runtime, not at build. (#254)
+if ! mkdir -p "${XDG_CONFIG_HOME:-/tmp/.config}" "${XDG_CACHE_HOME:-/tmp/.cache}"; then
+  echo "FATAL: cannot create Chromium config/cache dirs (${XDG_CONFIG_HOME:-/tmp/.config}, ${XDG_CACHE_HOME:-/tmp/.cache})." >&2
+  echo "       On a read_only rootfs, mount a writable tmpfs/emptyDir at /tmp (compose: 'tmpfs: [/tmp]'; k8s: an emptyDir at /tmp)." >&2
+  echo "       Without it Chromium cannot launch and sessions will fail (#254)." >&2
+  exit 1
+fi
+chown openwa:openwa "${XDG_CONFIG_HOME:-/tmp/.config}" "${XDG_CACHE_HOME:-/tmp/.cache}"
+
 # "$@" = CMD from Dockerfile (default: node dist/main).
 # gosu performs exec, so the node process replaces this shell and becomes the
 # direct child of dumb-init (PID 1), which can therefore forward SIGTERM cleanly.

--- a/docs/12-troubleshooting-faq.md
+++ b/docs/12-troubleshooting-faq.md
@@ -205,8 +205,8 @@ docker compose up -d
 stuck. Often seen on ARM64 (e.g. Raspberry Pi) after upgrading to v0.2.x.
 
 **Cause:** whatsapp-web.js auto-selects a WhatsApp Web client version, and an incompatible version
-stalls the post-link sync. (The `chrome_crashpad_handler: --database is required` log is a separate,
-harmless line — Chromium still launches.)
+stalls the post-link sync. (If you also see `chrome_crashpad_handler: --database is required` *and the
+session never starts at all*, that is a different problem — see "Session fails to launch …" below.)
 
 **Fix:** pin a known-good WhatsApp Web version with `WWEBJS_WEB_VERSION`:
 
@@ -218,6 +218,35 @@ WWEBJS_WEB_VERSION=2.3000.1023204257
 Restart the container after setting it. Browse newer versions at
 [wppconnect-team/wa-version](https://github.com/wppconnect-team/wa-version) (the `html/` folder).
 Set `WWEBJS_WEB_VERSION=latest` (or leave it unset) to restore the default auto-version behavior.
+
+### Issue: Session fails to launch with `chrome_crashpad_handler: --database is required`
+
+**Symptoms:** The session never starts; the engine log shows `Failed to launch the browser process` with
+`chrome_crashpad_handler: --database is required`, and the host kernel log shows a Chromium
+`trap int3` / `Trace/breakpoint trap (core dumped)`. Seen on hardened, `read_only` containers.
+
+**Cause:** Chromium resolves its home directory from the passwd entry (glibc `getpwuid()`) and **ignores
+`$HOME`**. The non-root `openwa` user has no home dir, so Chromium tries to use `/home/openwa`, which does
+not exist on the read-only rootfs — and aborts at launch. (Setting `HOME=` does **not** help, and
+`--crash-dumps-dir` is a no-op for the crashpad database on Debian/Ubuntu system Chromium.)
+
+**Fix:** Give Chromium writable, pre-created config/cache dirs via `XDG_CONFIG_HOME` / `XDG_CACHE_HOME`.
+The bundled image and `docker-compose.yml` already do this (the entrypoint creates them on the tmpfs `/tmp`,
+owned by `openwa`). If you run a custom container, ensure both are set to a writable, existing path:
+
+```bash
+XDG_CONFIG_HOME=/tmp/.config
+XDG_CACHE_HOME=/tmp/.cache
+# and create them owned by the runtime user before launch:
+#   mkdir -p /tmp/.config /tmp/.cache && chown <user> /tmp/.config /tmp/.cache
+```
+
+On a `read_only` rootfs you **must** also mount a writable tmpfs/emptyDir at `/tmp` (compose:
+`tmpfs: [/tmp]`; k8s: an `emptyDir` at `/tmp`) — otherwise the entrypoint cannot create these dirs and
+will exit at startup with a clear `FATAL:` message rather than crash-looping later.
+
+Do **not** work around this by dropping `--no-sandbox` security hardening or using `seccomp:unconfined`
+(confirmed not to help, and it widens the attack surface).
 
 ### Issue: Frequent Disconnections
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.2.5-blue.svg" alt="Version"/>
+  <img src="https://img.shields.io/badge/version-0.2.6-blue.svg" alt="Version"/>
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"/>
   <img src="https://img.shields.io/badge/node-22_LTS-brightgreen.svg" alt="Node"/>
   <img src="https://img.shields.io/badge/NestJS-11.x-red.svg" alt="NestJS"/>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openwa",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openwa",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwa",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API for WhatsApp",
   "author": "Yudhi Armyndharis & OpenWA Contributors",
   "private": true,

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -2,7 +2,6 @@ import { EventEmitter } from 'events';
 import { Client, LocalAuth, MessageMedia, MessageTypes } from 'whatsapp-web.js';
 import * as qrcode from 'qrcode';
 import * as path from 'path';
-import * as os from 'os';
 import {
   IWhatsAppEngine,
   EngineStatus,
@@ -162,14 +161,6 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
         '--no-zygote',
         '--disable-gpu',
       ];
-
-      // Give Chromium an explicit, writable crash-dumps dir so its crashpad handler always gets a
-      // --database. On some hardened/container hosts Chromium otherwise fails to launch with
-      // "chrome_crashpad_handler: --database is required" (#254/#242). Skipped if the operator
-      // already supplied their own --crash-dumps-dir via PUPPETEER_ARGS.
-      if (!puppeteerArgs.some(a => a.startsWith('--crash-dumps-dir'))) {
-        puppeteerArgs.push(`--crash-dumps-dir=${path.join(os.tmpdir(), 'openwa-crashpad')}`);
-      }
 
       // Add proxy configuration if provided
       if (this.config.proxy) {


### PR DESCRIPTION
## v0.2.6 — patch release

Stops Chromium from failing to launch on hardened `read_only` containers, and makes the Login language selector legible in dark mode.

### Fixed

- **`fix(docker)`: Chromium launch failure on hardened containers (#254).** Chromium resolves its home dir via glibc `getpwuid()` and **ignores `$HOME`**, so the home-less `openwa` user pointed it at a nonexistent `/home/openwa` → hard `SIGTRAP`/`int3` at launch (logged as `chrome_crashpad_handler: --database is required`). Now sets `XDG_CONFIG_HOME`/`XDG_CACHE_HOME` to writable dirs the entrypoint pre-creates owned by `openwa`. **Verified on the reporter's host** (Ubuntu 22.04 / x86_64 / kernel 5.15, hardened `read_only` compose). Removes the ineffective `--crash-dumps-dir` approach from 0.2.5 (a confirmed no-op for the crashpad database on Debian/Ubuntu system Chromium).
- **`fix(dashboard)`: Login language `<select>` popup illegible in dark mode (#249).** The login route never sets `data-theme`, so it relied solely on the `prefers-color-scheme` media block, which set dark colors but left `color-scheme` ambiguous — rendering the native option popup light with light text.

### Verification

- Root cause reproduced and fix confirmed on the reporter's host (`baseline → Trace/breakpoint trap`; `XDG fix → OK`).
- Full backend suite: **429/429 tests, 45 suites**. Root + dashboard builds green. Entrypoint `sh -n` valid.
- Two rounds of deep adversarial source-traced review (env propagation into `puppeteer-core`, entrypoint edge cases, multi-session/resource, full run-mode matrix) — all dimensions hold.

Closes #254
Closes #249
