### PR TITLE
chore(release): v0.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.6] - 2026-06-20
+
+A reliability, correctness, and dashboard release. **Identity & engine:** Baileys gains a persistent,
+cross-session `lid -> phone` table (shared resolution that survives restarts) plus a new `from` message
+filter, and its contact/chat *listing* ids are now engine-neutral (`@c.us`). **Webhooks:** message
+reactions now also fire as a `message.reaction` webhook (previously WebSocket-only). **Dashboard:**
+selectable appearance palettes with light/dark/system mode, and a redesigned Templates workspace.
+**Hardening:** the LibreTranslate client pins its outbound connection, and Baileys group-participant
+operations address participants in the engine wire dialect. **Two consumer-visible notes:** Baileys
+contact/chat-list ids flip `@s.whatsapp.net` -> `@c.us` (whatsapp-web.js already used `@c.us`), and
+webhooks subscribed with `*` now also receive `message.reaction`.
+
 ### Added
 
 - **Persistent, cross-session `lid -> phone` resolution + a `from` filter on message history.** A new
@@ -20,11 +32,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Baileys engine observes (inbound message `senderPn`/`participantPn`, the `chats.phoneNumberShare`
   event, contacts, and history sync), so it fills continuously without re-auth. Internally these ids are
   now carried by a typed `WaId` value object; it is in-memory only and serializes to the exact same
