### PR TITLE
feat(messaging): typing simulation (anti-ban) + fix duplicate dashboard messages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,13 @@ PUPPETEER_ARGS=--no-sandbox,--disable-setuid-sandbox,--disable-dev-shm-usage,--d
 # 2.3000.1023204257 is confirmed to reach "ready" (incl. ARM64 / Raspberry Pi 5) — uncomment it:
 # WWEBJS_WEB_VERSION=2.3000.1023204257
 
+# Humanise single sends: show a "typing…" indicator and pause briefly (length-scaled, jittered)
+# before each text send so messages don't look instantaneous (anti-ban). ON by default — set to
+# false to disable. SIMULATE_TYPING_MAX_MS caps the pause (default 5000). Does not affect bulk
+# sends, which have their own delayBetweenMessages throttle.
+# SIMULATE_TYPING=false
+# SIMULATE_TYPING_MAX_MS=5000
+
 # Observability — Prometheus scrape endpoint at GET /api/metrics.
 # Disabled by default; set a token to enable. Scrapers must send `Authorization: Bearer <token>`.
 # METRICS_TOKEN=change-me-to-a-long-random-string

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Typing simulation before single sends (anti-ban), on by default.** A text send now shows a "typing…"
+  indicator and pauses briefly (length-scaled, jittered) before sending, so automated messages don't look
+  instantaneous. Disable with `SIMULATE_TYPING=false`; cap the pause with `SIMULATE_TYPING_MAX_MS`
+  (default 5000). Exposed engine-agnostically via `IWhatsAppEngine.sendChatState` and a new
+  `POST /sessions/:id/chats/typing` endpoint (`state`: `typing` | `recording` | `paused`). Bulk sends are
+  unaffected (they keep their own `delayBetweenMessages` throttle).
+- The engine API (`GET /infra/engines`) and the dashboard Active Engine card now report the **underlying
+  engine library version** (e.g. `whatsapp-web.js 1.34.7`), distinct from the adapter plugin version.
+
+### Fixed
+
+- **Duplicate outgoing messages in the dashboard Chats view.** A race between the optimistic placeholder
+  and the realtime `message.sent` echo could render a sent message twice. Reconciliation is now race-safe.
+  (Display-only — the recipient always received exactly one message.)
+
+### Changed
+
+- `mark-chat-read` `chatId` validation is now engine-neutral (accepts any engine's JID scheme, e.g. a
+  Baileys `…@s.whatsapp.net`) instead of hardcoding the whatsapp-web.js `@c.us`/`@g.us`/`@lid` format.
+
 ## [0.2.6] - 2026-06-16
 
 A patch release: stop Chromium from failing to launch on hardened `read_only` containers, and make the

--- a/dashboard/src/pages/Chats.tsx
+++ b/dashboard/src/pages/Chats.tsx
@@ -512,11 +512,19 @@ export function Chats() {
         result = await messageApi.sendText(selectedSessionId, activeChat.id, textToSend);
       }
 
