### PR TITLE
chore(release): v0.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.7] - 2026-06-16
+
+A feature + fix release: typing simulation (anti-ban, on by default), a delete-chat endpoint, and a fix
+for duplicate outgoing messages in the dashboard — plus engine-agnostic groundwork and the nginx/
+singleton-lock container fixes.
 
 ### Added
 
@@ -17,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unaffected (they keep their own `delayBetweenMessages` throttle).
 - The engine API (`GET /infra/engines`) and the dashboard Active Engine card now report the **underlying
   engine library version** (e.g. `whatsapp-web.js 1.34.7`), distinct from the adapter plugin version.
+- **Delete a chat** from the chat list via `POST /sessions/:id/chats/delete` (e.g. to clear out groups
+  you've left). `OPERATOR` role, engine-agnostic DTO. Thanks @tobiasstrebitzer (#261).
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/rmyndharis/OpenWA/actions/workflows/ci.yml"><img src="https://github.com/rmyndharis/OpenWA/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"/></a>
-  <img src="https://img.shields.io/badge/version-0.2.6-blue.svg" alt="Version"/>
+  <img src="https://img.shields.io/badge/version-0.2.7-blue.svg" alt="Version"/>
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"/>
   <img src="https://img.shields.io/badge/node-22_LTS-brightgreen.svg" alt="Node"/>
   <img src="https://img.shields.io/badge/NestJS-11.x-red.svg" alt="NestJS"/>

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashboard",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashboard",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "dependencies": {
         "@tanstack/react-query": "^5.101.0",
         "@tanstack/react-table": "^8.21.3",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboard",
   "private": true,
-  "version": "0.2.6",
+  "version": "0.2.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.2.6-blue.svg" alt="Version"/>
+  <img src="https://img.shields.io/badge/version-0.2.7-blue.svg" alt="Version"/>
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"/>
   <img src="https://img.shields.io/badge/node-22_LTS-brightgreen.svg" alt="Node"/>
   <img src="https://img.shields.io/badge/NestJS-11.x-red.svg" alt="NestJS"/>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openwa",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openwa",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwa",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API for WhatsApp",
   "author": "Yudhi Armyndharis & OpenWA Contributors",
   "private": true,


### PR DESCRIPTION
## v0.2.7

Version bump + CHANGELOG finalize for the v0.2.7 release. Bundles the already-merged feature/fix PRs:

- **#264** — typing simulation (anti-ban, on by default) + fix duplicate dashboard messages + engine library version surfacing + engine-neutral `mark-chat-read` validation
- **#261** — `POST /sessions/:id/chats/delete` endpoint (@tobiasstrebitzer), DTO neutralized to match the engine-agnostic direction
- **#260** — dashboard nginx host fix + Chromium singleton-lock cleanup (finds from @Abhishekrajpurohit / #259)

Engine-pluggability decoupling beyond these is tracked in #265.

### Verification
Build ✅ · **437/437 tests** ✅ · dashboard build ✅ · lint ✅. The feature work was live-verified on a real WhatsApp account (dup-fix, typing visible, engine version in API).
