### PR TITLE
refactor(dashboard): narrow message type to the neutral MessageType union (#270 follow-up)

### DIFF
--- a/dashboard/src/pages/Chats.tsx
+++ b/dashboard/src/pages/Chats.tsx
@@ -14,7 +14,15 @@ import {
   CornerUpLeft,
   Trash2,
 } from 'lucide-react';
-import { sessionApi, messageApi, type Session, type Chat, type ChatMessage } from '../services/api';
+import {
+  sessionApi,
+  messageApi,
+  asMessageType,
+  type Session,
+  type Chat,
+  type ChatMessage,
+  type MessageType,
+} from '../services/api';
 import { useWebSocket } from '../hooks/useWebSocket';
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { useRole } from '../hooks/useRole';
@@ -65,6 +73,15 @@ interface IncomingWsMessage {
   quotedMessage?: { id: string; body: string };
   metadata?: ChatMessageView['metadata'];
 }
+
+// Map an attachment MIME type to the neutral MessageType for the optimistic outgoing bubble, so the
+// placeholder matches what the backend will persist (e.g. a PDF is `document`, not `application`).
+const messageTypeFromMime = (mimetype: string): MessageType => {
+  if (mimetype.startsWith('image/')) return 'image';
+  if (mimetype.startsWith('video/')) return 'video';
+  if (mimetype.startsWith('audio/')) return 'audio';
+  return 'document';
+};
 
 const getMediaSrc = (media?: MessageMedia): string => {
   if (!media || !media.data) return '';
@@ -191,7 +208,7 @@ export function Chats() {
           from: newMsg.from,
           to: newMsg.to,
           body: newMsg.body,
-          type: newMsg.type,
+          type: asMessageType(newMsg.type),
           direction: newMsg.fromMe ? 'outgoing' : 'incoming',
           status: 'sent',
           timestamp: newMsg.timestamp,
@@ -278,7 +295,7 @@ export function Chats() {
         prev.map(msg => {
           if (msg.id === event.id || msg.waMessageId === event.id) {
             // The backend emits an empty body; the localized "deleted" label is rendered below.
-            return { ...msg, body: '', type: event.type };
+            return { ...msg, body: '', type: asMessageType(event.type) };
           }
           return msg;
         }),
@@ -471,7 +488,7 @@ export function Chats() {
           ? textToSend
           : attachment.filename
         : textToSend,
-      type: attachment ? attachment.mimetype.split('/')[0] : 'text',
+      type: attachment ? messageTypeFromMime(attachment.mimetype) : 'text',
       direction: 'outgoing',
       status: 'pending',
       createdAt: new Date().toISOString(),

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -113,6 +113,29 @@ export interface Chat {
   lastMessage?: string;
 }
 
+// Engine-neutral message types (mirrors the backend's IWhatsAppEngine MessageType). The backend
+// normalizes raw engine tokens at the adapter boundary (#265/#270), so persisted rows, the
+// message.received/sent payloads, and the websocket all use these values.
+export const MESSAGE_TYPES = [
+  'text',
+  'image',
+  'video',
+  'audio',
+  'voice',
+  'document',
+  'sticker',
+  'location',
+  'contact',
+  'revoked',
+  'unknown',
+] as const;
+export type MessageType = (typeof MESSAGE_TYPES)[number];
+
+/** Coerce an arbitrary string (e.g. a raw websocket payload field) to a known MessageType. */
+export function asMessageType(value: string | undefined): MessageType {
+  return (MESSAGE_TYPES as readonly string[]).includes(value ?? '') ? (value as MessageType) : 'unknown';
+}
+
 export interface ChatMessage {
   id: string;
   waMessageId?: string;
@@ -120,7 +143,7 @@ export interface ChatMessage {
   from: string;
   to: string;
   body: string;
-  type: string;
+  type: MessageType;
   direction: 'incoming' | 'outgoing';
   status: 'pending' | 'sent' | 'delivered' | 'read' | 'failed';
   timestamp?: number;


### PR DESCRIPTION
Optional polish for v0.2.9 (non-breaking, dashboard-only). Follow-up to #270, which left the dashboard's message `type` as a bare `string`.

## What
- Add a `MessageType` union + `asMessageType()` boundary coercion in `api.ts` (mirrors the backend neutral enum), and narrow `ChatMessage.type: string → MessageType`.
- Coerce websocket-incoming + revoke event `type` at the boundary (`asMessageType`).
- Optimistic outgoing bubble maps the attachment MIME type to a neutral type via `messageTypeFromMime` — also **fixes a latent mismatch** where a document attachment was optimistically typed `application` (from `mimetype.split('/')[0]`) instead of `document`.

## Why
Compile-time exhaustiveness for the media render switch + `type !== 'text'` checks; removes the last `string`-typed message-type in the dashboard.

## Verification
Dashboard `build` ✓, `lint` (0 errors) ✓. No backend/API/i18n change.