-  neutral string, so **no webhook / WebSocket / REST response shape changes**.
+  neutral string, so **no webhook / WebSocket / REST response shape changes**. (#374)
+
+- **Webhook parity for message reactions (`message.reaction`).** Reactions were broadcast over the
+  WebSocket only; they are now also delivered as a `message.reaction` webhook with the same payload (the
+  reaction plus the post-apply reactions snapshot) and are selectable in the dashboard event picker.
+  Idempotency is salted per dispatch, so a re-reaction is a distinct delivery while retries dedupe.
+  **Consumer-visible:** webhooks subscribed with `*` now also receive this event. (#380)
+
+- **Dashboard appearance palettes + redesigned Templates workspace.** A new Appearance menu switches
+  light / dark / system mode and selectable accent palettes (persisted and applied across the UI). The
+  Templates page is redesigned into a searchable workspace with a saved-template library, editor, live
+  preview, and placeholder inputs. (#361)
 
 - **`BAILEYS_LOG_LEVEL`** (trace|debug|info|warn|error, silent by default) surfaces the Baileys library's
   own diagnostics; `trace` dumps the decoded WhatsApp wire frames to stdout (context "baileys-wire") for
-  analysis.
+  analysis. (#375)
 
 ### Fixed
 
@@ -34,12 +57,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   list, recent messages, or `lid -> phone` mappings ever arrived. The adapter now passes
   `shouldSyncHistoryMessage: () => true`, enabling the sync while keeping the full-archive download
   opt-in via `BAILEYS_SYNC_FULL_HISTORY` (WhatsApp sends the recent window + contact snapshot, not the
-  entire message history).
+  entire message history). (#375)
 
 - **Message history `chatId` filter now matches across dialects.** A chat addressed as `<phone>@c.us` (the
   neutral list id) now also returns messages stored under `<phone>@s.whatsapp.net` (e.g. an outbound send
   addressed by a raw engine id), so the conversation view is no longer empty when the stored and queried
-  dialects differ - the same resolution the `from` filter uses.
+  dialects differ - the same resolution the `from` filter uses. (#375)
 
 - **Baileys engine: contact and chat *listing* ids are now engine-neutral (`@c.us`).** `getContacts` /
   `getChats` / `getContactById` previously returned the raw `<phone>@s.whatsapp.net` id (visible in the
@@ -47,7 +70,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `@c.us` dialect like the message payloads; the read-back paths (`sendSeen` / `deleteChat` / contact
   lookup) accept the neutral id and fold it back internally, so sending and marking-read still round-trip.
   **Consumer-visible:** Baileys contact/chat-list ids flip `@s.whatsapp.net` -> `@c.us` (whatsapp-web.js
-  already used `@c.us`).
+  already used `@c.us`). (#374)
+
+- **Hardened the LibreTranslate translation client against DNS rebinding.** The client validated the
+  target host and then issued a separate request that re-resolved DNS at connect time. It now pins the
+  connection to the pre-validated address (the same SSRF-safe path webhook and media delivery use) and
+  refuses redirects, so the API key (sent in the request body) cannot be redirected to an internal target
+  between the host check and the connection. (#377)
+
+- **Baileys group-participant operations now address participants in the engine wire dialect.** Add /
+  remove / promote / demote and group creation passed neutral `<phone>@c.us` participant ids straight to
+  the wire, where they encode as an unknown server suffix instead of the `s.whatsapp.net` protocol token.
+  They now fold to the engine dialect before the call (matching how 1:1 sends already round-trip); `@lid`
+  and the `@g.us` group id are untouched, and the returned group info stays neutral `@c.us`. (#378)
+
+- **Italian translation corrections.** Updated and corrected the Italian (`it`) dashboard locale. (#376)
 
 ## [0.4.5] - 2026-06-20
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/rmyndharis/OpenWA/actions/workflows/ci.yml"><img src="https://github.com/rmyndharis/OpenWA/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"/></a>
-  <img src="https://img.shields.io/badge/version-0.4.5-blue.svg" alt="Version"/>
+  <img src="https://img.shields.io/badge/version-0.4.6-blue.svg" alt="Version"/>
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"/>
   <img src="https://img.shields.io/badge/node-22_LTS-brightgreen.svg" alt="Node"/>
   <img src="https://img.shields.io/badge/NestJS-11.x-red.svg" alt="NestJS"/>

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboard",
   "private": true,
-  "version": "0.4.5",
+  "version": "0.4.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/docs/05-database-design.md
+++ b/docs/05-database-design.md
@@ -349,6 +349,7 @@ CREATE INDEX idx_webhooks_active ON webhooks(active);
   "message.sent",
   "message.ack",
   "message.revoked",
+  "message.reaction",
   "session.status",
   "session.qr",
   "session.authenticated",

--- a/docs/07-api-collection.md
+++ b/docs/07-api-collection.md
@@ -71,7 +71,7 @@ curl -H "X-API-Key: $API_KEY" \
 ```json
 {
   "status": "ok",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "uptime": 86400,
   "timestamp": "2026-02-02T10:30:00Z",
   "checks": {
@@ -826,6 +826,7 @@ message.received       - New incoming message
 message.sent           - Message sent
 message.ack            - Message status (sent, delivered, read)
 message.revoked        - Message deleted
+message.reaction       - Reaction added, changed, or removed
 session.status         - Session status change
 session.qr             - QR code generated
 session.authenticated  - Session authenticated

--- a/docs/12-troubleshooting-faq.md
+++ b/docs/12-troubleshooting-faq.md
@@ -784,6 +784,7 @@ available_events:
   - message.sent         # Message sent
   - message.ack          # Message status update (sent, delivered, read)
   - message.revoked      # Message deleted
+  - message.reaction     # Reaction added, changed, or removed
 
   # Session
   - session.status       # Session status change

--- a/docs/13-horizontal-scaling.md
+++ b/docs/13-horizontal-scaling.md
@@ -105,7 +105,7 @@ version: '3.8'
 
 services:
   openwa:
-    image: ghcr.io/rmyndharis/openwa:0.4.5
+    image: ghcr.io/rmyndharis/openwa:0.4.6
     deploy:
       replicas: 1 # MUST stay 1 until session-claim is implemented — multiple replicas on one session volume corrupt WhatsApp auth (H1/H11)
       update_config:
@@ -263,7 +263,7 @@ spec:
     spec:
       containers:
         - name: openwa
-          image: ghcr.io/rmyndharis/openwa:0.4.5
+          image: ghcr.io/rmyndharis/openwa:0.4.6
           ports:
             - containerPort: 2785
               name: http

--- a/docs/15-project-roadmap.md
+++ b/docs/15-project-roadmap.md
@@ -491,7 +491,7 @@ v0.1.0 Release Package:
 ## 15.6 Future Roadmap (v0.3.0+)
 
 > **Note:** Version 0.1.0 is the initial stable release including all features from Phases 1-3.
-> Versions 0.1.7 through 0.4.5 have since shipped (see the CHANGELOG); v1.0.0
+> Versions 0.1.7 through 0.4.6 have since shipped (see the CHANGELOG); v1.0.0
 > onward is forward-looking.
 
 ```mermaid

--- a/docs/22-n8n-integration.md
+++ b/docs/22-n8n-integration.md
@@ -80,6 +80,7 @@ Start workflows when WhatsApp events occur.
 | `message.ack`           | Delivery/read status advanced       | Read receipts             |
 | `message.failed`        | Outgoing message failed             | Failure alerting          |
 | `message.revoked`       | Message deleted for everyone        | Deletion tracking         |
+| `message.reaction`      | Reaction added / changed / removed  | Reaction tracking         |
 | `session.status`        | Session status changed              | Lifecycle tracking        |
 | `session.qr`            | QR code generated                   | Reconnection alerts       |
 | `session.authenticated` | Session logged in (phone available) | Startup notifications     |

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.4.5-blue.svg" alt="Version"/>
+  <img src="https://img.shields.io/badge/version-0.4.6-blue.svg" alt="Version"/>
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"/>
   <img src="https://img.shields.io/badge/node-22_LTS-brightgreen.svg" alt="Node"/>
   <img src="https://img.shields.io/badge/NestJS-11.x-red.svg" alt="NestJS"/>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwa",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API for WhatsApp",
   "author": "Yudhi Armyndharis & OpenWA Contributors",
   "private": true,

--- a/src/config/swagger.config.ts
+++ b/src/config/swagger.config.ts
@@ -14,7 +14,7 @@ export function createSwaggerConfig(): Omit<OpenAPIObject, 'paths'> {
     new DocumentBuilder()
       .setTitle('OpenWA API')
       .setDescription('Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API')
-      .setVersion('0.4.5')
+      .setVersion('0.4.6')
       .addApiKey({ type: 'apiKey', name: 'X-API-Key', in: 'header' }, API_KEY_SECURITY_SCHEME)
       // Apply the scheme globally so Swagger UI sends the key with every request
       // (mirrors the global ApiKeyGuard). Without this, "Authorize" is cosmetic.


### PR DESCRIPTION
Release **v0.4.6** — a reliability, correctness, and dashboard release.

Bundles the work merged since v0.4.5:

**Added**
- Persistent, cross-session `lid -> phone` resolution + a `from` message-history filter (#374)
- `message.reaction` webhook parity (previously WebSocket-only); selectable in the dashboard (#380)
- Dashboard appearance palettes + light/dark/system mode and a redesigned Templates workspace (#361)
- `BAILEYS_LOG_LEVEL` diagnostics (#375)

**Fixed**
- Baileys contacts/chats/recent-history now sync on connect; cross-dialect `chatId` filter; contact/chat *listing* ids are now engine-neutral `@c.us` (#375, #374)
- Hardened the LibreTranslate client against DNS rebinding (connection pinned to the vetted address) (#377)
- Baileys group-participant ops address participants in the engine wire dialect (#378)
- Italian translation corrections (#376)

**⚠️ Consumer-visible:** Baileys contact/chat-list ids flip `@s.whatsapp.net` → `@c.us` (whatsapp-web.js already used `@c.us`); webhooks subscribed with `*` now also receive `message.reaction`.

Version bumped to 0.4.6 (backend + dashboard + Swagger + README/docs badges); CHANGELOG, API spec, and event-list docs updated. Verified locally: backend lint+build+987 tests, dashboard build+lint, i18n parity (498 keys × 9 locales).