### PR TITLE
fix(security): require OPERATOR for group/contact/label/channel/catalog/status writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+
+- **Write endpoints for groups, contacts, labels, channels, catalog, and status now require the
+  `OPERATOR` role**, closing an unintended privilege gap where a `VIEWER`-role API key could create/leave
+  groups, manage participants, block contacts, post statuses, send products, and mutate labels. Read
+  (`GET`) endpoints remain open to any valid key, matching the message/session controllers.
+  > ⚠️ If you used a `VIEWER` key for any of these write operations, switch it to `OPERATOR` (or `ADMIN`).
+
 ## [0.2.8] - 2026-06-17
 
 The engine-pluggability release: the whatsapp-web.js delivery-ack, message-type, and JID specifics are

--- a/src/modules/catalog/catalog.controller.ts
+++ b/src/modules/catalog/catalog.controller.ts
@@ -2,6 +2,8 @@ import { Controller, Get, Post, Param, Body, Query } from '@nestjs/common';
 import { ApiTags, ApiOperation } from '@nestjs/swagger';
 import { CatalogService } from './catalog.service';
 import { SendProductDto, SendCatalogDto, ProductQueryDto } from './dto/send-product.dto';
+import { RequireRole } from '../auth/decorators/auth.decorators';
+import { ApiKeyRole } from '../auth/entities/api-key.entity';
 
 @ApiTags('Catalog')
 @Controller('sessions/:sessionId')
@@ -27,12 +29,14 @@ export class CatalogController {
   }
 
   @Post('messages/send-product')
+  @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Send a product message' })
   async sendProduct(@Param('sessionId') sessionId: string, @Body() dto: SendProductDto) {
     return this.catalogService.sendProduct(sessionId, dto.chatId, dto.productId, dto.body);
   }
 
   @Post('messages/send-catalog')
+  @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Send catalog link' })
   async sendCatalog(@Param('sessionId') sessionId: string, @Body() dto: SendCatalogDto) {
     return this.catalogService.sendCatalog(sessionId, dto.chatId, dto.body);

--- a/src/modules/channel/channel.controller.ts
+++ b/src/modules/channel/channel.controller.ts
@@ -2,6 +2,8 @@ import { Controller, Get, Post, Delete, Param, Body, Query } from '@nestjs/commo
 import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBody, ApiQuery } from '@nestjs/swagger';
 import { ChannelService } from './channel.service';
 import { SubscribeChannelDto } from './dto/subscribe-channel.dto';
+import { RequireRole } from '../auth/decorators/auth.decorators';
+import { ApiKeyRole } from '../auth/entities/api-key.entity';
 
 @ApiTags('channels')
 @Controller('sessions/:sessionId/channels')
@@ -51,6 +53,7 @@ export class ChannelController {
   }
 
   @Post('subscribe')
