### PR TITLE
chore(release): v0.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.7] - 2026-06-21
+
+A webhooks, reliability, and dashboard release — no breaking changes; everything is additive or a
+fix. **Webhooks** gain optional smart pre-dispatch filters: a trigger can carry AND-ed conditions
+(sender/recipient/body/type/mentions/fromMe/hasMedia/isGroup) and fires only when they all match,
+with engine-neutral `WaId` contact matching and a FilterBuilder UI — a webhook with no filters
+behaves exactly as before. The whatsapp-web.js engine's first-boot init timeout is now configurable
+(`WWEBJS_AUTH_TIMEOUT_MS`) for slow environments. **Fixed:** the dashboard no longer crashes on
+PostgreSQL when a webhook exists (a JSON column type mismatch). **Dashboard:** a downed backend no
+longer floods the screen with error toasts.
+
 ### Added
 
 - **Smart webhook filters (optional, additive).** A webhook trigger can now carry an optional set of

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/rmyndharis/OpenWA/actions/workflows/ci.yml"><img src="https://github.com/rmyndharis/OpenWA/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"/></a>
-  <img src="https://img.shields.io/badge/version-0.4.6-blue.svg" alt="Version"/>
+  <img src="https://img.shields.io/badge/version-0.4.7-blue.svg" alt="Version"/>
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"/>
   <img src="https://img.shields.io/badge/node-22_LTS-brightgreen.svg" alt="Node"/>
   <img src="https://img.shields.io/badge/NestJS-11.x-red.svg" alt="NestJS"/>
@@ -53,7 +53,7 @@ Built on a **pluggable architecture**, OpenWA lets you swap database engines (SQ
 | ------------- | ------ | ------------------------------------ |
 | REST API      | ✅     | Full WhatsApp API via HTTP endpoints |
 | Multi-Session | ✅     | Manage multiple WhatsApp accounts    |
-| Webhooks      | ✅     | Real-time events with HMAC signature |
+| Webhooks      | ✅     | Real-time events with HMAC signature and optional smart pre-dispatch filters |
 | Web Dashboard | ✅     | Visual management interface          |
 | API Key Auth  | ✅     | Secure API authentication            |
 | Swagger Docs  | ✅     | Interactive API documentation        |
@@ -269,6 +269,11 @@ curl -X POST http://localhost:2785/api/sessions/{sessionId}/webhooks \
     "secret": "your-hmac-secret"
   }'
 ```
+
+> **Smart filters (optional):** add a `filters` object to fire the webhook only when conditions match
+> (AND), e.g. `{ "conditions": [{ "field": "sender", "operator": "is", "value": ["1234567890@c.us"] }] }`.
+> Fields: `sender` / `recipient` / `body` / `type` / `mentions` / `fromMe` / `hasMedia` / `isGroup`. A
+> webhook with no filters behaves exactly as before. See the API specification for the full schema.
 
 ---
 

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashboard",
-  "version": "0.4.5",
+  "version": "0.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashboard",
-      "version": "0.4.5",
+      "version": "0.4.7",
       "dependencies": {
         "@tanstack/react-query": "^5.101.0",
         "@tanstack/react-table": "^8.21.3",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboard",
   "private": true,
-  "version": "0.4.6",
+  "version": "0.4.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -1214,9 +1214,26 @@ POST /api/sessions/:sessionId/webhooks
   "secret": "your-webhook-secret",
   "headers": {
     "X-Custom-Header": "value"
+  },
+  "filters": {
+    "conditions": [
+      { "field": "sender", "operator": "is", "value": ["1234567890@c.us"] },
+      { "field": "body", "operator": "contains", "value": "invoice" }
+    ]
   }
 }
 ```
+
+**Smart filters (optional).** When `filters` is present, the webhook fires only if **all** conditions
+match (logical AND); a webhook with no filters behaves exactly as before. Conditions are evaluated per
+event before delivery and message-only fields are skipped for non-message events.
+
+| Field | Kind | Operators | Notes |
+|-------|------|-----------|-------|
+| `sender`, `recipient`, `mentions` | id | `is`, `isNot` | Matched by engine-neutral `WaId`; a plain number or any dialect (`@c.us` / `@s.whatsapp.net` / `@lid`) matches the same contact. `value` is an array. |
+| `body` | text | `contains`, `equals` | Optional `caseSensitive` (default `false`). |
+| `type` | enum | `is`, `isNot` | `text` / `image` / `video` / `audio` / `voice` / `document` / `sticker` / `location` / `contact` / `revoked` / `unknown`. |
+| `fromMe`, `hasMedia`, `isGroup` | boolean | `is` | `value` is a boolean. |
 
 **Response (201 Created):**
 ```json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openwa",
-  "version": "0.4.5",
+  "version": "0.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openwa",
-      "version": "0.4.5",
+      "version": "0.4.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwa",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API for WhatsApp",
   "author": "Yudhi Armyndharis & OpenWA Contributors",
   "private": true,


### PR DESCRIPTION
Release **v0.4.7** — a webhooks, reliability, and dashboard release. No breaking changes.

### Added
- **Smart webhook filters** (#379) — optional AND-ed pre-dispatch conditions with engine-neutral `WaId` matching + FilterBuilder UI.
- **`WWEBJS_AUTH_TIMEOUT_MS`** (#383) — configurable whatsapp-web.js first-boot init timeout for slow environments.

### Changed
- **Toast anti-spam** (#293) — a downed backend shows one "Server Connection Lost" toast instead of flooding the screen.

### Fixed
- **Postgres webhook-JSON crash** (#385 / #384) — dashboard no longer crashes when a webhook exists on PostgreSQL.

Also merged (not in release notes): #386 (docs refresh), #382 (internal dead-code cleanup).

Bumps `package.json` + `dashboard/package.json` to `0.4.7` and stamps the CHANGELOG. On merge, tag `v0.4.7` triggers the GH Release + GHCR multi-arch publish.