### PR TITLE
fix(dashboard): a11y — toast live region + API-key toggle labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Dashboard accessibility:** toast notifications are now an ARIA live region (`role="region"`/`aria-live`,
+  with `role="alert"` on error/warning toasts) so screen readers announce success/error feedback, and the
+  toast close button has an accessible name. The API-key visibility toggles on the Login and API Keys pages
+  now have state-reflecting `aria-label`s (show/hide). New `common.showApiKey`/`common.hideApiKey` strings
+  across all locales.
+
 ## [0.2.8] - 2026-06-17
 
 The engine-pluggability release: the whatsapp-web.js delivery-ack, message-type, and JID specifics are

--- a/dashboard/src/components/Toast.tsx
+++ b/dashboard/src/components/Toast.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useState, useCallback, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
 import { CheckCircle, XCircle, AlertCircle, Info, X } from 'lucide-react';
 import './Toast.css';
 
@@ -110,18 +111,24 @@ interface ToastContainerProps {
 }
 
 function ToastContainer({ toasts, removeToast }: ToastContainerProps) {
+  const { t } = useTranslation();
   return (
-    <div className="toast-container">
+    // Persistent live region so screen readers announce toasts as they appear.
+    <div className="toast-container" role="region" aria-live="polite" aria-atomic="false">
       {toasts.map(toast => {
         const Icon = icons[toast.type];
         return (
-          <div key={toast.id} className={`toast toast-${toast.type}`}>
+          <div
+            key={toast.id}
+            className={`toast toast-${toast.type}`}
+            role={toast.type === 'error' || toast.type === 'warning' ? 'alert' : 'status'}
+          >
             <Icon className="toast-icon" size={20} />
             <div className="toast-content">
               <div className="toast-title">{toast.title}</div>
               {toast.message && <div className="toast-message">{toast.message}</div>}
             </div>
-            <button className="toast-close" onClick={() => removeToast(toast.id)}>
+            <button className="toast-close" onClick={() => removeToast(toast.id)} aria-label={t('common.close')}>
               <X size={16} />
             </button>
           </div>

--- a/dashboard/src/i18n/locales/ar.json
+++ b/dashboard/src/i18n/locales/ar.json
@@ -9,6 +9,8 @@
     "edit": "تعديل",
     "create": "إنشاء",
     "close": "إغلاق",
+    "showApiKey": "إظهار مفتاح API",
+    "hideApiKey": "إخفاء مفتاح API",
     "submit": "إرسال",
     "confirm": "تأكيد",
     "search": "بحث",

--- a/dashboard/src/i18n/locales/en.json
+++ b/dashboard/src/i18n/locales/en.json
@@ -9,6 +9,8 @@
     "edit": "Edit",
     "create": "Create",
     "close": "Close",
+    "showApiKey": "Show API key",
+    "hideApiKey": "Hide API key",
     "submit": "Submit",
     "confirm": "Confirm",
     "search": "Search",

--- a/dashboard/src/i18n/locales/fr.json
+++ b/dashboard/src/i18n/locales/fr.json
@@ -9,6 +9,8 @@
     "edit": "Modifier",
     "create": "Créer",
     "close": "Fermer",
+    "showApiKey": "Afficher la clé API",
+    "hideApiKey": "Masquer la clé API",
     "submit": "Soumettre",
     "confirm": "Confirmer",
     "search": "Rechercher",

--- a/dashboard/src/i18n/locales/he.json
+++ b/dashboard/src/i18n/locales/he.json
@@ -9,6 +9,8 @@
     "edit": "עריכה",
     "create": "יצירה",
     "close": "סגירה",
+    "showApiKey": "הצג מפתח API",
+    "hideApiKey": "הסתר מפתח API",
     "submit": "שליחה",
     "confirm": "אישור",
     "search": "חיפוש",

--- a/dashboard/src/i18n/locales/it.json
+++ b/dashboard/src/i18n/locales/it.json
@@ -9,6 +9,8 @@
     "edit": "Modifica",
     "create": "Crea",
     "close": "Chiudi",
+    "showApiKey": "Mostra la chiave API",
+    "hideApiKey": "Nascondi la chiave API",
     "submit": "Invia",
     "confirm": "Conferma",
     "search": "Cerca",

--- a/dashboard/src/i18n/locales/te.json
+++ b/dashboard/src/i18n/locales/te.json
@@ -9,6 +9,8 @@
     "edit": "ఎడిట్ చేయి",
     "create": "సృష్టించు",
     "close": "మూసివేయి",
+    "showApiKey": "API కీని చూపు",
+    "hideApiKey": "API కీని దాచు",
     "submit": "సమర్పించు",
     "confirm": "ధృవీకరించు",
     "search": "వెతుకు",

--- a/dashboard/src/i18n/locales/zh-CN.json
+++ b/dashboard/src/i18n/locales/zh-CN.json
@@ -9,6 +9,8 @@
     "edit": "编辑",
     "create": "创建",
     "close": "关闭",
+    "showApiKey": "显示 API 密钥",
+    "hideApiKey": "隐藏 API 密钥",
     "submit": "提交",
     "confirm": "确认",
     "search": "搜索",

--- a/dashboard/src/i18n/locales/zh-HK.json
+++ b/dashboard/src/i18n/locales/zh-HK.json
@@ -9,6 +9,8 @@
     "edit": "編輯",
     "create": "建立",
     "close": "關閉",
+    "showApiKey": "顯示 API 金鑰",
+    "hideApiKey": "隱藏 API 金鑰",
     "submit": "提交",
     "confirm": "確認",
     "search": "搜尋",

--- a/dashboard/src/pages/ApiKeys.tsx
+++ b/dashboard/src/pages/ApiKeys.tsx
@@ -118,7 +118,11 @@ export function ApiKeys() {
           return (
             <span className="key-cell">
               <code>{visibleKeys.has(apiKey.id) ? apiKey.keyPrefix + '...' : apiKey.keyPrefix + '****'}</code>
-              <button className="icon-btn-sm" onClick={() => toggleKeyVisibility(apiKey.id)}>
+              <button
+                className="icon-btn-sm"
+                onClick={() => toggleKeyVisibility(apiKey.id)}
+                aria-label={visibleKeys.has(apiKey.id) ? t('common.hideApiKey') : t('common.showApiKey')}
+              >
                 {visibleKeys.has(apiKey.id) ? <EyeOff size={14} /> : <Eye size={14} />}
               </button>
             </span>

--- a/dashboard/src/pages/Login.tsx
+++ b/dashboard/src/pages/Login.tsx
@@ -93,7 +93,12 @@ export function Login({ onLogin }: LoginProps) {
                 placeholder={t('login.apiKeyPlaceholder')}
                 className={error ? 'error' : ''}
               />
-              <button type="button" className="toggle-visibility" onClick={() => setShowKey(!showKey)}>
+              <button
+                type="button"
+                className="toggle-visibility"
+                onClick={() => setShowKey(!showKey)}
+                aria-label={showKey ? t('common.hideApiKey') : t('common.showApiKey')}
+              >
                 {showKey ? <EyeOff size={20} /> : <Eye size={20} />}
               </button>
             </div>


### PR DESCRIPTION
v0.2.9 accessibility wins (from the improvement scan). Non-breaking, dashboard-only.

- **Toasts** — the primary success/error feedback channel had no ARIA live region, so screen readers never announced it. Now `role="region" aria-live="polite"` on the container, `role="alert"` on error/warning toasts, and an accessible name on the close button (`common.close`).
- **API-key visibility toggles** (Login + API Keys pages) — icon-only buttons with no accessible name (the long-deferred login-toggle a11y item). Now state-reflecting `aria-label` (show/hide) via new `common.showApiKey`/`common.hideApiKey` across all 8 locales (i18n parity preserved — verified).

## Verification
- Dashboard `build` + `lint` (0 errors) + `i18n:check` ✓.

## Remaining a11y items (separate follow-up PRs — isolated for careful review)
- Error states on Webhooks/ApiKeys/Logs (show an error+retry instead of a misleading empty state when the list fetch fails).
- Shared accessible `Modal` wrapper (role=dialog/aria-modal/Escape/focus management) across the ~8 modals — the higher-risk structural one; doing it on its own with care.