### PR TITLE
docs: changelog entry for procps browser-cleanup fix (#359)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Container no longer crashes on browser-cleanup paths when `ps` is missing.** The production image is based on
+  `node:22-slim`, which omits the `ps` binary; cleanup code that shells out to `ps` (e.g. process-tree kills) fails
+  with `spawn ps ENOENT`, and that unhandled child-process error can take down the whole Node runtime. The image now
+  installs `procps`. This does not change the underlying browser-init timeout — it only prevents the missing-`ps`
+  cleanup failure from being fatal. (#359)
+
 ### Documentation
 
 - **Documented chat-history limits.** A new guide explains the difference between the local message-history


### PR DESCRIPTION
## Summary

Adds the missing `[Unreleased]` CHANGELOG entry for #359 (which merged the `procps` Dockerfile fix without a changelog note).

## Context

#359 installs `procps` in the production image so the `ps` binary exists at runtime, preventing the `spawn ps ENOENT` cleanup crash class on `node:22-slim`. Verified locally: image builds clean, `ps` resolves and runs inside it, base image confirmed to lack it without the fix. Relates to #353 (cleanup crash class only; the underlying QR-init timeout remains tracked there).

## Testing

Docs-only change.