### PR TITLE
fix(session): scope GET /sessions to the calling key's allowedSessions

### DIFF
--- a/src/modules/session/session.controller.ts
+++ b/src/modules/session/session.controller.ts
@@ -15,8 +15,8 @@ import { Session } from './entities/session.entity';
 import { ChatSummary } from '../../engine/interfaces/whatsapp-engine.interface';
 import { AuditService } from '../audit/audit.service';
 import { AuditAction } from '../audit/entities/audit-log.entity';
-import { RequireRole } from '../auth/decorators/auth.decorators';
-import { ApiKeyRole } from '../auth/entities/api-key.entity';
+import { RequireRole, CurrentApiKey } from '../auth/decorators/auth.decorators';
+import { ApiKey, ApiKeyRole } from '../auth/entities/api-key.entity';
 
 @ApiTags('sessions')
 @Controller('sessions')
@@ -67,8 +67,10 @@ export class SessionController {
     description: 'List of sessions',
     type: [SessionResponseDto],
   })
-  async findAll(): Promise<SessionResponseDto[]> {
-    const sessions = await this.sessionService.findAll();
+  async findAll(@CurrentApiKey() apiKey?: ApiKey): Promise<SessionResponseDto[]> {
+    // Scope to the key's allowedSessions so a session-restricted key cannot enumerate every
+    // session. A null/empty allowlist (e.g. ADMIN) still lists all.
+    const sessions = await this.sessionService.findAll(apiKey?.allowedSessions);
     return sessions.map(s => this.transformSession(s));
   }
 

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken, getDataSourceToken } from '@nestjs/typeorm';
-import { Repository, DataSource } from 'typeorm';
+import { Repository, DataSource, In } from 'typeorm';
 import { NotFoundException, ConflictException, BadRequestException } from '@nestjs/common';
 import { SessionService } from './session.service';
 import { Session, SessionStatus } from './entities/session.entity';
@@ -184,6 +184,28 @@ describe('SessionService', () => {
 
       expect(result).toHaveLength(2);
       expect(repository.find).toHaveBeenCalledWith({ order: { createdAt: 'DESC' } });
+    });
+
+    it('scopes results to a session-restricted key (F-02)', async () => {
+      (repository.find as jest.Mock).mockResolvedValue([]);
+
+      await service.findAll(['sess-1', 'sess-2']);
+
+      expect(repository.find).toHaveBeenCalledWith({
+        where: { id: In(['sess-1', 'sess-2']) },
+        order: { createdAt: 'DESC' },
+      });
+    });
+
+    it('returns all sessions for an unrestricted key (null/empty allowlist)', async () => {
+      (repository.find as jest.Mock).mockResolvedValue([]);
+
+      await service.findAll(null);
+      await service.findAll([]);
+
+      expect(repository.find).toHaveBeenCalledTimes(2);
+      expect(repository.find).toHaveBeenNthCalledWith(1, { order: { createdAt: 'DESC' } });
+      expect(repository.find).toHaveBeenNthCalledWith(2, { order: { createdAt: 'DESC' } });
     });
   });
 

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -8,7 +8,7 @@ import {
   OnApplicationBootstrap,
 } from '@nestjs/common';
 import { InjectRepository, InjectDataSource } from '@nestjs/typeorm';
-import { Repository, In, Not, IsNull, DataSource } from 'typeorm';
+import { Repository, In, Not, IsNull, DataSource, FindManyOptions } from 'typeorm';
 import { Session, SessionStatus } from './entities/session.entity';
 import { Message, MessageDirection, MessageStatus } from '../message/entities/message.entity';
 import { CreateSessionDto } from './dto';
@@ -211,10 +211,15 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
     return saved;
   }
 
-  async findAll(): Promise<Session[]> {
-    const sessions = await this.sessionRepository.find({
-      order: { createdAt: 'DESC' },
-    });
+  async findAll(allowedSessions?: string[] | null): Promise<Session[]> {
+    // A session-restricted key only lists its own sessions; an unrestricted key (null/empty
+    // allowlist) lists all — mirroring the ApiKeyGuard allowedSessions model so a scoped key
+    // cannot enumerate every session through this aggregate route.
+    const options: FindManyOptions<Session> = { order: { createdAt: 'DESC' } };
+    if (allowedSessions && allowedSessions.length > 0) {
+      options.where = { id: In(allowedSessions) };
+    }
+    const sessions = await this.sessionRepository.find(options);
     return sessions.map(session => this.attachLastError(session));
   }
 


### PR DESCRIPTION
## Summary

A session-restricted API key (`allowedSessions` set) could enumerate **every** session via `GET /sessions`, defeating the tenant isolation `allowedSessions` is meant to provide.

## Root cause

`ApiKeyGuard` derives the session scope from `request.params['sessionId'] || request.params['id']` and `AuthService.validateApiKey` only enforces `allowedSessions` when that id is present (`&& sessionId`). `GET /sessions` (`SessionService.findAll`) has no session param, so the fence is skipped and the service returns all rows — the HTTP analogue of the cross-session leak the WS gateway explicitly blocks for the `*` wildcard.

## Fix

`SessionService.findAll(allowedSessions?)` scopes to the key's `allowedSessions` (threaded via `@CurrentApiKey()`); a null/empty allowlist (e.g. ADMIN) still lists all — matching the guard model. Bare-array response shape unchanged.

**Deliberately not changed:** the guard's scope derivation. Session detail/start/stop/qr routes use `:id`, so `params['id']` is load-bearing for *their* `allowedSessions` enforcement — narrowing it to `params['sessionId']` (as one might assume) would let a scoped key reach any session by id. The `/plugins/:id` over-match it causes is a fail-closed false-positive (a confusing 401), not a hole, and is better addressed where `:id` routes are disambiguated.

> Scope note: the aggregate stats/audit read routes are addressed separately via role-gating (they should be ADMIN-only, which sees all by design); this PR closes the session-enumeration leak that role-gating can't fix (OPERATOR legitimately needs to list its sessions).

## Tests (TDD)

`session.service.spec` — `findAll(['a','b'])` scopes with `In([...])`; `findAll(null)`/`findAll([])` list all (unrestricted).

## Verification

- `nest build` ✅ · ESLint ✅ · session suite **61/61** ✅ · full suite green except the unrelated pre-existing baileys C1 flake (passes in isolation).