+  @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Subscribe to a channel using invite code' })
   @ApiParam({ name: 'sessionId', description: 'Session ID' })
   @ApiBody({
@@ -75,6 +78,7 @@ export class ChannelController {
   }
 
   @Delete(':channelId')
+  @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Unsubscribe from a channel' })
   @ApiParam({ name: 'sessionId', description: 'Session ID' })
   @ApiParam({ name: 'channelId', description: 'Channel ID to unsubscribe from' })

--- a/src/modules/contact/contact.controller.ts
+++ b/src/modules/contact/contact.controller.ts
@@ -1,6 +1,8 @@
 import { Controller, Get, Post, Delete, Param, HttpCode, HttpStatus } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
 import { ContactService } from './contact.service';
+import { RequireRole } from '../auth/decorators/auth.decorators';
+import { ApiKeyRole } from '../auth/entities/api-key.entity';
 
 @ApiTags('contacts')
 @Controller('sessions/:sessionId/contacts')
@@ -81,6 +83,7 @@ export class ContactController {
   }
 
   @Post(':contactId/block')
+  @RequireRole(ApiKeyRole.OPERATOR)
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Block a contact' })
   @ApiParam({ name: 'sessionId', description: 'Session ID' })
@@ -95,6 +98,7 @@ export class ContactController {
   }
 
   @Delete(':contactId/block')
+  @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Unblock a contact' })
   @ApiParam({ name: 'sessionId', description: 'Session ID' })
   @ApiParam({ name: 'contactId', description: 'Contact ID (e.g., 628xxx@c.us)' })

--- a/src/modules/group/group.controller.ts
+++ b/src/modules/group/group.controller.ts
@@ -2,6 +2,8 @@ import { Controller, Get, Post, Put, Delete, Param, Body, HttpCode, HttpStatus }
 import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBody } from '@nestjs/swagger';
 import { GroupService } from './group.service';
 import { CreateGroupDto, ParticipantsDto, GroupSubjectDto, GroupDescriptionDto } from './dto/group.dto';
+import { RequireRole } from '../auth/decorators/auth.decorators';
+import { ApiKeyRole } from '../auth/entities/api-key.entity';
 
 @ApiTags('groups')
 @Controller('sessions/:sessionId/groups')
@@ -27,6 +29,7 @@ export class GroupController {
   }
 
   @Post()
+  @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Create a new group' })
   @ApiParam({ name: 'sessionId', description: 'Session ID' })
   @ApiBody({ type: CreateGroupDto })
@@ -36,6 +39,7 @@ export class GroupController {
   }
 
   @Post(':groupId/participants')
+  @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Add participants to a group' })
   @ApiParam({ name: 'sessionId', description: 'Session ID' })
   @ApiParam({ name: 'groupId', description: 'Group ID' })
@@ -52,6 +56,7 @@ export class GroupController {
   }
 
   @Delete(':groupId/participants')
+  @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Remove participants from a group' })
   @ApiParam({ name: 'sessionId', description: 'Session ID' })
   @ApiParam({ name: 'groupId', description: 'Group ID' })
@@ -67,6 +72,7 @@ export class GroupController {
   }
 
   @Post(':groupId/participants/promote')
+  @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Promote participants to admin' })
   @ApiParam({ name: 'sessionId', description: 'Session ID' })
   @ApiParam({ name: 'groupId', description: 'Group ID' })
@@ -83,6 +89,7 @@ export class GroupController {
   }
 
   @Post(':groupId/participants/demote')
+  @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Demote participants from admin' })
   @ApiParam({ name: 'sessionId', description: 'Session ID' })
   @ApiParam({ name: 'groupId', description: 'Group ID' })
@@ -99,6 +106,7 @@ export class GroupController {
   }
 
   @Put(':groupId/subject')
+  @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Change group name/subject' })
   @ApiParam({ name: 'sessionId', description: 'Session ID' })
   @ApiParam({ name: 'groupId', description: 'Group ID' })
@@ -114,6 +122,7 @@ export class GroupController {
   }
 
   @Put(':groupId/description')
+  @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Change group description' })
   @ApiParam({ name: 'sessionId', description: 'Session ID' })
   @ApiParam({ name: 'groupId', description: 'Group ID' })
@@ -129,6 +138,7 @@ export class GroupController {
   }
 
   @Post(':groupId/leave')
+  @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Leave a group' })
   @ApiParam({ name: 'sessionId', description: 'Session ID' })
   @ApiParam({ name: 'groupId', description: 'Group ID' })
@@ -155,6 +165,7 @@ export class GroupController {
   }
 
   @Post(':groupId/invite-code/revoke')
+  @RequireRole(ApiKeyRole.OPERATOR)
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Revoke group invite code and generate new one' })
   @ApiParam({ name: 'sessionId', description: 'Session ID' })

--- a/src/modules/label/label.controller.ts
+++ b/src/modules/label/label.controller.ts
@@ -2,6 +2,8 @@ import { Controller, Get, Post, Delete, Param, Body } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBody } from '@nestjs/swagger';
 import { LabelService } from './label.service';
 import { AddLabelDto } from './dto/add-label.dto';
