### PR TITLE
chore(ci): bump docker/setup-qemu-action v3 → v4 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
Non-breaking CI hygiene (targets v0.2.9).

The v0.2.8 release CI emitted a deprecation warning: `docker/setup-qemu-action@v3` runs on Node.js 20, which GitHub is forcing to Node 24. v4.1.0 (2026-05-27) runs on Node 24.

Bumps both usages (`ci.yml` + `release.yml`). Same QEMU step for the multi-arch Docker build — no behavior change. All other actions are already on Node-24-compatible majors (`checkout@v6`, `setup-node@v6`, `buildx@v4`, `login@v4`, `build-push@v7`, `upload-artifact@v7`).