### PR TITLE
fix(engine): cap inbound media size to prevent heap/DB/payload blow-up

### DIFF
--- a/src/engine/adapters/baileys.adapter.ts
+++ b/src/engine/adapters/baileys.adapter.ts
@@ -39,6 +39,7 @@ import { EngineNotSupportedError } from '../../common/errors/engine-not-supporte
 import { createLogger } from '../../common/services/logger.service';
 import { BaileysAdapterConfig, BaileysLogger } from '../types/baileys.types';
 import { BaileysSessionStore } from './baileys-session-store';
+import { capInboundMedia } from './inbound-media-cap';
 
 /** Linked-device identity shown in WhatsApp (Settings → Linked Devices). */
 const BAILEYS_BROWSER: [string, string, string] = ['OpenWA', 'Chrome', '120.0.0'];
@@ -796,7 +797,20 @@ export class BaileysAdapter implements IWhatsAppEngine {
           normalizedContent.stickerMessage;
         const mimetype = subMessage?.mimetype ?? '';
         const filename = normalizedContent.documentMessage?.fileName ?? undefined;
-        media = { mimetype, data: buf.toString('base64'), filename };
+        // Cap inbound media (lazy base64) so an oversized blob from an untrusted sender is never
+        // encoded/persisted/webhooked/broadcast — preventing heap blow-up. Envelope is kept.
+        media = capInboundMedia({
+          mimetype,
+          filename,
+          sizeBytes: buf.byteLength,
+          toBase64: () => buf.toString('base64'),
+        });
+        if (media.omitted) {
+          this.logger.warn('Inbound media exceeds MEDIA_DOWNLOAD_MAX_BYTES; dropped payload, kept envelope', {
+            msgId: msg.key.id,
+            sizeBytes: media.sizeBytes,
+          });
+        }
       } catch (err) {
         this.logger.debug('Failed to download inbound media; emitting message without media', {
           error: err instanceof Error ? err.message : String(err),

--- a/src/engine/adapters/inbound-media-cap.spec.ts
+++ b/src/engine/adapters/inbound-media-cap.spec.ts
@@ -1,0 +1,62 @@
+import { capInboundMedia, inboundMediaMaxBytes } from './inbound-media-cap';
+
+describe('inbound media cap (F-08)', () => {
+  const ENV = 'MEDIA_DOWNLOAD_MAX_BYTES';
+  const orig = process.env[ENV];
+  afterEach(() => {
+    if (orig === undefined) delete process.env[ENV];
+    else process.env[ENV] = orig;
+  });
+
+  describe('inboundMediaMaxBytes', () => {
+    it('defaults to 50 MiB', () => {
+      delete process.env[ENV];
+      expect(inboundMediaMaxBytes()).toBe(50 * 1024 * 1024);
+    });
+    it('honors a positive override', () => {
+      process.env[ENV] = '1024';
+      expect(inboundMediaMaxBytes()).toBe(1024);
+    });
+    it('falls back to the default for a non-positive/garbage override', () => {
+      process.env[ENV] = '0';
+      expect(inboundMediaMaxBytes()).toBe(50 * 1024 * 1024);
+      process.env[ENV] = 'abc';
+      expect(inboundMediaMaxBytes()).toBe(50 * 1024 * 1024);
+    });
+  });
+
+  describe('capInboundMedia', () => {
+    it('keeps media within the cap, encoding base64 exactly once', () => {
+      const toBase64 = jest.fn(() => 'BASE64DATA');
+      const res = capInboundMedia({
+        mimetype: 'image/png',
+        filename: 'p.png',
+        sizeBytes: 1000,
+        toBase64,
+        maxBytes: 5000,
+      });
+      expect(res).toEqual({ mimetype: 'image/png', filename: 'p.png', data: 'BASE64DATA' });
+      expect(toBase64).toHaveBeenCalledTimes(1);
+    });
+
+    it('drops over-cap media WITHOUT encoding it — marker only, no base64 (the RAM fix)', () => {
+      const toBase64 = jest.fn(() => 'SHOULD-NOT-BE-CALLED');
+      const res = capInboundMedia({
+        mimetype: 'video/mp4',
+        filename: 'v.mp4',
+        sizeBytes: 99_999,
+        toBase64,
+        maxBytes: 5000,
+      });
+      expect(res).toEqual({ mimetype: 'video/mp4', filename: 'v.mp4', omitted: true, sizeBytes: 99_999 });
+      expect(res.data).toBeUndefined();
+      expect(toBase64).not.toHaveBeenCalled();
+    });
+
+    it('treats exactly-at-the-cap as within the limit', () => {
+      const res = capInboundMedia({ mimetype: 'image/jpeg', sizeBytes: 5000, toBase64: () => 'D', maxBytes: 5000 });
+      expect(res.data).toBe('D');
+      expect(res.omitted).toBeUndefined();
+    });
+  });
+});

--- a/src/engine/adapters/inbound-media-cap.ts
+++ b/src/engine/adapters/inbound-media-cap.ts
@@ -1,0 +1,35 @@
+import type { IncomingMessage } from '../interfaces/whatsapp-engine.interface';
+
+/** Default inbound media cap: 50 MiB. Shares MEDIA_DOWNLOAD_MAX_BYTES with the outbound download cap. */
+const DEFAULT_INBOUND_MEDIA_MAX_BYTES = 50 * 1024 * 1024;
+
+/** Resolved inbound media byte cap; a non-positive/garbage override falls back to the default. */
+export function inboundMediaMaxBytes(): number {
+  const parsed = Number.parseInt(process.env.MEDIA_DOWNLOAD_MAX_BYTES ?? '', 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : DEFAULT_INBOUND_MEDIA_MAX_BYTES;
+}
+
+type InboundMedia = NonNullable<IncomingMessage['media']>;
+
+/**
+ * Cap inbound media from an untrusted sender. Within the limit, keep it (base64 encoded via
+ * `toBase64`). Over the limit, drop the blob and return a marker `{ mimetype, filename?, omitted,
+ * sizeBytes }` so the `media` field stays present (n8n/dashboard contract) while the multi-MB
+ * base64 is never encoded, persisted, webhooked, or broadcast.
+ *
+ * `toBase64` is a lazy callback so an over-cap payload is never base64-encoded — that +33% heap
+ * copy is exactly the OOM vector this guards against.
+ */
+export function capInboundMedia(args: {
+  mimetype: string;
+  filename?: string;
+  sizeBytes: number;
+  toBase64: () => string;
+  maxBytes?: number;
+}): InboundMedia {
+  const max = args.maxBytes ?? inboundMediaMaxBytes();
+  if (args.sizeBytes > max) {
+    return { mimetype: args.mimetype, filename: args.filename, omitted: true, sizeBytes: args.sizeBytes };
+  }
+  return { mimetype: args.mimetype, filename: args.filename, data: args.toBase64() };
+}

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -44,6 +44,7 @@ import {
   GroupCreateResult,
 } from '../types/whatsapp-web-js.types';
 import { buildIncomingMessageBase } from './message-mapper';
+import { capInboundMedia } from './inbound-media-cap';
 
 /** Default cap on a server-side media download: 50 MiB (overridable via MEDIA_DOWNLOAD_MAX_BYTES). */
 const DEFAULT_MEDIA_MAX_BYTES = 50 * 1024 * 1024;
@@ -285,11 +286,19 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
           try {
             const media = await msg.downloadMedia();
             if (media) {
-              incomingMessage.media = {
+              // Cap inbound media so an oversized blob isn't persisted/webhooked/broadcast.
+              incomingMessage.media = capInboundMedia({
                 mimetype: media.mimetype,
                 filename: media.filename || undefined,
-                data: media.data,
-              };
+                sizeBytes: Buffer.byteLength(media.data, 'base64'),
+                toBase64: () => media.data,
+              });
+              if (incomingMessage.media.omitted) {
+                this.logger.warn('Inbound media exceeds MEDIA_DOWNLOAD_MAX_BYTES; dropped payload, kept envelope', {
+                  msgId: msg.id._serialized,
+                  sizeBytes: incomingMessage.media.sizeBytes,
+                });
+              }
             }
           } catch (error) {
             this.logger.error('Error downloading media', String(error));
@@ -1015,11 +1024,13 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
         try {
           const media = await msg.downloadMedia();
           if (media) {
-            out.media = {
+            // Cap history media too: a large historical blob shouldn't bloat the response/heap.
+            out.media = capInboundMedia({
               mimetype: media.mimetype,
               filename: media.filename || undefined,
-              data: media.data,
-            };
+              sizeBytes: Buffer.byteLength(media.data, 'base64'),
+              toBase64: () => media.data,
+            });
           }
         } catch (error) {
           this.logger.warn(`Failed to download media for ${msg.id._serialized}: ${String(error)}`);

--- a/src/engine/interfaces/whatsapp-engine.interface.ts
+++ b/src/engine/interfaces/whatsapp-engine.interface.ts
@@ -79,7 +79,11 @@ export interface IncomingMessage {
   media?: {
     mimetype: string;
     filename?: string;
-    data?: string; // base64
+    data?: string; // base64; absent when the payload was omitted (see `omitted`)
+    /** True when the media exceeded the inbound size cap and the blob was dropped (envelope kept). */
+    omitted?: boolean;
+    /** Decoded byte size of the media; always set when `omitted` is true. */
+    sizeBytes?: number;
   };
   quotedMessage?: {
     id: string;


### PR DESCRIPTION
## Summary

Bounds inbound WhatsApp media so an untrusted sender can't OOM the process or bloat the DB. Previously there was **no cap** on the inbound path.

## Root cause

On both engines, inbound media is downloaded and base64-encoded into RAM with no size check, then `metadata.media` is persisted to `messages.metadata`, serialized into the `message.received` webhook body, and broadcast over WS:

- Baileys: `downloadMediaMessage(...) → buf.toString('base64')` (no check)
- wwebjs: `msg.downloadMedia() → media.data` (no check), incl. `getChatHistory`

The Express 25 MB body cap doesn't apply (this arrives on the engine socket, not HTTP), and the existing `MEDIA_DOWNLOAD_MAX_BYTES` only bounds the **outbound** URL-send path. A single large document/video (or a burst from many senders) holds buffer + base64 (~2.3×) on the heap, plus a copy in the DB row, the webhook JSON, and the WS frame — heap blow-up kills the single Node process (and every session).

## Fix

New pure `capInboundMedia` mirrors `MEDIA_DOWNLOAD_MAX_BYTES` (50 MiB default):

- **within cap:** keep media, base64-encode (lazily).
- **over cap:** drop the blob, return `{ mimetype, filename?, omitted: true, sizeBytes }`.

`toBase64` is a **lazy callback**, so an over-cap payload is never base64-encoded — that +33% heap copy is precisely the OOM vector. The `media` field stays present (n8n/dashboard contract preserved; `IncomingMessage.media` gains optional `omitted`/`sizeBytes`), under-cap media keeps its exact prior shape, and `capInboundMedia` never throws (safe for the `void` onMessage path). Wired into both engines' inbound message paths and the wwebjs `getChatHistory` media path, each logging a `warn` when it drops.

Follow-up (not this PR): persist a StorageService key reference instead of raw base64 in `messages.metadata`.

## Tests (TDD)

`inbound-media-cap.spec` — within-cap keeps data (encodes once); over-cap returns the marker and **never calls `toBase64`**; boundary (== cap) kept; env override + default + garbage-fallback.

## Verification

- `nest build` ✅ · ESLint ✅ · helper spec **6/6** ✅ · full suite **684/684** ✅