### PR TITLE
feat(dashboard): Kill Stuck button for failed sessions

### DIFF
--- a/dashboard/src/i18n/locales/ar.json
+++ b/dashboard/src/i18n/locales/ar.json
@@ -226,7 +226,8 @@
       "start": "بدء",
       "stop": "إيقاف",
       "reconnect": "إعادة الاتصال",
-      "delete": "حذف"
+      "delete": "حذف",
+      "killStuck": "Kill Stuck"
     },
     "toasts": {
       "readyTitle": "الجلسة جاهزة",
@@ -241,6 +242,16 @@
       "sessionId": "معرّف الجلسة",
       "lastActive": "آخر نشاط",
       "error": "خطأ"
+    },
+    "forceKill": {
+      "title": "Kill Stuck Session",
+      "message": "Are you sure you want to force-kill session \"{{name}}\"?",
+      "warning": "This will forcefully terminate the WhatsApp browser process. The session may need to be re-scanned on restart.",
+      "confirm": "Kill Session",
+      "successTitle": "Session Killed",
+      "success": "Session has been force-killed. You can restart it now.",
+      "failedTitle": "Force-Kill Failed",
+      "failed": "Failed to force-kill the session."
     }
   },
   "webhooks": {

--- a/dashboard/src/i18n/locales/en.json
+++ b/dashboard/src/i18n/locales/en.json
@@ -226,7 +226,8 @@
       "start": "Start",
       "stop": "Stop",
       "reconnect": "Reconnect",
-      "delete": "Delete"
+      "delete": "Delete",
+      "killStuck": "Kill Stuck"
     },
     "toasts": {
       "readyTitle": "Session Ready",
@@ -241,6 +242,16 @@
       "sessionId": "Session ID",
       "lastActive": "Last Active",
       "error": "Error"
+    },
+    "forceKill": {
+      "title": "Kill Stuck Session",
+      "message": "Are you sure you want to force-kill session \"{{name}}\"?",
+      "warning": "This will forcefully terminate the WhatsApp browser process. The session may need to be re-scanned on restart.",
+      "confirm": "Kill Session",
+      "successTitle": "Session Killed",
+      "success": "Session has been force-killed. You can restart it now.",
+      "failedTitle": "Force-Kill Failed",
+      "failed": "Failed to force-kill the session."
     }
   },
   "webhooks": {

--- a/dashboard/src/i18n/locales/es.json
+++ b/dashboard/src/i18n/locales/es.json
@@ -226,7 +226,8 @@
       "start": "Iniciar",
       "stop": "Detener",
       "reconnect": "Reconectar",
-      "delete": "Eliminar"
+      "delete": "Eliminar",
+      "killStuck": "Kill Stuck"
     },
     "toasts": {
       "readyTitle": "Sesión lista",
@@ -241,6 +242,16 @@
       "sessionId": "ID de sesión",
       "lastActive": "Última actividad",
       "error": "Error"
+    },
+    "forceKill": {
+      "title": "Kill Stuck Session",
+      "message": "Are you sure you want to force-kill session \"{{name}}\"?",
+      "warning": "This will forcefully terminate the WhatsApp browser process. The session may need to be re-scanned on restart.",
+      "confirm": "Kill Session",
+      "successTitle": "Session Killed",
+      "success": "Session has been force-killed. You can restart it now.",
+      "failedTitle": "Force-Kill Failed",
+      "failed": "Failed to force-kill the session."
     }
   },
   "webhooks": {

--- a/dashboard/src/i18n/locales/fr.json
+++ b/dashboard/src/i18n/locales/fr.json
@@ -226,7 +226,8 @@
       "start": "Démarrer",
       "stop": "Arrêter",
       "reconnect": "Reconnecter",
-      "delete": "Supprimer"
+      "delete": "Supprimer",
+      "killStuck": "Kill Stuck"
     },
     "toasts": {
       "readyTitle": "Session prête",
@@ -241,6 +242,16 @@
       "sessionId": "ID de session",
       "lastActive": "Dernière activité",
       "error": "Erreur"
+    },
+    "forceKill": {
+      "title": "Kill Stuck Session",
+      "message": "Are you sure you want to force-kill session \"{{name}}\"?",
+      "warning": "This will forcefully terminate the WhatsApp browser process. The session may need to be re-scanned on restart.",
+      "confirm": "Kill Session",
+      "successTitle": "Session Killed",
+      "success": "Session has been force-killed. You can restart it now.",
+      "failedTitle": "Force-Kill Failed",
+      "failed": "Failed to force-kill the session."
     }
   },
   "webhooks": {

--- a/dashboard/src/i18n/locales/he.json
+++ b/dashboard/src/i18n/locales/he.json
@@ -226,7 +226,8 @@
       "start": "הפעלה",
       "stop": "עצירה",
       "reconnect": "התחברות מחדש",
-      "delete": "מחיקה"
+      "delete": "מחיקה",
+      "killStuck": "Kill Stuck"
     },
     "toasts": {
       "readyTitle": "ה-Session מוכן",
@@ -241,6 +242,16 @@
       "sessionId": "מזהה Session",
       "lastActive": "פעילות אחרונה",
       "error": "שגיאה"
+    },
+    "forceKill": {
+      "title": "Kill Stuck Session",
+      "message": "Are you sure you want to force-kill session \"{{name}}\"?",
+      "warning": "This will forcefully terminate the WhatsApp browser process. The session may need to be re-scanned on restart.",
+      "confirm": "Kill Session",
+      "successTitle": "Session Killed",
+      "success": "Session has been force-killed. You can restart it now.",
+      "failedTitle": "Force-Kill Failed",
+      "failed": "Failed to force-kill the session."
     }
   },
   "webhooks": {

--- a/dashboard/src/i18n/locales/it.json
+++ b/dashboard/src/i18n/locales/it.json
@@ -226,7 +226,8 @@
       "start": "Avvia",
       "stop": "Ferma",
       "reconnect": "Riconnetti",
-      "delete": "Elimina"
+      "delete": "Elimina",
+      "killStuck": "Kill Stuck"
     },
     "toasts": {
       "readyTitle": "Sessione Pronta",
@@ -241,6 +242,16 @@
       "sessionId": "ID Sessione",
       "lastActive": "Ultima Attività",
       "error": "Errore"
+    },
+    "forceKill": {
+      "title": "Kill Stuck Session",
+      "message": "Are you sure you want to force-kill session \"{{name}}\"?",
+      "warning": "This will forcefully terminate the WhatsApp browser process. The session may need to be re-scanned on restart.",
+      "confirm": "Kill Session",
+      "successTitle": "Session Killed",
+      "success": "Session has been force-killed. You can restart it now.",
+      "failedTitle": "Force-Kill Failed",
+      "failed": "Failed to force-kill the session."
     }
   },
   "webhooks": {

--- a/dashboard/src/i18n/locales/te.json
+++ b/dashboard/src/i18n/locales/te.json
@@ -226,7 +226,8 @@
       "start": "ప్రారంభించు",
       "stop": "ఆపివేయి",
       "reconnect": "మళ్లీ కనెక్ట్ చేయి",
-      "delete": "తొలగించు"
+      "delete": "తొలగించు",
+      "killStuck": "Kill Stuck"
     },
     "toasts": {
       "readyTitle": "సెషన్ సిద్ధంగా ఉంది",
@@ -241,6 +242,16 @@
       "sessionId": "సెషన్ ID",
       "lastActive": "చివరిసారి యాక్టివ్",
       "error": "లోపం"
+    },
+    "forceKill": {
+      "title": "Kill Stuck Session",
+      "message": "Are you sure you want to force-kill session \"{{name}}\"?",
+      "warning": "This will forcefully terminate the WhatsApp browser process. The session may need to be re-scanned on restart.",
+      "confirm": "Kill Session",
+      "successTitle": "Session Killed",
+      "success": "Session has been force-killed. You can restart it now.",
+      "failedTitle": "Force-Kill Failed",
+      "failed": "Failed to force-kill the session."
     }
   },
   "webhooks": {

--- a/dashboard/src/i18n/locales/zh-CN.json
+++ b/dashboard/src/i18n/locales/zh-CN.json
@@ -226,7 +226,8 @@
       "start": "启动",
       "stop": "停止",
       "reconnect": "重新连接",
-      "delete": "删除"
+      "delete": "删除",
+      "killStuck": "Kill Stuck"
     },
     "toasts": {
       "readyTitle": "会话就绪",
@@ -241,6 +242,16 @@
       "sessionId": "会话 ID",
       "lastActive": "上次活跃",
       "error": "错误"
+    },
+    "forceKill": {
+      "title": "Kill Stuck Session",
+      "message": "Are you sure you want to force-kill session \"{{name}}\"?",
+      "warning": "This will forcefully terminate the WhatsApp browser process. The session may need to be re-scanned on restart.",
+      "confirm": "Kill Session",
+      "successTitle": "Session Killed",
+      "success": "Session has been force-killed. You can restart it now.",
+      "failedTitle": "Force-Kill Failed",
+      "failed": "Failed to force-kill the session."
     }
   },
   "webhooks": {

--- a/dashboard/src/i18n/locales/zh-HK.json
+++ b/dashboard/src/i18n/locales/zh-HK.json
@@ -226,7 +226,8 @@
       "start": "啟動",
       "stop": "停止",
       "reconnect": "重新連線",
-      "delete": "刪除"
+      "delete": "刪除",
+      "killStuck": "Kill Stuck"
     },
     "toasts": {
       "readyTitle": "工作階段就緒",
@@ -241,6 +242,16 @@
       "sessionId": "工作階段 ID",
       "lastActive": "上次活躍",
       "error": "錯誤"
+    },
+    "forceKill": {
+      "title": "Kill Stuck Session",
+      "message": "Are you sure you want to force-kill session \"{{name}}\"?",
+      "warning": "This will forcefully terminate the WhatsApp browser process. The session may need to be re-scanned on restart.",
+      "confirm": "Kill Session",
+      "successTitle": "Session Killed",
+      "success": "Session has been force-killed. You can restart it now.",
+      "failedTitle": "Force-Kill Failed",
+      "failed": "Failed to force-kill the session."
     }
   },
   "webhooks": {

--- a/dashboard/src/pages/Sessions.tsx
+++ b/dashboard/src/pages/Sessions.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { Plus, QrCode, RefreshCw, Trash2, Eye, Loader2, Play, Square, X, Search, Filter } from 'lucide-react';
+import { Plus, QrCode, RefreshCw, Trash2, Eye, Loader2, Play, Square, X, Search, Filter, Skull } from 'lucide-react';
 import { sessionApi, type Session } from '../services/api';
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { useToast } from '../components/Toast';
@@ -25,6 +25,7 @@ export function Sessions() {
   const [statusFilter, setStatusFilter] = useState('all');
   const [selectedSession, setSelectedSession] = useState<Session | null>(null);
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
+  const [killConfirmId, setKillConfirmId] = useState<string | null>(null);
 
   const fetchSessions = useCallback(async (): Promise<Session[]> => {
     try {
@@ -201,6 +202,20 @@ export function Sessions() {
     } catch (err) {
       console.error('Failed to stop:', err);
       fetchSessions();
+    }
+  };
+
+  const handleForceKill = async (id: string) => {
+    try {
+      await sessionApi.forceKill(id);
+      setSessions(sessions.map(s => (s.id === id ? { ...s, status: 'disconnected' } : s)));
+      toast.success(t('sessions.forceKill.successTitle'), t('sessions.forceKill.success'));
+    } catch (err) {
+      console.error('Failed to force-kill:', err);
+      toast.error(t('sessions.forceKill.failedTitle'), t('sessions.forceKill.failed'));
+      fetchSessions();
+    } finally {
+      setKillConfirmId(null);
     }
   };
 
@@ -462,6 +477,37 @@ export function Sessions() {
         </div>
       )}
 
+      {killConfirmId && (
+        <div className="modal-overlay" onClick={() => setKillConfirmId(null)}>
+          <div className="modal confirm-modal" onClick={e => e.stopPropagation()}>
+            <div className="modal-header">
+              <h2>{t('sessions.forceKill.title')}</h2>
+              <button className="btn-icon" onClick={() => setKillConfirmId(null)}>
+                <X size={20} />
+              </button>
+            </div>
+            <div className="modal-body">
+              <p>
+                <Trans
+                  i18nKey="sessions.forceKill.message"
+                  values={{ name: sessions.find(s => s.id === killConfirmId)?.name }}
+                  components={{ strong: <strong /> }}
+                />
+              </p>
+              <p className="text-muted">{t('sessions.forceKill.warning')}</p>
+            </div>
+            <div className="modal-footer">
+              <button className="btn-secondary" onClick={() => setKillConfirmId(null)}>
+                {t('common.cancel')}
+              </button>
+              <button className="btn-danger" onClick={() => handleForceKill(killConfirmId)}>
+                {t('sessions.forceKill.confirm')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       <div className="sessions-grid">
         {filteredSessions.length === 0 ? (
           <div className="empty-state">
@@ -540,6 +586,12 @@ export function Sessions() {
                   <button className="btn-action danger" onClick={() => setDeleteConfirmId(session.id)}>
                     <Trash2 size={16} />
                     {t('sessions.actions.delete')}
+                  </button>
+                )}
+                {canWrite && session.status === 'failed' && (
+                  <button className="btn-action danger" onClick={() => setKillConfirmId(session.id)}>
+                    <Skull size={16} />
+                    {t('sessions.actions.killStuck')}
                   </button>
                 )}
               </div>

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -317,6 +317,7 @@ export const sessionApi = {
   delete: (id: string) => request<void>(`/sessions/${id}`, { method: 'DELETE' }),
   start: (id: string) => request<Session>(`/sessions/${id}/start`, { method: 'POST' }),
   stop: (id: string) => request<Session>(`/sessions/${id}/stop`, { method: 'POST' }),
+  forceKill: (id: string) => request<Session>(`/sessions/${id}/force-kill`, { method: 'POST' }),
   getQR: (id: string) => request<{ qrCode: string; status: string }>(`/sessions/${id}/qr`),
   getStats: () => request<SessionStats>('/sessions/stats/overview'),
   getGroups: (id: string) =>


### PR DESCRIPTION
Adds a **Kill Stuck** button to session cards with `status === 'failed'`.

Clicking shows a confirmation modal, then calls `POST /api/sessions/:id/force-kill` which triggers the engine-level `forceDestroy()` — killing Chromium processes holding the session's profile directory, then tearing down the client.

This PR was previously part of #317 (closed) which depended on a backend PR that was also closed. The backend is now on main as of v0.4.2+.