### PR TITLE
fix(baileys): fold neutral @c.us participant ids to engine dialect for group ops

### DIFF
--- a/src/engine/adapters/baileys-session-store.ts
+++ b/src/engine/adapters/baileys-session-store.ts
@@ -161,12 +161,14 @@ export class BaileysSessionStore {
   }
 
   /**
-   * Fold an app-facing neutral id back to the engine's raw dialect for map lookups. The contacts /
-   * chats / lastMessages maps are keyed by Baileys' raw `@s.whatsapp.net`, but the app now hands us the
-   * neutral `@c.us` (contact/chat ids are emitted neutral). Groups/lids/others share the dialect, so
-   * pass them through unchanged.
+   * Fold an app-facing neutral id back to the engine's raw dialect. The contacts / chats / lastMessages
+   * maps are keyed by Baileys' raw `@s.whatsapp.net`, but the app now hands us the neutral `@c.us`
+   * (contact/chat ids are emitted neutral), so map lookups must fold first. The outbound group-participant
+   * ops fold for the same reason: only `@s.whatsapp.net` encodes to the single-byte protocol token, whereas
+   * a raw `c.us` server suffix would go on the wire as an unknown string. Groups/lids/others share the
+   * dialect, so pass them through unchanged.
    */
-  private toEngineJid(jid: string): string {
+  toEngineJid(jid: string): string {
     const parsed = parseWaId(jid);
     return parsed.kind === 'user' ? `${parsed.userPart}@s.whatsapp.net` : jid;
   }

--- a/src/engine/adapters/baileys.adapter.spec.ts
+++ b/src/engine/adapters/baileys.adapter.spec.ts
@@ -1253,6 +1253,35 @@ describe('BaileysAdapter group management', () => {
     expect(fakeSock.groupParticipantsUpdate).toHaveBeenCalledWith('123-456@g.us', ['628111@s.whatsapp.net'], action);
   });
 
+  // A neutral `<phone>@c.us` participant id must reach Baileys as `<phone>@s.whatsapp.net` — only the
+  // latter encodes to the single-byte protocol token; a raw `c.us` server suffix goes on the wire as an
+  // unknown 4-byte string. The group id (`@g.us`) and `@lid` (a first-class addressing mode) are untouched.
+  it.each([
+    ['addParticipants', 'add'],
+    ['removeParticipants', 'remove'],
+    ['promoteParticipants', 'promote'],
+    ['demoteParticipants', 'demote'],
+  ])('%s folds a neutral @c.us participant id to the engine dialect on the wire', async (method, action) => {
+    const adapter = await ready();
+    await (adapter as unknown as Record<string, (g: string, p: string[]) => Promise<void>>)[method]('123-456@g.us', [
+      '628111@c.us',
+    ]);
+    expect(fakeSock.groupParticipantsUpdate).toHaveBeenCalledWith('123-456@g.us', ['628111@s.whatsapp.net'], action);
+  });
+
+  it('participant ops pass @lid ids through unchanged (lid addressing mode)', async () => {
+    const adapter = await ready();
+    await adapter.addParticipants('123-456@g.us', ['111@lid']);
+    expect(fakeSock.groupParticipantsUpdate).toHaveBeenCalledWith('123-456@g.us', ['111@lid'], 'add');
+  });
+
+  it('createGroup folds neutral @c.us participants to the engine dialect, keeping @lid raw', async () => {
+    fakeSock.groupCreate.mockResolvedValue(META);
+    const adapter = await ready();
+    await adapter.createGroup('G', ['628111@c.us', '222@lid']);
+    expect(fakeSock.groupCreate).toHaveBeenCalledWith('G', ['628111@s.whatsapp.net', '222@lid']);
+  });
+
   it('leaveGroup / setGroupSubject / setGroupDescription delegate to the socket', async () => {
     const adapter = await ready();
     await adapter.leaveGroup('123-456@g.us');

--- a/src/engine/adapters/baileys.adapter.ts
+++ b/src/engine/adapters/baileys.adapter.ts
@@ -572,28 +572,36 @@ export class BaileysAdapter implements IWhatsAppEngine {
 
   async createGroup(name: string, participants: string[]): Promise<Group> {
     this.ensureReady();
-    const metadata = await this.sock!.groupCreate(name, participants);
+    const metadata = await this.sock!.groupCreate(name, this.toEngineParticipants(participants));
     return mapBaileysGroup(metadata, this.normalizedSelfJid(), jid => this.sessionStore.toNeutralJid(jid));
   }
 
   async addParticipants(groupId: string, participants: string[]): Promise<void> {
     this.ensureReady();
-    await this.sock!.groupParticipantsUpdate(groupId, participants, 'add');
+    await this.sock!.groupParticipantsUpdate(groupId, this.toEngineParticipants(participants), 'add');
   }
 
   async removeParticipants(groupId: string, participants: string[]): Promise<void> {
     this.ensureReady();
-    await this.sock!.groupParticipantsUpdate(groupId, participants, 'remove');
+    await this.sock!.groupParticipantsUpdate(groupId, this.toEngineParticipants(participants), 'remove');
   }
 
   async promoteParticipants(groupId: string, participants: string[]): Promise<void> {
     this.ensureReady();
-    await this.sock!.groupParticipantsUpdate(groupId, participants, 'promote');
+    await this.sock!.groupParticipantsUpdate(groupId, this.toEngineParticipants(participants), 'promote');
   }
 
   async demoteParticipants(groupId: string, participants: string[]): Promise<void> {
     this.ensureReady();
-    await this.sock!.groupParticipantsUpdate(groupId, participants, 'demote');
+    await this.sock!.groupParticipantsUpdate(groupId, this.toEngineParticipants(participants), 'demote');
+  }
+
+  /**
+   * Fold neutral `<phone>@c.us` participant ids back to the engine wire dialect (`@s.whatsapp.net`) before
+   * a group write. `@lid` (a first-class addressing mode) and the group id itself are left untouched.
+   */
+  private toEngineParticipants(participants: string[]): string[] {
+    return participants.map(p => this.sessionStore.toEngineJid(p));
   }
 
   async leaveGroup(groupId: string): Promise<void> {


### PR DESCRIPTION
## What

The engine boundary uses a neutral JID dialect (`<phone>@c.us`, `<id>@g.us`, `<lid>@lid`). The Baileys group-participant operations — `addParticipants` / `removeParticipants` / `promoteParticipants` / `demoteParticipants` and `createGroup` — passed the caller-supplied participant ids straight to `groupParticipantsUpdate` / `groupCreate`. A neutral `<phone>@c.us` id is then placed **raw** on the binary wire as an unknown `c.us` server suffix, instead of the single-byte `s.whatsapp.net` protocol token. This broke the engine's neutral-id round-trip invariant for group ops.

(1:1 messaging is unaffected — Baileys' `relayMessage` re-derives the destination from the decoded user part.)

## Change

Fold participant ids back to the engine dialect via the existing `toEngineJid` transform (now reused at the adapter boundary through a small `toEngineParticipants` helper) before the group calls. `@lid` (a first-class addressing mode) and the `@g.us` group id are left untouched.

## Preserved behaviour

- A `@s.whatsapp.net` participant id (the previous shape) is idempotent through the transform.
- `getGroupInfo` / `getGroups` still return **neutral** `@c.us` participant ids — the displayed ids are re-canonicalized from Baileys' response metadata, independent of the outbound wire dialect.
- The whatsapp-web.js engine is deliberately untouched (`@c.us` is its correct native dialect).

## Tests

New `baileys.adapter.spec.ts` cases assert that `@c.us` participants reach the socket as `@s.whatsapp.net` across all four ops and `createGroup`, while `@lid` passes through unchanged. Backend `lint` + `build` + full `jest` green.