### PR TITLE
ci(release): publish the GitHub Release only after the image build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,10 @@ jobs:
   release:
     name: GitHub Release
     runs-on: ubuntu-latest
-    needs: [test]
+    # Gate the public Release on a successfully built+pushed image, so a tag never produces a GitHub
+    # Release without a matching container image (the docker job also builds the dashboard, which the
+    # test gate above does not). Trades a few minutes of buildx latency for release/image consistency.
+    needs: [test, docker]
     steps:
       - uses: actions/checkout@v6
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **A published GitHub Release now waits for the container image build.** The release workflow's
+  GitHub Release job now depends on the Docker image job, so a `v*` tag can no longer publish release
+  notes without a matching multi-arch image on GHCR. A failed image build leaves the tag without a
+  Release until the workflow is re-run. (#389)
+
 ### Fixed
 
 - **Dashboard collapses duplicate connection-lost toasts during a reverse-proxy outage.** When the

--- a/docs/09-testing-strategy.md
+++ b/docs/09-testing-strategy.md
@@ -142,8 +142,9 @@ CI is defined in `.github/workflows/ci.yml`.
 | `build` | backend build after lint/test/dashboard jobs pass |
 | `docker` | multi-arch Docker build and push on branch pushes |
 
-Release tags run `.github/workflows/release.yml`, which gates release and Docker publishing behind tests
-and build.
+Release tags run `.github/workflows/release.yml`, which gates Docker publishing behind tests and build,
+and publishes the GitHub Release only after the image build succeeds — so a tag never ends up with
+release notes but no matching multi-arch image.
 
 ## 09.7 Testing Guidelines
 


### PR DESCRIPTION
## What

On a `v*` tag, the release workflow's `release` (GitHub Release) and `docker` (multi-arch image) jobs both depended only on the backend `test` gate and ran **in parallel**. So the GitHub Release could be created even if the image build failed — leaving a public release/tag with no matching image on GHCR (and the dashboard build, which only happens inside the image build, is not exercised by the `test` gate at all).

## Change

`release` now `needs: [test, docker]`, so the GitHub Release is published only after the image is built and pushed.

```diff
   release:
     name: GitHub Release
     runs-on: ubuntu-latest
-    needs: [test]
+    needs: [test, docker]
```

## Safety / failure modes

- On a tag push the `docker` job has **no `if:` gate**, so it is never skipped — it either succeeds (release proceeds) or fails (release is skipped). No deadlock path.
- Job graph: `test → docker → release` (verified no cycle). `docker` still `needs: [test]`; only `release` gained the `docker` dependency.
- Trade-off: a transient image-build/registry failure now blocks the Release until a re-run, instead of producing a release with no image. Consistency over availability — appropriate for a release pipeline.

## Docs

Updated `docs/09-testing-strategy.md` to describe the new ordering.