+import { RequireRole } from '../auth/decorators/auth.decorators';
+import { ApiKeyRole } from '../auth/entities/api-key.entity';
 
 @ApiTags('labels')
 @Controller('sessions/:sessionId/labels')
@@ -47,6 +49,7 @@ export class LabelController {
   }
 
   @Post('chat/:chatId')
+  @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Add a label to a chat' })
   @ApiParam({ name: 'sessionId', description: 'Session ID' })
   @ApiParam({ name: 'chatId', description: 'Chat ID' })
@@ -73,6 +76,7 @@ export class LabelController {
   }
 
   @Delete('chat/:chatId/:labelId')
+  @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Remove a label from a chat' })
   @ApiParam({ name: 'sessionId', description: 'Session ID' })
   @ApiParam({ name: 'chatId', description: 'Chat ID' })

--- a/src/modules/status/status.controller.ts
+++ b/src/modules/status/status.controller.ts
@@ -3,6 +3,8 @@ import { ApiTags, ApiOperation } from '@nestjs/swagger';
 import { StatusService } from './status.service';
 import { SendTextStatusDto } from './dto/send-text-status.dto';
 import { SendImageStatusDto, SendVideoStatusDto } from './dto/send-media-status.dto';
+import { RequireRole } from '../auth/decorators/auth.decorators';
+import { ApiKeyRole } from '../auth/entities/api-key.entity';
 
 @ApiTags('Status')
 @Controller('sessions/:sessionId/status')
@@ -22,6 +24,7 @@ export class StatusController {
   }
 
   @Post('send-text')
+  @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Post a text status' })
   async sendTextStatus(@Param('sessionId') sessionId: string, @Body() dto: SendTextStatusDto) {
     return this.statusService.postTextStatus(sessionId, dto.text, {
@@ -31,18 +34,21 @@ export class StatusController {
   }
 
   @Post('send-image')
+  @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Post an image status' })
   async sendImageStatus(@Param('sessionId') sessionId: string, @Body() dto: SendImageStatusDto) {
     return this.statusService.postImageStatus(sessionId, dto.image, dto.caption);
   }
 
   @Post('send-video')
+  @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Post a video status' })
   async sendVideoStatus(@Param('sessionId') sessionId: string, @Body() dto: SendVideoStatusDto) {
     return this.statusService.postVideoStatus(sessionId, dto.video, dto.caption);
   }
 
   @Delete(':statusId')
+  @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Delete own status' })
   async deleteStatus(@Param('sessionId') sessionId: string, @Param('statusId') statusId: string) {
     await this.statusService.deleteStatus(sessionId, statusId);


### PR DESCRIPTION
v0.2.9 **security** item (from the improvement scan). Shipped in 0.2.x as a security exception, with a migration note.

## Problem
`contact`, `group`, `label`, `channel`, `catalog`, and `status` controllers carried **no `@RequireRole`**, so any valid API key — including a **`VIEWER`** key — could perform state-changing operations: create/leave groups, add/remove/promote participants, block contacts, post statuses, send catalog products, mutate labels. The `message`/`session`/`webhook` controllers already require `OPERATOR` for writes — this was an inconsistency and a real privilege gap.

## Fix
Added `@RequireRole(ApiKeyRole.OPERATOR)` to **all 21 `POST`/`PUT`/`DELETE`** endpoints across the six controllers. `GET` endpoints stay open to any valid key (matching `MessageController.getMessages`).

| Controller | writes guarded |
|---|---|
| group | 9 | 
| status | 4 |
| contact / label / channel / catalog | 2 each |

## ⚠️ Migration
A `VIEWER`-role key can no longer perform these writes — use `OPERATOR` (or `ADMIN`). Documented in the CHANGELOG.

## Deep review
- Verified write/read split per controller (writes==guards; zero GETs guarded).
- ADMIN/OPERATOR unaffected; only VIEWER loses these (intended).
- Dashboard already hides write actions behind the operator role (`useRole().canWrite`) → no dashboard regression.
- `build` + `lint` + **473 tests** green. (Caught & fixed a shell-quoting glitch in the import lines during prep before committing.)