### PR TITLE
chore(release): v0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.5] - 2026-06-20
+
+A Baileys engine quality-and-correctness release, plus a chat-history enhancement. **Identity:** inbound
+Baileys message ids are now engine-neutral (`@c.us`, matching whatsapp-web.js), the dashboard Chats list
+shows saved/contact names instead of raw JIDs, and `@lid` (privacy-id) senders resolve to a phone number.
+**Messaging:** an opt-in `deep=true` mode lets the live chat-history endpoint reach up to 2000 messages
+back on whatsapp-web.js, and Baileys can now send captions with document messages. **One behavior change
+to note:** `message.received` / `revoked` / `reaction` webhook and WebSocket payloads from a Baileys
+session now carry `@c.us` ids where they previously carried `@s.whatsapp.net` (or a resolved `@lid`) — a
+consumer that stored or compared the old ids will see the new value.
+
 ### Added
 
 - **Opt-in deep chat history (`deep=true`).** `GET /sessions/:id/messages/:chatId/history` was capped at
@@ -47,6 +58,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   payloads from a Baileys session now carry `@c.us` ids where they previously carried
   `@s.whatsapp.net` (or a resolved `@lid`); a consumer that stored or compared the old ids will see the
   new value. Outbound sending and contact/chat list ids are unchanged for now.
+
+- **Baileys engine: documents can now be sent with a caption.** `sendDocumentMessage` dropped
+  `media.caption` on the Baileys engine, while whatsapp-web.js already forwarded it. Baileys now sends the
+  caption too (parity across engines); the document stores the caption as its message body, falling back
+  to the filename when absent. (#363)
 
 ## [0.4.4] - 2026-06-20
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/rmyndharis/OpenWA/actions/workflows/ci.yml"><img src="https://github.com/rmyndharis/OpenWA/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"/></a>
-  <img src="https://img.shields.io/badge/version-0.4.4-blue.svg" alt="Version"/>
+  <img src="https://img.shields.io/badge/version-0.4.5-blue.svg" alt="Version"/>
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"/>
   <img src="https://img.shields.io/badge/node-22_LTS-brightgreen.svg" alt="Node"/>
   <img src="https://img.shields.io/badge/NestJS-11.x-red.svg" alt="NestJS"/>

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboard",
   "private": true,
-  "version": "0.4.4",
+  "version": "0.4.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/docs/07-api-collection.md
+++ b/docs/07-api-collection.md
@@ -71,7 +71,7 @@ curl -H "X-API-Key: $API_KEY" \
 ```json
 {
   "status": "ok",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "uptime": 86400,
   "timestamp": "2026-02-02T10:30:00Z",
   "checks": {

--- a/docs/13-horizontal-scaling.md
+++ b/docs/13-horizontal-scaling.md
@@ -105,7 +105,7 @@ version: '3.8'
 
 services:
   openwa:
-    image: ghcr.io/rmyndharis/openwa:0.4.4
+    image: ghcr.io/rmyndharis/openwa:0.4.5
     deploy:
       replicas: 1 # MUST stay 1 until session-claim is implemented — multiple replicas on one session volume corrupt WhatsApp auth (H1/H11)
       update_config:
@@ -263,7 +263,7 @@ spec:
     spec:
       containers:
         - name: openwa
-          image: ghcr.io/rmyndharis/openwa:0.4.4
+          image: ghcr.io/rmyndharis/openwa:0.4.5
           ports:
             - containerPort: 2785
               name: http

--- a/docs/15-project-roadmap.md
+++ b/docs/15-project-roadmap.md
@@ -491,7 +491,7 @@ v0.1.0 Release Package:
 ## 15.6 Future Roadmap (v0.3.0+)
 
 > **Note:** Version 0.1.0 is the initial stable release including all features from Phases 1-3.
-> Versions 0.1.7 through 0.4.4 have since shipped (see the CHANGELOG); v1.0.0
+> Versions 0.1.7 through 0.4.5 have since shipped (see the CHANGELOG); v1.0.0
 > onward is forward-looking.
 
 ```mermaid

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.4.4-blue.svg" alt="Version"/>
+  <img src="https://img.shields.io/badge/version-0.4.5-blue.svg" alt="Version"/>
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"/>
   <img src="https://img.shields.io/badge/node-22_LTS-brightgreen.svg" alt="Node"/>
   <img src="https://img.shields.io/badge/NestJS-11.x-red.svg" alt="NestJS"/>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwa",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API for WhatsApp",
   "author": "Yudhi Armyndharis & OpenWA Contributors",
   "private": true,

--- a/src/config/swagger.config.ts
+++ b/src/config/swagger.config.ts
@@ -14,7 +14,7 @@ export function createSwaggerConfig(): Omit<OpenAPIObject, 'paths'> {
     new DocumentBuilder()
       .setTitle('OpenWA API')
       .setDescription('Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API')
-      .setVersion('0.4.4')
+      .setVersion('0.4.5')
       .addApiKey({ type: 'apiKey', name: 'X-API-Key', in: 'header' }, API_KEY_SECURITY_SCHEME)
       // Apply the scheme globally so Swagger UI sends the key with every request
       // (mirrors the global ApiKeyGuard). Without this, "Authorize" is cosmetic.


### PR DESCRIPTION
Release **v0.4.5** — a Baileys quality/correctness patch plus a chat-history enhancement.

## Included (already merged to main)
- **#342** engine-neutral Baileys inbound ids (`@c.us`)
- **#363** Baileys document captions (engine parity)
- **#370** (closes #369) Baileys Chats list shows saved/contact names
- **#371** (closes #347) opt-in `deep=true` chat history (ceiling 2000, metadata-only)
- **#372** (closes #362) Baileys `@lid → phone` resolution via the inbound message key

## Release chores in this PR
- Version bump `0.4.4 → 0.4.5`: `package.json`, `dashboard/package.json`, `src/config/swagger.config.ts`, README + docs version badges, `docs/07-api-collection.md`, `docs/13-horizontal-scaling.md` image tags, `docs/15-project-roadmap.md` range.
- CHANGELOG: consolidated `[Unreleased]` → `[0.4.5] - 2026-06-20` with a summary, and added the missing #363 entry. Fresh empty `[Unreleased]` left at the top.

## ⚠️ Behavior change to note
`message.received` / `revoked` / `reaction` webhook + WebSocket payloads from a **Baileys** session now carry `@c.us` ids where they previously carried `@s.whatsapp.net` (or a resolved `@lid`). A consumer that stored or compared the old ids will see the new value. whatsapp-web.js is unaffected; outbound sending and contact/chat list ids are unchanged.

## Verification
- Backend: `eslint` clean, `nest build` clean, `jest` **942/942** pass (86 suites).
- Dashboard: `vite build` OK, `eslint` 0 errors (3 pre-existing warnings).

After merge: tag `v0.4.5` → `release.yml` publishes the multi-arch GHCR image and creates the GitHub Release from the CHANGELOG section.