### PR TITLE
chore(cache): remove unused session-cache invalidation methods

### DIFF
--- a/src/common/cache/cache.service.ts
+++ b/src/common/cache/cache.service.ts
@@ -254,39 +254,4 @@ export class CacheService implements OnModuleDestroy {
       this.logger.warn(`Cache write failed (sessions:stats): ${String(error)}`);
     }
   }
-
-  // ========== Invalidation ==========
-
-  async invalidateSession(id: string): Promise<void> {
-    if (!(await this.isAvailable())) return;
-    try {
-      await this.redis!.del(`session:${id}:status`, `session:${id}:info`, `session:${id}:qr`);
-      // Also invalidate list since a session changed
-      await this.redis!.del('sessions:list', 'sessions:stats');
-    } catch (error) {
-      this.logger.warn(`Cache invalidation failed: ${String(error)}`);
-    }
-  }
-
-  async invalidateSessionsList(): Promise<void> {
-    if (!(await this.isAvailable())) return;
-    try {
-      await this.redis!.del('sessions:list', 'sessions:stats');
-    } catch (error) {
-      this.logger.warn(`Cache invalidation failed: ${String(error)}`);
-    }
-  }
-
-  async invalidateAll(): Promise<void> {
-    if (!(await this.isAvailable())) return;
-    try {
-      const keys = await this.redis!.keys('session:*');
-      keys.push('sessions:list', 'sessions:stats');
-      if (keys.length > 0) {
-        await this.redis!.del(...keys);
-      }
-    } catch (error) {
-      this.logger.warn(`Cache invalidation failed: ${String(error)}`);
-    }
-  }
 }


### PR DESCRIPTION
## What

`CacheService.invalidateAll`, `invalidateSession`, and `invalidateSessionsList` have **zero callers** anywhere in the codebase (verified by repo-wide grep; no spec references them either). The session cache is **TTL-only** — entries expire on their own (15s–10min), and nothing ever invoked proactive invalidation — so these three methods were vestigial scaffolding.

Removing them also drops a blocking `redis.keys('session:*')` scan that lived inside the never-called `invalidateAll` (a latent footgun had it ever been wired up).

## Notes

- **No behaviour change** — the methods were dead code; the cache continues to rely on TTL expiry exactly as it does today.
- If proactive cache-busting on session changes is ever wanted, that's a separate, additive feature (wire `invalidateSession` into the session lifecycle) — intentionally out of scope here.
- Build + lint + full backend suite (987 tests) green.