### PR TITLE
docs: align Node.js runtime version

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -188,7 +188,7 @@ socket.on('message', msg => {
 
 | Layer     | Technology                    |
 | --------- | ----------------------------- |
-| Runtime   | Node.js 20 LTS                |
+| Runtime   | Node.js 22 LTS                |
 | Framework | NestJS 11.x                   |
 | Language  | TypeScript 5.x                |
 | WA Engine | whatsapp-web.js               |

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "author": "Yudhi Armyndharis & OpenWA Contributors",
   "private": true,
   "license": "MIT",
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",


### PR DESCRIPTION
## Summary

- Update the documentation tech stack to consistently reference Node.js 22 LTS.
- Add a package `engines.node` requirement so the runtime expectation is visible to package managers and contributors.

## Context

The documentation badge already references Node.js 22 LTS, while the Tech Stack table still referenced Node.js 20 LTS. This PR aligns those references and makes the runtime requirement explicit in `package.json`.

## Testing

Not run. Documentation/package metadata only.