### PR TITLE
fix(docker): pass WWEBJS_WEB_VERSION through to the container (#273)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `…@c.us` form (e.g. a `@lid` identifier) rather than echoing the input. And status/story
   broadcasts are flagged with a neutral `isStatusBroadcast` on the message payload, so engine-neutral code no longer
   matches the engine-specific `status@broadcast` pseudo-JID. A non-whatsapp-web.js engine supplies its own JID scheme.
+### Fixed
+
+- The `WWEBJS_WEB_VERSION` (and `WWEBJS_WEB_VERSION_REMOTE_PATH`) workaround for sessions stuck at
+  "authenticating" (#251) is now actually passed through by the Docker Compose files. The `environment:`
+  blocks enumerate vars explicitly with no `env_file`, so setting `WWEBJS_WEB_VERSION` in `.env` previously
+  never reached the container — making the documented fix a no-op for Compose users. Added the passthrough
+  (empty default = auto-select, no behavior change when unset) to `docker-compose.yml` and
+  `docker-compose.dev.yml`. (#273)
 
 ## [0.2.7] - 2026-06-16
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -49,6 +49,12 @@ services:
       - SESSION_DATA_PATH=/app/data/sessions
       - PUPPETEER_HEADLESS=true
       - PUPPETEER_ARGS=--no-sandbox,--disable-setuid-sandbox,--disable-dev-shm-usage,--disable-gpu
+      # Pin the WhatsApp Web version if a session hangs at "authenticating" after scanning the QR
+      # (whatsapp-web.js 1.34.x can stall on an incompatible auto-selected WA-Web version, #251/#273).
+      # Empty = auto-select (default). Set WWEBJS_WEB_VERSION in .env to a known-good version — see
+      # docs/12-troubleshooting-faq.md.
+      - WWEBJS_WEB_VERSION=${WWEBJS_WEB_VERSION:-}
+      - WWEBJS_WEB_VERSION_REMOTE_PATH=${WWEBJS_WEB_VERSION_REMOTE_PATH:-}
       - STORAGE_TYPE=local
       - STORAGE_LOCAL_PATH=/app/data/media
       - WEBHOOK_TIMEOUT=10000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,6 +111,12 @@ services:
       - SESSION_DATA_PATH=/app/data/sessions
       - PUPPETEER_HEADLESS=${PUPPETEER_HEADLESS:-true}
       - PUPPETEER_ARGS=${PUPPETEER_ARGS:---no-sandbox,--disable-setuid-sandbox,--disable-dev-shm-usage,--disable-gpu}
+      # Pin the WhatsApp Web version if a session hangs at "authenticating" after scanning the QR
+      # (whatsapp-web.js 1.34.x can stall on an incompatible auto-selected WA-Web version, #251/#273).
+      # Empty = auto-select (default). Set WWEBJS_WEB_VERSION in .env to a known-good version — see
+      # docs/12-troubleshooting-faq.md. (Without this line the var in .env never reaches the container.)
+      - WWEBJS_WEB_VERSION=${WWEBJS_WEB_VERSION:-}
+      - WWEBJS_WEB_VERSION_REMOTE_PATH=${WWEBJS_WEB_VERSION_REMOTE_PATH:-}
       # Storage
       - STORAGE_TYPE=${STORAGE_TYPE:-local}
       - STORAGE_LOCAL_PATH=/app/data/media


### PR DESCRIPTION
Fixes #273 (recurrence of #251).

## Problem

Sessions hang at **"authenticating"** after the QR is scanned when whatsapp-web.js 1.34.x auto-selects an incompatible WA-Web version. The documented workaround is to pin `WWEBJS_WEB_VERSION` (see `docs/12-troubleshooting-faq.md`, and the commented hint in `.env.example`).

But the Docker Compose files enumerate env vars explicitly in the `environment:` block and have **no `env_file:`** — so `WWEBJS_WEB_VERSION` set in a user's `.env` **never reached the container**. The workaround was a silent no-op for every Compose user (the most common deployment), which is why this keeps recurring. #273's reporter is on `docker-compose.dev.yml`, which hardcodes env and offered no way to pass it at all.

## Fix

Add the passthrough to the Engine section of both compose files:

```yaml
- WWEBJS_WEB_VERSION=${WWEBJS_WEB_VERSION:-}
- WWEBJS_WEB_VERSION_REMOTE_PATH=${WWEBJS_WEB_VERSION_REMOTE_PATH:-}
```

- **Empty default** ⇒ unset ⇒ whatsapp-web.js auto-selects, exactly as before — **no behavior change** when the user doesn't set it.
- A comment points to the troubleshooting FAQ.
- Deliberately **not** shipping an active default pin: a hardcoded version rots and would itself break when WhatsApp retires it — the knob stays opt-in.

## Verification

- Both compose files parse as valid YAML.
- No app code touched.

After this, a Compose user who hits the hang can set `WWEBJS_WEB_VERSION=<known-good>` in `.env` and it actually takes effect.