### PR TITLE
fix(contract): honor webhook timeout, bound shutdown, unify unsupported-op 501, validate engine/storage env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -168,10 +168,15 @@ WEBHOOK_SSRF_PROTECT=true
 # MEDIA_DOWNLOAD_TIMEOUT_MS=30000     # abort a slow media download (default 30s)
 
 # =============================================================================
-# RATE LIMITING
+# RATE LIMITING  (all TTLs are in MILLISECONDS)
 # =============================================================================
-RATE_LIMIT_TTL=60                   # Time window in seconds
-RATE_LIMIT_MAX=100                  # Max requests per window
+# The "medium" tier is the one enforced on the API; short/long are optional extra tiers.
+RATE_LIMIT_MEDIUM_TTL=60000         # window in ms (default 60000 = 60s)
+RATE_LIMIT_MEDIUM_LIMIT=100         # max requests per window
+# RATE_LIMIT_SHORT_TTL=1000         # 1s burst window (default)
+# RATE_LIMIT_SHORT_LIMIT=10
+# RATE_LIMIT_LONG_TTL=3600000       # 1h window (default)
+# RATE_LIMIT_LONG_LIMIT=1000
 
 # =============================================================================
 # PLUGINS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`WEBHOOK_TIMEOUT` is honored on the primary (queued) delivery path and the test endpoint.** The
+  configured timeout was applied only on the deprecated direct path; the BullMQ webhook processor and
+  `POST /webhooks/:id/test` hardcoded 10s, so raising `WEBHOOK_TIMEOUT` had no effect when `QUEUE_ENABLED=true`.
+- **Graceful shutdown is bounded.** `CacheService` awaited `redis.quit()` with no deadline; on a half-open
+  socket that reply never arrives, blocking `app.close()` until the orchestrator `SIGKILL`s the process. It
+  now force-disconnects after a short timeout so shutdown always completes.
+- **Unsupported status/catalog operations return a consistent `501`.** On whatsapp-web.js several stubs threw
+  a raw `Error` (HTTP 500) while Baileys returned 501; both engines now surface 501 uniformly.
+- **A misconfigured `ENGINE_TYPE` / `STORAGE_TYPE` fails fast at boot** instead of silently falling back to the
+  default engine/storage (a typo was previously swallowed).
+
+### Changed
+
+- **The `/api/metrics` scrape is memoized for a few seconds.** Each scrape ran a full session scan plus
+  several aggregate queries; back-to-back scrapes (or multiple Prometheus replicas) now share a short-lived
+  rendered result. Stale-by-a-few-seconds metrics are expected for Prometheus.
+- Internal: removed a dead "invalid key" branch in the WebSocket connect handler (`validateApiKey` always
+  throws on failure, so the surrounding `catch` is the real rejection path).
+
+### Documentation
+
+- Documented the webhook `idempotencyKey` / `deliveryId` fields (in the body and the `X-OpenWA-Idempotency-Key`
+  / `X-OpenWA-Delivery-Id` headers) and the dedup-on-`idempotencyKey` rule in the n8n integration guide.
+- Corrected the `.env.example` rate-limit variables to the names the app actually reads
+  (`RATE_LIMIT_MEDIUM_TTL` / `RATE_LIMIT_MEDIUM_LIMIT`, in milliseconds) — the advertised
+  `RATE_LIMIT_TTL` / `RATE_LIMIT_MAX` were read by nothing.
+
 ## [0.4.2] - 2026-06-19
 
 Bug-fix and hardening release: access-control tightening, session-lifecycle resilience, data-migration

--- a/docs/22-n8n-integration.md
+++ b/docs/22-n8n-integration.md
@@ -94,6 +94,8 @@ Start workflows when WhatsApp events occur.
   "event": "message.received",
   "timestamp": "2024-01-15T10:30:00Z",
   "sessionId": "default",
