### PR TITLE
feat(engine): configurable first-boot init timeout for whatsapp-web.js (WWEBJS_AUTH_TIMEOUT_MS)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,6 +65,11 @@ PUPPETEER_ARGS=--no-sandbox,--disable-setuid-sandbox,--disable-dev-shm-usage,--d
 # 2.3000.1023204257 is confirmed to reach "ready" (incl. ARM64 / Raspberry Pi 5) — uncomment it:
 # WWEBJS_WEB_VERSION=2.3000.1023204257
 
+# Extend the initial boot/inject wait (milliseconds) before QR generation. On slow first boots
+# (WSL2 or low-resource containers) the default 30000ms can expire before WhatsApp Web finishes
+# loading. Raise it (e.g. 120000) if startup times out. Unset keeps the default (30000).
+# WWEBJS_AUTH_TIMEOUT_MS=120000
+
 # Baileys engine (used when ENGINE_TYPE=baileys). WebSocket client, no Chromium.
 # NOTE: the Baileys engine is loaded lazily (dynamic import, only when ENGINE_TYPE=baileys), so there is no
 # global Node.js version floor. Node.js 22 LTS is recommended for all deployments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Configurable first-boot init timeout for the whatsapp-web.js engine (`WWEBJS_AUTH_TIMEOUT_MS`).**
