### PR TITLE
feat(session): add POST delete-chat endpoint

### DIFF
--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -1157,6 +1157,17 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     }
   }
 
+  async deleteChat(chatId: string): Promise<boolean> {
+    this.ensureReady();
+    try {
+      const chat = await this.client!.getChatById(chatId);
+      return await chat.delete();
+    } catch (error) {
+      this.logger.error(`Error deleting chat ${chatId}`, String(error));
+      return false;
+    }
+  }
+
   private ensureReady(): void {
     if (this.status !== EngineStatus.READY || !this.client) {
       // Typed so the global filter returns 409 Conflict ("session not connected")

--- a/src/engine/interfaces/whatsapp-engine.interface.ts
+++ b/src/engine/interfaces/whatsapp-engine.interface.ts
@@ -369,4 +369,5 @@ export interface IWhatsAppEngine {
   // Chats
   getChats(): Promise<ChatSummary[]>;
   sendSeen(chatId: string): Promise<boolean>;
+  deleteChat(chatId: string): Promise<boolean>;
 }

--- a/src/modules/session/dto/delete-chat.dto.ts
+++ b/src/modules/session/dto/delete-chat.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, Matches } from 'class-validator';
+
+export class DeleteChatDto {
+  @ApiProperty({
+    description:
+      'WhatsApp chat ID to delete from the chat list (e.g., 1234567890@c.us, 1234567890-123@g.us, or 1234567890@lid)',
+    example: '1234567890-123@g.us',
+  })
+  @IsString()
+  @IsNotEmpty()
+  // Reject malformed IDs early with a clear 400 instead of a silent no-op at the engine layer.
+  @Matches(/^[0-9-]+@(?:[cg]\.us|lid)$/, {
+    message: 'chatId must be a valid WhatsApp JID (e.g. 1234567890@c.us, 1234567890-123@g.us, or 1234567890@lid)',
+  })
+  chatId: string;
+}

--- a/src/modules/session/dto/index.ts
+++ b/src/modules/session/dto/index.ts
@@ -1,4 +1,5 @@
 export * from './create-session.dto';
 export * from './session-response.dto';
 export * from './mark-chat-read.dto';
+export * from './delete-chat.dto';
 export * from './request-pairing-code.dto';

--- a/src/modules/session/session.controller.ts
+++ b/src/modules/session/session.controller.ts
@@ -6,6 +6,7 @@ import {
   SessionResponseDto,
   QRCodeResponseDto,
   MarkChatReadDto,
+  DeleteChatDto,
   RequestPairingCodeDto,
   PairingCodeResponseDto,
 } from './dto';
@@ -209,6 +210,18 @@ export class SessionController {
   @ApiResponse({ status: 404, description: 'Session not found' })
   async markChatRead(@Param('id') id: string, @Body() dto: MarkChatReadDto): Promise<{ success: boolean }> {
     const success = await this.sessionService.sendSeen(id, dto.chatId);
+    return { success };
+  }
+
+  @Post(':id/chats/delete')
+  @RequireRole(ApiKeyRole.OPERATOR)
+  @ApiOperation({ summary: 'Delete a chat from the chat list (e.g. a group you have left)' })
+  @ApiParam({ name: 'id', description: 'Session ID' })
+  @ApiResponse({ status: 200, description: 'Chat deleted successfully' })
+  @ApiResponse({ status: 400, description: 'Session not ready' })
+  @ApiResponse({ status: 404, description: 'Session not found' })
+  async deleteChat(@Param('id') id: string, @Body() dto: DeleteChatDto): Promise<{ success: boolean }> {
+    const success = await this.sessionService.deleteChat(id, dto.chatId);
     return { success };
   }
 

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -77,6 +77,7 @@ describe('SessionService', () => {
       getGroups: jest.fn().mockResolvedValue([]),
       getChats: jest.fn().mockResolvedValue([]),
       sendSeen: jest.fn().mockResolvedValue(true),
+      deleteChat: jest.fn().mockResolvedValue(true),
     };
 
     engineFactory = {
@@ -673,6 +674,31 @@ describe('SessionService', () => {
       (repository.findOne as jest.Mock).mockResolvedValue(session);
 
       await expect(service.sendSeen('sess-uuid-1', '123@c.us')).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  // ── deleteChat ────────────────────────────────────────────────────
+
+  describe('deleteChat', () => {
+    it('should delegate to engine.deleteChat with the chatId', async () => {
+      const session = createMockSession();
+      (repository.findOne as jest.Mock).mockResolvedValue(session);
+      (repository.update as jest.Mock).mockResolvedValue({ affected: 1 });
+
+      await service.start('sess-uuid-1');
+      mockEngine.deleteChat.mockResolvedValue(true);
+
+      const result = await service.deleteChat('sess-uuid-1', '1234567890-123@g.us');
+
+      expect(mockEngine.deleteChat).toHaveBeenCalledWith('1234567890-123@g.us');
+      expect(result).toBe(true);
+    });
+
+    it('should throw BadRequestException when session is not started', async () => {
+      const session = createMockSession();
+      (repository.findOne as jest.Mock).mockResolvedValue(session);
+
+      await expect(service.deleteChat('sess-uuid-1', '1234567890-123@g.us')).rejects.toThrow(BadRequestException);
     });
   });
 

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -804,6 +804,17 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
     return engine.sendSeen(chatId);
   }
 
+  async deleteChat(id: string, chatId: string): Promise<boolean> {
+    await this.findOne(id); // Verify session exists
+    const engine = this.engines.get(id);
+
+    if (!engine) {
+      throw new BadRequestException('Session is not started');
+    }
+
+    return engine.deleteChat(chatId);
+  }
+
   private async updateStatus(id: string, status: SessionStatus): Promise<void> {
     await this.sessionRepository.update(id, { status });
     this.logger.debug(`Session status updated to ${status}`, {


### PR DESCRIPTION
## Description

Adds a new endpoint for removing a chat from the chat list directly via the WhatsApp client — useful for cleaning up stale conversations such as groups you have already left, which otherwise linger in the chat list.

**Endpoint:** `POST /api/sessions/:id/chats/delete`

**Body:**
- `chatId` (required): the WhatsApp JID of the chat to delete (e.g. `1234567890@c.us`, `1234567890-123@g.us`, or `1234567890@lid`). Validated as a JID up-front so malformed IDs return a clear `400` instead of a silent no-op.

## Implementation

- Adds `deleteChat(chatId)` to `IWhatsAppEngine`
- Implements it in the whatsapp-web-js adapter via `chat.delete()`
- Integrates through `SessionService` and `SessionController`
- Adds `DeleteChatDto` with JID validation
- `OPERATOR` role required (mutation), mirroring `markChatRead`
- Adds two unit tests mirroring `sendSeen` (delegation + not-started guard)

## Type of Change

- New feature

## Checklist

- [x] Unit tests added (delegation + not-started guard)
- [x] ESLint passes
- [x] Prettier formatting passes
- [x] Build succeeds
- [x] Self-reviewed
- [x] Documentation updated (Swagger annotations sufficient)

## Testing

`npm run build`, `npm run lint`, and the new `session.service.spec.ts` `deleteChat` tests all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
