### PR TITLE
fix(docker): include procps for browser cleanup paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ RUN apt-get update && apt-get install -y \
     dumb-init \
     gosu \
     curl \
+    procps \
     && rm -rf /var/lib/apt/lists/*
 
 # Set Chrome executable path for Puppeteer


### PR DESCRIPTION
## Summary

- Install `procps` in the production Docker image so `ps` is available at runtime.

## Context

Follow-up to #355 / #353.

The previous PR was accidentally closed after the branch was reset while addressing review feedback. This PR reapplies the accepted Dockerfile-only fix on a fresh branch.

The production image is based on `node:22-slim`, which does not include `ps` by default. `tree-kill` can attempt to spawn `ps` during browser cleanup paths, so installing `procps` prevents that missing-binary cleanup crash class.

This does not address the original browser timeout itself; it prevents the missing-`ps` cleanup failure from bringing down the runtime.

## Testing

Not run. Dockerfile-only change.