### PR TITLE
fix(security): pin outbound webhook and media fetches to the SSRF-validated IP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Outbound webhook and media fetches are pinned to the SSRF-validated IP.** The host safety check
+  and the actual connection previously resolved DNS independently, leaving a narrow window in which a
+  hostile low-TTL DNS answer could pass validation as a public address and then have the connection
+  re-resolve to an internal one (DNS rebinding). The connection now reuses the exact address vetted by
+  the guard — preserving the original hostname for TLS SNI and the `Host` header, and offering all
+  vetted addresses so A-record failover still works — closing the window across webhook delivery
+  (direct, queued, and test) and server-side media downloads.
+
 ## [0.4.2] - 2026-06-19
 
 Bug-fix and hardening release: access-control tightening, session-lifecycle resilience, data-migration

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openwa",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openwa",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -41,6 +41,7 @@
         "sqlite3": "^5.1.7",
         "tar-stream": "^3.2.0",
         "typeorm": "^0.3.29",
+        "undici": "^6.27.0",
         "uuid": "^14.0.0",
         "whatsapp-web.js": "^1.34.7"
       },
@@ -761,6 +762,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1266,6 +1268,7 @@
       "resolved": "https://registry.npmjs.org/@bull-board/api/-/api-8.0.0.tgz",
       "integrity": "sha512-GYXJNJclgm9H5Tt/tmuNWfjyF2BuygMwl8xrRIfxxOTgcK4SB8zNUPveTcHGAOoKKtPDVotHNZCBRrFCcOAXMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "redis-info": "^3.1.0"
       },
@@ -1304,6 +1307,7 @@
       "resolved": "https://registry.npmjs.org/@bull-board/ui/-/ui-8.0.0.tgz",
       "integrity": "sha512-X/F256CmpBj9oj+fK2wOzjygkhTtjgWnc3f/SxPiUs3rQFvgYCplJLEaURh13J+Tpq46/1drAxq4Ukt4e5LelA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bull-board/api": "8.0.0"
       }
@@ -1672,6 +1676,7 @@
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
       "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -1703,6 +1708,7 @@
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
       "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
@@ -3491,6 +3497,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/bull-shared/-/bull-shared-11.0.4.tgz",
       "integrity": "sha512-VBJcDHSAzxQnpcDfA0kt9MTGUD1XZzfByV70su0W0eDCQ9aqIEBlzWRW21tv9FG9dIut22ysgDidshdjlnczLw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "2.8.1"
       },
@@ -3645,6 +3652,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.27.tgz",
       "integrity": "sha512-kEGSzqM2lWr4whh4Ubflw+oPZSEzxvRMu9WL+LveZploJWTjec5bBlCiRVlVzTPg2kIwBiLwWSvCCW7Wnin1gg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "21.3.4",
         "iterare": "1.2.1",
@@ -3691,6 +3699,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.27.tgz",
       "integrity": "sha512-K6DX7hcqmZdeXkv7tsPakKBRCgqL19a4mtbX4FluY0hWtFdtPKp6lbe+lb8gWPfvLdbOWr/CPScn7BSjBX+Ecg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-safe-stringify": "2.1.1",
         "iterare": "1.2.1",
@@ -3750,6 +3759,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.27.tgz",
       "integrity": "sha512-0ZFhz6H6EdGh4xQVbUNwjoAwBuz73P7FvUAl67h9CTdMqQlJDaQYJApBv8pKfVZ1fGjMCbl0m9DcC6pXaZPWSQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -3771,6 +3781,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-11.1.27.tgz",
       "integrity": "sha512-xgpLzaIDGOCC6xOAtHnRAz8sqieFgGxxu3MN5ID026Jt6oeL3efp29N5QHhPr7UlqBfy/Jd02uj0POkZq6Au3Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "socket.io": "4.8.3",
         "tslib": "2.8.1"
@@ -3983,6 +3994,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-11.0.1.tgz",
       "integrity": "sha512-8rw/nKT0S+L+MkzgE9F2/mox7mAgsPlwfzmW9gsESN1lmQtIrVEfiiBwC2O8+guS1jBfQehJIdcdUj2OAp4VUQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "@nestjs/core": "^10.0.0 || ^11.0.0",
@@ -4563,6 +4575,7 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -4682,6 +4695,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
       "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -4907,6 +4921,7 @@
       "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.0",
         "@typescript-eslint/types": "8.61.0",
@@ -5658,6 +5673,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5746,6 +5762,7 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6343,6 +6360,7 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -6645,6 +6663,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6735,6 +6754,7 @@
       "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-5.78.1.tgz",
       "integrity": "sha512-zD5IT+qMqbMgPFPdL9FwnZka1bz6nckM+5lXj4N0vsXqdzoVO6wizmXpwsg/4GnHmXJsL7XOKeWA64tYUdPrOA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cron-parser": "4.9.0",
         "ioredis": "5.10.1",
@@ -7052,6 +7072,7 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -7121,13 +7142,15 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/class-validator": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
       "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -7980,7 +8003,8 @@
       "version": "0.0.1581282",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
       "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -8478,6 +8502,7 @@
       "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -8537,6 +8562,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -10048,6 +10074,7 @@
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.1.tgz",
       "integrity": "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.10.0",
         "cluster-key-slot": "1.1.1",
@@ -10330,6 +10357,7 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -12321,7 +12349,6 @@
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -12710,6 +12737,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
       "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.13.0",
         "pg-pool": "^3.14.0",
@@ -13039,6 +13067,7 @@
       "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -13754,7 +13783,8 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -13904,6 +13934,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -14504,6 +14535,7 @@
       "integrity": "sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "node-addon-api": "^7.0.0",
@@ -15029,6 +15061,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -15397,6 +15430,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -15581,6 +15615,7 @@
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.30.tgz",
       "integrity": "sha512-8T35PzjefOdqc2ZR9mwLQj0pUGp6lQhMbK2EvVMwJVJWlaoHm0v/Q6dThNOZkFchD+0yMg8gwjKM28ePiLSXSQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.2.0",
