### PR TITLE
fix(engine): make WWEBJS_AUTH_TIMEOUT_MS effective in Docker and bound its parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dashboard now folds the repeated request failures into a single connection-lost toast instead of
   stacking ordinary error toasts. The thrown error now always carries the HTTP status code (which the
   toast de-duplication matches on), rather than a status text that is empty over HTTP/2. (#388)
+- **`WWEBJS_AUTH_TIMEOUT_MS` now takes effect in Docker, and is validated as a safe integer.** The
+  configurable first-boot init timeout added in 0.4.7 was never forwarded into the container by Docker
+  Compose, so setting it in `.env` had no effect on the recommended deployment path — the engine kept
+  the 30000ms default. Both compose files now pass it through (unset still means the default). The
+  value is also validated as a positive safe integer, so an accidental huge or overflowing value falls
+  back to the default instead of making the engine's first-boot wait run effectively unbounded. (#393)
 
 ## [0.4.7] - 2026-06-21
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -55,6 +55,8 @@ services:
       # docs/12-troubleshooting-faq.md.
       - WWEBJS_WEB_VERSION=${WWEBJS_WEB_VERSION:-}
       - WWEBJS_WEB_VERSION_REMOTE_PATH=${WWEBJS_WEB_VERSION_REMOTE_PATH:-}
+      # Raise whatsapp-web.js's first-boot init wait (default 30000ms) on slow boots. Empty = default.
+      - WWEBJS_AUTH_TIMEOUT_MS=${WWEBJS_AUTH_TIMEOUT_MS:-}
       - STORAGE_TYPE=local
       - STORAGE_LOCAL_PATH=/app/data/media
       - WEBHOOK_TIMEOUT=10000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,10 @@ services:
       # docs/12-troubleshooting-faq.md. (Without this line the var in .env never reaches the container.)
       - WWEBJS_WEB_VERSION=${WWEBJS_WEB_VERSION:-}
       - WWEBJS_WEB_VERSION_REMOTE_PATH=${WWEBJS_WEB_VERSION_REMOTE_PATH:-}
+      # Raise whatsapp-web.js's first-boot init wait (default 30000ms) on slow boots — e.g. WSL2 or
+      # low-resource hosts where the QR can time out before WA Web loads. Empty = default; see
+      # docs/12-troubleshooting-faq.md. (Without this line the var in .env never reaches the container.)
+      - WWEBJS_AUTH_TIMEOUT_MS=${WWEBJS_AUTH_TIMEOUT_MS:-}
       # Storage
       - STORAGE_TYPE=${STORAGE_TYPE:-local}
       - STORAGE_LOCAL_PATH=/app/data/media

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -362,4 +362,19 @@ describe('resolveAuthTimeoutMs (#353 — configurable first-boot init wait)', ()
       expect(resolveAuthTimeoutMs()).toBeUndefined();
     }
   });
+
+  it('ignores all-digit values that are not finite safe integers (falls back to the default)', () => {
+    // A huge digit string coerces to Infinity; MAX_SAFE_INTEGER + 1 is a finite but unsafe integer.
+    // Both pass the /^\d+$/ shape check, so without a numeric guard they would reach whatsapp-web.js
+    // as an effectively unbounded inject wait.
+    for (const bad of ['9'.repeat(352), String(Number.MAX_SAFE_INTEGER + 1)]) {
+      process.env.WWEBJS_AUTH_TIMEOUT_MS = bad;
+      expect(resolveAuthTimeoutMs()).toBeUndefined();
+    }
+  });
+
+  it('accepts large but safe integer millisecond values', () => {
+    process.env.WWEBJS_AUTH_TIMEOUT_MS = '600000';
+    expect(resolveAuthTimeoutMs()).toBe(600000);
+  });
 });

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -134,8 +134,8 @@ export function resolveWebVersionPin():
  * Optional override for whatsapp-web.js's initial boot/inject wait (#353). On slow first boots
  * (e.g. WSL2 or low-resource containers) the default 30s `authTimeoutMs` can expire before WhatsApp
  * Web finishes loading, aborting QR generation. Set WWEBJS_AUTH_TIMEOUT_MS to a larger value in
- * milliseconds (e.g. 120000) to extend it. Unset or a non-positive-integer value keeps the
- * whatsapp-web.js default (30000ms).
+ * milliseconds (e.g. 120000) to extend it. Unset, or a value that is not a positive safe integer,
+ * keeps the whatsapp-web.js default (30000ms).
  */
 export function resolveAuthTimeoutMs(): number | undefined {
   const raw = process.env.WWEBJS_AUTH_TIMEOUT_MS?.trim();
@@ -143,7 +143,9 @@ export function resolveAuthTimeoutMs(): number | undefined {
     return undefined;
   }
   const ms = Number(raw);
-  return ms > 0 ? ms : undefined;
+  // Number.isSafeInteger rejects Infinity (from huge digit strings) and >2^53 unsafe integers — both
+  // pass the /^\d+$/ shape check but would make whatsapp-web.js's inject loop wait effectively forever.
+  return Number.isSafeInteger(ms) && ms > 0 ? ms : undefined;
 }
 
 /**


### PR DESCRIPTION
## What

Completes the configurable whatsapp-web.js first-boot init timeout (`WWEBJS_AUTH_TIMEOUT_MS`, shipped in 0.4.7) in two ways:

1. **Docker passthrough.** Neither `docker-compose.yml` nor `docker-compose.dev.yml` forwarded the variable into the container's environment. Compose only injects host/`.env` vars that a service explicitly lists, so an operator who followed `.env.example` + `docs/12-troubleshooting-faq.md` ("set `WWEBJS_AUTH_TIMEOUT_MS`, restart the container") saw **no effect** — the engine silently kept the 30000ms default in the primary deployment path. Both compose files now pass it through, mirroring the existing `WWEBJS_WEB_VERSION` lines.

2. **Bounded parsing.** `resolveAuthTimeoutMs()` validated only `/^\d+$/` and `ms > 0`, so a huge digit string (→ `Infinity`) or `MAX_SAFE_INTEGER + 1` (an unsafe integer) slipped through and would be handed to whatsapp-web.js, whose inject loop would then wait effectively forever. It now requires a positive **safe** integer; out-of-range values fall back to the default. No arbitrary upper cap is imposed (the knob is a deliberate tuning value).

## Verify

- `docker compose config` with `WWEBJS_AUTH_TIMEOUT_MS` unset → `""` (→ `undefined` → 30000ms default, unchanged); set to `120000` → reaches the container. Dev compose validates.
- New parser tests: huge digit string and `MAX_SAFE_INTEGER + 1` → `undefined`; a large-but-safe value (`600000`) still parses.
- `npm run lint` ✓ · `npm run build` ✓ · `npm test` ✓ (91 suites / 1030 tests, +2 new)
- Sole reader is the parser; single callsite omits the key on `undefined`; docs already describe the documented behavior, which now actually takes effect — no doc change needed.

## Safety

`unset → empty → undefined → wwebjs default`, so behavior is identical unless an operator deliberately sets a positive value. The only newly-rejected inputs are absurd (> ~285,000 years) or overflowing — none a real deployment would use.