### PR TITLE
Quality: Path Traversal Vulnerability in isPathWithin

### DIFF
--- a/src/common/utils/path-safety.ts
+++ b/src/common/utils/path-safety.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import * as path from 'path';
 
 /**
@@ -11,7 +12,7 @@ import * as path from 'path';
  * from being treated as inside the root.
  */
 export function isPathWithin(root: string, target: string): boolean {
-  const resolvedRoot = path.resolve(root);
-  const resolvedTarget = path.resolve(resolvedRoot, target);
+  const resolvedRoot = fs.realpathSync(path.resolve(root));
+  const resolvedTarget = fs.realpathSync(path.resolve(resolvedRoot, target));
   return resolvedTarget === resolvedRoot || resolvedTarget.startsWith(resolvedRoot + path.sep);
 }


### PR DESCRIPTION
## Problem

The `isPathWithin` utility in `path-safety.ts` uses `path.resolve(resolvedRoot, target)` which follows symlinks. An attacker could bypass the path check by providing a symlink that points outside the root directory. Additionally, the function does not handle cases where `root` contains trailing spaces or special characters that might affect path resolution on certain platforms.

**Severity**: `critical`
**File**: `src/common/utils/path-safety.ts`

## Solution

Use `fs.realpath` to resolve symlinks before comparison, and normalize the root path. Consider using a library like `resolve-path` or implementing a more robust check that verifies the resolved target is actually within the root directory after symlink resolution.

## Changes

- `src/common/utils/path-safety.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
