### PR TITLE
fix(plugins): redact secret-flagged config on read, restore on write

### DIFF
--- a/src/modules/plugins/plugins.service.ts
+++ b/src/modules/plugins/plugins.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { PluginLoaderService, PluginStatus } from '../../core/plugins';
 import { PluginDto } from './dto/plugin.dto';
+import { redactSecretConfig, restoreSecretConfig } from './redact-config';
 
 @Injectable()
 export class PluginsService {
@@ -17,7 +18,7 @@ export class PluginsService {
       description: plugin.manifest.description,
       author: plugin.manifest.author,
       status: plugin.status,
-      config: plugin.config,
+      config: redactSecretConfig(plugin.config, plugin.manifest.configSchema),
       builtIn: plugin.manifest.id === 'whatsapp-web.js', // Built-in engines
       provides: plugin.manifest.provides ?? [],
       configSchema: plugin.manifest.configSchema,
@@ -42,7 +43,7 @@ export class PluginsService {
       description: plugin.manifest.description,
       author: plugin.manifest.author,
       status: plugin.status,
-      config: plugin.config,
+      config: redactSecretConfig(plugin.config, plugin.manifest.configSchema),
       builtIn: plugin.manifest.id === 'whatsapp-web.js',
       provides: plugin.manifest.provides ?? [],
       configSchema: plugin.manifest.configSchema,
@@ -104,7 +105,10 @@ export class PluginsService {
     }
 
     try {
-      this.pluginLoader.updatePluginConfig(id, config);
+      // The dashboard PUTs the whole (redacted) config back, so a sentinel secret means "unchanged":
+      // restore the stored value instead of overwriting the real secret with the mask.
+      const merged = restoreSecretConfig(config, plugin.config, plugin.manifest.configSchema);
+      this.pluginLoader.updatePluginConfig(id, merged);
       return { success: true, message: `Plugin ${id} configuration updated` };
     } catch (error) {
       return {

--- a/src/modules/plugins/redact-config.spec.ts
+++ b/src/modules/plugins/redact-config.spec.ts
@@ -1,0 +1,58 @@
+import { SECRET_SENTINEL, redactSecretConfig, restoreSecretConfig } from './redact-config';
+import type { PluginConfigSchema } from '../../core/plugins/plugin.interfaces';
+
+// F-13 — plugin config (incl. fields a plugin marks `secret`, e.g. an API key) was returned
+// verbatim by the GET routes, readable by any key. Redact on read; restore on write so the
+// dashboard PUTting the masked value back doesn't overwrite the real secret.
+const schema: PluginConfigSchema = {
+  type: 'object',
+  properties: {
+    apiKey: { type: 'string', secret: true },
+    endpoint: { type: 'string' },
+  },
+};
+
+describe('redactSecretConfig (F-13)', () => {
+  it('masks secret-flagged non-empty values, leaves non-secret fields intact', () => {
+    expect(redactSecretConfig({ apiKey: 's3cr3t', endpoint: 'https://x' }, schema)).toEqual({
+      apiKey: SECRET_SENTINEL,
+      endpoint: 'https://x',
+    });
+  });
+
+  it('does not mask an empty/absent secret (so "***" never implies a secret that is not set)', () => {
+    expect(redactSecretConfig({ apiKey: '', endpoint: 'https://x' }, schema)).toEqual({
+      apiKey: '',
+      endpoint: 'https://x',
+    });
+    expect(redactSecretConfig({ endpoint: 'https://x' }, schema)).toEqual({ endpoint: 'https://x' });
+  });
+
+  it('returns a copy unchanged when there is no schema', () => {
+    const cfg = { apiKey: 's3cr3t' };
+    const out = redactSecretConfig(cfg, undefined);
+    expect(out).toEqual(cfg);
+    expect(out).not.toBe(cfg); // copy, not the same ref
+  });
+});
+
+describe('restoreSecretConfig (F-13)', () => {
+  it('keeps the existing stored secret when the incoming value is the sentinel (unchanged round-trip)', () => {
+    const merged = restoreSecretConfig(
+      { apiKey: SECRET_SENTINEL, endpoint: 'https://new' },
+      { apiKey: 'real-secret' },
+      schema,
+    );
+    expect(merged).toEqual({ apiKey: 'real-secret', endpoint: 'https://new' });
+  });
+
+  it('stores a genuinely new secret value', () => {
+    const merged = restoreSecretConfig({ apiKey: 'brand-new' }, { apiKey: 'real-secret' }, schema);
+    expect(merged.apiKey).toBe('brand-new');
+  });
+
+  it('drops a sentinel/empty secret when there is nothing stored to keep', () => {
+    expect(restoreSecretConfig({ apiKey: SECRET_SENTINEL }, {}, schema)).not.toHaveProperty('apiKey');
+    expect(restoreSecretConfig({ apiKey: '' }, undefined, schema)).not.toHaveProperty('apiKey');
+  });
+});

--- a/src/modules/plugins/redact-config.ts
+++ b/src/modules/plugins/redact-config.ts
@@ -1,0 +1,54 @@
+import type { PluginConfigSchema } from '../../core/plugins/plugin.interfaces';
+
+/** Mask shown for a stored secret on read. Treated as "unchanged" on write. */
+export const SECRET_SENTINEL = '***';
+
+function secretKeys(schema?: PluginConfigSchema): string[] {
+  if (!schema?.properties) return [];
+  return Object.entries(schema.properties)
+    .filter(([, prop]) => prop?.secret)
+    .map(([key]) => key);
+}
+
+const isMeaningful = (v: unknown): boolean => v !== undefined && v !== null && v !== '';
+
+/**
+ * Replace secret-flagged, non-empty config values with {@link SECRET_SENTINEL} so a read (GET
+ * /plugins) never leaks them. An empty/absent secret is left as-is so the mask never implies a
+ * secret that isn't set. Returns a copy; non-secret fields and shape are untouched (bare payload).
+ */
+export function redactSecretConfig(
+  config: Record<string, unknown> | undefined,
+  schema?: PluginConfigSchema,
+): Record<string, unknown> {
+  const out = { ...(config ?? {}) };
+  for (const key of secretKeys(schema)) {
+    if (isMeaningful(out[key])) out[key] = SECRET_SENTINEL;
+  }
+  return out;
+}
+
+/**
+ * On write (PUT /plugins/:id/config), the dashboard sends the whole config back — including the
+ * masked secret. Treat a sentinel/empty secret as "keep existing": restore the stored value, or
+ * drop the key when there's nothing stored, so the real secret is never overwritten by the mask.
+ * A genuinely-new secret value is stored as provided.
+ */
+export function restoreSecretConfig(
+  incoming: Record<string, unknown>,
+  existing: Record<string, unknown> | undefined,
+  schema?: PluginConfigSchema,
+): Record<string, unknown> {
+  const out = { ...incoming };
+  for (const key of secretKeys(schema)) {
+    const v = out[key];
+    if (v === SECRET_SENTINEL || !isMeaningful(v)) {
+      if (existing && isMeaningful(existing[key])) {
+        out[key] = existing[key];
+      } else {
+        delete out[key];
+      }
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

`GET /plugins` and `/plugins/:id` leaked plugin secrets (e.g. an API key) to any key. This redacts them server-side.

## Root cause

The GET routes carry no `@RequireRole`, so any active key (including a read-only VIEWER) passes the guard, and `PluginsService.findAll/findOne` returned `config: plugin.config` **verbatim** — including any field a plugin marks `secret` in its `configSchema`. There was no server-side masking (the `secret` flag was only consumed by the dashboard for input masking).

## Fix

- **Read:** `redactSecretConfig` replaces secret-flagged, *non-empty* values with a sentinel (`***`), keeping the bare-payload shape and keys (so the dashboard/n8n don't break). An empty/absent secret is left as-is, so the mask never implies a secret that isn't set.
- **Write:** the dashboard PUTs the whole config back, so `updateConfig` uses `restoreSecretConfig` to treat a sentinel/empty secret as "keep existing" — the real stored value is restored rather than overwritten by the mask; a genuinely-new value is stored as provided.

Logic lives in a pure, unit-tested helper. Response shape is unchanged (redaction masks values only). Role-gating the GET routes was rejected as the fix because the dashboard Plugins page authenticates with the logged-in key (which may be non-ADMIN) and would 403.

## Tests (TDD)

`redact-config.spec` — redact masks secrets / leaves non-secret + empty / copies when no schema; restore keeps existing on sentinel, stores new values, drops sentinel-with-nothing-to-keep.

## Verification

- `nest build` ✅ · ESLint ✅ · helper spec **6/6** ✅ · full suite **684/684** ✅