+  "idempotencyKey": "a1b2c3d4e5f6...",
+  "deliveryId": "9f8e7d6c5b4a...",
   "data": {
     "id": "3EB0F5A2B4C...",
     "chatId": "628123456789@c.us",
@@ -104,6 +106,12 @@ Start workflows when WhatsApp events occur.
   }
 }
 ```
+
+> **Deduplication.** Every delivery includes `idempotencyKey` and `deliveryId` in the body **and** as the
+> `X-OpenWA-Idempotency-Key` / `X-OpenWA-Delivery-Id` headers. `idempotencyKey` is **stable across retries**
+> of the same event, while `deliveryId` is unique per HTTP attempt. Because a webhook can be retried, add a
+> dedup step keyed on `idempotencyKey` (e.g. an n8n IF or "Remove Duplicates" node) so a retried delivery
+> isn't processed twice.
 
 ## Example Workflows
 

--- a/src/common/cache/cache.service.spec.ts
+++ b/src/common/cache/cache.service.spec.ts
@@ -1,0 +1,44 @@
+import { ConfigService } from '@nestjs/config';
+import { CacheService, CACHE_QUIT_TIMEOUT_MS } from './cache.service';
+
+describe('CacheService.onModuleDestroy (bounded shutdown)', () => {
+  const makeService = (): CacheService => {
+    const configService = { get: jest.fn().mockReturnValue(false) } as unknown as ConfigService;
+    return new CacheService(configService);
+  };
+  const withRedis = (service: CacheService, redis: unknown): void => {
+    (service as unknown as { redis: unknown }).redis = redis;
+  };
+
+  it('returns immediately when there is no redis client', async () => {
+    await expect(makeService().onModuleDestroy()).resolves.toBeUndefined();
+  });
+
+  it('completes via a clean quit() without force-disconnecting', async () => {
+    const service = makeService();
+    const redis = { quit: jest.fn().mockResolvedValue('OK'), disconnect: jest.fn() };
+    withRedis(service, redis);
+
+    await service.onModuleDestroy();
+
+    expect(redis.quit).toHaveBeenCalledTimes(1);
+    expect(redis.disconnect).not.toHaveBeenCalled();
+  });
+
+  it('force-disconnects when quit() hangs past the deadline (shutdown still completes)', async () => {
+    jest.useFakeTimers();
+    try {
+      const service = makeService();
+      const redis = { quit: jest.fn(() => new Promise<string>(() => {})), disconnect: jest.fn() }; // never resolves
+      withRedis(service, redis);
+
+      const done = service.onModuleDestroy();
+      await jest.advanceTimersByTimeAsync(CACHE_QUIT_TIMEOUT_MS);
+      await done;
+
+      expect(redis.disconnect).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/src/common/cache/cache.service.ts
+++ b/src/common/cache/cache.service.ts
@@ -27,6 +27,9 @@ const TTL = {
   SESSIONS_STATS: 15, // 15 sec
 };
 
+/** Max time to await a graceful `redis.quit()` on shutdown before force-disconnecting (see onModuleDestroy). */
+export const CACHE_QUIT_TIMEOUT_MS = 2000;
+
 @Injectable()
 export class CacheService implements OnModuleDestroy {
   private readonly logger = createLogger('CacheService');
@@ -111,8 +114,25 @@ export class CacheService implements OnModuleDestroy {
   }
 
   async onModuleDestroy(): Promise<void> {
-    if (this.redis) {
-      await this.redis.quit();
+    if (!this.redis) return;
+    const redis = this.redis;
+
+    // Bound the teardown: redis.quit() waits for the QUIT reply, which never arrives on a half-open /
+    // partitioned socket — leaving app.close() blocked until the orchestrator SIGKILLs the process.
+    // Force-disconnect after a short deadline so shutdown always completes.
+    let timer: NodeJS.Timeout | undefined;
+    const forceDisconnect = new Promise<void>(resolve => {
+      timer = setTimeout(() => {
+        redis.disconnect();
+        resolve();
+      }, CACHE_QUIT_TIMEOUT_MS);
+      timer.unref();
+    });
+
+    try {
+      await Promise.race([redis.quit().catch(() => undefined), forceDisconnect]);
+    } finally {
+      if (timer) clearTimeout(timer);
     }
   }
 

--- a/src/config/env.validation.spec.ts
+++ b/src/config/env.validation.spec.ts
@@ -23,4 +23,16 @@ describe('validateEnv', () => {
     expect(() => validateEnv({ PORT: '70000' })).toThrow(/PORT/);
     expect(() => validateEnv({ PORT: '2785' })).not.toThrow();
   });
+
+  it('rejects an ENGINE_TYPE typo instead of silently falling back to whatsapp-web.js', () => {
+    expect(() => validateEnv({ ENGINE_TYPE: 'bailys' })).toThrow(/ENGINE_TYPE/);
+    expect(() => validateEnv({ ENGINE_TYPE: 'whatsapp-web.js' })).not.toThrow();
+    expect(() => validateEnv({ ENGINE_TYPE: 'baileys' })).not.toThrow();
+  });
+
+  it('rejects a STORAGE_TYPE typo instead of silently falling back to local', () => {
+    expect(() => validateEnv({ STORAGE_TYPE: 'ss' })).toThrow(/STORAGE_TYPE/);
+    expect(() => validateEnv({ STORAGE_TYPE: 'local' })).not.toThrow();
+    expect(() => validateEnv({ STORAGE_TYPE: 's3' })).not.toThrow();
+  });
 });

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -22,6 +22,18 @@ export function validateEnv(config: EnvConfig): EnvConfig {
     errors.push(`DATABASE_TYPE must be "sqlite" or "postgres" (got "${dbType}")`);
   }
 
+  // Whitelist the registered engine/storage ids so a typo fails fast at boot instead of silently
+  // falling back to the default (engine.factory swallows an unknown ENGINE_TYPE → legacy wwebjs;
+  // STORAGE_TYPE → local). Values must match the ids registered in engine.factory / configuration.
+  const checkEnum = (key: string, allowed: string[]): void => {
+    const value = str(key);
+    if (value !== undefined && !allowed.includes(value)) {
+      errors.push(`${key} must be one of ${allowed.map(v => `"${v}"`).join(', ')} (got "${value}")`);
+    }
+  };
+  checkEnum('ENGINE_TYPE', ['whatsapp-web.js', 'baileys']);
+  checkEnum('STORAGE_TYPE', ['local', 's3']);
+
   if (dbType === 'postgres') {
     for (const key of ['DATABASE_HOST', 'DATABASE_USERNAME', 'DATABASE_PASSWORD']) {
       if (!str(key)) {

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -34,6 +34,7 @@ import {
 } from '../interfaces/whatsapp-engine.interface';
 import { createLogger } from '../../common/services/logger.service';
 import { EngineNotReadyError } from '../../common/errors/engine-not-ready.error';
+import { EngineNotSupportedError } from '../../common/errors/engine-not-supported.error';
 import { MessageNotFoundError } from '../../common/errors/message-not-found.error';
 import { assertSafeFetchUrl } from '../../common/security/ssrf-guard';
 import {
@@ -1129,22 +1130,22 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     this.ensureReady();
     // whatsapp-web.js doesn't have native status posting
     // This would require using the underlying WhatsApp Web API directly
-    throw new Error('postTextStatus not yet implemented in whatsapp-web.js adapter');
+    throw new EngineNotSupportedError('postTextStatus');
   }
 
   async postImageStatus(_media: MediaInput, _caption?: string): Promise<StatusResult> {
     this.ensureReady();
-    throw new Error('postImageStatus not yet implemented in whatsapp-web.js adapter');
+    throw new EngineNotSupportedError('postImageStatus');
   }
 
   async postVideoStatus(_media: MediaInput, _caption?: string): Promise<StatusResult> {
     this.ensureReady();
-    throw new Error('postVideoStatus not yet implemented in whatsapp-web.js adapter');
+    throw new EngineNotSupportedError('postVideoStatus');
   }
 
   async deleteStatus(_statusId: string): Promise<void> {
     this.ensureReady();
-    throw new Error('deleteStatus not yet implemented in whatsapp-web.js adapter');
+    throw new EngineNotSupportedError('deleteStatus');
   }
 
   // ========== Catalog (Phase 3) ==========
@@ -1173,12 +1174,12 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
 
   async sendProduct(_chatId: string, _productId: string, _body?: string): Promise<MessageResult> {
     this.ensureReady();
-    throw new Error('sendProduct not yet implemented in whatsapp-web.js adapter');
+    throw new EngineNotSupportedError('sendProduct');
   }
 
   async sendCatalog(_chatId: string, _body?: string): Promise<MessageResult> {
     this.ensureReady();
-    throw new Error('sendCatalog not yet implemented in whatsapp-web.js adapter');
+    throw new EngineNotSupportedError('sendCatalog');
   }
 
   /* eslint-enable @typescript-eslint/require-await, @typescript-eslint/no-unused-vars */

--- a/src/modules/events/events.gateway.spec.ts
+++ b/src/modules/events/events.gateway.spec.ts
@@ -1,3 +1,4 @@
+import { UnauthorizedException } from '@nestjs/common';
 import { Socket } from 'socket.io';
 import { EventsGateway, isSessionSubscriptionAllowed } from './events.gateway';
 import { AuthService } from '../auth/auth.service';
@@ -65,8 +66,8 @@ describe('EventsGateway connection auth + subscribe re-validation', () => {
     expect(authService.validateApiKey).not.toHaveBeenCalled();
   });
 
-  it('rejects a connection with an invalid API key', async () => {
-    authService.validateApiKey.mockResolvedValue(null);
+  it('rejects a connection when validateApiKey throws (the real auth-failure contract)', async () => {
+    authService.validateApiKey.mockRejectedValue(new UnauthorizedException('Invalid API key'));
     const sock = makeSocket({ apiKey: 'bad' });
     await gateway.handleConnection(asSocket(sock));
     expect(sock.disconnect).toHaveBeenCalled();

--- a/src/modules/events/events.gateway.ts
+++ b/src/modules/events/events.gateway.ts
@@ -87,13 +87,9 @@ export class EventsGateway implements OnGatewayInit, OnGatewayConnection, OnGate
     }
 
     try {
+      // validateApiKey THROWS on any failure (it never resolves to a falsy value), so the rejection
+      // path is the catch below — a separate `if (!validKey)` branch here was dead code.
       const validKey = await this.authService.validateApiKey(apiKey);
-      if (!validKey) {
-        this.logger.warn(`Client ${client.id} rejected: Invalid API key`);
-        client.emit('message', this.createError('UNAUTHORIZED', 'Invalid API key'));
-        client.disconnect();
-        return;
-      }
 
       // Store the validated key AND the raw key — the raw key lets handleSubscribe
       // RE-validate on each subscription so a key revoked mid-connection is caught.

--- a/src/modules/metrics/metrics.service.spec.ts
+++ b/src/modules/metrics/metrics.service.spec.ts
@@ -1,6 +1,6 @@
 import { NotFoundException, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { MetricsService } from './metrics.service';
+import { MetricsService, METRICS_RENDER_TTL_MS } from './metrics.service';
 import { StatsService, OverviewStats } from '../stats/stats.service';
 
 describe('MetricsService', () => {
@@ -58,6 +58,27 @@ describe('MetricsService', () => {
       // Every metric must declare HELP/TYPE before its sample.
       expect(out).toContain('# TYPE openwa_messages_total counter');
       expect(out.endsWith('\n')).toBe(true);
+    });
+
+    it('memoizes the rendered output within the TTL (one getOverview per window)', async () => {
+      jest.useFakeTimers();
+      try {
+        const config = {
+          get: (k: string) => (k === 'METRICS_TOKEN' ? 's3cret' : undefined),
+        } as unknown as ConfigService;
+        const getOverview = jest.fn().mockResolvedValue(overview);
+        const svc = new MetricsService(config, { getOverview } as unknown as StatsService);
+
+        await svc.render();
+        await svc.render();
+        expect(getOverview).toHaveBeenCalledTimes(1); // 2nd scrape served from the memo, no DB work
+
+        jest.advanceTimersByTime(METRICS_RENDER_TTL_MS + 1);
+        await svc.render();
+        expect(getOverview).toHaveBeenCalledTimes(2); // window expired → recomputed
+      } finally {
+        jest.useRealTimers();
+      }
     });
   });
 });

--- a/src/modules/metrics/metrics.service.ts
+++ b/src/modules/metrics/metrics.service.ts
@@ -12,8 +12,17 @@ import { StatsService } from '../stats/stats.service';
  * is required. This keeps operational internals (session counts, failure totals) from
  * being exposed publicly by default on a self-hosted box.
  */
+/**
+ * How long a rendered scrape is reused before recomputing. getOverview() runs a full session scan plus
+ * several aggregate queries, so back-to-back scrapes (or several Prometheus replicas) would otherwise
+ * each pay the full DB cost. Stale-by-a-few-seconds metrics are fine for Prometheus.
+ */
+export const METRICS_RENDER_TTL_MS = 5000;
+
 @Injectable()
 export class MetricsService {
+  private cachedRender: { at: number; text: string } | null = null;
+
   constructor(
     private readonly config: ConfigService,
     private readonly statsService: StatsService,
@@ -47,8 +56,13 @@ export class MetricsService {
     return timingSafeEqual(ab, bb);
   }
 
-  /** Render the current metrics in Prometheus text exposition format. */
+  /** Render the current metrics in Prometheus text exposition format (memoized for a short TTL). */
   async render(): Promise<string> {
+    const now = Date.now();
+    if (this.cachedRender && now - this.cachedRender.at < METRICS_RENDER_TTL_MS) {
+      return this.cachedRender.text;
+    }
+
     const overview = await this.statsService.getOverview();
     const mem = process.memoryUsage();
     const lines: string[] = [];
@@ -83,7 +97,9 @@ export class MetricsService {
     lines.push('# TYPE openwa_messages_failed_total counter');
     lines.push(`openwa_messages_failed_total ${overview.messages.failed}`);
 
-    return lines.join('\n') + '\n';
+    const text = lines.join('\n') + '\n';
+    this.cachedRender = { at: now, text };
+    return text;
   }
 
   private escapeLabel(value: string): string {

--- a/src/modules/queue/processors/webhook.processor.spec.ts
+++ b/src/modules/queue/processors/webhook.processor.spec.ts
@@ -1,5 +1,6 @@
 import { Job } from 'bullmq';
 import { Repository } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
 import { WebhookProcessor } from './webhook.processor';
 import { Webhook } from '../../webhook/entities/webhook.entity';
 import { HookManager } from '../../../core/hooks';
@@ -14,6 +15,7 @@ describe('WebhookProcessor', () => {
   let processor: WebhookProcessor;
   let repo: { update: jest.Mock };
   let hookManager: { execute: jest.Mock };
+  let configService: { get: jest.Mock };
   let mockFetch: jest.Mock;
   const origProtect = process.env.WEBHOOK_SSRF_PROTECT;
 
@@ -44,7 +46,12 @@ describe('WebhookProcessor', () => {
   beforeEach(() => {
     repo = { update: jest.fn().mockResolvedValue({ affected: 1 }) };
     hookManager = { execute: jest.fn().mockResolvedValue({ continue: true, data: {} }) };
-    processor = new WebhookProcessor(repo as unknown as Repository<Webhook>, hookManager as unknown as HookManager);
+    configService = { get: jest.fn((key: string, def?: unknown) => (key === 'webhook.timeout' ? 25000 : def)) };
+    processor = new WebhookProcessor(
+      repo as unknown as Repository<Webhook>,
+      hookManager as unknown as HookManager,
+      configService as unknown as ConfigService,
+    );
     mockFetch = jest.fn();
     global.fetch = mockFetch as typeof global.fetch;
     process.env.WEBHOOK_SSRF_PROTECT = 'false'; // delivery-logic tests; redirect test flips it on
@@ -54,6 +61,17 @@ describe('WebhookProcessor', () => {
     mockFetch.mockReset();
     if (origProtect === undefined) delete process.env.WEBHOOK_SSRF_PROTECT;
     else process.env.WEBHOOK_SSRF_PROTECT = origProtect;
+  });
+
+  it('uses the configured WEBHOOK_TIMEOUT for the request abort signal (not a hardcoded 10s)', async () => {
+    const timeoutSpy = jest.spyOn(AbortSignal, 'timeout');
+    mockFetch.mockResolvedValue({ ok: true, status: 200 });
+
+    await processor.process(makeJob());
+
+    expect(configService.get).toHaveBeenCalledWith('webhook.timeout', 10000);
+    expect(timeoutSpy).toHaveBeenCalledWith(25000);
+    timeoutSpy.mockRestore();
   });
 
   it('on success updates lastTriggeredAt and fires webhook:delivered', async () => {

--- a/src/modules/queue/processors/webhook.processor.ts
+++ b/src/modules/queue/processors/webhook.processor.ts
@@ -1,6 +1,7 @@
 import { Processor, WorkerHost } from '@nestjs/bullmq';
 import { Job } from 'bullmq';
 import { InjectRepository } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
 import { Repository } from 'typeorm';
 import { createLogger } from '../../../common/services/logger.service';
 import { QUEUE_NAMES } from '../queue-names';
@@ -24,6 +25,7 @@ export class WebhookProcessor extends WorkerHost {
     @InjectRepository(Webhook, 'data')
     private readonly webhookRepository: Repository<Webhook>,
     private readonly hookManager: HookManager,
+    private readonly configService: ConfigService,
   ) {
     super();
   }
@@ -57,7 +59,8 @@ export class WebhookProcessor extends WorkerHost {
         method: 'POST',
         headers: requestHeaders,
         body: JSON.stringify(payload),
-        signal: AbortSignal.timeout(10000),
+        // Honor WEBHOOK_TIMEOUT on the primary (queued) path too — not just the deprecated direct one.
+        signal: AbortSignal.timeout(this.configService.get<number>('webhook.timeout', 10000)),
         redirect: ssrfProtected ? 'manual' : 'follow',
       });
       if (ssrfProtected) {

--- a/src/modules/webhook/webhook.service.spec.ts
+++ b/src/modules/webhook/webhook.service.spec.ts
@@ -56,7 +56,8 @@ describe('WebhookService', () => {
       get: jest.fn().mockImplementation(<T>(key: string, def?: T): T | boolean | number => {
         if (key === 'queue.enabled') return false;
         if (key === 'webhook.retryDelay') return 100;
-        if (key === 'webhook.timeout') return 10000;
+        // Distinct from the hardcoded 10000 fallback so a regression to a literal timeout is caught.
+        if (key === 'webhook.timeout') return 25000;
         return def as T;
       }),
     };
@@ -272,12 +273,28 @@ describe('WebhookService', () => {
         },
       });
 
+      const timeoutSpy = jest.spyOn(AbortSignal, 'timeout');
       await service.dispatch('sess-1', 'message.received', { from: '628123456789@c.us' });
 
       expect(mockFetch).toHaveBeenCalledWith(
         'https://example.com/webhook',
         expect.objectContaining({ method: 'POST' }),
       );
+      // Direct delivery path honors the configured WEBHOOK_TIMEOUT, not a literal 10s.
+      expect(timeoutSpy).toHaveBeenCalledWith(25000);
+      timeoutSpy.mockRestore();
+    });
+
+    it('test() probes the receiver using the configured WEBHOOK_TIMEOUT', async () => {
+      const webhook = createMockWebhook({ events: ['message.received'] });
+      (repository.findOne as jest.Mock).mockResolvedValue(webhook);
+      const timeoutSpy = jest.spyOn(AbortSignal, 'timeout');
+
+      await service.test('sess-1', webhook.id);
+
+      expect(mockFetch).toHaveBeenCalled();
+      expect(timeoutSpy).toHaveBeenCalledWith(25000);
+      timeoutSpy.mockRestore();
     });
 
     it('should NOT dispatch to webhooks that do not match the event', async () => {

--- a/src/modules/webhook/webhook.service.ts
+++ b/src/modules/webhook/webhook.service.ts
@@ -177,7 +177,8 @@ export class WebhookService {
         method: 'POST',
         headers,
         body,
-        signal: AbortSignal.timeout(10000),
+        // Use the configured WEBHOOK_TIMEOUT (single source of truth across queued/test/direct paths).
+        signal: AbortSignal.timeout(this.configService.get<number>('webhook.timeout', 10000)),
         redirect: ssrfProtected ? 'manual' : 'follow',
       });
       if (ssrfProtected) {


### PR DESCRIPTION
Eight small contract / lifecycle / config / doc fixes. No breaking changes; defaults unchanged.

## Fixed
- **`WEBHOOK_TIMEOUT` is honored on the primary (queued) path and the test endpoint.** The configured timeout was applied only on the deprecated direct path; the BullMQ webhook processor and `POST /webhooks/:id/test` hardcoded 10s, so raising `WEBHOOK_TIMEOUT` had no effect when `QUEUE_ENABLED=true` (the recommended production path). All three sites now read `webhook.timeout`. *(The processor gains a `ConfigService` constructor dependency; `ConfigModule` is global so DI resolves it.)*
- **Graceful shutdown is bounded.** `CacheService.onModuleDestroy` awaited `redis.quit()` with no deadline; on a half-open socket the QUIT reply never arrives, blocking `app.close()` until the orchestrator `SIGKILL`s the process. It now force-disconnects after a short timeout (timer cleared on a clean quit) so shutdown always completes.
- **Unsupported status/catalog operations return a consistent `501`.** Six whatsapp-web.js stubs threw a raw `Error` → HTTP 500, while Baileys returned 501 for the same ops. They now throw `EngineNotSupportedError` (501) uniformly. *(The silent `return null/[]` read stubs are intentionally left for a capability-gated follow-up — flipping a 200-empty to 501 would change behavior for clients that treat empty as success.)*
- **A misconfigured `ENGINE_TYPE` / `STORAGE_TYPE` fails fast at boot.** A typo (`ENGINE_TYPE=bailys`) was swallowed and silently fell back to the legacy engine; `validateEnv` now whitelists the registered ids.

## Changed
- **`/api/metrics` is memoized for a few seconds.** Each scrape ran a full session scan + several aggregate queries; back-to-back scrapes (or multiple Prometheus replicas) now share a short-lived rendered result. Stale-by-a-few-seconds metrics are expected for Prometheus. The `METRICS_TOKEN` gate and `@SkipThrottle` are unchanged.
- Internal: removed a dead `if (!validKey)` branch in the WebSocket connect handler — `validateApiKey` always throws on failure, so the surrounding `catch` is the real rejection path. The load-bearing `handleSubscribe` null-branch (revoked-mid-connection) is untouched.

## Documentation
- Documented the webhook `idempotencyKey` / `deliveryId` fields (body + `X-OpenWA-Idempotency-Key` / `X-OpenWA-Delivery-Id` headers) and the dedup-on-`idempotencyKey` rule in the n8n integration guide.
- Corrected `.env.example` rate-limit variables to the names the app actually reads (`RATE_LIMIT_MEDIUM_TTL` / `RATE_LIMIT_MEDIUM_LIMIT`, in milliseconds); the advertised `RATE_LIMIT_TTL` / `RATE_LIMIT_MAX` were read by nothing.

## Tests
New/updated unit tests: webhook timeout flows from config on the processor **and** both `webhook.service` sites (`AbortSignal.timeout` spy, distinct value); cache shutdown force-disconnects when `quit()` hangs and doesn't when it's clean; `validateEnv` accepts/rejects engine & storage ids; metrics `render()` is memoized within the TTL and recomputes after; the WS connect rejection asserts the real throw contract. Full backend 736/736; dashboard build + lint clean.

> An adversarial review found **no must-fix issues**; its one nice-to-have (the two `webhook.service` timeout sites weren't value-asserted) was closed before opening this PR.

## Deferred (own follow-up)
- **Settings `PUT`**: `PUT /settings` mutates an in-memory field that's lost on restart and never re-applied to runtime config. Making it honest is an API-contract decision (persist + re-apply the truly-mutable values vs. return `501`/read-only for env-derived ones), so it's out of scope here.
