### PR TITLE
fix(dashboard): include HTTP status in proxy error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Dashboard collapses duplicate connection-lost toasts during a reverse-proxy outage.** When the
+  backend is unreachable behind a reverse proxy that returns a non-JSON `502`/`503` page, the
+  dashboard now folds the repeated request failures into a single connection-lost toast instead of
+  stacking ordinary error toasts. The thrown error now always carries the HTTP status code (which the
+  toast de-duplication matches on), rather than a status text that is empty over HTTP/2. (#388)
+
 ## [0.4.7] - 2026-06-21
 
 A webhooks, reliability, and dashboard release — no breaking changes; everything is additive or a

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -305,7 +305,10 @@ async function request<T>(endpoint: string, options: RequestInit = {}): Promise<
   }
 
   if (!response.ok) {
-    const error = await response.json().catch(() => ({ message: response.statusText }));
+    // On a non-JSON body (e.g. a reverse-proxy 502/503 HTML page) fall through to `HTTP <status>`
+    // rather than statusText: the status code is what the toast connection-lost de-dup matches on,
+    // and statusText is empty over HTTP/2 anyway.
+    const error = await response.json().catch(() => ({}));
     throw new Error(error.message || `HTTP ${response.status}`);
   }
 


### PR DESCRIPTION
## What

When the backend is unreachable behind a reverse proxy that returns a **non-JSON `502`/`503`** page (HTML, plain text), the dashboard API client threw an `Error` whose message was the response's `statusText` (e.g. `Bad Gateway`). The connection-lost toast de-duplication in `Toast.tsx` keys on the HTTP status code (`http 502` / `http 503`), so these messages slipped past it and stacked up as several ordinary error toasts during an outage instead of folding into one connection-lost toast.

`statusText` is also always empty over HTTP/2 (per the WHATWG fetch spec), so the previous fallback was already lossy for the proxies that most commonly front a dashboard.

## Change

`request()` now drops the `statusText` seed on a non-JSON body, so a non-ok response with no JSON falls through to `HTTP ${status}` — which the existing de-dup detector matches. JSON API errors (the normal NestJS `{ statusCode, message, error }` shape) are unchanged: their `message` is still surfaced verbatim.

```diff
- const error = await response.json().catch(() => ({ message: response.statusText }));
+ const error = await response.json().catch(() => ({}));
  throw new Error(error.message || `HTTP ${response.status}`);
```

## Scope / safety

- Only the `!response.ok` + non-JSON-body path changes. The `401` redirect, `204`, network-reject, and JSON-error paths are untouched.
- No code parses `error.message` or `statusText`; the sole consumer is the toast detector, which now matches correctly.
- Callsites surfacing `err.message` (`Sessions`, `Plugins`, `Infrastructure`) now de-dupe proxy outages into a single toast.

## Verify

- `cd dashboard && npm run build` ✓
- `cd dashboard && npm run lint` ✓ (0 errors; the 3 warnings are pre-existing and unrelated)
- Backend is untouched by this change.