### PR TITLE
fix(dashboard): resolve MessageTester recipient via the engine, not a hand-built JID (#265)

### DIFF
--- a/dashboard/src/i18n/locales/ar.json
+++ b/dashboard/src/i18n/locales/ar.json
@@ -451,7 +451,8 @@
       "messageId": "معرّف الرسالة",
       "error": "خطأ"
     },
-    "sendFailed": "فشل إرسال الرسالة"
+    "sendFailed": "فشل إرسال الرسالة",
+    "notOnWhatsApp": "هذا الرقم غير مسجَّل على واتساب"
   },
   "infrastructure": {
     "title": "البنية التحتية",

--- a/dashboard/src/i18n/locales/en.json
+++ b/dashboard/src/i18n/locales/en.json
@@ -451,7 +451,8 @@
       "messageId": "Message ID",
       "error": "Error"
     },
-    "sendFailed": "Failed to send message"
+    "sendFailed": "Failed to send message",
+    "notOnWhatsApp": "This number is not registered on WhatsApp"
   },
   "infrastructure": {
     "title": "Infrastructure",

--- a/dashboard/src/i18n/locales/fr.json
+++ b/dashboard/src/i18n/locales/fr.json
@@ -451,7 +451,8 @@
       "messageId": "ID du message",
       "error": "Erreur"
     },
-    "sendFailed": "Échec de l'envoi du message"
+    "sendFailed": "Échec de l'envoi du message",
+    "notOnWhatsApp": "Ce numéro n'est pas enregistré sur WhatsApp"
   },
   "infrastructure": {
     "title": "Infrastructure",

--- a/dashboard/src/i18n/locales/he.json
+++ b/dashboard/src/i18n/locales/he.json
@@ -451,7 +451,8 @@
       "messageId": "מזהה הודעה",
       "error": "שגיאה"
     },
-    "sendFailed": "שליחת ההודעה נכשלה"
+    "sendFailed": "שליחת ההודעה נכשלה",
+    "notOnWhatsApp": "מספר זה אינו רשום בוואטסאפ"
   },
   "infrastructure": {
     "title": "תשתית",

--- a/dashboard/src/i18n/locales/it.json
+++ b/dashboard/src/i18n/locales/it.json
@@ -451,7 +451,8 @@
       "messageId": "ID Messaggio",
       "error": "Errore"
     },
-    "sendFailed": "Impossibile inviare il messaggio"
+    "sendFailed": "Impossibile inviare il messaggio",
+    "notOnWhatsApp": "Questo numero non è registrato su WhatsApp"
   },
   "infrastructure": {
     "title": "Infrastruttura",

--- a/dashboard/src/i18n/locales/te.json
+++ b/dashboard/src/i18n/locales/te.json
@@ -451,7 +451,8 @@
       "messageId": "సందేశం ID",
       "error": "లోపం"
     },
-    "sendFailed": "సందేశాన్ని పంపడం విఫలమైంది"
+    "sendFailed": "సందేశాన్ని పంపడం విఫలమైంది",
+    "notOnWhatsApp": "ఈ నంబర్ WhatsAppలో నమోదు కాలేదు"
   },
   "infrastructure": {
     "title": "ఇన్‌ఫ్రాస్ట్రక్చర్",

--- a/dashboard/src/i18n/locales/zh-CN.json
+++ b/dashboard/src/i18n/locales/zh-CN.json
@@ -451,7 +451,8 @@
       "messageId": "消息 ID",
       "error": "错误"
     },
-    "sendFailed": "发送消息失败"
+    "sendFailed": "发送消息失败",
+    "notOnWhatsApp": "该号码未在 WhatsApp 注册"
   },
   "infrastructure": {
     "title": "基础设施",

--- a/dashboard/src/i18n/locales/zh-HK.json
+++ b/dashboard/src/i18n/locales/zh-HK.json
@@ -451,7 +451,8 @@
       "messageId": "訊息 ID",
       "error": "錯誤"
     },
-    "sendFailed": "傳送訊息失敗"
+    "sendFailed": "傳送訊息失敗",
+    "notOnWhatsApp": "此號碼未在 WhatsApp 註冊"
   },
   "infrastructure": {
     "title": "基礎架構",

--- a/dashboard/src/pages/MessageTester.tsx
+++ b/dashboard/src/pages/MessageTester.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Send, CheckCircle, XCircle, Loader2 } from 'lucide-react';
-import { messageApi } from '../services/api';
+import { messageApi, contactApi } from '../services/api';
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { useRole } from '../hooks/useRole';
 import { useSessionsQuery, useSessionGroupsQuery } from '../hooks/queries';
@@ -59,9 +59,23 @@ export function MessageTester() {
     setIsLoading(true);
     setResponse(null);
 
-    const chatId = recipientType === 'group' ? targetId : targetId.replace(/[^0-9]/g, '') + '@c.us';
-
     try {
+      // For a personal recipient, let the engine resolve the number to its canonical chat id rather
+      // than hand-building an engine-specific JID here (#265) — also surfaces unregistered numbers.
+      let chatId = targetId;
+      if (recipientType !== 'group') {
+        const resolved = await contactApi.checkNumber(session, targetId.replace(/[^0-9]/g, ''));
+        if (!resolved.exists || !resolved.whatsappId) {
+          setResponse({
+            success: false,
+            timestamp: new Date().toISOString(),
+            error: t('messageTester.notOnWhatsApp'),
+          });
+          return;
+        }
+        chatId = resolved.whatsappId;
+      }
+
       let result;
       if (messageType === 'text') {
         result = await messageApi.sendText(session, chatId, content);

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -358,6 +358,22 @@ export const templateApi = {
 };
 
 // =============================================================================
+// Contact API
+// =============================================================================
+
+export interface CheckNumberResponse {
+  number: string;
+  exists: boolean;
+  /** Engine-canonical WhatsApp id for the number (e.g. `…@c.us` or `…@lid`), or null if unregistered. */
+  whatsappId: string | null;
+}
+
+export const contactApi = {
+  checkNumber: (sessionId: string, number: string) =>
+    request<CheckNumberResponse>(`/sessions/${sessionId}/contacts/check/${encodeURIComponent(number)}`),
+};
+
+// =============================================================================
 // API Key API
 // =============================================================================
 


### PR DESCRIPTION
Part of #265 — removes the **last** engine-neutral-layer JID leak (a non-breaking, dashboard-only follow-up; targets v0.2.9).

## Problem
`MessageTester.tsx` built the chat id as `` `${digits}@c.us` `` client-side, hardcoding the whatsapp-web.js JID scheme into the dashboard. Under a different engine (e.g. Baileys, `@s.whatsapp.net`) this would send to the wrong/invalid id.

## Fix
For a **personal** recipient, resolve the number through the existing check endpoint (`GET /sessions/:id/contacts/check/:number`), which returns the engine-canonical `whatsappId` (via #271's `getNumberId` — may be `@c.us` or `@lid`), and send to that. If the number isn't on WhatsApp, show a clear `notOnWhatsApp` message instead of attempting a doomed send. **Group** sends keep the real `@g.us` JID from the group picker.

- New `contactApi.checkNumber` in the dashboard API client.
- New `messageTester.notOnWhatsApp` string across **all 8 locales** (i18n parity preserved — 484 keys).
- No backend / API contract change → **non-breaking**.

## Verification
- Dashboard `build` ✓, `lint` (0 errors) ✓, `i18n:check` ✓.

After this, grep for `@c.us`/`@g.us` construction in engine-neutral code is clean (only the adapter + Swagger doc examples remain). Completes the JID sub-item of #265.