### PR TITLE
feat(webhook): dispatch message.reaction events (WebSocket/webhook parity)

### DIFF
--- a/dashboard/src/pages/Webhooks.tsx
+++ b/dashboard/src/pages/Webhooks.tsx
@@ -34,6 +34,7 @@ const availableEventNames = [
   'message.ack',
   'message.failed',
   'message.revoked',
+  'message.reaction',
   'session.status',
   'session.qr',
   'session.authenticated',

--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -1324,6 +1324,7 @@ Examples:
 - message.sent: msg_{sessionId}_{messageId}
 - message.ack: ack_{sessionId}_{messageId}_{status}
 - message.failed: failed_{sessionId}_{messageId}_{status}
+- message.reaction: react_{sessionId}_{messageId}_{senderId}
 - session.status: sess_{sessionId}_{status}
 - group.join: grp_{groupId}_{participantId}_join
 ```
@@ -1663,6 +1664,7 @@ ws.send(JSON.stringify({
 | `message.sent` | Message sent successfully |
 | `message.ack` | Message acknowledgment (delivered, read) |
 | `message.revoked` | Message was deleted |
+| `message.reaction` | A reaction was added, changed, or removed on a message |
 | `group.join` | Group join event |
 | `group.leave` | Group leave event |
 | `group.update` | Group info updated |

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -810,6 +810,32 @@ describe('SessionService', () => {
       expect(chains.size).toBe(0);
     });
 
+    it('dispatches message.reaction to the webhook with the post-apply reactions snapshot', async () => {
+      const callbacks = await startAndCaptureCallbacks();
+      type Row = { metadata?: Record<string, unknown> };
+      const clone = (r: Row): Row => JSON.parse(JSON.stringify(r)) as Row;
+      let stored: Row = { metadata: {} };
+      (messageRepository.findOne as jest.Mock).mockImplementation(() => Promise.resolve(clone(stored)));
+      (messageRepository.save as jest.Mock).mockImplementation((m: Row) => {
+        stored = clone(m);
+        return Promise.resolve(m);
+      });
+
+      callbacks.onMessageReaction!({ messageId: 'wa-1', chatId: 'c', senderId: 'alice', reaction: '👍' });
+      for (let i = 0; i < 3; i++) await flush();
+
+      const dispatched = dispatchedEvents('message.reaction');
+      expect(dispatched).toHaveLength(1);
+      // Webhook payload mirrors the WS payload: the event plus the post-apply reactions snapshot.
+      expect(dispatched[0][2]).toMatchObject({
+        messageId: 'wa-1',
+        chatId: 'c',
+        senderId: 'alice',
+        reaction: '👍',
+        reactions: { alice: '👍' },
+      });
+    });
+
     it('dispatches message.received (not message.sent) on an incoming message event', async () => {
       const callbacks = await startAndCaptureCallbacks();
 

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -812,6 +812,9 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
       await this.messageRepository.save(msg);
 
       this.eventsGateway.emitMessageReaction(id, { ...event, reactions });
+      // Webhook parity with the WebSocket broadcast: same payload (event + post-apply snapshot), so a
+      // webhook-only consumer observes reactions too. Idempotency for this event is salted per dispatch.
+      void this.webhookService.dispatch(id, 'message.reaction', { ...event, reactions });
     } catch (err) {
       this.logger.error(`Failed to update message reaction: ${event.messageId}`, String(err));
     }

--- a/src/modules/webhook/dto/webhook.dto.ts
+++ b/src/modules/webhook/dto/webhook.dto.ts
@@ -22,6 +22,7 @@ export const WEBHOOK_EVENTS = [
   'message.ack',
   'message.failed',
   'message.revoked',
+  'message.reaction',
   'session.status',
   'session.qr',
   'session.authenticated',

--- a/src/modules/webhook/utils/idempotency.util.spec.ts
+++ b/src/modules/webhook/utils/idempotency.util.spec.ts
@@ -111,6 +111,37 @@ describe('Idempotency Utils', () => {
       expect(a).toBe('ack_A_X_read');
     });
 
+    it('salts message.reaction keys so a re-reaction (same sender/emoji, later time) is a distinct event', () => {
+      // A reaction has no unique id and is a read-modify-write: the same sender can go 👍 → remove → 👍.
+      // Keying on (sender, message, emoji) alone would collapse the re-reaction onto the earlier one.
+      const a = generateIdempotencyKey(
+        'message.reaction',
+        { sessionId: 'A', messageId: 'MSG1', senderId: '628111@c.us', reaction: '👍' },
+        '2026-06-20T00:00:00.000Z',
+      );
+      const b = generateIdempotencyKey(
+        'message.reaction',
+        { sessionId: 'A', messageId: 'MSG1', senderId: '628111@c.us', reaction: '👍' },
+        '2026-06-20T00:05:00.000Z',
+      );
+      expect(a).not.toBe(b);
+    });
+
+    it('is retry-stable for message.reaction: the same occurrence regenerates the same key', () => {
+      const at = '2026-06-20T00:00:00.000Z';
+      const data = { sessionId: 'A', messageId: 'MSG1', senderId: '628111@c.us', reaction: '👍' };
+      expect(generateIdempotencyKey('message.reaction', data, at)).toBe(
+        generateIdempotencyKey('message.reaction', data, at),
+      );
+    });
+
+    it('gives two senders reacting to the same message DISTINCT message.reaction keys', () => {
+      const at = '2026-06-20T00:00:00.000Z';
+      const a = generateIdempotencyKey('message.reaction', { sessionId: 'A', messageId: 'M', senderId: 'S1' }, at);
+      const b = generateIdempotencyKey('message.reaction', { sessionId: 'A', messageId: 'M', senderId: 'S2' }, at);
+      expect(a).not.toBe(b);
+    });
+
     it('should generate key for group.join', () => {
       const key = generateIdempotencyKey('group.join', {
         groupId: 'grp_1',

--- a/src/modules/webhook/utils/idempotency.util.ts
+++ b/src/modules/webhook/utils/idempotency.util.ts
@@ -56,6 +56,14 @@ export function generateIdempotencyKey(event: string, data: Record<string, unkno
     case 'message.revoked':
       return `rev_${toStr(data.sessionId)}_${toStr(data.id ?? data.messageId)}`;
 
+    case 'message.reaction':
+      // A reaction carries no unique id and is a read-modify-write of the message's reactions map; the
+      // same sender can re-apply the same emoji over time (👍 → remove → 👍). Keying on
+      // (sender, target message) alone would collapse a genuine re-reaction onto the earlier one, so salt
+      // with occurredAt (captured once per dispatch, reused across retries): distinct occurrences get
+      // distinct keys while retries of the same delivery stay stable.
+      return `react_${toStr(data.sessionId)}_${toStr(data.messageId)}_${toStr(data.senderId)}${occurrence}`;
+
     case 'session.status':
       // Salted so repeated transitions to the same status (e.g. across disconnect/reconnect cycles)
       // stay distinct instead of collapsing onto one key.


### PR DESCRIPTION
## What

Message reactions were broadcast over **WebSocket only** — a webhook-only consumer could never observe reactions, an undocumented asymmetry (`message.reaction` was a subscribable WS event but not a webhook event).

## Change

- Register `message.reaction` in `WEBHOOK_EVENTS` (among the dispatched events) and expose it in the dashboard event picker.
- Dispatch it from `SessionService.applyReaction`, alongside the existing WebSocket emit, with the **same payload** (`{ messageId, chatId, reaction, senderId, reactions }`, where `reactions` is the post-apply snapshot). Dispatch is fire-and-forget and happens only after the reaction is persisted.
- Add a dedicated idempotency-key case.

## Idempotency

A reaction carries no unique id and is a read-modify-write of the message's reactions map — the same sender can re-apply the same emoji over time (👍 → remove → 👍). Keying on `(sender, message)` alone would collapse a genuine re-reaction onto the earlier one. The key is therefore **salted with the per-dispatch `occurredAt`** (captured once, reused across retries) — the same mechanism the recurring `session.*` lifecycle events use: distinct occurrences get distinct keys while retries of one delivery stay stable.

## ⚠️ Consumer-visible

Webhooks subscribed with the wildcard `'*'` will **begin receiving `message.reaction`** deliveries. Existing semantics for all other events are unchanged.

## Tests

- `idempotency.util.spec.ts`: salt distinctness (re-reaction is a distinct event), retry-stability, two-sender distinctness.
- `session.service.spec.ts`: a reaction now dispatches `message.reaction` with the post-apply `reactions` snapshot.
- Backend `lint` + `build` + full `jest` (980) green; dashboard `build` + `lint` green. API spec updated.