### PR TITLE
fix(security): refuse the dev API key in production

### DIFF
--- a/src/config/bootstrap-security.spec.ts
+++ b/src/config/bootstrap-security.spec.ts
@@ -111,6 +111,22 @@ describe('assertNoDefaultSecretsInProduction', () => {
     );
   });
 
+  it('refuses prod when ALLOW_DEV_API_KEY=true (it seeds the public dev-admin-key as ADMIN)', () => {
+    expect(() => assertNoDefaultSecretsInProduction({ nodeEnv: 'production', allowDevApiKey: 'true' })).toThrow(
+      /ALLOW_DEV_API_KEY/,
+    );
+  });
+
+  it('refuses prod with API_MASTER_KEY set to the well-known dev-admin-key', () => {
+    expect(() => assertNoDefaultSecretsInProduction({ nodeEnv: 'production', apiMasterKey: 'dev-admin-key' })).toThrow(
+      /API_MASTER_KEY/,
+    );
+  });
+
+  it('allows ALLOW_DEV_API_KEY=true outside production (the dev opt-in still works)', () => {
+    expect(() => assertNoDefaultSecretsInProduction({ nodeEnv: 'development', allowDevApiKey: 'true' })).not.toThrow();
+  });
+
   it('allows the default sqlite + local-storage prod setup (no secrets needed)', () => {
     expect(() =>
       assertNoDefaultSecretsInProduction({ nodeEnv: 'production', databaseType: 'sqlite', storageType: 'local' }),

--- a/src/config/bootstrap-security.ts
+++ b/src/config/bootstrap-security.ts
@@ -50,6 +50,7 @@ const FORBIDDEN_PROD_SECRETS = new Set([
   'minioadmin',
   'your-secure-password',
   'dev-master-key',
+  'dev-admin-key',
   'changeme',
   'change-me',
   'password',
@@ -65,6 +66,8 @@ export interface SecretCheckEnv {
   s3AccessKey?: string;
   s3SecretKey?: string;
   apiMasterKey?: string;
+  /** ALLOW_DEV_API_KEY — when 'true' it seeds the well-known public `dev-admin-key` as an ADMIN credential. */
+  allowDevApiKey?: string;
 }
 
 /**
@@ -89,6 +92,11 @@ export function assertNoDefaultSecretsInProduction(env: SecretCheckEnv): void {
   // API_MASTER_KEY is optional, but if provided it must not be a known default.
   if (env.apiMasterKey && FORBIDDEN_PROD_SECRETS.has(env.apiMasterKey.trim().toLowerCase())) {
     problems.push('API_MASTER_KEY');
+  }
+  // ALLOW_DEV_API_KEY=true seeds the publicly-documented `dev-admin-key` as an ADMIN credential
+  // (when no API_MASTER_KEY is set) — never allow that opt-in to be carried into production.
+  if (env.allowDevApiKey === 'true') {
+    problems.push('ALLOW_DEV_API_KEY (seeds the public dev-admin-key)');
   }
 
   if (problems.length > 0) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -99,6 +99,7 @@ async function bootstrap() {
     s3AccessKey: process.env.S3_ACCESS_KEY,
     s3SecretKey: process.env.S3_SECRET_KEY,
     apiMasterKey: process.env.API_MASTER_KEY,
+    allowDevApiKey: process.env.ALLOW_DEV_API_KEY,
   });
 
   // Disable Nest's default body parser so we can set an explicit size cap below.


### PR DESCRIPTION
## Summary

Closes a fail-fast gap: a deployment could boot in **production** with the publicly-known `dev-admin-key` as an ADMIN credential.

## Root cause

`resolveSeedApiKey()` returns the literal `'dev-admin-key'` whenever `ALLOW_DEV_API_KEY=true` and `API_MASTER_KEY` is unset — regardless of `NODE_ENV`. On first boot that key is seeded as ADMIN and written to `data/.api-key`. The production secret guard (`assertNoDefaultSecretsInProduction`) checked `DATABASE_PASSWORD`/`S3_*`/`API_MASTER_KEY` but **never inspected `ALLOW_DEV_API_KEY`**, and `'dev-admin-key'` wasn't in the forbidden-secrets set — so the entire purpose of the fail-fast (refuse known-default credentials in prod) was bypassed for this one.

## Fix

- `assertNoDefaultSecretsInProduction` now refuses to start in production when `ALLOW_DEV_API_KEY=true`.
- `'dev-admin-key'` added to `FORBIDDEN_PROD_SECRETS` (defense-in-depth: also rejects `API_MASTER_KEY=dev-admin-key`).
- `main.ts` threads `ALLOW_DEV_API_KEY` into the guard.

Development is unchanged — the guard is a no-op outside production, so the dev opt-in still works locally. The only new behavior is a fail-closed boot when the dev flag is (mis)configured in prod.

## Tests (TDD)

`bootstrap-security.spec` — prod + `ALLOW_DEV_API_KEY=true` throws; prod + `API_MASTER_KEY=dev-admin-key` throws; `development` + `ALLOW_DEV_API_KEY=true` does not throw.

## Verification

- `nest build` ✅ · ESLint ✅ · guard spec **20/20** ✅ · full suite **681/681** ✅