### PR TITLE
fix(docker): align dashboard nginx host + clear stale Chromium singleton locks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ uploads/
 .worktrees/
 
 # AI Agents
+.playwright-mcp/
 .remember/
 .agent/
 .claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Dashboard (simple nginx image) proxied API/WebSocket requests to a `openwa` host that doesn't match the
+  backend service name; `dashboard/nginx.conf` now targets `openwa-api` for both `/api/` and `/socket.io/`,
+  matching the production compose and `Dockerfile.traefik`. Thanks @Abhishekrajpurohit (#259).
+- The container entrypoint now clears stale Chromium `SingletonLock`/`SingletonSocket`/`SingletonCookie` files
+  from session profiles on start, so a session can re-launch after an unclean shutdown instead of failing with
+  "profile appears to be in use by another Chromium process" (exit Code 21). Thanks @Abhishekrajpurohit (#259).
+
 ## [0.2.6] - 2026-06-16
 
 A patch release: stop Chromium from failing to launch on hardened `read_only` containers, and make the

--- a/dashboard/nginx.conf
+++ b/dashboard/nginx.conf
@@ -15,7 +15,7 @@ server {
 
     # Proxy API requests to backend
     location /api/ {
-        proxy_pass http://openwa:2785;
+        proxy_pass http://openwa-api:2785;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
@@ -25,7 +25,7 @@ server {
 
     # WebSocket proxy
     location /socket.io/ {
-        proxy_pass http://openwa:2785;
+        proxy_pass http://openwa-api:2785;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,6 +6,12 @@ set -e
 mkdir -p /app/data/sessions /app/data/media /app/data/plugins
 chown -R openwa:openwa /app/data
 
+# Chromium leaves SingletonLock/SingletonSocket/SingletonCookie in each session profile and does
+# not remove them on an unclean shutdown; stale locks block the next launch ("profile appears to be
+# in use by another Chromium process", exit Code 21). No Chromium is running yet at entrypoint time,
+# so clearing them lets sessions re-launch after a crash/restart. (#259)
+rm -f /app/data/sessions/*/Singleton* 2>/dev/null || true
+
 # Chromium resolves its home from the passwd entry (no /home/openwa exists), so it hard-crashes at
 # launch unless its config/cache dirs exist and are writable. XDG_CONFIG_HOME/XDG_CACHE_HOME (set in
 # the image) point here; create them owned by openwa. On a read_only rootfs these live on tmpfs /tmp,


### PR DESCRIPTION
## Summary

Two small, verified Docker-runtime fixes salvaged from #259 (declined as-is for an accidental submodule commit + a devDeps-shipping Dockerfile change). Credit to @Abhishekrajpurohit for the findings.

### 1. nginx hostname (`dashboard/nginx.conf`)
The simple dashboard image proxied `/api/` and `/socket.io/` to a bare `openwa` host. The canonical backend is **`openwa-api`** — the production compose service name, the dev `container_name`, and what `dashboard/Dockerfile.traefik` already uses. Both blocks now target `openwa-api`.
- No regression: in `docker-compose.dev.yml` (the only deployment that builds the simple `dashboard/Dockerfile`) the backend resolves as **both** `openwa` and `openwa-api` on the user-defined network, so the new value works everywhere the old one did — and is correct for production/standalone naming.

### 2. Chromium singleton-lock cleanup (`docker-entrypoint.sh`)
Chromium leaves `SingletonLock`/`SingletonSocket`/`SingletonCookie` in each session profile and does not remove them on an unclean shutdown; the stale locks block the next launch ("profile appears to be in use by another Chromium process", exit Code 21). The entrypoint now clears them on start (no Chromium is running at that point, so it's safe).

```sh
rm -f /app/data/sessions/*/Singleton* 2>/dev/null || true
```

## Also included
- `chore: ignore .playwright-mcp/ artifacts` — a one-line `.gitignore` hygiene addition (separate commit), called out explicitly so it isn't silently bundled with the fixes.

## Verification
- Path traced to whatsapp-web.js LocalAuth profile layout (`<SESSION_DATA_PATH>/session-<id>/`); glob matches, removes only `Singleton*`, **preserves** real profile data (`Cookies`/`Preferences`/`Default/`).
- `set -e`-safe under POSIX `sh` (unmatched glob is a no-op; `rm -f` never errors on missing files).
- `sh -n docker-entrypoint.sh` clean. Reviewed for regressions across all dashboard build variants and compose topologies.

Holding the release — to batch with the next set of changes rather than cut a same-day patch.