+  On slow first boots (e.g. WSL2 or low-resource containers) the engine's fixed 30s wait for WhatsApp
+  Web to finish loading could expire before the QR code was generated, aborting startup. Set
+  `WWEBJS_AUTH_TIMEOUT_MS` to a larger value in milliseconds (e.g. `120000`) to extend it; unset keeps
+  the previous 30000ms default, so existing deployments are unchanged. (#353)
+
 ### Changed
 
 - **Dashboard collapses connection-error spam into a single toast.** When the backend is unreachable

--- a/docs/12-troubleshooting-faq.md
+++ b/docs/12-troubleshooting-faq.md
@@ -220,6 +220,25 @@ Restart the container after setting it. Browse newer versions at
 [wppconnect-team/wa-version](https://github.com/wppconnect-team/wa-version) (the `html/` folder).
 Set `WWEBJS_WEB_VERSION=latest` (or leave it unset) to restore the default auto-version behavior.
 
+### Issue: QR generation times out on slow first boot (WSL2 / low-resource)
+
+> **Engine:** This issue applies to the `whatsapp-web.js` engine only. If you are using `ENGINE_TYPE=baileys`, skip this section.
+
+**Symptoms:** On the first launch the session never produces a QR code and fails after ~30 seconds,
+often inside WSL2 or a resource-constrained container while WhatsApp Web is still loading.
+
+**Cause:** whatsapp-web.js waits a fixed 30000ms for WhatsApp Web to finish its initial load before
+generating the QR. On a slow first boot that window can expire before the page is ready.
+
+**Fix:** raise the boot/inject wait (milliseconds) with `WWEBJS_AUTH_TIMEOUT_MS`:
+
+```bash
+# Allow up to 2 minutes for the first-boot init wait:
+WWEBJS_AUTH_TIMEOUT_MS=120000
+```
+
+Restart the container after setting it. Leave it unset to keep the default (30000ms).
+
 ### Issue: Session fails to launch with `chrome_crashpad_handler: --database is required`
 
 > **Engine:** This issue applies to the `whatsapp-web.js` engine only (Chromium/Puppeteer-based). It does not affect `ENGINE_TYPE=baileys`.

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -4,6 +4,7 @@ import {
   extractLinkedParentJID,
   isSupportedProxyUrl,
   loadRemoteMedia,
+  resolveAuthTimeoutMs,
   resolveWebVersionPin,
   wwebjsAckToDeliveryStatus,
 } from './whatsapp-web-js.adapter';
@@ -335,5 +336,30 @@ describe('resolveWebVersionPin (#251 — opt-in WA-Web version pin)', () => {
     process.env.WWEBJS_WEB_VERSION = '2.9999.0';
     process.env.WWEBJS_WEB_VERSION_REMOTE_PATH = 'https://cdn.example.com/wa/{version}.html';
     expect(resolveWebVersionPin()?.webVersionCache.remotePath).toBe('https://cdn.example.com/wa/2.9999.0.html');
+  });
+});
+
+describe('resolveAuthTimeoutMs (#353 — configurable first-boot init wait)', () => {
+  const orig = process.env.WWEBJS_AUTH_TIMEOUT_MS;
+  afterEach(() => {
+    if (orig === undefined) delete process.env.WWEBJS_AUTH_TIMEOUT_MS;
+    else process.env.WWEBJS_AUTH_TIMEOUT_MS = orig;
+  });
+
+  it('returns undefined (wwebjs default) when unset', () => {
+    delete process.env.WWEBJS_AUTH_TIMEOUT_MS;
+    expect(resolveAuthTimeoutMs()).toBeUndefined();
+  });
+
+  it('parses a positive integer milliseconds value', () => {
+    process.env.WWEBJS_AUTH_TIMEOUT_MS = '120000';
+    expect(resolveAuthTimeoutMs()).toBe(120000);
+  });
+
+  it('ignores non-positive-integer values (falls back to the default)', () => {
+    for (const bad of ['', '  ', '0', '-5', '1.5', 'abc', '60s']) {
+      process.env.WWEBJS_AUTH_TIMEOUT_MS = bad;
+      expect(resolveAuthTimeoutMs()).toBeUndefined();
+    }
   });
 });

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -131,6 +131,22 @@ export function resolveWebVersionPin():
 }
 
 /**
+ * Optional override for whatsapp-web.js's initial boot/inject wait (#353). On slow first boots
+ * (e.g. WSL2 or low-resource containers) the default 30s `authTimeoutMs` can expire before WhatsApp
+ * Web finishes loading, aborting QR generation. Set WWEBJS_AUTH_TIMEOUT_MS to a larger value in
+ * milliseconds (e.g. 120000) to extend it. Unset or a non-positive-integer value keeps the
+ * whatsapp-web.js default (30000ms).
+ */
+export function resolveAuthTimeoutMs(): number | undefined {
+  const raw = process.env.WWEBJS_AUTH_TIMEOUT_MS?.trim();
+  if (!raw || !/^\d+$/.test(raw)) {
+    return undefined;
+  }
+  const ms = Number(raw);
+  return ms > 0 ? ms : undefined;
+}
+
+/**
  * Extracts the JID of the parent community a group is linked to, if any.
  * The field name has varied across whatsapp-web.js/WA Web versions, so
  * known candidates are checked in order.
@@ -200,6 +216,13 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
         this.logger.log(`Pinning WhatsApp Web version ${versionPin.webVersion}`);
       }
 
+      // Extend the first-boot init wait on slow setups (WSL2/low-resource), #353. Opt-in:
+      // unset keeps whatsapp-web.js's 30000ms default.
+      const authTimeoutMs = resolveAuthTimeoutMs();
+      if (authTimeoutMs) {
+        this.logger.log(`Using auth timeout ${authTimeoutMs}ms`);
+      }
+
       this.client = new Client({
         authStrategy: new LocalAuth({
           clientId: this.config.sessionId,
@@ -212,6 +235,7 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
           // whatsapp-web.js fall back to Puppeteer's bundled Chromium.
           ...(this.config.puppeteer?.executablePath ? { executablePath: this.config.puppeteer.executablePath } : {}),
         },
+        ...(authTimeoutMs !== undefined ? { authTimeoutMs } : {}),
         ...(versionPin ?? {}),
       });
 


### PR DESCRIPTION
## Problem

On slow first boots (e.g. WSL2 or low-resource containers), the whatsapp-web.js engine's fixed **30s** wait for WhatsApp Web to finish loading can expire before the QR code is generated — the session fails during init with **no QR ever produced**. Reported in #353 (the second, still-open half of that issue; the `spawn ps ENOENT` crash from the same report shipped in v0.4.4).

## Change

Expose whatsapp-web.js's native `authTimeoutMs` option through a new **opt-in** env var:

```bash
# Allow up to 2 minutes for the first-boot init wait (milliseconds):
WWEBJS_AUTH_TIMEOUT_MS=120000
```

- **Unset / non-positive-integer → unchanged.** Falls back to the wwebjs default (30000ms), so existing deployments behave exactly as before.
- Resolved the same way as the existing `WWEBJS_WEB_VERSION` pin — read + validated directly in the adapter (`resolveAuthTimeoutMs()`), so it applies uniformly to **both** the factory-fallback and plugin-registration construction paths without threading config through two places.

## Why `authTimeoutMs` is the right knob

Tracing wwebjs `Client.initialize()` (v1.34.7):

1. `puppeteer.launch()` — puppeteer's own launch timeout
2. `page.goto(WhatsWebURL, { timeout: 0 })` — **no timeout**, waits for `load`
3. `inject()` — polls for WhatsApp Web to become ready, bounded by **`authTimeoutMs`** (default 30000), else throws `auth timeout`

The QR is only emitted after step 3 succeeds. On a slow boot the WA-Web bundle can take >30s to initialize, so `inject()` throws before any QR — exactly the reported symptom. Raising `authTimeoutMs` extends precisely this window. `engine.initialize()` is awaited with no outer `Promise.race`, so nothing caps the value.

**Known limitation (deliberate):** this does not extend the `puppeteer.launch()` timeout (step 1, Chromium process startup). For the reported symptom (past launch, stuck at init) that's correct; a separate launch-timeout knob can be added later if needed.

## Tests

- New `resolveAuthTimeoutMs` unit tests: unset → default, valid positive int parsed, invalid values (`0`, negative, float, non-numeric, units) rejected.
- Backend gate green: lint clean, `nest build` clean, **990/990** unit tests pass.

## Docs

- `.env.example`: documented `WWEBJS_AUTH_TIMEOUT_MS`.
- `docs/12-troubleshooting-faq.md`: new "QR generation times out on slow first boot (WSL2 / low-resource)" entry.

Refs #353.