### PR TITLE
fix: Chromium singleton locks, crashpad --database, auth hang, and 502 Bad Gateway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,8 +65,8 @@ WORKDIR /app
 # Copy package files
 COPY package*.json ./
 
-# Install production dependencies only
-RUN npm ci --omit=dev && npm cache clean --force
+# Copy node_modules from builder (includes native modules like sqlite3 built with full toolchain)
+COPY --from=builder /app/node_modules ./node_modules
 
 # Copy built application from builder stage
 COPY --from=builder /app/dist ./dist

--- a/dashboard/nginx.conf
+++ b/dashboard/nginx.conf
@@ -15,7 +15,7 @@ server {
 
     # Proxy API requests to backend
     location /api/ {
-        proxy_pass http://openwa:2785;
+        proxy_pass http://openwa-api:2785;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
@@ -25,7 +25,7 @@ server {
 
     # WebSocket proxy
     location /socket.io/ {
-        proxy_pass http://openwa:2785;
+        proxy_pass http://openwa-api:2785;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -38,13 +38,15 @@ services:
       - NODE_ENV=development
       - PORT=2785
       - HOME=/tmp
+      - XDG_CONFIG_HOME=/tmp/.chromium
+      - WWEBJS_WEB_VERSION=2.3000.1023204257
       - DATABASE_TYPE=sqlite
       - DATABASE_NAME=/app/data/openwa.sqlite
       - DATABASE_SYNCHRONIZE=true
       - ENGINE_TYPE=whatsapp-web.js
       - SESSION_DATA_PATH=/app/data/sessions
       - PUPPETEER_HEADLESS=true
-      - PUPPETEER_ARGS=--no-sandbox,--disable-setuid-sandbox,--disable-dev-shm-usage,--disable-gpu
+      - PUPPETEER_ARGS=--no-sandbox,--disable-setuid-sandbox,--disable-dev-shm-usage,--disable-gpu,--no-zygote
       - STORAGE_TYPE=local
       - STORAGE_LOCAL_PATH=/app/data/media
       - WEBHOOK_TIMEOUT=10000

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,6 +3,19 @@
 # openwa user via gosu so the Node process never holds root privileges.
 set -e
 
+# Wipe all Chromium singleton locks — Chromium doesn't clean these up on crash,
+# so stale locks block subsequent launches of sessions that reuse the same profile path.
+rm -rf /tmp/.chromium /app/data/sessions/*/SingletonLock \
+       /app/data/sessions/*/SingletonSocket \
+       /app/data/sessions/*/SingletonCookie 2>/dev/null || true
+
+# Create the XDG Crashpad directory so Chromium's crashpad handler can initialise
+# without throwing "chrome_crashpad_handler: --database is required".
+# Chromium reads $XDG_CONFIG_HOME/Crashpad (falls back to $HOME/.config/Crashpad).
+# With HOME=/tmp in docker-compose, this gives /tmp/.config/Crashpad (#254/#242).
+mkdir -p /tmp/.config/Crashpad
+chown -R openwa:openwa /tmp/.config
+
 mkdir -p /app/data/sessions /app/data/media /app/data/plugins
 chown -R openwa:openwa /app/data
 


### PR DESCRIPTION
## Summary

Fixes 4 runtime issues that block session start on a clean Docker setup:

### 1. `Dockerfile` — sqlite3 native module build failure
`npm ci --omit=dev` cannot build sqlite3's native addon (needs dev toolchain). Fixed by copying the complete `node_modules` from the builder stage, which has all native modules pre-built.

### 2. `dashboard/nginx.conf` — 502 Bad Gateway
Dashboard nginx proxied to `http://openwa:2785` but the container is named `openwa-api`. Fixed in both the `/api/` and `/socket.io/` location blocks.

### 3. `docker-compose.dev.yml` — Chromium auth hang + crashpad
- Added `WWEBJS_WEB_VERSION=2.3000.1023204257` (known-good WA Web version, confirmed in #251) to prevent session hanging at \`authenticating\` indefinitely
- Added `XDG_CONFIG_HOME=/tmp/.chromium` for explicit Chromium config path
- Added `--no-zygote` to `PUPPETEER_ARGS` to prevent zygote process from interfering with crashpad hooks

### 4. `docker-entrypoint.sh` — Chromium singleton lock files + crashpad handler
Chromium doesn't clean up `SingletonLock`, `SingletonSocket`, or `SingletonCookie` files on crash. These stale locks block subsequent launches (Code 21: "profile appears to be in use by another Chromium process"). Fixed by wiping all lock files and `/tmp/.chromium` on every container start, and creating `/tmp/.config/Crashpad` so the crashpad handler can initialise without throwing \`--database is required\` (refs #254, #242).

## Testing
- Session start: \`initializing → authenticating → ready\` completes in ~15s
- No crashpad \`--database is required\` errors
- No singleton lock errors after container restart
- Dashboard API proxy: 200 OK on all endpoints