### PR TITLE
feat(engine): opaque per-engine config (engine-agnostic EngineFactory)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ plugins instead of in core (#265).
 - **`auto-reply` reference extension plugin**, first-party and **registered disabled by default** — enable
   it via `POST /plugins/auto-reply/enable` to exercise the capability layer end-to-end. (#294)
 
+### Changed
+
+- Engine config is now **opaque per-engine**: `EngineFactory` passes only engine-neutral fields
+  (`sessionId`/`proxyUrl`/`proxyType`) to an engine plugin and supplies engine-specific config (Puppeteer
+  for whatsapp-web.js) as a blob via the plugin context, so a non-browser engine can be added without the
+  factory knowing browser fields. No env-var or behavior change for existing deployments. (#296)
+
 ## [0.2.10] - 2026-06-17
 
 Completes the v0.2.9 non-breaking batch with three dashboard/CI follow-ups that belonged to the same

--- a/src/core/plugins/plugin-loader.service.spec.ts
+++ b/src/core/plugins/plugin-loader.service.spec.ts
@@ -24,3 +24,38 @@ describe('resolvePluginMainPath', () => {
     expect(() => resolvePluginMainPath(dir, 'my-plugin', '../other-plugin/evil.js')).toThrow(/escapes/);
   });
 });
+
+import { PluginLoaderService } from './plugin-loader.service';
+import { ConfigService } from '@nestjs/config';
+import { ModuleRef } from '@nestjs/core';
+import { HookManager } from '../hooks';
+import { PluginStorageService } from './plugin-storage.service';
+import { IPlugin, PluginManifest, PluginType } from './plugin.interfaces';
+
+describe('PluginLoaderService.registerBuiltInPlugin config', () => {
+  function makeLoader(): PluginLoaderService {
+    const configService = { get: jest.fn().mockReturnValue(undefined) } as unknown as ConfigService;
+    const pluginStorage = {} as unknown as PluginStorageService;
+    return new PluginLoaderService(configService, new HookManager(), pluginStorage, {} as unknown as ModuleRef);
+  }
+  const manifest: PluginManifest = {
+    id: 'cfg-test',
+    name: 'Cfg Test',
+    version: '1.0.0',
+    type: PluginType.ENGINE,
+    main: 'index.ts',
+  };
+  const instance = {} as unknown as IPlugin;
+
+  it('stores the supplied config on the plugin instance', () => {
+    const loader = makeLoader();
+    loader.registerBuiltInPlugin(manifest, instance, { sessionDataPath: '/d', puppeteer: { headless: false } });
+    expect(loader.getPlugin('cfg-test')?.config).toEqual({ sessionDataPath: '/d', puppeteer: { headless: false } });
+  });
+
+  it('defaults to an empty config when none is supplied (back-compat)', () => {
+    const loader = makeLoader();
+    loader.registerBuiltInPlugin(manifest, instance);
+    expect(loader.getPlugin('cfg-test')?.config).toEqual({});
+  });
+});

--- a/src/core/plugins/plugin-loader.service.ts
+++ b/src/core/plugins/plugin-loader.service.ts
@@ -410,11 +410,11 @@ export class PluginLoaderService implements OnModuleInit {
   // Built-in Plugin Registration (for Phase 4)
   // ============================================================================
 
-  registerBuiltInPlugin(manifest: PluginManifest, instance: IPlugin): void {
+  registerBuiltInPlugin(manifest: PluginManifest, instance: IPlugin, config: Record<string, unknown> = {}): void {
     const pluginInstance: PluginInstance = {
       manifest,
       status: PluginStatus.INSTALLED,
-      config: {},
+      config,
       instance,
       loadedAt: new Date(),
     };

--- a/src/engine/engine.factory.spec.ts
+++ b/src/engine/engine.factory.spec.ts
@@ -31,11 +31,9 @@ describe('EngineFactory', () => {
     const factory = new EngineFactory(buildConfigService(), pluginLoader);
     factory.create({ sessionId: 'sess-1', proxyUrl: 'http://p', proxyType: 'http' });
 
+    // Plain-object (not objectContaining) assertion: any browser key (headless/puppeteerArgs/
+    // executablePath/sessionDataPath) leaking into the per-call config would fail this exact match.
     expect(createEngine).toHaveBeenCalledWith({ sessionId: 'sess-1', proxyUrl: 'http://p', proxyType: 'http' });
-    const passed = createEngine.mock.calls[0][0] as Record<string, unknown>;
-    for (const k of ['headless', 'puppeteerArgs', 'executablePath', 'sessionDataPath']) {
-      expect(passed).not.toHaveProperty(k);
-    }
   });
 
   it('registers the built-in engine with the opaque engine config blob (#219 guarantee moves to context.config)', async () => {

--- a/src/engine/engine.factory.spec.ts
+++ b/src/engine/engine.factory.spec.ts
@@ -3,6 +3,11 @@ import { ConfigService } from '@nestjs/config';
 import { PluginLoaderService, PluginType } from '../core/plugins';
 
 describe('EngineFactory', () => {
+  const engineBlob = {
+    type: 'whatsapp-web.js',
+    sessionDataPath: '/var/data/sessions',
+    puppeteer: { headless: true, args: ['--no-sandbox'], executablePath: '/usr/bin/chromium-browser' },
+  };
   const buildConfigService = (overrides: Record<string, unknown> = {}): ConfigService => {
     const values: Record<string, unknown> = {
       'engine.type': 'whatsapp-web.js',
@@ -10,12 +15,13 @@ describe('EngineFactory', () => {
       'engine.puppeteer.headless': true,
       'engine.puppeteer.args': ['--no-sandbox'],
       'engine.puppeteer.executablePath': '/usr/bin/chromium-browser',
+      engine: engineBlob,
       ...overrides,
     };
     return { get: jest.fn((key: string) => values[key]) } as unknown as ConfigService;
   };
 
-  it('threads the resolved puppeteer config (executablePath/sessionDataPath) to the plugin — #219', () => {
+  it('passes ONLY engine-neutral fields to createEngine (no Puppeteer leak)', () => {
     const createEngine = jest.fn().mockReturnValue({});
     const pluginInstance = { type: PluginType.ENGINE, createEngine };
     const pluginLoader = {
@@ -23,31 +29,39 @@ describe('EngineFactory', () => {
     } as unknown as PluginLoaderService;
 
     const factory = new EngineFactory(buildConfigService(), pluginLoader);
-    factory.create({ sessionId: 'sess-1' });
+    factory.create({ sessionId: 'sess-1', proxyUrl: 'http://p', proxyType: 'http' });
 
-    // Finding 2: the built-in plugin registers with an empty context config, so the
-    // factory must resolve and pass these through — otherwise sessionDataPath and the
-    // executable path silently fall back to relative-path defaults.
-    expect(createEngine).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sessionId: 'sess-1',
-        sessionDataPath: '/var/data/sessions',
-        headless: true,
-        puppeteerArgs: ['--no-sandbox'],
-        executablePath: '/usr/bin/chromium-browser',
-      }),
+    expect(createEngine).toHaveBeenCalledWith({ sessionId: 'sess-1', proxyUrl: 'http://p', proxyType: 'http' });
+    const passed = createEngine.mock.calls[0][0] as Record<string, unknown>;
+    for (const k of ['headless', 'puppeteerArgs', 'executablePath', 'sessionDataPath']) {
+      expect(passed).not.toHaveProperty(k);
+    }
+  });
+
+  it('registers the built-in engine with the opaque engine config blob (#219 guarantee moves to context.config)', async () => {
+    const registerBuiltInPlugin = jest.fn();
+    const pluginLoader = {
+      registerBuiltInPlugin,
+      enablePlugin: jest.fn().mockResolvedValue(undefined),
+      getPlugin: jest.fn(),
+    } as unknown as PluginLoaderService;
+
+    const factory = new EngineFactory(buildConfigService(), pluginLoader);
+    await factory.onModuleInit();
+
+    expect(registerBuiltInPlugin).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'whatsapp-web.js', type: PluginType.ENGINE }),
+      expect.anything(),
+      engineBlob,
     );
   });
 
-  it('falls back to the direct adapter (with executablePath) when no engine plugin is available', () => {
+  it('falls back to the direct adapter when no engine plugin is available', () => {
     const pluginLoader = {
       getPlugin: jest.fn().mockReturnValue(undefined),
     } as unknown as PluginLoaderService;
 
     const factory = new EngineFactory(buildConfigService(), pluginLoader);
-
-    // The fallback path must not throw and must produce an engine instance even when
-    // the plugin registry is empty (legacy support).
     expect(() => factory.create({ sessionId: 'sess-2' })).not.toThrow();
   });
 });

--- a/src/engine/engine.factory.ts
+++ b/src/engine/engine.factory.ts
@@ -42,7 +42,9 @@ export class EngineFactory implements OnModuleInit {
     };
 
     const wwjsPlugin = new WhatsAppWebJsPlugin();
-    this.pluginLoader.registerBuiltInPlugin(wwjsManifest, wwjsPlugin);
+    // Supply the engine config sub-tree (engine.* from configuration.ts) as an opaque blob;
+    // the plugin reads its own namespace (puppeteer.*, sessionDataPath) from context.config.
+    this.pluginLoader.registerBuiltInPlugin(wwjsManifest, wwjsPlugin, this.configService.get('engine') ?? {});
 
     // Auto-enable the configured engine
     try {
@@ -65,20 +67,13 @@ export class EngineFactory implements OnModuleInit {
     const enginePlugin = this.pluginLoader.getPlugin(this.engineType);
 
     if (enginePlugin?.instance && this.isEnginePlugin(enginePlugin.instance)) {
+      // Engine-neutral per-call config only. Engine-specific config (e.g. Puppeteer for
+      // whatsapp-web.js) is supplied to the plugin as an opaque blob via context.config at
+      // registration, so the factory never assembles browser-shaped fields.
       return enginePlugin.instance.createEngine({
         sessionId: options.sessionId,
         proxyUrl: options.proxyUrl,
         proxyType: options.proxyType,
-        // Resolve engine runtime config here (the built-in plugin registers with an
-        // empty context config) so sessionDataPath / puppeteer settings honour the
-        // environment instead of falling back to relative-path defaults.
-        sessionDataPath: this.configService.get<string>('engine.sessionDataPath') ?? './data/sessions',
-        headless: this.configService.get<boolean>('engine.puppeteer.headless') ?? true,
-        puppeteerArgs: this.configService.get<string[]>('engine.puppeteer.args') ?? [
-          '--no-sandbox',
-          '--disable-setuid-sandbox',
-        ],
-        executablePath: this.configService.get<string>('engine.puppeteer.executablePath'),
       }) as IWhatsAppEngine;
     }
 

--- a/src/plugins/engines/whatsapp-web-js/index.spec.ts
+++ b/src/plugins/engines/whatsapp-web-js/index.spec.ts
@@ -4,33 +4,38 @@ jest.mock('../../../engine/adapters/whatsapp-web-js.adapter', () => ({
 
 import { WhatsAppWebJsPlugin } from './index';
 import { WhatsAppWebJsAdapter } from '../../../engine/adapters/whatsapp-web-js.adapter';
+import { PluginContext } from '../../../core/plugins';
 
-describe('WhatsAppWebJsPlugin.createEngine (#219)', () => {
+describe('WhatsAppWebJsPlugin.createEngine (opaque config)', () => {
   beforeEach(() => {
     (WhatsAppWebJsAdapter as unknown as jest.Mock).mockClear();
   });
 
-  it('prefers per-call config over context/defaults and threads executablePath', () => {
-    const plugin = new WhatsAppWebJsPlugin();
+  function withContext(plugin: WhatsAppWebJsPlugin, config: Record<string, unknown>): void {
+    // onLoad sets this.context synchronously; the returned promise can be ignored here.
+    void plugin.onLoad({ config, logger: { log: jest.fn() } } as unknown as PluginContext);
+  }
 
-    plugin.createEngine({
-      sessionId: 'sess-1',
+  it('reads browser config from context.config (the opaque engine blob), not per-call', () => {
+    const plugin = new WhatsAppWebJsPlugin();
+    withContext(plugin, {
       sessionDataPath: '/data/sessions',
-      headless: false,
-      puppeteerArgs: ['--single-process'],
-      executablePath: '/usr/bin/chromium',
+      puppeteer: { headless: false, args: ['--single-process'], executablePath: '/usr/bin/chromium' },
     });
+
+    plugin.createEngine({ sessionId: 'sess-1', proxyUrl: 'http://p', proxyType: 'http' });
 
     expect(WhatsAppWebJsAdapter).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionId: 'sess-1',
         sessionDataPath: '/data/sessions',
         puppeteer: { headless: false, args: ['--single-process'], executablePath: '/usr/bin/chromium' },
+        proxy: { url: 'http://p', type: 'http' },
       }),
     );
   });
 
-  it('falls back to safe defaults when no config is supplied', () => {
+  it('falls back to safe defaults when context has no config', () => {
     const plugin = new WhatsAppWebJsPlugin();
 
     plugin.createEngine({ sessionId: 'sess-2' });

--- a/src/plugins/engines/whatsapp-web-js/index.ts
+++ b/src/plugins/engines/whatsapp-web-js/index.ts
@@ -29,24 +29,21 @@ export class WhatsAppWebJsPlugin implements IEnginePlugin {
 
   createEngine(config: Record<string, unknown>): IWhatsAppEngine {
     const sessionId = config.sessionId as string;
-    // Prefer the per-call config resolved by EngineFactory (from ConfigService);
-    // fall back to any plugin-level context config, then to safe defaults. The
-    // built-in plugin registers with an empty context config, so without the
-    // per-call values sessionDataPath/headless/executablePath would silently
-    // fall back to relative-path defaults and ignore the environment.
-    const sessionDataPath =
-      (config.sessionDataPath as string | undefined) ??
-      (this.context?.config.sessionDataPath as string | undefined) ??
-      './data/sessions';
-    const headless =
-      (config.headless as boolean | undefined) ?? (this.context?.config.headless as boolean | undefined) ?? true;
-    const puppeteerArgs = (config.puppeteerArgs as string[] | undefined) ??
-      (this.context?.config.puppeteerArgs as string[] | undefined) ?? ['--no-sandbox', '--disable-setuid-sandbox'];
-    const executablePath =
-      (config.executablePath as string | undefined) ?? (this.context?.config.executablePath as string | undefined);
-
     const proxyUrl = config.proxyUrl as string | undefined;
     const proxyType = config.proxyType as 'http' | 'https' | 'socks4' | 'socks5' | undefined;
+
+    // Browser config is this engine's OWN namespace, read from the opaque per-engine blob the
+    // factory supplies via context.config (the `engine` sub-tree in configuration.ts). The
+    // per-call config carries only engine-neutral fields (sessionId, proxy).
+    const engineConfig = (this.context?.config ?? {}) as {
+      sessionDataPath?: string;
+      puppeteer?: { headless?: boolean; args?: string[]; executablePath?: string };
+    };
+    const puppeteer = engineConfig.puppeteer ?? {};
+    const sessionDataPath = engineConfig.sessionDataPath ?? './data/sessions';
+    const headless = puppeteer.headless ?? true;
+    const puppeteerArgs = puppeteer.args ?? ['--no-sandbox', '--disable-setuid-sandbox'];
+    const executablePath = puppeteer.executablePath;
 
     return new WhatsAppWebJsAdapter({
       sessionId,


### PR DESCRIPTION
## Summary

Makes `EngineFactory` **engine-agnostic**: it passes only engine-neutral fields (`sessionId`/`proxyUrl`/`proxyType`) to a plugin's `createEngine`, and supplies engine-specific config (Puppeteer for whatsapp-web.js) as an **opaque blob via the plugin context**. This is the one real neutral-layer blocker for adding a non-browser engine — so a future Baileys engine can be added without the factory knowing browser fields.

Spec #2 of the engine-pluggability work (#265). **No env-var or behavior change for existing deployments** — the adapter receives byte-identical config.

## Changes

- `registerBuiltInPlugin` gains an optional `config` parameter (default `{}`, so existing callers are unaffected).
- `EngineFactory.create()` passes only `{ sessionId, proxyUrl, proxyType }`; `registerBuiltInEngines()` feeds `configService.get('engine')` as the opaque blob; the whatsapp-web.js plugin reads its own browser config (`puppeteer.*`, `sessionDataPath`) from `context.config`.
- Two existing `#219` tests are rewritten to assert the new opaque-config behavior — the guarantee that env config reaches the adapter now flows through `context.config` (proven by registration-feeds-blob + plugin-reads-blob + the e2e boot), not through `create()`'s arguments.

## Notes

- `configuration.ts` and `createFallbackEngine()` are **unchanged**; env-var names are unchanged → fully backward-compatible.
- A future Baileys engine reads `context.config.baileys.*`; the factory needs no change. The Baileys adapter itself (event model, auth/QR, JID normalization, ~70 methods) is a separate follow-up.

## Tests

- **514/514 unit**, **e2e boot 4/4** (proves the registration → `context.config` → `createEngine` flow boots and a session creates its engine).
- Build + lint clean (backend + dashboard).

Relates to #265.
