### PR TITLE
fix(db): parse JSON columns on Postgres to prevent dashboard crash (#384)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Dashboard no longer crashes ("Something went wrong") when a webhook exists on PostgreSQL.** JSON
+  columns (`webhooks.events`/`headers`, `sessions.config`, `messages.metadata`, `message_batches.*`)
+  were declared `jsonb` in their entities but created as `text` by the baseline migration, so on
+  Postgres the driver returned them as raw JSON strings and the dashboard's `events.map()` threw an
+  uncaught error. `jsonColumnType()` now resolves to `simple-json` on both dialects (parsed in JS on
+  read) — no schema migration or data conversion, since the write format was already identical. This
+  also corrects the same latent string-instead-of-object behavior for session reconnect config,
+  message-reaction persistence, and bulk-send batches on Postgres. The dashboard additionally
+  normalizes webhook `events` to an array at the query boundary as defense-in-depth. (#385)
+
 ## [0.4.6] - 2026-06-20
 
 A reliability, correctness, and dashboard release. **Identity & engine:** Baileys gains a persistent,

--- a/dashboard/src/hooks/queries.ts
+++ b/dashboard/src/hooks/queries.ts
@@ -72,6 +72,10 @@ export function useWebhooksQuery() {
     queryKey: queryKeys.webhooks,
     queryFn: webhookApi.listAll,
     staleTime: 30_000,
+    // Normalize `events` to an array at the data boundary so every consumer (list render + edit
+    // modal) can trust the declared string[] shape. A malformed payload then renders as no tags
+    // instead of taking down the whole SPA via events.map() in the ErrorBoundary.
+    select: webhooks => webhooks.map(w => ({ ...w, events: Array.isArray(w.events) ? w.events : [] })),
   });
 }
 

--- a/src/common/utils/column-types.spec.ts
+++ b/src/common/utils/column-types.spec.ts
@@ -12,7 +12,12 @@ describe('cross-DB column type helpers (data connection dialect)', () => {
 
   it('resolves Postgres types when DATABASE_TYPE=postgres', () => {
     process.env.DATABASE_TYPE = 'postgres';
-    expect(jsonColumnType()).toBe('jsonb');
+    // JSON columns are 'simple-json' on BOTH dialects: the baseline migration created these as
+    // `text`, and the pg driver returns a `text` column as a raw (unparsed) string. A 'jsonb'-typed
+    // entity reading a text column hands back that string, so e.g. webhook.events arrives as
+    // '["message.received"]' and the dashboard's events.map() throws. 'simple-json' JSON-parses on
+    // read regardless of dialect, matching the actual text columns. Dates still differ by dialect.
+    expect(jsonColumnType()).toBe('simple-json');
     expect(dateColumnType()).toBe('timestamp');
   });
 

--- a/src/common/utils/column-types.ts
+++ b/src/common/utils/column-types.ts
@@ -18,9 +18,16 @@
 const isPostgres = (): boolean => process.env.DATABASE_TYPE === 'postgres';
 
 /**
- * Returns 'jsonb' for PostgreSQL, 'simple-json' for SQLite.
+ * Always 'simple-json' (TypeORM JSON.stringify/parse over a `text` column), on BOTH dialects.
+ *
+ * The baseline migration created these columns as `text` on Postgres too (never `jsonb`). The pg
+ * driver only auto-parses real json/jsonb columns, so a `jsonb`-typed entity reading the actual
+ * `text` column hands back a RAW string — e.g. webhook.events comes through as the string
+ * '["message.received"]', and the dashboard's events.map() throws (full-page crash). 'simple-json'
+ * parses on read regardless of dialect, matching the real columns. No native jsonb queries exist
+ * (all JSON filtering is done in JS), so nothing is lost.
  */
-export const jsonColumnType = (): 'jsonb' | 'simple-json' => (isPostgres() ? 'jsonb' : 'simple-json');
+export const jsonColumnType = (): 'simple-json' => 'simple-json';
 
 /**
  * Returns 'timestamp' for PostgreSQL, 'text' for SQLite.


### PR DESCRIPTION
## Summary

Fixes #384 — the dashboard's full-page ErrorBoundary ("Something went wrong") fires on **Postgres** whenever a webhook exists.

## Root cause

JSON columns are declared `jsonb` in their entities (via `jsonColumnType()`) but the baseline migration created them as **`text`**. The `pg` driver only auto-parses real `json`/`jsonb` columns, so a `jsonb`-typed entity reads a `text` column back as a **raw string**. `webhooks.events` thus reaches the API as the string `'["message.received"]'`, and the dashboard's `events.map()` throws an uncaught `TypeError` → full-page crash.

- **SQLite was unaffected** — it already uses `simple-json`, which JSON-parses on read.
- **Not n8n-specific** — n8n and the dashboard form create webhooks through the same service, so storage is identical. The trigger is simply "a webhook row exists" on Postgres.
- **Webhook *delivery* kept working** by accident — the backend's `events.includes(event)` substring-matches the string.
- **Systemic** — the same drift affects `sessions.config`, `messages.metadata`, and `message_batches.*` (all returned unparsed strings on Postgres); `webhooks.events` is just the one that visibly crashes.

## Fix

- **`jsonColumnType()` returns `simple-json` on both dialects** — matches the actual `text` columns the migrations created and parses JSON in JS on read. The honest fix: the migrations always created `text`; the entity was wrong to claim `jsonb`. No migration or data conversion needed (existing text is already valid JSON), and no native `jsonb` queries exist to lose. Also corrects the latent `sessions.config`/`metadata` string bugs.
- **Dashboard `Array.isArray` guard** on the events render — defense in depth so one malformed field can never crash the entire SPA (the issue explicitly asks the dashboard to load regardless).
- **Regression test** — `column-types.spec.ts` now locks `simple-json` for Postgres (TDD: watched it fail on `jsonb`, pass on `simple-json`).

## Verification

- Backend: 990/990 tests pass, build + lint clean
- Dashboard: build + lint clean (only pre-existing warnings)

## Compatibility

No schema migration, no data conversion. Existing Postgres rows store valid JSON text (`'["message.received"]'`, `'{}'`) that `simple-json` parses cleanly on read; writes continue to store the same text format. Backend dispatch matching becomes strictly correct (exact array-element match instead of substring).

Closes #384