### PR TITLE
refactor(engine): neutral DeliveryStatus instead of raw whatsapp-web.js ack int (#265)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Message delivery status is now engine-agnostic** (engine-pluggability decoupling, #265). The raw whatsapp-web.js
+  ack integer no longer leaks past the engine adapter — a neutral `DeliveryStatus`
+  (`pending`/`sent`/`delivered`/`read`/`failed`) flows through the interface, services, webhooks, websocket, and
+  dashboard, so a non-whatsapp-web.js engine (e.g. Baileys) can map its own delivery codes at the adapter boundary.
+  - The `message.ack`/`message.failed` webhooks now include a neutral **`status`** field. The legacy **`ack`** integer
+    is **kept (deprecated)** for backward compatibility — new consumers should read `status`.
+  - Dashboard chat delivery ticks now update **live** over the websocket (the ack push was previously never emitted).
+  - Minor deprecated-surface deltas: the legacy webhook `ack` reports `3` (not `4`) for a "played" voice/video receipt,
+    and a play-after-read no longer emits a second `message.ack` (both map to `status: 'read'`).
+
 ## [0.2.7] - 2026-06-16
 
 A feature + fix release: typing simulation (anti-ban, on by default), a delete-chat endpoint, and a fix

--- a/dashboard/src/hooks/useWebSocket.ts
+++ b/dashboard/src/hooks/useWebSocket.ts
@@ -22,10 +22,10 @@ interface MessageEvent {
 interface MessageAckEvent {
   sessionId: string;
   messageId: string;
-  ack: number;
-  ackName: string;
+  // Neutral delivery status emitted by the backend (engine-agnostic), not a raw wwebjs ack integer.
+  status: 'pending' | 'sent' | 'delivered' | 'read' | 'failed';
   chatId?: string;
-  timestamp: string;
+  timestamp?: string;
 }
 
 interface MessageReactionEvent {
@@ -192,8 +192,7 @@ export function useWebSocket(events: WebSocketEvents = {}) {
           events.onMessageAck?.({
             sessionId,
             messageId: String(data.messageId),
-            ack: Number(data.ack),
-            ackName: String(data.ackName),
+            status: data.status as MessageAckEvent['status'],
             chatId: data.chatId as string | undefined,
             timestamp: msg.timestamp,
           });

--- a/dashboard/src/pages/Chats.tsx
+++ b/dashboard/src/pages/Chats.tsx
@@ -216,21 +216,14 @@ export function Chats() {
   );
 
   const handleIncomingMessageAck = useCallback(
-    (event: { sessionId: string; messageId: string; ack: number }) => {
+    (event: { sessionId: string; messageId: string; status: ChatMessageView['status'] }) => {
       if (event.sessionId !== selectedSessionId) return;
 
       setMessages(prev =>
         prev.map(msg => {
           if (msg.id === event.messageId || msg.waMessageId === event.messageId) {
-            const statusMap: Record<number, ChatMessageView['status']> = {
-              [-1]: 'failed',
-              [0]: 'pending',
-              [1]: 'sent',
-              [2]: 'delivered',
-              [3]: 'read',
-              [4]: 'read',
-            };
-            return { ...msg, status: statusMap[event.ack] || msg.status };
+            // Backend now sends the neutral delivery status directly (no engine-specific ack codes).
+            return { ...msg, status: event.status || msg.status };
           }
           return msg;
         }),

--- a/dashboard/src/pages/Chats.tsx
+++ b/dashboard/src/pages/Chats.tsx
@@ -32,6 +32,26 @@ interface ChatMessageView extends ChatMessage {
   };
 }
 
+// Delivery acks must only ADVANCE the tick, never regress it. The backend DB update is forward-only
+// (ackStatusTransitionFrom), but the live websocket ack fires on every receipt (incl. pending/sent)
+// and engine acks can arrive out of order or be replayed on reconnect — so a late/duplicate lower
+// ack must not visually downgrade a row already shown as delivered/read. This mirrors the backend's
+// transition rules exactly: pending<sent<delivered<read advances by rank; `failed` only applies from
+// pending/sent (a late failure must not clobber a confirmed delivered/read), and is terminal once set.
+const DELIVERY_RANK: Record<string, number> = { pending: 0, sent: 1, delivered: 2, read: 3 };
+const mergeDeliveryStatus = (
+  current: ChatMessageView['status'] | undefined,
+  incoming: ChatMessageView['status'] | undefined,
+): ChatMessageView['status'] | undefined => {
+  if (!incoming) return current;
+  if (!current) return incoming;
+  if (current === 'failed') return 'failed'; // terminal — nothing advances from failed
+  if (incoming === 'failed') return current === 'pending' || current === 'sent' ? 'failed' : current;
+  if (!(incoming in DELIVERY_RANK)) return current; // unknown status — ignore
+  if (!(current in DELIVERY_RANK)) return incoming;
+  return DELIVERY_RANK[incoming] >= DELIVERY_RANK[current] ? incoming : current;
+};
+
 interface IncomingWsMessage {
   id: string;
   chatId: string;
@@ -223,7 +243,8 @@ export function Chats() {
         prev.map(msg => {
           if (msg.id === event.messageId || msg.waMessageId === event.messageId) {
             // Backend now sends the neutral delivery status directly (no engine-specific ack codes).
-            return { ...msg, status: event.status || msg.status };
+            // Merge forward-only so an out-of-order/replayed lower ack can't downgrade the tick.
+            return { ...msg, status: mergeDeliveryStatus(msg.status, event.status) ?? msg.status };
           }
           return msg;
         }),

--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -1286,14 +1286,16 @@ OpenWA provides an idempotency mechanism to prevent duplicate processing on the 
 #### Idempotency Key Format
 
 ```
-Format: {event_type}_{unique_identifier}_{timestamp}
+Keys are content-based and do NOT include a timestamp, so a replayed/retried event with an
+identical payload produces the same key for correct de-duplication.
 
 Examples:
-- message.received: msg_{messageId}_{timestamp}
-- message.sent: msg_{messageId}_{timestamp}
-- message.ack: ack_{messageId}_{ackLevel}_{timestamp}
-- session.status: sess_{sessionId}_{status}_{timestamp}
-- group.join: grp_{groupId}_{participantId}_{timestamp}
+- message.received: msg_{sessionId}_{messageId}
+- message.sent: msg_{sessionId}_{messageId}
+- message.ack: ack_{sessionId}_{messageId}_{status}
+- message.failed: failed_{sessionId}_{messageId}_{status}
+- session.status: sess_{sessionId}_{status}
+- group.join: grp_{groupId}_{participantId}_join
 ```
 
 #### Client-Side Idempotency Implementation
@@ -1455,21 +1457,25 @@ flowchart TB
   "timestamp": "2025-02-02T10:00:00.000Z",
   "sessionId": "sess_abc123",
   "data": {
+    "id": "true_628123456789@c.us_3EB0ABC123",
     "messageId": "true_628123456789@c.us_3EB0ABC123",
-    "ack": 3,
-    "ackName": "read"
+    "status": "read",
+    "ack": 3
   }
 }
 ```
 
-| Ack | Name | Description |
-|-----|------|-------------|
-| 0 | error | Error |
-| 1 | pending | Pending |
-| 2 | sent | Sent to server |
-| 3 | delivered | Delivered |
-| 4 | read | Read |
-| 5 | played | Played (audio) |
+Read the engine-neutral **`status`** field — it is the canonical delivery state and is identical
+across engines. The legacy **`ack`** integer is **deprecated**, derived from `status` for backward
+compatibility only (a non-whatsapp-web.js engine still reports the same `status`).
+
+| `status` | `ack` (deprecated) | Description |
+|----------|--------------------|-------------|
+| `pending` | 0 | Queued, not yet sent to the server |
+| `sent` | 1 | Sent to the server |
+| `delivered` | 2 | Delivered to the recipient's device |
+| `read` | 3 | Read by the recipient (a played voice/video note also reports `read`) |
+| `failed` | -1 | Delivery failed (also dispatched as a separate `message.failed` event) |
 
 ### session.status
 

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -21,7 +21,7 @@ describe('wwebjsAckToDeliveryStatus (engine ack-int -> neutral DeliveryStatus bo
     [4, 'read'], // PLAYED collapses to read
     [5, 'read'], // any future/higher ack stays read, never crashes
   ])('maps wwebjs ack %i -> %s', (ack, expected) => {
-    expect(wwebjsAckToDeliveryStatus(ack as number)).toBe(expected);
+    expect(wwebjsAckToDeliveryStatus(ack)).toBe(expected);
   });
 });
 

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -4,9 +4,26 @@ import {
   extractLinkedParentJID,
   loadRemoteMedia,
   resolveWebVersionPin,
+  wwebjsAckToDeliveryStatus,
 } from './whatsapp-web-js.adapter';
 import { EngineNotReadyError } from '../../common/errors/engine-not-ready.error';
 import { SsrfBlockedError } from '../../common/security/ssrf-guard';
+
+describe('wwebjsAckToDeliveryStatus (engine ack-int -> neutral DeliveryStatus boundary, #265)', () => {
+  // Regression-locks the integer boundary the decoupling moved behaviour into, incl. the
+  // PLAYED(4) -> 'read' collapse that the old ackToMessageStatus(4) -> READ test used to cover.
+  it.each([
+    [-1, 'failed'],
+    [0, 'pending'],
+    [1, 'sent'],
+    [2, 'delivered'],
+    [3, 'read'],
+    [4, 'read'], // PLAYED collapses to read
+    [5, 'read'], // any future/higher ack stays read, never crashes
+  ])('maps wwebjs ack %i -> %s', (ack, expected) => {
+    expect(wwebjsAckToDeliveryStatus(ack as number)).toBe(expected);
+  });
+});
 
 describe('extractLinkedParentJID (#201)', () => {
   it('returns null when no metadata is provided', () => {

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -28,6 +28,7 @@ import {
   PaginatedProducts,
   ChatSummary,
   ChatState,
+  DeliveryStatus,
   RevokedMessage,
   ReactionEvent,
 } from '../interfaces/whatsapp-engine.interface';
@@ -52,6 +53,19 @@ const DEFAULT_MEDIA_TIMEOUT_MS = 30_000;
 function positiveIntFromEnv(name: string, fallback: number): number {
   const parsed = Number.parseInt(process.env[name] ?? '', 10);
   return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/**
+ * Map a whatsapp-web.js MessageAck integer to the neutral DeliveryStatus.
+ * wwebjs: -1 ERROR, 0 PENDING, 1 SERVER (sent), 2 DEVICE (delivered), 3 READ, 4 PLAYED.
+ * PLAYED collapses to `read` (preserving prior behaviour, which treated ack>=3 as read).
+ */
+export function wwebjsAckToDeliveryStatus(ack: number): DeliveryStatus {
+  if (ack < 0) return 'failed';
+  if (ack >= 3) return 'read';
+  if (ack === 2) return 'delivered';
+  if (ack === 1) return 'sent';
+  return 'pending';
 }
 
 /**
@@ -318,7 +332,9 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     });
 
     this.client.on('message_ack', (msg, ack) => {
-      this.callbacks.onMessageAck?.(msg.id._serialized, ack);
+      // Map the whatsapp-web.js MessageAck integer to the neutral DeliveryStatus here, at the
+      // adapter boundary, so no downstream consumer ever sees engine-specific ack codes.
+      this.callbacks.onMessageAck?.(msg.id._serialized, wwebjsAckToDeliveryStatus(ack));
     });
 
     this.client.on('message_revoke_everyone', after => {

--- a/src/engine/interfaces/whatsapp-engine.interface.ts
+++ b/src/engine/interfaces/whatsapp-engine.interface.ts
@@ -233,6 +233,13 @@ export interface ChatSummary {
 export type ChatState = 'typing' | 'recording' | 'paused';
 
 /**
+ * Engine-neutral message delivery status. Each adapter maps its native delivery signal
+ * (e.g. whatsapp-web.js MessageAck integers, Baileys WAMessageStatus) to this vocabulary,
+ * so no consumer outside the adapter sees engine-specific ack codes.
+ */
+export type DeliveryStatus = 'pending' | 'sent' | 'delivered' | 'read' | 'failed';
+
+/**
  * Structured payload for a remotely-revoked ("deleted for everyone") message.
  * The engine layer never emits a localized display string; `body` is intentionally
  * empty and the dashboard renders the localized "message deleted" text.
@@ -263,7 +270,11 @@ export interface EngineEventCallbacks {
    * linked phone, which the `message`/`onMessage` event never delivers. Used to emit `message.sent`.
    */
   onMessageCreate?: (message: IncomingMessage) => void;
-  onMessageAck?: (messageId: string, ack: number) => void;
+  /**
+   * Fired when the delivery status of an outgoing message advances. The adapter maps its native
+   * delivery signal to the neutral `DeliveryStatus`, so consumers never see engine-specific codes.
+   */
+  onMessageAck?: (messageId: string, status: DeliveryStatus) => void;
   onMessageRevoked?: (message: RevokedMessage) => void;
   onMessageReaction?: (event: ReactionEvent) => void;
   onDisconnected?: (reason: string) => void;

--- a/src/modules/events/events.gateway.ts
+++ b/src/modules/events/events.gateway.ts
@@ -33,6 +33,7 @@ import type {
   WSPongResponse,
 } from './dto/ws-messages.dto';
 import { SUBSCRIBABLE_EVENTS, buildRoomName } from './dto/ws-messages.dto';
+import type { DeliveryStatus } from '../../engine/interfaces/whatsapp-engine.interface';
 
 /**
  * Whether an API key may subscribe to a session's WebSocket event rooms.
@@ -289,9 +290,9 @@ export class EventsGateway implements OnGatewayInit, OnGatewayConnection, OnGate
   }
 
   /**
-   * Emit message acknowledgment
+   * Emit a live delivery-status update (neutral DeliveryStatus, e.g. delivered/read/failed).
    */
-  emitMessageAck(sessionId: string, data: { messageId: string; ack: number; ackName: string }) {
+  emitMessageAck(sessionId: string, data: { messageId: string; status: DeliveryStatus }) {
     this.emitToRooms(sessionId, 'message.ack', data);
   }
 

--- a/src/modules/message/message-status.util.spec.ts
+++ b/src/modules/message/message-status.util.spec.ts
@@ -1,23 +1,32 @@
-import { ackToMessageStatus, ackStatusTransitionFrom } from './message-status.util';
+import { deliveryStatusToMessageStatus, deliveryStatusToAck, ackStatusTransitionFrom } from './message-status.util';
 import { MessageStatus } from './entities/message.entity';
 
-describe('ackToMessageStatus', () => {
-  it('maps an error ack (<0) to FAILED', () => {
-    expect(ackToMessageStatus(-1)).toBe(MessageStatus.FAILED);
+describe('deliveryStatusToMessageStatus', () => {
+  it("maps 'failed' to FAILED", () => {
+    expect(deliveryStatusToMessageStatus('failed')).toBe(MessageStatus.FAILED);
   });
 
-  it('maps device ack (2) to DELIVERED', () => {
-    expect(ackToMessageStatus(2)).toBe(MessageStatus.DELIVERED);
+  it("maps 'delivered' to DELIVERED", () => {
+    expect(deliveryStatusToMessageStatus('delivered')).toBe(MessageStatus.DELIVERED);
   });
 
-  it('maps read/played ack (>=3) to READ', () => {
-    expect(ackToMessageStatus(3)).toBe(MessageStatus.READ);
-    expect(ackToMessageStatus(4)).toBe(MessageStatus.READ);
+  it("maps 'read' to READ", () => {
+    expect(deliveryStatusToMessageStatus('read')).toBe(MessageStatus.READ);
   });
 
-  it('returns null for pending (0) and server-sent (1) — no upgrade beyond SENT', () => {
-    expect(ackToMessageStatus(0)).toBeNull();
-    expect(ackToMessageStatus(1)).toBeNull();
+  it("returns null for 'pending'/'sent' — no upgrade beyond SENT", () => {
+    expect(deliveryStatusToMessageStatus('pending')).toBeNull();
+    expect(deliveryStatusToMessageStatus('sent')).toBeNull();
+  });
+});
+
+describe('deliveryStatusToAck (deprecated legacy ack integer)', () => {
+  it('derives the legacy wwebjs-style ack integer from the neutral status', () => {
+    expect(deliveryStatusToAck('failed')).toBe(-1);
+    expect(deliveryStatusToAck('pending')).toBe(0);
+    expect(deliveryStatusToAck('sent')).toBe(1);
+    expect(deliveryStatusToAck('delivered')).toBe(2);
+    expect(deliveryStatusToAck('read')).toBe(3);
   });
 });
 

--- a/src/modules/message/message-status.util.ts
+++ b/src/modules/message/message-status.util.ts
@@ -1,19 +1,44 @@
 import { MessageStatus } from './entities/message.entity';
+import { DeliveryStatus } from '../../engine/interfaces/whatsapp-engine.interface';
 
 /**
- * Maps a whatsapp-web.js ack level to the delivery status it implies, or null
- * when the ack carries no upgrade beyond the stored `SENT` state.
- *
- * wwebjs MessageAck: -1 ERROR, 0 PENDING, 1 SERVER (sent), 2 DEVICE (delivered),
- * 3 READ, 4 PLAYED. This is how the stored message reflects *real* delivery
- * state (#220): a send that never receives ack≥2 stays `SENT`, visibly
- * "not delivered".
+ * Maps a neutral engine DeliveryStatus to the stored MessageStatus it implies, or null when the
+ * status carries no upgrade beyond the stored `SENT` state. This is how the stored message reflects
+ * *real* delivery state (#220): a send that never advances past `sent` stays `SENT`, visibly
+ * "not delivered". Engine-specific ack codes are mapped to DeliveryStatus inside the adapter.
  */
-export function ackToMessageStatus(ack: number): MessageStatus | null {
-  if (ack < 0) return MessageStatus.FAILED;
-  if (ack >= 3) return MessageStatus.READ;
-  if (ack === 2) return MessageStatus.DELIVERED;
-  return null; // 0 (pending) / 1 (server-received) — message is already SENT, no upgrade
+export function deliveryStatusToMessageStatus(status: DeliveryStatus): MessageStatus | null {
+  switch (status) {
+    case 'failed':
+      return MessageStatus.FAILED;
+    case 'read':
+      return MessageStatus.READ;
+    case 'delivered':
+      return MessageStatus.DELIVERED;
+    default:
+      return null; // pending / sent — already at/below SENT, no upgrade
+  }
+}
+
+/**
+ * @deprecated Legacy whatsapp-web.js-style ack integer, derived from the neutral DeliveryStatus
+ * solely for backward compatibility of the `message.ack`/`message.failed` webhook payload's `ack`
+ * field. New consumers should read the neutral `status` field instead. (-1 error, 0 pending,
+ * 1 sent, 2 delivered, 3 read.)
+ */
+export function deliveryStatusToAck(status: DeliveryStatus): number {
+  switch (status) {
+    case 'failed':
+      return -1;
+    case 'read':
+      return 3;
+    case 'delivered':
+      return 2;
+    case 'sent':
+      return 1;
+    default:
+      return 0; // pending
+  }
 }
 
 /**

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -89,6 +89,7 @@ describe('SessionService', () => {
       emitSessionStatus: jest.fn(),
       emitMessage: jest.fn(),
       emitMessageSent: jest.fn(),
+      emitMessageAck: jest.fn(),
       emitMessageRevoked: jest.fn(),
       emitMessageReaction: jest.fn(),
     };
@@ -434,7 +435,7 @@ describe('SessionService', () => {
       const callbacks = await startAndCaptureCallbacks();
       expect(typeof callbacks.onMessageAck).toBe('function');
 
-      callbacks.onMessageAck!('wa-msg-1', 2); // ack=2 -> DELIVERED
+      callbacks.onMessageAck!('wa-msg-1', 'delivered');
       await flush();
 
       expect(messageRepository.update).toHaveBeenCalledWith(
@@ -477,17 +478,17 @@ describe('SessionService', () => {
       const callbacks = await startAndCaptureCallbacks();
       expect(typeof callbacks.onMessageAck).toBe('function');
 
-      callbacks.onMessageAck!('wa-out-1', 3);
+      callbacks.onMessageAck!('wa-out-1', 'read');
       await flush();
 
       expect(dispatchedEvents('message.ack')).toHaveLength(1);
       expect(dispatchedEvents('message.sent')).toHaveLength(0);
     });
 
-    it('reflects delivery on the stored message: ack=2 updates status to DELIVERED (#220)', async () => {
+    it("reflects delivery on the stored message: 'delivered' updates status to DELIVERED (#220)", async () => {
       const callbacks = await startAndCaptureCallbacks();
 
-      callbacks.onMessageAck!('wa-out-1', 2);
+      callbacks.onMessageAck!('wa-out-1', 'delivered');
       await flush();
 
       expect(messageRepository.update as jest.Mock).toHaveBeenCalledWith(
@@ -496,10 +497,10 @@ describe('SessionService', () => {
       );
     });
 
-    it('marks the stored message FAILED and dispatches message.failed on an error ack (<0) (#220)', async () => {
+    it("marks the stored message FAILED and dispatches message.failed on a 'failed' status (#220)", async () => {
       const callbacks = await startAndCaptureCallbacks();
 
-      callbacks.onMessageAck!('wa-out-1', -1);
+      callbacks.onMessageAck!('wa-out-1', 'failed');
       await flush();
 
       expect(messageRepository.update as jest.Mock).toHaveBeenCalledWith(
@@ -509,10 +510,10 @@ describe('SessionService', () => {
       expect(dispatchedEvents('message.failed')).toHaveLength(1);
     });
 
-    it('does not upgrade the stored status (or emit message.failed) for a server-only ack (1)', async () => {
+    it("does not upgrade the stored status (or emit message.failed) for a 'sent' status", async () => {
       const callbacks = await startAndCaptureCallbacks();
 
-      callbacks.onMessageAck!('wa-out-1', 1);
+      callbacks.onMessageAck!('wa-out-1', 'sent');
       await flush();
 
       expect(messageRepository.update as jest.Mock).not.toHaveBeenCalled();

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -18,13 +18,14 @@ import {
   EngineStatus,
   ChatSummary,
   ChatState,
+  DeliveryStatus,
   IncomingMessage,
 } from '../../engine/interfaces/whatsapp-engine.interface';
 import { createLogger } from '../../common/services/logger.service';
 import { EventsGateway } from '../events/events.gateway';
 import { WebhookService } from '../webhook/webhook.service';
 import { HookManager } from '../../core/hooks';
-import { ackToMessageStatus, ackStatusTransitionFrom } from '../message/message-status.util';
+import { deliveryStatusToMessageStatus, deliveryStatusToAck, ackStatusTransitionFrom } from '../message/message-status.util';
 
 interface ReconnectState {
   attempts: number;
@@ -462,48 +463,65 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
             this.eventsGateway.emitMessageSent(id, finalMessage);
           });
       },
-      onMessageAck: (messageId, ack): void => {
-        this.logger.debug(`Message ack: ${messageId} -> ${ack}`, {
+      onMessageAck: (messageId, status: DeliveryStatus): void => {
+        this.logger.debug(`Message ack: ${messageId} -> ${status}`, {
           sessionId: id,
           messageId,
-          ack,
+          status,
           action: 'message_ack',
         });
 
-        // Reflect real delivery state on the stored message (#220): ack=2 -> delivered, >=3 -> read,
-        // <0 -> failed. A send that never reaches ack>=2 stays SENT — visibly "not delivered".
+        // Reflect real delivery state on the stored message (#220): delivered/read/failed advance the
+        // stored status; pending/sent carry no upgrade (it's already SENT — visibly "not delivered").
         // The UPDATE is guarded to the allowed prior statuses so delivery state only ADVANCES: an
         // out-of-order/late ack cannot downgrade a higher status, which also makes these
         // fire-and-forget writes race-safe at the DB level.
-        const status = ackToMessageStatus(ack);
-        if (status) {
+        const messageStatus = deliveryStatusToMessageStatus(status);
+        if (messageStatus) {
           void this.messageRepository
             // Scope by sessionId: waMessageId is unique per account/chat, not global —
             // an ack on one session must never advance a same-id row in another session.
-            .update({ sessionId: id, waMessageId: messageId, status: In(ackStatusTransitionFrom(status)) }, { status })
+            .update(
+              { sessionId: id, waMessageId: messageId, status: In(ackStatusTransitionFrom(messageStatus)) },
+              { status: messageStatus },
+            )
             .then(result => {
               // affected:0 — the row was not advanced: either the send's 2nd save (which sets
               // waMessageId) hasn't committed yet, or the status is already at/above the target.
               if (result.affected === 0) {
-                this.logger.debug(`Message ack ${messageId}: no status row advanced to ${status} (ack=${ack})`, {
+                this.logger.debug(`Message ack ${messageId}: no status row advanced to ${messageStatus} (${status})`, {
                   sessionId: id,
                   messageId,
-                  ack,
+                  status,
                   action: 'message_ack_noop',
                 });
               }
             });
         }
 
+        // Push the live delivery/read tick to the dashboard over the websocket (neutral status).
+        this.eventsGateway.emitMessageAck(id, { messageId, status });
+
         // Dispatch the delivery/read receipt to webhooks (#155). Outgoing `message.sent` is handled
         // solely by `onMessageCreate`, so the ack path deliberately does NOT emit `message.sent`.
         // `id` mirrors the field every other message.* webhook carries (and the idempotency key
-        // resolver reads); `messageId` is kept for backward compatibility.
-        void this.webhookService.dispatch(id, 'message.ack', { id: messageId, messageId, ack });
+        // resolver reads). `ack` is a deprecated legacy field kept for backward compatibility —
+        // new consumers should read the neutral `status`.
+        void this.webhookService.dispatch(id, 'message.ack', {
+          id: messageId,
+          messageId,
+          status,
+          ack: deliveryStatusToAck(status),
+        });
 
         // Surface delivery failures actively so consumers don't have to poll for them (#220).
-        if (ack < 0) {
-          void this.webhookService.dispatch(id, 'message.failed', { id: messageId, messageId, ack });
+        if (status === 'failed') {
+          void this.webhookService.dispatch(id, 'message.failed', {
+            id: messageId,
+            messageId,
+            status,
+            ack: deliveryStatusToAck(status),
+          });
         }
       },
       onMessageRevoked: (message): void => {

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -25,7 +25,11 @@ import { createLogger } from '../../common/services/logger.service';
 import { EventsGateway } from '../events/events.gateway';
 import { WebhookService } from '../webhook/webhook.service';
 import { HookManager } from '../../core/hooks';
-import { deliveryStatusToMessageStatus, deliveryStatusToAck, ackStatusTransitionFrom } from '../message/message-status.util';
+import {
+  deliveryStatusToMessageStatus,
+  deliveryStatusToAck,
+  ackStatusTransitionFrom,
+} from '../message/message-status.util';
 
 interface ReconnectState {
   attempts: number;

--- a/src/modules/webhook/utils/idempotency.util.spec.ts
+++ b/src/modules/webhook/utils/idempotency.util.spec.ts
@@ -7,7 +7,7 @@ describe('Idempotency Utils', () => {
       expect(key).toBe('msg_A_ABC123');
     });
 
-    it('should generate a session-scoped key for message.ack', () => {
+    it('falls back to the legacy `ack` integer for message.ack when no `status` is present', () => {
       const key = generateIdempotencyKey('message.ack', { messageId: 'ABC123', ack: 3, sessionId: 'A' });
       expect(key).toBe('ack_A_ABC123_3');
     });
@@ -23,9 +23,9 @@ describe('Idempotency Utils', () => {
       expect(key).toBe('msg_A_REAL');
     });
 
-    it('should use the `id` field for message.ack (the real dispatch shape)', () => {
-      const key = generateIdempotencyKey('message.ack', { id: 'ABC123', ack: 3, sessionId: 'A' });
-      expect(key).toBe('ack_A_ABC123_3');
+    it('keys message.ack on the neutral `status` (the real dispatch shape), preferring it over `ack`', () => {
+      const key = generateIdempotencyKey('message.ack', { id: 'ABC123', status: 'read', ack: 3, sessionId: 'A' });
+      expect(key).toBe('ack_A_ABC123_read');
     });
 
     it('should use the `id` field for message.revoked (the real dispatch shape)', () => {
@@ -34,8 +34,8 @@ describe('Idempotency Utils', () => {
     });
 
     it('gives the same waMessageId in different sessions DISTINCT keys', () => {
-      const a = generateIdempotencyKey('message.ack', { id: 'X', ack: 2, sessionId: 'A' });
-      const b = generateIdempotencyKey('message.ack', { id: 'X', ack: 2, sessionId: 'B' });
+      const a = generateIdempotencyKey('message.ack', { id: 'X', status: 'delivered', sessionId: 'A' });
+      const b = generateIdempotencyKey('message.ack', { id: 'X', status: 'delivered', sessionId: 'B' });
       expect(a).not.toBe(b);
     });
 

--- a/src/modules/webhook/utils/idempotency.util.ts
+++ b/src/modules/webhook/utils/idempotency.util.ts
@@ -40,11 +40,12 @@ export function generateIdempotencyKey(event: string, data: Record<string, unkno
       return `msg_${toStr(data.sessionId)}_${toStr(data.id ?? data.messageId)}`;
 
     case 'message.ack':
-      // Message ID + ack status together are unique
-      return `ack_${toStr(data.sessionId)}_${toStr(data.id ?? data.messageId)}_${toStr(data.ack, '0')}`;
+      // Message ID + delivery status together are unique. Key on the neutral `status`; fall back to
+      // the legacy `ack` integer for backward compatibility with older payloads.
+      return `ack_${toStr(data.sessionId)}_${toStr(data.id ?? data.messageId)}_${toStr(data.status ?? data.ack, '0')}`;
 
     case 'message.failed':
-      return `failed_${toStr(data.sessionId)}_${toStr(data.id ?? data.messageId)}_${toStr(data.ack, '0')}`;
+      return `failed_${toStr(data.sessionId)}_${toStr(data.id ?? data.messageId)}_${toStr(data.status ?? data.ack, '0')}`;
 
     case 'message.revoked':
       return `rev_${toStr(data.sessionId)}_${toStr(data.id ?? data.messageId)}`;


### PR DESCRIPTION
First item of the **#265** engine-pluggability decoupling: stop the whatsapp-web.js `MessageAck` integer from leaking past the engine adapter.

## What changed
- **Neutral `DeliveryStatus`** (`pending`|`sent`|`delivered`|`read`|`failed`) added to `IWhatsAppEngine`; `onMessageAck` now delivers a `DeliveryStatus`, not a raw int.
- The wwebjs ack integer is mapped to `DeliveryStatus` **only inside the adapter** (`wwebjsAckToDeliveryStatus`). No consumer outside the adapter sees engine ack codes anymore.
- `message-status.util`: `ackToMessageStatus(int)` → `deliveryStatusToMessageStatus(status)`; added deprecated `deliveryStatusToAck(status)` to derive the legacy webhook `ack` int. **Behaviour is byte-identical for every ack value** (verified end-to-end).
- **Webhook (non-breaking):** `message.ack`/`message.failed` now carry a neutral **`status`**; the legacy **`ack`** int is kept (deprecated). Idempotency keys prefer `status`.
- **Live ws delivery ticks (bonus fix):** `session.service` now actually emits `message.ack` over the websocket — `emitMessageAck` was previously **never called**, so the dashboard's live tick path was dead. The dashboard consumes the neutral status string; the integer `statusMap {-1..4}` is removed.

A Baileys/other engine adapter now only needs to map its native delivery codes to `DeliveryStatus`.

## Decisions (confirmed with maintainer)
- Webhook kept **non-breaking** (add `status`, keep deprecated `ack`).
- The dead ws delivery-tick path **wired live** with the neutral status.
- `PLAYED(4)` collapses to `read` (the DB already did this). Documented deltas: the deprecated webhook `ack` reports `3` not `4` for a played receipt, and play-after-read no longer double-fires `message.ack`.

## Verification
- Backend build ✅ · **445 tests** ✅ (added a `wwebjsAckToDeliveryStatus` boundary test regression-locking the int→status map incl. PLAYED→read) · lint ✅ · dashboard build + lint ✅.
- Adversarial review (3 dimensions, each independently verified): all **hold** — exact behavior preservation, type-sound live ws path, no remaining raw-ack leak outside the adapter.

Part of #265.
