### PR TITLE
fix(baileys): allow sending captions with document messages

### DIFF
--- a/src/engine/adapters/baileys.adapter.spec.ts
+++ b/src/engine/adapters/baileys.adapter.spec.ts
@@ -852,12 +852,14 @@ describe('BaileysAdapter media sends', () => {
       mimetype: 'application/pdf',
       data: Buffer.from('PDFDATA').toString('base64'),
       filename: 'doc.pdf',
+      caption: 'a document',
     });
     expect(loadRemoteMediaBuffer).not.toHaveBeenCalled();
     expect(fakeSock.sendMessage).toHaveBeenCalledWith('628111@s.whatsapp.net', {
       document: Buffer.from('PDFDATA'),
       mimetype: 'application/pdf',
       fileName: 'doc.pdf',
+      caption: 'a document',
     });
   });
 

--- a/src/engine/adapters/baileys.adapter.ts
+++ b/src/engine/adapters/baileys.adapter.ts
@@ -380,7 +380,12 @@ export class BaileysAdapter implements IWhatsAppEngine {
   async sendDocumentMessage(chatId: string, media: MediaInput): Promise<MessageResult> {
     this.ensureReady();
     const { data, mimetype } = await this.resolveMediaBuffer(media);
-    return this.sendContent(chatId, { document: data, mimetype, fileName: media.filename ?? 'file' });
+    return this.sendContent(chatId, {
+      document: data,
+      mimetype,
+      fileName: media.filename ?? 'file',
+      caption: media.caption,
+    });
   }
 
   async sendStickerMessage(chatId: string, media: MediaInput): Promise<MessageResult> {

--- a/src/modules/message/message.service.ts
+++ b/src/modules/message/message.service.ts
@@ -219,7 +219,7 @@ export class MessageService {
     // Save message as pending BEFORE sending
     const message = await this.saveOutgoingMessage(sessionId, {
       chatId: dto.chatId,
-      body: dto.filename || '',
+      body: dto.caption || dto.filename || '',
       type: 'document',
       metadata: {
         media: { mimetype: dto.mimetype, filename: dto.filename, data: dto.base64 || dto.url },


### PR DESCRIPTION
The baileys adapter was ignoring the `caption` field when sending document messages. This commit passes the `caption`
  from the media payload to the `sendContent` method. Additionally, it updates `message.service.ts` to correctly store the document's caption in the database instead of defaulting to the filename.

## Description
This PR fixes an issue where the `caption` field was being completely ignored when sending document payloads (like PDFs) using the Baileys adapter.

- Updated `baileys.adapter.ts` to properly pass the `caption` property to the underlying `sendContent` method.
    - Updated `message.service.ts` so the database stores the `caption` as the message `body` for documents, falling back to the filename if a caption isn't provided.
    - Added test coverage in `baileys.adapter.spec.ts` to prevent future regressions.

## Type of Change
- [x ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] Tests added/updated
- [ ] Documentation updated
- [x] Lint passes
- [x] Self-reviewed

## Screenshots (if applicable)
N/A
## Related Issues
Closes #