@@ -15800,6 +15835,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15868,6 +15904,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {
@@ -16131,6 +16176,7 @@
       "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -16199,6 +16245,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "sqlite3": "^5.1.7",
     "tar-stream": "^3.2.0",
     "typeorm": "^0.3.29",
+    "undici": "^6.27.0",
     "uuid": "^14.0.0",
     "whatsapp-web.js": "^1.34.7"
   },

--- a/src/common/media/load-remote-media.spec.ts
+++ b/src/common/media/load-remote-media.spec.ts
@@ -1,10 +1,16 @@
+import { fetch as undiciFetch } from 'undici';
 import { loadRemoteMediaBuffer } from './load-remote-media';
 import { SsrfBlockedError } from '../security/ssrf-guard';
 
+// Media download goes through undici's fetch (via the SSRF-pinning helper); mock it, not global fetch.
+jest.mock('undici', () => {
+  const actual = jest.requireActual<typeof import('undici')>('undici');
+  return { __esModule: true, ...actual, fetch: jest.fn() };
+});
+
 describe('loadRemoteMediaBuffer', () => {
-  const realFetch = global.fetch;
   afterEach(() => {
-    global.fetch = realFetch;
+    (undiciFetch as jest.Mock).mockReset();
     delete process.env.MEDIA_DOWNLOAD_MAX_BYTES;
   });
 
@@ -28,28 +34,24 @@ describe('loadRemoteMediaBuffer', () => {
   });
 
   it('blocks an internal URL via the SSRF guard before any fetch', async () => {
-    const fetchMock = jest.fn();
-    global.fetch = fetchMock as typeof fetch;
+    const fetchMock = undiciFetch as jest.Mock;
     await expect(loadRemoteMediaBuffer('http://127.0.0.1/x.png')).rejects.toBeInstanceOf(SsrfBlockedError);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('fetches a public URL and returns the bytes + content-type', async () => {
-    const fetchMock = jest
-      .fn()
-      .mockResolvedValue(fakeResponse([1, 2, 3], { 'content-type': 'image/png', 'content-length': '3' }));
-    global.fetch = fetchMock as typeof fetch;
+    const fetchMock = undiciFetch as jest.Mock;
+    fetchMock.mockResolvedValue(fakeResponse([1, 2, 3], { 'content-type': 'image/png', 'content-length': '3' }));
     const res = await loadRemoteMediaBuffer('http://8.8.8.8/x.png');
     expect(res.mimetype).toBe('image/png');
     expect(Array.from(res.data)).toEqual([1, 2, 3]);
     // Never follow redirects (a 3xx could reach an internal host the guard never validated).
-    expect(fetchMock).toHaveBeenCalledWith('http://8.8.8.8/x.png', expect.objectContaining({ redirect: 'error' }));
+    expect(fetchMock).toHaveBeenCalledWith('http://8.8.8.8/x.png', expect.objectContaining({ redirect: 'manual' }));
   });
 
   it('rejects a body that exceeds the byte cap', async () => {
     process.env.MEDIA_DOWNLOAD_MAX_BYTES = '2';
-    const fetchMock = jest.fn().mockResolvedValue(fakeResponse([1, 2, 3], { 'content-type': 'image/png' }));
-    global.fetch = fetchMock as typeof fetch;
+    (undiciFetch as jest.Mock).mockResolvedValue(fakeResponse([1, 2, 3], { 'content-type': 'image/png' }));
     await expect(loadRemoteMediaBuffer('http://8.8.8.8/x.png')).rejects.toThrow(/exceeds/i);
   });
 });

--- a/src/common/media/load-remote-media.ts
+++ b/src/common/media/load-remote-media.ts
@@ -1,4 +1,4 @@
-import { assertSafeFetchUrl } from '../security/ssrf-guard';
+import { withSafeFetch } from '../security/ssrf-guard';
 
 /** Default cap on a server-side media download: 50 MiB (overridable via MEDIA_DOWNLOAD_MAX_BYTES). */
 const DEFAULT_MEDIA_MAX_BYTES = 50 * 1024 * 1024;
@@ -13,48 +13,51 @@ function positiveIntFromEnv(name: string, fallback: number): number {
 /**
  * Fetch remote media as a Buffer for sending, with an SSRF host guard, a byte cap, and a timeout.
  * The guard runs BEFORE any network call, so an internal/reserved URL throws `SsrfBlockedError`
- * and no outbound socket is opened. `redirect: 'error'` is used because the guard only validated
- * the original host — a followed 3xx could reach an internal target. The cap is enforced while
- * streaming (Content-Length may be absent or wrong) to bound memory use.
+ * and no outbound socket is opened. It goes through `withSafeFetch`, which pins the connection to
+ * the vetted IP and refuses redirects (the guard only validated the original host — a followed 3xx
+ * could reach an internal target). The cap is enforced while streaming (Content-Length may be absent
+ * or wrong) to bound memory use.
  *
  * Engine-neutral: returns raw bytes + the response content-type, so any engine adapter can use it.
  */
 export async function loadRemoteMediaBuffer(url: string): Promise<{ data: Buffer; mimetype: string }> {
-  await assertSafeFetchUrl(url);
-
   const maxBytes = positiveIntFromEnv('MEDIA_DOWNLOAD_MAX_BYTES', DEFAULT_MEDIA_MAX_BYTES);
   const timeoutMs = positiveIntFromEnv('MEDIA_DOWNLOAD_TIMEOUT_MS', DEFAULT_MEDIA_TIMEOUT_MS);
 
-  const response = await fetch(url, { redirect: 'error', signal: AbortSignal.timeout(timeoutMs) });
-  if (!response.ok) {
-    throw new Error(`Media fetch failed with status ${response.status}`);
-  }
-
-  const declaredLength = Number(response.headers.get('content-length') ?? '');
-  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
-    throw new Error(`Media exceeds the ${maxBytes}-byte limit`);
-  }
-
-  const reader = response.body?.getReader();
-  if (!reader) {
-    throw new Error('Media response has no body');
-  }
-
-  const chunks: Buffer[] = [];
-  let total = 0;
-  for (;;) {
-    const { done, value } = await reader.read();
-    if (done) {
-      break;
+  // Always guarded (media SSRF is independent of the webhook opt-out); withSafeFetch validates the
+  // host, pins the connection to the vetted IP, and refuses redirects. The streaming cap runs inside
+  // the callback so the connection stays open for the body read and is torn down right after.
+  return withSafeFetch(url, { signal: AbortSignal.timeout(timeoutMs) }, async response => {
+    if (!response.ok) {
+      throw new Error(`Media fetch failed with status ${response.status}`);
     }
-    total += value.byteLength;
-    if (total > maxBytes) {
-      await reader.cancel();
+
+    const declaredLength = Number(response.headers.get('content-length') ?? '');
+    if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
       throw new Error(`Media exceeds the ${maxBytes}-byte limit`);
     }
-    chunks.push(Buffer.from(value));
-  }
 
-  const mimetype = (response.headers.get('content-type') ?? '').split(';')[0].trim();
-  return { data: Buffer.concat(chunks), mimetype };
+    const reader = response.body?.getReader();
+    if (!reader) {
+      throw new Error('Media response has no body');
+    }
+
+    const chunks: Buffer[] = [];
+    let total = 0;
+    for (;;) {
+      const { done, value } = (await reader.read()) as { done: boolean; value: Uint8Array };
+      if (done) {
+        break;
+      }
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel();
+        throw new Error(`Media exceeds the ${maxBytes}-byte limit`);
+      }
+      chunks.push(Buffer.from(value));
+    }
+
+    const mimetype = (response.headers.get('content-type') ?? '').split(';')[0].trim();
+    return { data: Buffer.concat(chunks), mimetype };
+  });
 }

--- a/src/common/security/ssrf-guard.spec.ts
+++ b/src/common/security/ssrf-guard.spec.ts
@@ -4,7 +4,25 @@ import {
   assertNoRedirect,
   SsrfBlockedError,
   isSsrfProtectionEnabled,
+  resolveSafeFetchTarget,
+  pinnedLookup,
+  withSafeFetch,
 } from './ssrf-guard';
+import * as dnsPromises from 'dns/promises';
+import { fetch as undiciFetch } from 'undici';
+
+// Default to the real resolver (so the localhost/real-DNS cases below behave normally); individual
+// tests override a single call with mockResolvedValueOnce to simulate a specific resolution.
+jest.mock('dns/promises', () => {
+  const actual = jest.requireActual<typeof import('dns/promises')>('dns/promises');
+  return { __esModule: true, ...actual, lookup: jest.fn(actual.lookup) };
+});
+
+// Mock undici's fetch (keep the real Agent so withSafeFetch builds a real pinned dispatcher).
+jest.mock('undici', () => {
+  const actual = jest.requireActual<typeof import('undici')>('undici');
+  return { __esModule: true, ...actual, fetch: jest.fn() };
+});
 
 describe('isBlockedAddress', () => {
   it.each([
@@ -56,6 +74,7 @@ describe('assertSafeFetchUrl', () => {
   });
 
   it('rejects a hostname that resolves to loopback (localhost)', async () => {
+    (dnsPromises.lookup as jest.Mock).mockResolvedValueOnce([{ address: '127.0.0.1', family: 4 }]);
     await expect(assertSafeFetchUrl('http://localhost:9999/hook')).rejects.toThrow(SsrfBlockedError);
   });
 
@@ -112,6 +131,110 @@ describe('assertNoRedirect (redirect bypass)', () => {
 
   it('passes a normal 2xx response', () => {
     expect(() => assertNoRedirect({ status: 200, type: 'basic' }, 'http://ok.example')).not.toThrow();
+  });
+});
+
+describe('pinnedLookup (DNS-rebind defense)', () => {
+  it('returns the captured addresses and never re-resolves DNS (all: true)', () => {
+    const pinned = [{ address: '93.184.216.34', family: 4 }];
+    const callback = jest.fn();
+    pinnedLookup(pinned)('evil.example', { all: true }, callback);
+    expect(callback).toHaveBeenCalledWith(null, pinned);
+  });
+
+  it('returns the first captured address in single-result form (all: false)', () => {
+    const pinned = [
+      { address: '93.184.216.34', family: 4 },
+      { address: '93.184.216.35', family: 4 },
+    ];
+    const callback = jest.fn();
+    pinnedLookup(pinned)('evil.example', { all: false }, callback);
+    expect(callback).toHaveBeenCalledWith(null, '93.184.216.34', 4);
+  });
+});
+
+describe('resolveSafeFetchTarget', () => {
+  const orig = process.env.SSRF_ALLOWED_HOSTS;
+  afterEach(() => {
+    if (orig === undefined) delete process.env.SSRF_ALLOWED_HOSTS;
+    else process.env.SSRF_ALLOWED_HOSTS = orig;
+  });
+
+  it('returns null for a public literal IP (no hostname to rebind)', async () => {
+    await expect(resolveSafeFetchTarget('https://8.8.8.8/hook')).resolves.toBeNull();
+  });
+
+  it('returns null for an allowlisted host (trusted, no pin needed)', async () => {
+    process.env.SSRF_ALLOWED_HOSTS = 'minio';
+    await expect(resolveSafeFetchTarget('http://minio:9000/x.png')).resolves.toBeNull();
+  });
+
+  it('throws for a blocked literal address', async () => {
+    await expect(resolveSafeFetchTarget('http://127.0.0.1/x')).rejects.toThrow(SsrfBlockedError);
+  });
+
+  it('returns the resolved public addresses for a hostname (the IPs to pin to)', async () => {
+    (dnsPromises.lookup as jest.Mock).mockResolvedValueOnce([{ address: '93.184.216.34', family: 4 }]);
+    await expect(resolveSafeFetchTarget('https://example.com/hook')).resolves.toEqual([
+      { address: '93.184.216.34', family: 4 },
+    ]);
+  });
+
+  it('throws when a hostname resolves to a blocked address', async () => {
+    (dnsPromises.lookup as jest.Mock).mockResolvedValueOnce([{ address: '10.0.0.5', family: 4 }]);
+    await expect(resolveSafeFetchTarget('https://rebind.example/hook')).rejects.toThrow(SsrfBlockedError);
+  });
+});
+
+describe('withSafeFetch (guarded + pinned fetch)', () => {
+  afterEach(() => {
+    (undiciFetch as jest.Mock).mockReset();
+  });
+
+  it('rejects a blocked host before performing any fetch (fail-closed)', async () => {
+    const use = jest.fn();
+    await expect(withSafeFetch('http://127.0.0.1/hook', {}, use, { guard: true })).rejects.toThrow(SsrfBlockedError);
+    expect(use).not.toHaveBeenCalled();
+  });
+
+  it('pins the connection by passing a dispatcher to fetch for a hostname target', async () => {
+    // The security property: for a DNS hostname the connection MUST go through a pinned dispatcher,
+    // else fetch re-resolves DNS independently and the rebind window reopens. Removing the pin
+    // (dispatcher = undefined) makes this fail.
+    (dnsPromises.lookup as jest.Mock).mockResolvedValueOnce([{ address: '93.184.216.34', family: 4 }]);
+    (undiciFetch as jest.Mock).mockResolvedValue({ status: 200, type: 'basic' });
+    const use = jest.fn(() => 'used');
+
+    const result = await withSafeFetch('https://example.com/hook', { method: 'POST' }, use, { guard: true });
+
+    expect(result).toBe('used');
+    expect(use).toHaveBeenCalledTimes(1);
+    const [url, init] = (undiciFetch as jest.Mock).mock.calls[0] as [string, { redirect: string; dispatcher: unknown }];
+    expect(url).toBe('https://example.com/hook');
+    expect(init.redirect).toBe('manual');
+    expect(init.dispatcher).toBeDefined();
+  });
+
+  it('refuses a redirect on the pinned path (real undici manual-redirect shape: 302/basic)', async () => {
+    (dnsPromises.lookup as jest.Mock).mockResolvedValueOnce([{ address: '93.184.216.34', family: 4 }]);
+    (undiciFetch as jest.Mock).mockResolvedValue({ status: 302, type: 'basic' });
+
+    await expect(withSafeFetch('https://example.com/hook', {}, jest.fn(), { guard: true })).rejects.toThrow(
+      SsrfBlockedError,
+    );
+  });
+
+  it('skips validation and pinning entirely when guard is false (SSRF opt-out)', async () => {
+    (undiciFetch as jest.Mock).mockResolvedValue({ status: 200, type: 'basic' });
+    const use = jest.fn(() => 'ok');
+
+    // An internal host would normally be blocked — with guard:false it is delivered unpinned.
+    const result = await withSafeFetch('http://127.0.0.1/hook', {}, use, { guard: false });
+
+    expect(result).toBe('ok');
+    const [, init] = (undiciFetch as jest.Mock).mock.calls[0] as [string, { redirect: string; dispatcher: unknown }];
+    expect(init.redirect).toBe('follow');
+    expect(init.dispatcher).toBeUndefined();
   });
 });
 

--- a/src/common/security/ssrf-guard.ts
+++ b/src/common/security/ssrf-guard.ts
@@ -1,5 +1,7 @@
-import { isIPv4, isIPv6 } from 'net';
+import { isIPv4, isIPv6, type LookupFunction } from 'net';
 import { lookup } from 'dns/promises';
+import { type LookupAddress, type LookupOptions } from 'dns';
+import { Agent, fetch as undiciFetch, type RequestInit, type Response } from 'undici';
 
 /** Thrown when an outbound URL is blocked by the SSRF guard. */
 export class SsrfBlockedError extends Error {
@@ -119,12 +121,18 @@ export function assertNoRedirect(response: { status: number; type?: string }, ur
 }
 
 /**
- * Resolves an outbound URL and throws SsrfBlockedError if its scheme is not
- * http(s) or if the host (literal or any DNS-resolved address) is internal/reserved.
- * Guards both webhook delivery and server-side media fetches. Hosts named in
- * `SSRF_ALLOWED_HOSTS` are allowed through (escape-hatch for trusted internal targets).
+ * Validate an outbound URL and resolve its host ONCE. Throws SsrfBlockedError if the scheme is not
+ * http(s) or if the host (literal or any DNS-resolved address) is internal/reserved. Guards both
+ * webhook delivery and server-side media fetches. Hosts named in `SSRF_ALLOWED_HOSTS` are allowed
+ * through (escape-hatch for trusted internal targets).
+ *
+ * Returns the vetted resolved addresses so a caller can PIN the connection to them — defeating the
+ * DNS-rebinding window where the address validated here differs from the one `fetch` would re-resolve.
+ * Returns null when there is nothing to pin: an allowlisted host (trusted — deliberately left
+ * unpinned, since the operator opts in to whatever its DNS returns) or a literal IP (no DNS, so no
+ * rebind is possible — fetch connects straight to the validated literal).
  */
-export async function assertSafeFetchUrl(rawUrl: string): Promise<void> {
+export async function resolveSafeFetchTarget(rawUrl: string): Promise<LookupAddress[] | null> {
   let url: URL;
   try {
     url = new URL(rawUrl);
@@ -139,14 +147,14 @@ export async function assertSafeFetchUrl(rawUrl: string): Promise<void> {
   const host = url.hostname.replace(/^\[|\]$/g, ''); // strip IPv6 brackets
 
   if (getAllowedHosts().has(host.toLowerCase())) {
-    return; // explicitly allowlisted internal target
+    return null; // explicitly allowlisted internal target
   }
 
   if (isIPv4(host) || isIPv6(host)) {
     if (isBlockedAddress(host)) {
       throw new SsrfBlockedError(`Blocked internal address: ${host}`);
     }
-    return;
+    return null; // literal IP — fetch connects directly, nothing to rebind
   }
 
   const resolved = await lookup(host, { all: true });
@@ -157,5 +165,67 @@ export async function assertSafeFetchUrl(rawUrl: string): Promise<void> {
     if (isBlockedAddress(address)) {
       throw new SsrfBlockedError(`Host ${host} resolves to a blocked internal address: ${address}`);
     }
+  }
+  return resolved; // vetted addresses — pin the connection to these
+}
+
+/**
+ * Backwards-compatible assertion form: validate the URL (used at webhook registration time, where
+ * only the throw/no-throw outcome matters).
+ */
+export async function assertSafeFetchUrl(rawUrl: string): Promise<void> {
+  await resolveSafeFetchTarget(rawUrl);
+}
+
+/**
+ * Build a `net`-style lookup function that always returns the pre-validated addresses and never
+ * consults DNS — so a connection using it cannot be re-resolved to a different (internal) address.
+ */
+export function pinnedLookup(addresses: LookupAddress[]): LookupFunction {
+  // undici always invokes the lookup with an options object; `all: true` expects the address array,
+  // otherwise a single (address, family) pair.
+  const fn = (_hostname: string, options: LookupOptions, callback: (...args: unknown[]) => void): void => {
+    if (options.all) {
+      callback(null, addresses);
+    } else {
+      callback(null, addresses[0].address, addresses[0].family);
+    }
+  };
+  return fn as unknown as LookupFunction;
+}
+
+/**
+ * Perform an SSRF-safe fetch and hand the response to `use`, then tear down the per-request
+ * connection. The host is validated and resolved ONCE; the connection is pinned to the vetted IP(s)
+ * via an undici dispatcher so it cannot be re-resolved to an internal address between check and
+ * connect (DNS-rebinding TOCTOU). The original hostname is preserved for TLS SNI and the Host header,
+ * so virtual hosting and certificate validation are unaffected, and ALL vetted addresses are offered
+ * so A-record failover still works. Redirects are refused (the guard only validated the original host).
+ *
+ * `use` must read everything it needs from the response before returning — the dispatcher (and its
+ * sockets) is destroyed once `use` settles, so a still-streaming body would be cut off.
+ *
+ * @param opts.guard - when false (the WEBHOOK_SSRF_PROTECT opt-out), skips validation/pinning and
+ *   performs a plain redirect-following fetch. Defaults to true (always guard).
+ */
+export async function withSafeFetch<T>(
+  rawUrl: string,
+  init: RequestInit,
+  use: (response: Response) => Promise<T> | T,
+  opts: { guard?: boolean } = {},
+): Promise<T> {
+  const guard = opts.guard ?? true;
+  if (!guard) {
+    return use(await undiciFetch(rawUrl, { ...init, redirect: 'follow' }));
+  }
+
+  const target = await resolveSafeFetchTarget(rawUrl);
+  const dispatcher = target ? new Agent({ connect: { lookup: pinnedLookup(target) } }) : undefined;
+  try {
+    const response = await undiciFetch(rawUrl, { ...init, redirect: 'manual', dispatcher });
+    assertNoRedirect(response, rawUrl);
+    return await use(response);
+  } finally {
+    if (dispatcher) await dispatcher.destroy().catch(() => undefined);
   }
 }

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -9,6 +9,14 @@ import {
 import { EngineNotReadyError } from '../../common/errors/engine-not-ready.error';
 import { EngineStatus } from '../interfaces/whatsapp-engine.interface';
 import { SsrfBlockedError } from '../../common/security/ssrf-guard';
+import { fetch as undiciFetch } from 'undici';
+
+// loadRemoteMedia now fetches bytes through the SSRF-pinned path (undici fetch), then builds the
+// MessageMedia locally — so mock undici fetch, not MessageMedia.fromUrl.
+jest.mock('undici', () => {
+  const actual = jest.requireActual<typeof import('undici')>('undici');
+  return { __esModule: true, ...actual, fetch: jest.fn() };
+});
 
 describe('wwebjsAckToDeliveryStatus (engine ack-int -> neutral DeliveryStatus boundary, #265)', () => {
   // Regression-locks the integer boundary the decoupling moved behaviour into, incl. the
@@ -62,22 +70,57 @@ describe('extractLinkedParentJID (#201)', () => {
   });
 });
 
-describe('loadRemoteMedia — media-fetch SSRF guard + cap + timeout', () => {
+describe('loadRemoteMedia — routes through the SSRF-pinned media fetch', () => {
   let fromUrlSpy: jest.SpyInstance;
 
+  // A Response-like with a single-chunk body stream (mirrors load-remote-media.spec).
+  const fakeResponse = (bytes: number[], headers: Record<string, string>) => ({
+    ok: true,
+    status: 200,
+    headers: { get: (k: string) => headers[k.toLowerCase()] ?? null },
+    body: {
+      getReader: () => {
+        let done = false;
+        return {
+          read: () =>
+            done
+              ? Promise.resolve({ done: true, value: undefined })
+              : ((done = true), Promise.resolve({ done: false, value: new Uint8Array(bytes) })),
+          cancel: () => Promise.resolve(),
+        };
+      },
+    },
+  });
+
   beforeEach(() => {
-    fromUrlSpy = jest
-      .spyOn(MessageMedia, 'fromUrl')
-      .mockResolvedValue(new MessageMedia('image/png', 'ZmFrZQ==', 'x.png'));
+    // Spied only to assert the vulnerable fromUrl path is NEVER taken.
+    fromUrlSpy = jest.spyOn(MessageMedia, 'fromUrl');
+    (undiciFetch as jest.Mock).mockReset();
   });
 
   afterEach(() => {
     fromUrlSpy.mockRestore();
+    (undiciFetch as jest.Mock).mockReset();
     delete process.env.SSRF_ALLOWED_HOSTS;
+  });
+
+  it('builds MessageMedia from the pinned fetch bytes, never via MessageMedia.fromUrl', async () => {
+    (undiciFetch as jest.Mock).mockResolvedValue(fakeResponse([104, 105], { 'content-type': 'image/png' }));
+
+    const media = await loadRemoteMedia('https://8.8.8.8/x.png');
+
+    expect(fromUrlSpy).not.toHaveBeenCalled(); // the unpinned node-fetch path is gone
+    expect(media.mimetype).toBe('image/png');
+    expect(media.data).toBe(Buffer.from([104, 105]).toString('base64'));
+    expect(undiciFetch).toHaveBeenCalledWith(
+      'https://8.8.8.8/x.png',
+      expect.objectContaining({ redirect: 'manual' }), // pinned + redirects refused
+    );
   });
 
   it('blocks an internal/loopback URL BEFORE any fetch (no outbound socket)', async () => {
     await expect(loadRemoteMedia('http://127.0.0.1/x.png')).rejects.toBeInstanceOf(SsrfBlockedError);
+    expect(undiciFetch).not.toHaveBeenCalled();
     expect(fromUrlSpy).not.toHaveBeenCalled();
   });
 
@@ -85,28 +128,17 @@ describe('loadRemoteMedia — media-fetch SSRF guard + cap + timeout', () => {
     await expect(loadRemoteMedia('http://169.254.169.254/latest/meta-data/x.png')).rejects.toBeInstanceOf(
       SsrfBlockedError,
     );
-    expect(fromUrlSpy).not.toHaveBeenCalled();
-  });
-
-  it('fetches a public URL with a byte cap and an abort-timeout signal', async () => {
-    await loadRemoteMedia('https://8.8.8.8/x.png');
-
-    expect(fromUrlSpy).toHaveBeenCalledTimes(1);
-    const [url, options] = fromUrlSpy.mock.calls[0] as [
-      string,
-      { reqOptions: { size: number; signal: unknown; redirect: string } },
-    ];
-    expect(url).toBe('https://8.8.8.8/x.png');
-    expect(typeof options.reqOptions.size).toBe('number');
-    expect(options.reqOptions.size).toBeGreaterThan(0);
-    expect(options.reqOptions.signal).toBeInstanceOf(AbortSignal);
-    expect(options.reqOptions.redirect).toBe('error'); // never follow redirects
+    expect(undiciFetch).not.toHaveBeenCalled();
   });
 
   it('honors the SSRF_ALLOWED_HOSTS escape-hatch for trusted internal media stores', async () => {
     process.env.SSRF_ALLOWED_HOSTS = 'minio';
-    await loadRemoteMedia('http://minio:9000/bucket/x.png');
-    expect(fromUrlSpy).toHaveBeenCalledTimes(1);
+    (undiciFetch as jest.Mock).mockResolvedValue(fakeResponse([1], { 'content-type': 'image/png' }));
+
+    const media = await loadRemoteMedia('http://minio:9000/bucket/x.png');
+
+    expect(media.mimetype).toBe('image/png');
+    expect(fromUrlSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -35,7 +35,7 @@ import {
 import { createLogger } from '../../common/services/logger.service';
 import { EngineNotReadyError } from '../../common/errors/engine-not-ready.error';
 import { MessageNotFoundError } from '../../common/errors/message-not-found.error';
-import { assertSafeFetchUrl } from '../../common/security/ssrf-guard';
+import { loadRemoteMediaBuffer } from '../../common/media/load-remote-media';
 import {
   GroupChat,
   GroupMetadataRaw,
@@ -46,16 +46,6 @@ import {
 } from '../types/whatsapp-web-js.types';
 import { buildIncomingMessageBase } from './message-mapper';
 import { capInboundMedia } from './inbound-media-cap';
-
-/** Default cap on a server-side media download: 50 MiB (overridable via MEDIA_DOWNLOAD_MAX_BYTES). */
-const DEFAULT_MEDIA_MAX_BYTES = 50 * 1024 * 1024;
-/** Default timeout for a server-side media download: 30s (overridable via MEDIA_DOWNLOAD_TIMEOUT_MS). */
-const DEFAULT_MEDIA_TIMEOUT_MS = 30_000;
-
-function positiveIntFromEnv(name: string, fallback: number): number {
-  const parsed = Number.parseInt(process.env[name] ?? '', 10);
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
-}
 
 /**
  * Map a whatsapp-web.js MessageAck integer to the neutral DeliveryStatus.
@@ -78,16 +68,13 @@ export function wwebjsAckToDeliveryStatus(ack: number): DeliveryStatus {
  * existing MIME-detection behavior.
  */
 export async function loadRemoteMedia(url: string): Promise<MessageMedia> {
-  await assertSafeFetchUrl(url);
-  return MessageMedia.fromUrl(url, {
-    reqOptions: {
-      size: positiveIntFromEnv('MEDIA_DOWNLOAD_MAX_BYTES', DEFAULT_MEDIA_MAX_BYTES),
-      signal: AbortSignal.timeout(positiveIntFromEnv('MEDIA_DOWNLOAD_TIMEOUT_MS', DEFAULT_MEDIA_TIMEOUT_MS)),
-      // Never follow redirects: the SSRF guard only validated the original host, so a
-      // followed 3xx could reach an internal target. node-fetch rejects on redirect.
-      redirect: 'error',
-    },
-  });
+  // Fetch through the SSRF-pinned path: it validates the host, pins the connection to the vetted IP
+  // (so a DNS rebind can't redirect it to an internal target between check and connect), caps bytes,
+  // and refuses redirects. We then build the MessageMedia from the returned bytes — NOT via
+  // MessageMedia.fromUrl, whose bundled node-fetch performs its own unpinned DNS re-resolution.
+  const { data, mimetype } = await loadRemoteMediaBuffer(url);
+  const filename = new URL(url).pathname.split('/').pop() || undefined;
+  return new MessageMedia(mimetype || 'application/octet-stream', data.toString('base64'), filename);
 }
 
 export interface WhatsAppWebJsConfig {

--- a/src/modules/queue/processors/webhook.processor.spec.ts
+++ b/src/modules/queue/processors/webhook.processor.spec.ts
@@ -4,6 +4,13 @@ import { WebhookProcessor } from './webhook.processor';
 import { Webhook } from '../../webhook/entities/webhook.entity';
 import { HookManager } from '../../../core/hooks';
 import { WebhookJobData } from '../../webhook/webhook.service';
+import { fetch as undiciFetch } from 'undici';
+
+// Delivery goes through undici's fetch (via the SSRF-pinning helper), so mock that, not global fetch.
+jest.mock('undici', () => {
+  const actual = jest.requireActual<typeof import('undici')>('undici');
+  return { __esModule: true, ...actual, fetch: jest.fn() };
+});
 
 /**
  * Regression coverage for the production (QUEUE_ENABLED) webhook delivery path, which was
@@ -45,8 +52,7 @@ describe('WebhookProcessor', () => {
     repo = { update: jest.fn().mockResolvedValue({ affected: 1 }) };
     hookManager = { execute: jest.fn().mockResolvedValue({ continue: true, data: {} }) };
     processor = new WebhookProcessor(repo as unknown as Repository<Webhook>, hookManager as unknown as HookManager);
-    mockFetch = jest.fn();
-    global.fetch = mockFetch as typeof global.fetch;
+    mockFetch = undiciFetch as jest.Mock;
     process.env.WEBHOOK_SSRF_PROTECT = 'false'; // delivery-logic tests; redirect test flips it on
   });
 

--- a/src/modules/queue/processors/webhook.processor.ts
+++ b/src/modules/queue/processors/webhook.processor.ts
@@ -7,7 +7,7 @@ import { QUEUE_NAMES } from '../queue-names';
 import { WebhookJobData } from '../../webhook/webhook.service';
 import { Webhook } from '../../webhook/entities/webhook.entity';
 import { HookManager } from '../../../core/hooks';
-import { assertSafeFetchUrl, assertNoRedirect, isSsrfProtectionEnabled } from '../../../common/security/ssrf-guard';
+import { withSafeFetch, isSsrfProtectionEnabled } from '../../../common/security/ssrf-guard';
 
 export interface WebhookJobResult {
   statusCode: number;
@@ -48,27 +48,23 @@ export class WebhookProcessor extends WorkerHost {
       'X-OpenWA-Retry-Count': String(job.attemptsMade),
     };
 
-    const ssrfProtected = isSsrfProtectionEnabled();
     try {
-      if (ssrfProtected) {
-        await assertSafeFetchUrl(url);
-      }
-      const response = await fetch(url, {
-        method: 'POST',
-        headers: requestHeaders,
-        body: JSON.stringify(payload),
-        signal: AbortSignal.timeout(10000),
-        redirect: ssrfProtected ? 'manual' : 'follow',
-      });
-      if (ssrfProtected) {
-        assertNoRedirect(response, url);
-      }
+      const { status, statusText, ok } = await withSafeFetch(
+        url,
+        {
+          method: 'POST',
+          headers: requestHeaders,
+          body: JSON.stringify(payload),
+          signal: AbortSignal.timeout(10000),
+        },
+        response => ({ status: response.status, statusText: response.statusText, ok: response.ok }),
+        { guard: isSsrfProtectionEnabled() },
+      );
 
       const responseTime = Date.now() - startTime;
-      const success = response.ok;
 
-      if (!success) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      if (!ok) {
+        throw new Error(`HTTP ${status}: ${statusText}`);
       }
 
       // Update lastTriggeredAt on successful delivery
@@ -84,7 +80,7 @@ export class WebhookProcessor extends WorkerHost {
           event,
           webhookId,
           deliveryId: payload.deliveryId,
-          statusCode: response.status,
+          statusCode: status,
           responseTime,
           attempt: job.attemptsMade + 1,
         },
@@ -96,14 +92,14 @@ export class WebhookProcessor extends WorkerHost {
         event,
         deliveryId: payload.deliveryId,
         idempotencyKey: payload.idempotencyKey,
-        statusCode: response.status,
+        statusCode: status,
         responseTime,
         attempt: job.attemptsMade + 1,
         action: 'webhook_delivered',
       });
 
       return {
-        statusCode: response.status,
+        statusCode: status,
         success: true,
         responseTime,
       };

--- a/src/modules/webhook/webhook.service.spec.ts
+++ b/src/modules/webhook/webhook.service.spec.ts
@@ -4,6 +4,12 @@ jest.mock('dns/promises', () => ({
   lookup: jest.fn().mockResolvedValue([{ address: '93.184.216.34', family: 4 }]),
 }));
 
+// Webhook delivery goes through undici's fetch (via the SSRF-pinning helper); mock it, not global fetch.
+jest.mock('undici', () => {
+  const actual = jest.requireActual<typeof import('undici')>('undici');
+  return { __esModule: true, ...actual, fetch: jest.fn() };
+});
+
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { getQueueToken } from '@nestjs/bullmq';
@@ -11,6 +17,7 @@ import { Repository } from 'typeorm';
 import { NotFoundException, BadRequestException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import * as crypto from 'crypto';
+import { fetch as undiciFetch } from 'undici';
 import { WebhookService, WebhookPayload } from './webhook.service';
 import { Webhook } from './entities/webhook.entity';
 import { HookManager } from '../../core/hooks';
@@ -232,10 +239,9 @@ describe('WebhookService', () => {
   // ── dispatch (direct mode — queue disabled) ───────────────────────
 
   describe('dispatch (direct mode)', () => {
-    const mockFetch = jest.fn();
+    const mockFetch = undiciFetch as jest.Mock;
 
     beforeEach(() => {
-      global.fetch = mockFetch as typeof global.fetch;
       mockFetch.mockResolvedValue({ ok: true, status: 200 });
     });
 
@@ -340,11 +346,11 @@ describe('WebhookService', () => {
       (repository.update as jest.Mock).mockResolvedValue({ affected: 1 });
 
       const captured: Record<string, string> = {};
-      const mockFetch = jest.fn().mockImplementation((_url: string, opts: RequestInit) => {
+      const mockFetch = undiciFetch as jest.Mock;
+      mockFetch.mockImplementation((_url: string, opts: RequestInit) => {
         Object.assign(captured, opts.headers as Record<string, string>);
         return Promise.resolve({ ok: true, status: 200 });
       });
-      global.fetch = mockFetch as typeof global.fetch;
 
       const payload: WebhookPayload = {
         event: 'message.received',
@@ -371,11 +377,10 @@ describe('WebhookService', () => {
   // ── redirect refusal ─────────────────────────────────────────
 
   describe('dispatch — redirect refusal', () => {
-    const mockFetch = jest.fn();
+    const mockFetch = undiciFetch as jest.Mock;
     const origProtect = process.env.WEBHOOK_SSRF_PROTECT;
 
     beforeEach(() => {
-      global.fetch = mockFetch as typeof global.fetch;
       process.env.WEBHOOK_SSRF_PROTECT = 'true';
     });
 
@@ -433,11 +438,11 @@ describe('WebhookService', () => {
       (repository.update as jest.Mock).mockResolvedValue({ affected: 1 });
 
       const capturedHeaders: Record<string, string> = {};
-      const mockFetch = jest.fn().mockImplementation((_url: string, opts: RequestInit) => {
+      const mockFetch = undiciFetch as jest.Mock;
+      mockFetch.mockImplementation((_url: string, opts: RequestInit) => {
         Object.assign(capturedHeaders, opts.headers as Record<string, string>);
         return Promise.resolve({ ok: true, status: 200 });
       });
-      global.fetch = mockFetch as typeof global.fetch;
 
       const sigPayload: WebhookPayload = {
         event: 'message.received',

--- a/src/modules/webhook/webhook.service.ts
+++ b/src/modules/webhook/webhook.service.ts
@@ -12,7 +12,7 @@ import { QUEUE_NAMES } from '../queue/queue-names';
 import { generateIdempotencyKey, generateDeliveryId } from './utils/idempotency.util';
 import {
   assertSafeFetchUrl,
-  assertNoRedirect,
+  withSafeFetch,
   isSsrfProtectionEnabled,
   SsrfBlockedError,
 } from '../../common/security/ssrf-guard';
@@ -168,26 +168,13 @@ export class WebhookService {
       headers['X-OpenWA-Signature'] = this.generateSignature(body, webhook.secret);
     }
 
-    const ssrfProtected = isSsrfProtectionEnabled();
     try {
-      if (ssrfProtected) {
-        await assertSafeFetchUrl(webhook.url);
-      }
-      const response = await fetch(webhook.url, {
-        method: 'POST',
-        headers,
-        body,
-        signal: AbortSignal.timeout(10000),
-        redirect: ssrfProtected ? 'manual' : 'follow',
-      });
-      if (ssrfProtected) {
-        assertNoRedirect(response, webhook.url);
-      }
-
-      return {
-        success: response.ok,
-        statusCode: response.status,
-      };
+      return await withSafeFetch(
+        webhook.url,
+        { method: 'POST', headers, body, signal: AbortSignal.timeout(10000) },
+        response => ({ success: response.ok, statusCode: response.status }),
+        { guard: isSsrfProtectionEnabled() },
+      );
     } catch (error) {
       return {
         success: false,
@@ -369,24 +356,21 @@ export class WebhookService {
       headers['X-OpenWA-Signature'] = this.generateSignature(body, webhook.secret);
     }
 
-    const ssrfProtected = isSsrfProtectionEnabled();
     try {
-      if (ssrfProtected) {
-        await assertSafeFetchUrl(webhook.url);
-      }
-      const response = await fetch(webhook.url, {
-        method: 'POST',
-        headers,
-        body,
-        signal: AbortSignal.timeout(this.configService.get<number>('webhook.timeout', 10000)),
-        redirect: ssrfProtected ? 'manual' : 'follow',
-      });
-      if (ssrfProtected) {
-        assertNoRedirect(response, webhook.url);
-      }
+      const { ok, status, statusText } = await withSafeFetch(
+        webhook.url,
+        {
+          method: 'POST',
+          headers,
+          body,
+          signal: AbortSignal.timeout(this.configService.get<number>('webhook.timeout', 10000)),
+        },
+        response => ({ ok: response.ok, status: response.status, statusText: response.statusText }),
+        { guard: isSsrfProtectionEnabled() },
+      );
 
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      if (!ok) {
+        throw new Error(`HTTP ${status}: ${statusText}`);
       }
 
       // Update last triggered timestamp


### PR DESCRIPTION
## Problem

The SSRF guard and the actual outbound connection resolved DNS **independently**: `assertSafeFetchUrl(url)` did its own `dns.lookup` to validate the host, then `fetch(url)` performed a *second*, unrelated resolution at connect time. An attacker controlling a domain's authoritative DNS with a ~0 TTL could answer a public address to the guard and an internal one (loopback, RFC1918, `169.254.169.254` cloud metadata) to the fetch — a classic DNS-rebinding TOCTOU. This affected webhook delivery (the OPERATOR-set URL) and server-side media fetches.

## Fix

A single guarded helper, `withSafeFetch`, that resolves and validates the host **once**, then pins the connection to the vetted IP via an undici dispatcher whose `connect.lookup` returns only those addresses — so the connection cannot be re-resolved between check and connect. Key invariants preserved:

- **TLS SNI + `Host` header stay the original hostname** (not the IP), so certificate validation and virtual hosting are unaffected.
- **All vetted addresses are offered**, so A-record round-robin / failover still works.
- **Redirects are refused** (`redirect: 'manual'` + `assertNoRedirect`) — the guard only validated the original host.
- The `WEBHOOK_SSRF_PROTECT` opt-out and `SSRF_ALLOWED_HOSTS` escape-hatch behave exactly as before; literal-IP and allowlisted-host targets need no pin.

Routed through it: webhook delivery (direct, queued, and the test endpoint), the engine-neutral media download, **and** the whatsapp-web.js send-media-by-URL path — which previously used `MessageMedia.fromUrl` (bundled `node-fetch`, its own unpinned re-resolution) and is the default engine, so it was still exploitable. It now fetches via the pinned helper and builds `MessageMedia` from the bytes, mirroring the Baileys path.

## Dependency

Adds `undici` (the official Node HTTP client — the engine behind global `fetch`), pinned to v6 to match Node 22's bundled major. Global `fetch` exposes no per-request DNS hook; undici's dispatcher is the documented way to pin a connection's IP while keeping SNI. No audit advisories.

## Compatibility

No wire-format or response-shape change; non-breaking. SemVer: patch.

## Tests

- `ssrf-guard.spec.ts`: `pinnedLookup` returns the captured addresses and never re-resolves (rebind-immune); `withSafeFetch` passes a real pinned dispatcher for a hostname target (a regression that removes the pin fails this), refuses redirects on the pinned path, and is fail-closed before any socket.
- `load-remote-media.spec.ts` / `whatsapp-web-js.adapter.spec.ts`: media now flows through the pinned fetch and never via `MessageMedia.fromUrl`.
- Full backend suite 739/739; dashboard build + lint clean.