### PR TITLE
chore(db): scope the data migration CLI to data-owned entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   GitHub Release job now depends on the Docker image job, so a `v*` tag can no longer publish release
   notes without a matching multi-arch image on GHCR. A failed image build leaves the tag without a
   Release until the workflow is re-run. (#389)
+- **The data migration CLI is scoped to the data-owned tables.** `data-source.ts` (used by
+  `migration:generate` / `migration:run`) now lists only the data connection's entities
+  (session/webhook/message/template/engine), mirroring the runtime data connection, instead of a
+  broad glob that also pulled in the main-owned `api_keys`/`audit_logs` entities. Generating a data
+  migration no longer emits spurious auth/audit DDL into the data database. No runtime or schema
+  change for existing installs. (#391)
 
 ### Fixed
 

--- a/src/database/data-source.spec.ts
+++ b/src/database/data-source.spec.ts
@@ -1,0 +1,34 @@
+import { globSync } from 'glob';
+import dataDataSource from './data-source';
+
+// The data CLI DataSource manages the DATA connection's migrations (session/webhook/message/
+// template/engine). It must NOT pull in the auth/audit entities — those belong to the always-SQLite
+// MAIN connection (data-source-main.ts). A broad '**' entity glob would sweep the main-owned
+// entities into `migration:generate` against the data DB and emit spurious auth/audit DDL.
+describe('data CLI DataSource', () => {
+  const resolveEntityFiles = (): string[] =>
+    (dataDataSource.options.entities as string[])
+      .flatMap(pattern => globSync(pattern))
+      .map(file => file.replace(/\\/g, '/'));
+
+  it('resolves the data-owned entities (session, webhook, message, template, engine)', () => {
+    const files = resolveEntityFiles();
+    expect(files.some(f => f.endsWith('session.entity.ts'))).toBe(true);
+    expect(files.some(f => f.endsWith('webhook.entity.ts'))).toBe(true);
+    expect(files.some(f => f.endsWith('message.entity.ts'))).toBe(true);
+    expect(files.some(f => f.endsWith('template.entity.ts'))).toBe(true);
+    expect(files.some(f => f.endsWith('lid-mapping.entity.ts'))).toBe(true);
+  });
+
+  it('never resolves the main-owned api-key/audit-log entities', () => {
+    const files = resolveEntityFiles();
+    expect(files.some(f => f.endsWith('api-key.entity.ts'))).toBe(false);
+    expect(files.some(f => f.endsWith('audit-log.entity.ts'))).toBe(false);
+  });
+
+  it('does not use a catch-all entity glob (guards against re-broadening)', () => {
+    for (const pattern of dataDataSource.options.entities as string[]) {
+      expect(pattern).not.toMatch(/\/\.\.\/\*\*\/\*\.entity/);
+    }
+  });
+});

--- a/src/database/data-source.ts
+++ b/src/database/data-source.ts
@@ -10,7 +10,16 @@ const dbType = process.env.DATABASE_TYPE || 'sqlite';
 const sqliteDataSource = new DataSource({
   type: 'sqlite',
   database: process.env.DATABASE_NAME || './data/openwa.sqlite',
-  entities: [__dirname + '/../**/*.entity{.ts,.js}'],
+  // Scoped to the DATA-owned modules only (session/webhook/message/template/engine), mirroring the
+  // runtime data connection (app.module.ts). A broad '**' glob would also sweep in the main-owned
+  // auth/audit entities and pollute `migration:generate` against the data DB with their DDL.
+  entities: [
+    __dirname + '/../modules/session/**/*.entity{.ts,.js}',
+    __dirname + '/../modules/webhook/**/*.entity{.ts,.js}',
+    __dirname + '/../modules/message/**/*.entity{.ts,.js}',
+    __dirname + '/../modules/template/**/*.entity{.ts,.js}',
+    __dirname + '/../engine/**/*.entity{.ts,.js}',
+  ],
   migrations: [__dirname + '/migrations/*{.ts,.js}'],
   synchronize: false,
   logging: process.env.DATABASE_LOGGING === 'true',
@@ -24,7 +33,16 @@ const postgresDataSource = new DataSource({
   username: process.env.DATABASE_USERNAME,
   password: process.env.DATABASE_PASSWORD,
   database: process.env.DATABASE_NAME || 'openwa',
-  entities: [__dirname + '/../**/*.entity{.ts,.js}'],
+  // Scoped to the DATA-owned modules only (session/webhook/message/template/engine), mirroring the
+  // runtime data connection (app.module.ts). A broad '**' glob would also sweep in the main-owned
+  // auth/audit entities and pollute `migration:generate` against the data DB with their DDL.
+  entities: [
+    __dirname + '/../modules/session/**/*.entity{.ts,.js}',
+    __dirname + '/../modules/webhook/**/*.entity{.ts,.js}',
+    __dirname + '/../modules/message/**/*.entity{.ts,.js}',
+    __dirname + '/../modules/template/**/*.entity{.ts,.js}',
+    __dirname + '/../engine/**/*.entity{.ts,.js}',
+  ],
   migrations: [__dirname + '/migrations/*{.ts,.js}'],
   synchronize: false, // Never auto-sync in production
   logging: process.env.DATABASE_LOGGING === 'true',


### PR DESCRIPTION
## What

`src/database/data-source.ts` — the standalone TypeORM CLI DataSource used by `migration:generate` / `migration:run` against the **data** connection — declared its entities with a broad `__dirname + '/../**/*.entity{.ts,.js}'` glob. That glob also matches the **main-owned** `ApiKey` and `AuditLog` entities, which live on the always-SQLite `main` connection (`data-source-main.ts`). As a result, `migration:generate` run against the data DB could see auth/audit entities and emit spurious `api_keys` / `audit_logs` DDL into the *data* migration set.

## Change

Narrow the data CLI entities to the data connection's modules — `session` / `webhook` / `message` / `template` / `engine` — mirroring `data-source-main.ts` and the runtime data connection in `app.module.ts`.

## Why it's safe

- **CLI-only.** Nothing at runtime imports `data-source.ts`; the app wires its connections via its own `forRootAsync` factories. Verified no importer in `src/` (only `package.json` `migration:*` scripts reference it).
- **Only `migration:generate` changes behavior** (it now diffs against the correct entity set). `migration:run` / `migration:revert` / `migration:show` use the unchanged `migrations` array and never consult entities.
- **Historical migrations are untouched** — no edits to already-applied migrations, so no replay/checksum impact and no risk to legacy rows on pre-split upgrades.
- The entity partition was enumerated: all 7 data entities live under the five scoped dirs; only `api-key`/`audit-log` are main-owned. Nothing is dropped.

## Tests

New `src/database/data-source.spec.ts` resolves the configured entity globs against the filesystem and asserts the data entities are covered while `api-key.entity.ts` / `audit-log.entity.ts` are never resolved, plus a guard against re-broadening to a catch-all glob.

## Verify

- `npm run lint` ✓ · `npm run build` ✓ · `npm test` ✓ (91 suites / 1028 tests, +3 new)