### PR TITLE
chore(release): v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4] - 2026-06-20
+
+A reliability and correctness patch. Engine: Baileys reconnect no longer leaks its socket, and a session
+keeps its operator config even if the engine plugin fails to enable before `onLoad`. Templates: names are now
+unique per session (deterministic resolve, `409` on duplicate, with a lossless de-duplicating migration).
+Tooling: the migration CLI can manage the main (auth/audit) connection, and the Docker image ships `procps`
+so a missing-`ps` cleanup path can't crash the container. **One behavior change to note:** `PUT /settings`
+now returns `501` — settings are environment-derived and read-only at runtime — instead of a misleading `200`
+(no dashboard flow uses the write).
+
 ### Added
 
 - **CLI migration commands for the main (auth/audit) connection.** The app runs the main connection as a separate

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/rmyndharis/OpenWA/actions/workflows/ci.yml"><img src="https://github.com/rmyndharis/OpenWA/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"/></a>
-  <img src="https://img.shields.io/badge/version-0.4.3-blue.svg" alt="Version"/>
+  <img src="https://img.shields.io/badge/version-0.4.4-blue.svg" alt="Version"/>
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"/>
   <img src="https://img.shields.io/badge/node-22_LTS-brightgreen.svg" alt="Node"/>
   <img src="https://img.shields.io/badge/NestJS-11.x-red.svg" alt="NestJS"/>

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboard",
   "private": true,
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/docs/07-api-collection.md
+++ b/docs/07-api-collection.md
@@ -71,7 +71,7 @@ curl -H "X-API-Key: $API_KEY" \
 ```json
 {
   "status": "ok",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "uptime": 86400,
   "timestamp": "2026-02-02T10:30:00Z",
   "checks": {

--- a/docs/13-horizontal-scaling.md
+++ b/docs/13-horizontal-scaling.md
@@ -105,7 +105,7 @@ version: '3.8'
 
 services:
   openwa:
-    image: ghcr.io/rmyndharis/openwa:0.4.3
+    image: ghcr.io/rmyndharis/openwa:0.4.4
     deploy:
       replicas: 1 # MUST stay 1 until session-claim is implemented — multiple replicas on one session volume corrupt WhatsApp auth (H1/H11)
       update_config:
@@ -263,7 +263,7 @@ spec:
     spec:
       containers:
         - name: openwa
-          image: ghcr.io/rmyndharis/openwa:0.4.3
+          image: ghcr.io/rmyndharis/openwa:0.4.4
           ports:
             - containerPort: 2785
               name: http

--- a/docs/15-project-roadmap.md
+++ b/docs/15-project-roadmap.md
@@ -491,7 +491,7 @@ v0.1.0 Release Package:
 ## 15.6 Future Roadmap (v0.3.0+)
 
 > **Note:** Version 0.1.0 is the initial stable release including all features from Phases 1-3.
-> Versions 0.1.7 through 0.4.3 have since shipped (see the CHANGELOG); v1.0.0
+> Versions 0.1.7 through 0.4.4 have since shipped (see the CHANGELOG); v1.0.0
 > onward is forward-looking.
 
 ```mermaid

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.4.3-blue.svg" alt="Version"/>
+  <img src="https://img.shields.io/badge/version-0.4.4-blue.svg" alt="Version"/>
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"/>
   <img src="https://img.shields.io/badge/node-22_LTS-brightgreen.svg" alt="Node"/>
   <img src="https://img.shields.io/badge/NestJS-11.x-red.svg" alt="NestJS"/>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwa",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API for WhatsApp",
   "author": "Yudhi Armyndharis & OpenWA Contributors",
   "private": true,

--- a/src/config/swagger.config.ts
+++ b/src/config/swagger.config.ts
@@ -14,7 +14,7 @@ export function createSwaggerConfig(): Omit<OpenAPIObject, 'paths'> {
     new DocumentBuilder()
       .setTitle('OpenWA API')
       .setDescription('Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API')
-      .setVersion('0.4.3')
+      .setVersion('0.4.4')
       .addApiKey({ type: 'apiKey', name: 'X-API-Key', in: 'header' }, API_KEY_SECURITY_SCHEME)
       // Apply the scheme globally so Swagger UI sends the key with every request
       // (mirrors the global ApiKeyGuard). Without this, "Authorize" is cosmetic.


### PR DESCRIPTION
Release **v0.4.4** — a reliability and correctness patch.

Bundles the work merged since v0.4.3: the reliability/correctness fixes (#364), the `procps` Docker fix (#359), and the chat-history-limits docs (#356/#357).

## Highlights
- **Engine:** Baileys reconnect no longer leaks its socket; a session keeps operator config even if the engine plugin fails to enable before `onLoad`.
- **Templates:** names are unique per session (deterministic resolve, `409` on duplicate) with a lossless de-duplicating migration.
- **Tooling:** migration CLI can manage the main (auth/audit) connection; Docker image ships `procps`.
- **Behavior change:** `PUT /settings` now returns `501` (env-derived, read-only) instead of a misleading `200` — no dashboard flow uses the write.

## This PR
- Version bump 0.4.3 → 0.4.4 (package.json, dashboard/package.json, swagger, README + docs badges, scaling-example image tags, roadmap, API collection).
- CHANGELOG `[Unreleased]` → `[0.4.4]` with release summary.

Full gate green locally (903 tests, backend lint+build, dashboard build+lint).