-      setMessages(prev =>
-        prev.map(m =>
+      setMessages(prev => {
+        // Race guard: the realtime `message.sent` echo can arrive before this response and already
+        // append the message by its real WA id (the dedup at receive time misses because the
+        // optimistic placeholder still carries the temp id). If so, drop the placeholder instead of
+        // renaming it — otherwise both the echo and the renamed temp render as duplicate bubbles.
+        const echoAlreadyAdded = prev.some(m => m.id === result.messageId || m.waMessageId === result.messageId);
+        if (echoAlreadyAdded) {
+          return prev.filter(m => m.id !== tempId);
+        }
+        return prev.map(m =>
           m.id === tempId ? { ...m, id: result.messageId, waMessageId: result.messageId, status: 'sent' } : m,
-        ),
-      );
+        );
+      });
 
       // Update sidebar chat list (move active chat to the top with the new snippet)
       setChats(prevChats => {

--- a/dashboard/src/pages/Plugins.tsx
+++ b/dashboard/src/pages/Plugins.tsx
@@ -178,7 +178,10 @@ export default function Plugins() {
             </div>
             <div>
               <h3 className="engine-title">{t('plugins.engineCard')}</h3>
-              <span className="engine-name">{currentEngine}</span>
+              <span className="engine-name">
+                {currentEngine}
+                {activeEngine?.library && ` · ${activeEngine.library.name} ${activeEngine.library.version}`}
+              </span>
             </div>
           </div>
           <span className="status-badge connected">{t('plugins.running')}</span>

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -492,6 +492,8 @@ export interface Engine {
   name: string;
   enabled: boolean;
   features: string[];
+  /** Underlying engine library (e.g. whatsapp-web.js 1.34.7), distinct from the adapter version. */
+  library?: { name: string; version: string };
 }
 
 // =============================================================================

--- a/src/core/plugins/plugin.interfaces.ts
+++ b/src/core/plugins/plugin.interfaces.ts
@@ -147,6 +147,10 @@ export interface IEnginePlugin extends IPlugin {
 
   // Get supported features
   getFeatures: () => string[];
+
+  // Underlying engine library name + version (e.g. { name: 'whatsapp-web.js', version: '1.34.7' }) —
+  // distinct from the adapter/plugin's own manifest version. Optional: an engine may not report it.
+  getEngineLibrary?: () => { name: string; version: string };
 }
 
 // ============================================================================

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -27,6 +27,7 @@ import {
   ProductQueryOptions,
   PaginatedProducts,
   ChatSummary,
+  ChatState,
   RevokedMessage,
   ReactionEvent,
 } from '../interfaces/whatsapp-engine.interface';
@@ -1154,6 +1155,23 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     } catch (error) {
       this.logger.error(`Error marking chat ${chatId} as read`, String(error));
       return false;
+    }
+  }
+
+  async sendChatState(chatId: string, state: ChatState): Promise<void> {
+    this.ensureReady();
+    try {
+      const chat = await this.client!.getChatById(chatId);
+      if (state === 'typing') {
+        await chat.sendStateTyping();
+      } else if (state === 'recording') {
+        await chat.sendStateRecording();
+      } else {
+        await chat.clearState();
+      }
+    } catch (error) {
+      // Presence is best-effort — a failure here must never break the surrounding send.
+      this.logger.error(`Error setting chat state '${state}' for ${chatId}`, String(error));
     }
   }
 

--- a/src/engine/engine.factory.ts
+++ b/src/engine/engine.factory.ts
@@ -124,17 +124,28 @@ export class EngineFactory implements OnModuleInit {
   // Query Methods for API/Dashboard
   // ============================================================================
 
-  getAvailableEngines(): Array<{ id: string; name: string; enabled: boolean; features: string[] }> {
+  getAvailableEngines(): Array<{
+    id: string;
+    name: string;
+    enabled: boolean;
+    features: string[];
+    library?: { name: string; version: string };
+  }> {
     const enginePlugins = this.pluginLoader.getPluginsByType(PluginType.ENGINE);
 
     return enginePlugins.map(plugin => {
-      const features = plugin.instance && this.isEnginePlugin(plugin.instance) ? plugin.instance.getFeatures() : [];
+      const inst = plugin.instance;
+      const features = inst && this.isEnginePlugin(inst) ? inst.getFeatures() : [];
+      // The real underlying library version (e.g. whatsapp-web.js 1.34.7), distinct from the
+      // plugin's manifest version — so the dashboard can show which engine is actually running.
+      const library = inst && this.isEnginePlugin(inst) ? inst.getEngineLibrary?.() : undefined;
 
       return {
         id: plugin.manifest.id,
         name: plugin.manifest.name,
         enabled: this.pluginLoader.isPluginEnabled(plugin.manifest.id),
         features,
+        library,
       };
     });
   }

--- a/src/engine/interfaces/whatsapp-engine.interface.ts
+++ b/src/engine/interfaces/whatsapp-engine.interface.ts
@@ -227,6 +227,12 @@ export interface ChatSummary {
 }
 
 /**
+ * Engine-neutral chat presence state. `typing`/`recording` show the indicator to the chat;
+ * `paused` clears it. Best-effort: engines without a presence concept may no-op.
+ */
+export type ChatState = 'typing' | 'recording' | 'paused';
+
+/**
  * Structured payload for a remotely-revoked ("deleted for everyone") message.
  * The engine layer never emits a localized display string; `body` is intentionally
  * empty and the dashboard renders the localized "message deleted" text.
@@ -369,4 +375,9 @@ export interface IWhatsAppEngine {
   // Chats
   getChats(): Promise<ChatSummary[]>;
   sendSeen(chatId: string): Promise<boolean>;
+  /**
+   * Send a typing/recording presence indicator to a chat, or clear it (`paused`).
+   * Engine-agnostic and best-effort: engines without a presence concept should no-op.
+   */
+  sendChatState(chatId: string, state: ChatState): Promise<void>;
 }

--- a/src/modules/message/message.service.spec.ts
+++ b/src/modules/message/message.service.spec.ts
@@ -28,6 +28,7 @@ function createMockEngine() {
     getMessageReactions: jest.fn().mockResolvedValue([]),
     deleteMessage: jest.fn().mockResolvedValue(undefined),
     getChatHistory: jest.fn().mockResolvedValue([]),
+    sendChatState: jest.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -38,6 +39,16 @@ describe('MessageService', () => {
   let hookManager: jest.Mocked<Partial<HookManager>>;
   let templateService: jest.Mocked<Partial<TemplateService>>;
   let mockEngine: ReturnType<typeof createMockEngine>;
+
+  // Auto-typing is on by default; disable it for the unrelated send tests so they don't incur the
+  // real setTimeout delay and don't add an extra sendChatState call. The auto-typing suite opts in.
+  beforeEach(() => {
+    process.env.SIMULATE_TYPING = 'false';
+  });
+  afterEach(() => {
+    delete process.env.SIMULATE_TYPING;
+    delete process.env.SIMULATE_TYPING_MAX_MS;
+  });
 
   beforeEach(async () => {
     repository = {
@@ -80,6 +91,24 @@ describe('MessageService', () => {
   });
 
   // ── sendText ──────────────────────────────────────────────────────
+
+  describe('auto-typing before send (SIMULATE_TYPING, on by default)', () => {
+    it('sends a typing presence before the message by default', async () => {
+      delete process.env.SIMULATE_TYPING; // default = on
+      process.env.SIMULATE_TYPING_MAX_MS = '1'; // keep the humanising delay ~instant in tests
+
+      await service.sendText('sess-1', { chatId: '628123456789@c.us', text: 'Hello' });
+
+      expect(mockEngine.sendChatState).toHaveBeenCalledWith('628123456789@c.us', 'typing');
+      expect(mockEngine.sendTextMessage).toHaveBeenCalledWith('628123456789@c.us', 'Hello');
+    });
+
+    it('does not send typing presence when SIMULATE_TYPING=false', async () => {
+      process.env.SIMULATE_TYPING = 'false';
+      await service.sendText('sess-1', { chatId: '628123456789@c.us', text: 'Hello' });
+      expect(mockEngine.sendChatState).not.toHaveBeenCalled();
+    });
+  });
 
   describe('sendText', () => {
     it('should send text message and return messageId + timestamp', async () => {

--- a/src/modules/message/message.service.ts
+++ b/src/modules/message/message.service.ts
@@ -4,7 +4,7 @@ import { Repository } from 'typeorm';
 import { SessionService } from '../session/session.service';
 import { SendTextMessageDto, SendMediaMessageDto, MessageResponseDto } from './dto';
 import { SendTemplateMessageDto } from './dto/send-template.dto';
-import { MediaInput } from '../../engine/interfaces/whatsapp-engine.interface';
+import { MediaInput, IWhatsAppEngine } from '../../engine/interfaces/whatsapp-engine.interface';
 import { Message, MessageDirection, MessageStatus } from './entities/message.entity';
 import { HookManager } from '../../core/hooks';
 import { TemplateService } from '../template/template.service';
@@ -53,6 +53,9 @@ export class MessageService {
       body: finalDto.text,
       type: 'text',
     });
+
+    // Opt-in humanising "typing…" pause before the actual send (anti-automation signal).
+    await this.simulateTypingIfEnabled(engine, finalDto.chatId, finalDto.text);
 
     try {
       const result = await engine.sendTextMessage(finalDto.chatId, finalDto.text);
@@ -563,6 +566,27 @@ export class MessageService {
       throw new BadRequestException(`Session '${sessionId}' is not active. Start the session first.`);
     }
     return engine;
+  }
+
+  /**
+   * Humanising delay: show the engine's typing indicator and pause for a length-scaled, jittered
+   * interval before the real send, so automated single sends don't look instantaneous (anti-ban).
+   * ON by default — set `SIMULATE_TYPING=false` to disable. Engine-agnostic (goes through
+   * `sendChatState`) and strictly best-effort — it never throws and never blocks the send if presence
+   * fails or the engine has no presence concept. `SIMULATE_TYPING_MAX_MS` (default 5000) caps the pause.
+   * Note: this covers single sends only; bulk sends use their own `delayBetweenMessages` throttle.
+   */
+  private async simulateTypingIfEnabled(engine: IWhatsAppEngine, chatId: string, text: string): Promise<void> {
+    if (process.env.SIMULATE_TYPING === 'false') return;
+    try {
+      await engine.sendChatState(chatId, 'typing');
+      const maxMs = Number(process.env.SIMULATE_TYPING_MAX_MS) || 5000;
+      const planned = Math.min(maxMs, 500 + text.length * 45);
+      const jittered = Math.round(planned * (0.85 + Math.random() * 0.3)); // ±15% so it isn't metronomic
+      await new Promise(resolve => setTimeout(resolve, jittered));
+    } catch (error) {
+      this.logger.warn(`simulateTyping skipped: ${error instanceof Error ? error.message : String(error)}`);
+    }
   }
 
   /**

--- a/src/modules/session/dto/index.ts
+++ b/src/modules/session/dto/index.ts
@@ -1,4 +1,5 @@
 export * from './create-session.dto';
 export * from './session-response.dto';
 export * from './mark-chat-read.dto';
+export * from './send-chat-state.dto';
 export * from './request-pairing-code.dto';

--- a/src/modules/session/dto/mark-chat-read.dto.spec.ts
+++ b/src/modules/session/dto/mark-chat-read.dto.spec.ts
@@ -5,12 +5,17 @@ import { MarkChatReadDto } from './mark-chat-read.dto';
 const errorCount = (chatId: unknown): number => validateSync(plainToInstance(MarkChatReadDto, { chatId })).length;
 
 describe('MarkChatReadDto chatId validation', () => {
-  it.each(['1234567890@c.us', '1234567890-123@g.us', '1234567890@lid'])('accepts a valid JID: %s', chatId => {
-    expect(errorCount(chatId)).toBe(0);
-  });
+  // Engine-neutral: accept any active engine's JID scheme — whatsapp-web.js (@c.us/@g.us/@lid)
+  // AND a swapped engine like Baileys (@s.whatsapp.net). The adapter validates/normalises further.
+  it.each(['1234567890@c.us', '1234567890-123@g.us', '1234567890@lid', '1234567890@s.whatsapp.net'])(
+    'accepts a valid JID across engines: %s',
+    chatId => {
+      expect(errorCount(chatId)).toBe(0);
+    },
+  );
 
-  it.each(['', 'not-a-jid', 'abc@c.us', '1234567890@s.whatsapp.net', '1234567890@lid.us'])(
-    'rejects an invalid chatId: %s',
+  it.each(['', 'not-a-jid', 'no-at-host', '1234567890@', '@host.example', 'has space@c.us'])(
+    'rejects a malformed chatId: %s',
     chatId => {
       expect(errorCount(chatId)).toBeGreaterThan(0);
     },

--- a/src/modules/session/dto/mark-chat-read.dto.ts
+++ b/src/modules/session/dto/mark-chat-read.dto.ts
@@ -3,15 +3,16 @@ import { IsNotEmpty, IsString, Matches } from 'class-validator';
 
 export class MarkChatReadDto {
   @ApiProperty({
-    description: 'WhatsApp chat ID to mark as read (e.g., 1234567890@c.us, 1234567890-123@g.us, or 1234567890@lid)',
+    description: "Chat ID in the active engine's native format (e.g. 1234567890@c.us on whatsapp-web.js)",
     example: '1234567890@c.us',
   })
   @IsString()
   @IsNotEmpty()
-  // Reject malformed IDs early with a clear 400 instead of a silent no-op at the engine layer.
-  // @lid is the privacy "Linked ID" address newer WhatsApp assigns to some 1:1 contacts.
-  @Matches(/^[0-9-]+@(?:[cg]\.us|lid)$/, {
-    message: 'chatId must be a valid WhatsApp JID (e.g. 1234567890@c.us, 1234567890-123@g.us, or 1234567890@lid)',
+  // Engine-neutral structural check (localpart@host, no whitespace) so a different engine's JID
+  // scheme (e.g. Baileys 1234@s.whatsapp.net) is accepted too; the adapter validates/normalises
+  // further for its own engine. Keeps the early-400 on obvious garbage without coupling to wwebjs.
+  @Matches(/^[^\s@]+@[^\s@]+$/, {
+    message: 'chatId must be a valid chat JID in the form localpart@host',
   })
   chatId: string;
 }

--- a/src/modules/session/dto/send-chat-state.dto.ts
+++ b/src/modules/session/dto/send-chat-state.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsIn, IsNotEmpty, IsString } from 'class-validator';
+import type { ChatState } from '../../../engine/interfaces/whatsapp-engine.interface';
+
+export class SendChatStateDto {
+  @ApiProperty({
+    // Engine-neutral on purpose: the chat id is whatever the active engine uses
+    // (e.g. <number>@c.us on whatsapp-web.js, <number>@s.whatsapp.net on Baileys).
+    // The adapter validates/normalises it — we only require a non-empty string here.
+    description: "Chat ID, in the active engine's native format (e.g. 1234567890@c.us)",
+    example: '1234567890@c.us',
+  })
+  @IsString()
+  @IsNotEmpty()
+  chatId: string;
+
+  @ApiProperty({
+    description: "Presence to send: 'typing' or 'recording' shows the indicator; 'paused' clears it",
+    enum: ['typing', 'recording', 'paused'],
+    example: 'typing',
+  })
+  @IsIn(['typing', 'recording', 'paused'])
+  state: ChatState;
+}

--- a/src/modules/session/session.controller.ts
+++ b/src/modules/session/session.controller.ts
@@ -6,6 +6,7 @@ import {
   SessionResponseDto,
   QRCodeResponseDto,
   MarkChatReadDto,
+  SendChatStateDto,
   RequestPairingCodeDto,
   PairingCodeResponseDto,
 } from './dto';
@@ -210,6 +211,17 @@ export class SessionController {
   async markChatRead(@Param('id') id: string, @Body() dto: MarkChatReadDto): Promise<{ success: boolean }> {
     const success = await this.sessionService.sendSeen(id, dto.chatId);
     return { success };
+  }
+
+  @Post(':id/chats/typing')
+  @RequireRole(ApiKeyRole.OPERATOR)
+  @ApiOperation({ summary: "Send a typing/recording presence indicator to a chat (or clear it with 'paused')" })
+  @ApiParam({ name: 'id', description: 'Session ID' })
+  @ApiResponse({ status: 200, description: 'Presence sent' })
+  @ApiResponse({ status: 404, description: 'Session not found' })
+  async sendChatState(@Param('id') id: string, @Body() dto: SendChatStateDto): Promise<{ success: boolean }> {
+    await this.sessionService.sendChatState(id, dto.chatId, dto.state);
+    return { success: true };
   }
 
   @Get('stats/overview')

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -77,6 +77,7 @@ describe('SessionService', () => {
       getGroups: jest.fn().mockResolvedValue([]),
       getChats: jest.fn().mockResolvedValue([]),
       sendSeen: jest.fn().mockResolvedValue(true),
+      sendChatState: jest.fn().mockResolvedValue(undefined),
     };
 
     engineFactory = {
@@ -673,6 +674,29 @@ describe('SessionService', () => {
       (repository.findOne as jest.Mock).mockResolvedValue(session);
 
       await expect(service.sendSeen('sess-uuid-1', '123@c.us')).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  // ── sendChatState (typing/recording/paused) ───────────────────────
+
+  describe('sendChatState', () => {
+    it('should delegate to engine.sendChatState with the chatId and state', async () => {
+      const session = createMockSession();
+      (repository.findOne as jest.Mock).mockResolvedValue(session);
+      (repository.update as jest.Mock).mockResolvedValue({ affected: 1 });
+
+      await service.start('sess-uuid-1');
+
+      await service.sendChatState('sess-uuid-1', '123@c.us', 'typing');
+
+      expect(mockEngine.sendChatState).toHaveBeenCalledWith('123@c.us', 'typing');
+    });
+
+    it('should throw BadRequestException when session is not started', async () => {
+      const session = createMockSession();
+      (repository.findOne as jest.Mock).mockResolvedValue(session);
+
+      await expect(service.sendChatState('sess-uuid-1', '123@c.us', 'typing')).rejects.toThrow(BadRequestException);
     });
   });
 

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -17,6 +17,7 @@ import {
   IWhatsAppEngine,
   EngineStatus,
   ChatSummary,
+  ChatState,
   IncomingMessage,
 } from '../../engine/interfaces/whatsapp-engine.interface';
 import { createLogger } from '../../common/services/logger.service';
@@ -802,6 +803,17 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
     }
 
     return engine.sendSeen(chatId);
+  }
+
+  async sendChatState(id: string, chatId: string, state: ChatState): Promise<void> {
+    await this.findOne(id); // Verify session exists
+    const engine = this.engines.get(id);
+
+    if (!engine) {
+      throw new BadRequestException('Session is not started');
+    }
+
+    await engine.sendChatState(chatId, state);
   }
 
   private async updateStatus(id: string, status: SessionStatus): Promise<void> {

--- a/src/plugins/engines/whatsapp-web-js/index.ts
+++ b/src/plugins/engines/whatsapp-web-js/index.ts
@@ -92,6 +92,19 @@ export class WhatsAppWebJsPlugin implements IEnginePlugin {
     ];
   }
 
+  getEngineLibrary(): { name: string; version: string } {
+    // The actual whatsapp-web.js library version (e.g. 1.34.7), surfaced so operators can see which
+    // engine version is really running — distinct from this adapter plugin's manifest version (1.0.0).
+    let version = 'unknown';
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      version = (require('whatsapp-web.js/package.json') as { version: string }).version;
+    } catch {
+      // Keep 'unknown' if the package metadata can't be resolved at runtime.
+    }
+    return { name: 'whatsapp-web.js', version };
+  }
+
   healthCheck(): Promise<{ healthy: boolean; message?: string }> {
     return Promise.resolve({ healthy: true, message: 'WhatsApp-web.js engine is available' });
   }


### PR DESCRIPTION
## Summary

Two user-facing fixes/features from live testing, plus a small dose of engine-agnostic decoupling — kept deliberately scoped (the larger coupling refactors are tracked as follow-ups, not bundled here).

### 🐛 Fix: duplicate outgoing messages in the dashboard Chats view
A race between the optimistic placeholder and the realtime `message.sent` echo could render a sent message **twice**. The dedup at receive time missed because the placeholder still carried its temp id when the echo (with the real WA id) arrived first. Reconciliation is now race-safe — if the echo already added the message, the placeholder is dropped instead of renamed into a duplicate.
- **Display-only**: the recipient always received exactly one message (verified on a real phone).
- The intermittence (only *some* sends doubled) was the race signature; confirmed fixed live.

### ✨ Feature: typing simulation (anti-ban), engine-agnostic, on by default
- New engine seam: **`IWhatsAppEngine.sendChatState(chatId, 'typing' | 'recording' | 'paused')`** — neutral, so a future Baileys adapter just implements it (whatsapp-web.js → `sendStateTyping`/`sendStateRecording`/`clearState`; engines without presence no-op). Backs the previously **dead** `typing-indicator` capability claim.
- New endpoint: **`POST /sessions/:id/chats/typing`** with a **neutral DTO** (no `@c.us` coupling).
- **Auto-typing on single sends, ON by default**: `sendText` shows "typing…" and pauses a length-scaled, jittered interval before sending. Opt out with `SIMULATE_TYPING=false`; cap with `SIMULATE_TYPING_MAX_MS` (default 5000). Strictly best-effort (never throws/blocks a send).
- **Bulk is unaffected** — it bypasses `sendText` and keeps its own `delayBetweenMessages` throttle.

### 🔎 Fix: surface the real engine library version
`GET /infra/engines` and the dashboard Active Engine card now show the **underlying library version** (e.g. `whatsapp-web.js 1.34.7`), distinct from the adapter plugin's static manifest version (`v1.0.0`) — which was misleading operators.

### ♻️ Decouple: `mark-chat-read` JID validation
Relaxed the wwebjs-only `@c.us`/`@g.us`/`@lid` regex to an engine-neutral `localpart@host` check, so a swapped engine (e.g. Baileys `@s.whatsapp.net`) is accepted; the adapter validates/normalises per engine.

## Pluggable-architecture note
This was built engine-agnostic on purpose. A broader audit found systemic whatsapp-web.js coupling outside the adapter layer (raw `ack` integers, raw `MessageTypes`, JID construction in controllers/dashboard, browser config in the neutral engine contract, single-engine registry). Those are **intentionally not** in this PR — they're tracked as separate follow-up issues to avoid a large regression surface.

## Verification
- Backend build ✅ · **435/435 tests** (+6 new: `sendChatState` delegation/guard, auto-typing default-on/off gating, engine-neutral JID DTO) · lint ✅
- Dashboard build ✅ · lint ✅ (pre-existing warnings only)
- **Live on a real WhatsApp account**: dup-fix confirmed (single bubbles); typing indicator confirmed visible on a real contact; engine version surfacing confirmed in the API.
