### PR TITLE
fix(media): return 413 for an oversized base64 media payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sends) was bounded only by the coarse whole-request `BODY_SIZE_LIMIT`, unlike remote-URL and inbound
   media which already enforce `MEDIA_DOWNLOAD_MAX_BYTES`. The decoded size of an outbound base64 blob
   is now checked against the same `MEDIA_DOWNLOAD_MAX_BYTES` cap (default 50 MiB) before it is sent or
-  persisted; an oversized blob is rejected with `400`. The bulk-send nested media payloads are now
-  validated as typed objects, so unknown or malformed media fields are rejected rather than silently
-  persisted — bulk requests carrying junk inside a media object will now get a `400`. (#394)
+  persisted; an oversized blob is rejected with `413 Payload Too Large` (the documented
+  `MESSAGE_MEDIA_TOO_LARGE`). The bulk-send nested media payloads are now validated as typed objects,
+  so unknown or malformed media fields are rejected rather than silently persisted — bulk requests
+  carrying junk inside a media object will now get a `400`. (#394, #395)
 
 ## [0.4.7] - 2026-06-21
 

--- a/src/modules/message/bulk-message.service.spec.ts
+++ b/src/modules/message/bulk-message.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { BadRequestException } from '@nestjs/common';
+import { PayloadTooLargeException } from '@nestjs/common';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { BulkMessageService, resolveFinalBatchStatus, sanitizeBatchError } from './bulk-message.service';
 import { MessageBatch, BatchStatus } from './entities/message-batch.entity';
@@ -207,7 +207,7 @@ describe('BulkMessageService.createBatch base64 media cap', () => {
             },
           ],
         } as unknown as SendBulkMessageDto),
-      ).rejects.toBeInstanceOf(BadRequestException);
+      ).rejects.toBeInstanceOf(PayloadTooLargeException);
       expect(repo.save).not.toHaveBeenCalled();
     } finally {
       delete process.env.MEDIA_DOWNLOAD_MAX_BYTES;

--- a/src/modules/message/media-cap.util.spec.ts
+++ b/src/modules/message/media-cap.util.spec.ts
@@ -1,4 +1,4 @@
-import { BadRequestException } from '@nestjs/common';
+import { PayloadTooLargeException } from '@nestjs/common';
 import { assertBase64WithinMediaCap } from './media-cap.util';
 
 describe('assertBase64WithinMediaCap', () => {
@@ -24,12 +24,12 @@ describe('assertBase64WithinMediaCap', () => {
 
   it('rejects a base64 payload over the cap with a 400', () => {
     process.env.MEDIA_DOWNLOAD_MAX_BYTES = '1024';
-    expect(() => assertBase64WithinMediaCap(base64OfBytes(1025))).toThrow(BadRequestException);
+    expect(() => assertBase64WithinMediaCap(base64OfBytes(1025))).toThrow(PayloadTooLargeException);
   });
 
   it('honors the MEDIA_DOWNLOAD_MAX_BYTES override (shared with the URL/inbound caps)', () => {
     process.env.MEDIA_DOWNLOAD_MAX_BYTES = '2048';
     expect(() => assertBase64WithinMediaCap(base64OfBytes(2000))).not.toThrow();
-    expect(() => assertBase64WithinMediaCap(base64OfBytes(4096))).toThrow(BadRequestException);
+    expect(() => assertBase64WithinMediaCap(base64OfBytes(4096))).toThrow(PayloadTooLargeException);
   });
 });

--- a/src/modules/message/media-cap.util.ts
+++ b/src/modules/message/media-cap.util.ts
@@ -1,4 +1,4 @@
-import { BadRequestException } from '@nestjs/common';
+import { PayloadTooLargeException } from '@nestjs/common';
 import { inboundMediaMaxBytes } from '../../engine/adapters/inbound-media-cap';
 
 /**
@@ -16,6 +16,8 @@ export function assertBase64WithinMediaCap(base64: string | null | undefined): v
   }
   const maxBytes = inboundMediaMaxBytes();
   if (Buffer.byteLength(base64, 'base64') > maxBytes) {
-    throw new BadRequestException(`Base64 media exceeds the maximum allowed size of ${maxBytes} bytes`);
+    // 413 Payload Too Large, matching the documented MESSAGE_MEDIA_TOO_LARGE error code — distinct
+    // from a generic 400 so clients can handle an oversized media payload specifically.
+    throw new PayloadTooLargeException(`Base64 media exceeds the maximum allowed size of ${maxBytes} bytes`);
   }
 }

--- a/src/modules/message/message.service.spec.ts
+++ b/src/modules/message/message.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { BadRequestException, NotFoundException, PayloadTooLargeException } from '@nestjs/common';
 import { MessageService } from './message.service';
 import { Message, MessageDirection, MessageStatus } from './entities/message.entity';
 import { SessionService } from '../session/session.service';
@@ -312,7 +312,7 @@ describe('MessageService', () => {
             base64: Buffer.alloc(1025).toString('base64'),
             mimetype: 'image/png',
           }),
-        ).rejects.toBeInstanceOf(BadRequestException);
+        ).rejects.toBeInstanceOf(PayloadTooLargeException);
         expect(mockEngine.sendImageMessage).not.toHaveBeenCalled();
       } finally {
         delete process.env.MEDIA_DOWNLOAD_MAX_BYTES;


### PR DESCRIPTION
## What

The outbound base64 media size cap threw `BadRequestException` (**400**). But `docs/06-api-specification.md` already documents `MESSAGE_MEDIA_TOO_LARGE` → **413** for "Media size exceeds limit" — and nothing in the codebase emitted 413, so the documented contract was unfulfilled and a client checking for 413 would not catch the 400.

## Change

The cap now throws `PayloadTooLargeException` (413), fulfilling the documented `MESSAGE_MEDIA_TOO_LARGE` contract and letting clients distinguish an oversized media payload from a generic validation error. Bulk nested-media **whitelist** violations (unknown/malformed fields) remain `400` — those are structural validation, not size.

## Tests

Updated the three cap specs to assert `PayloadTooLargeException`. Full suite green (93 suites / 1039 tests).

## Verify

- `npm run lint` ✓ · `npm run build` ✓ · `npm test` ✓
- `docs/06-api-specification.md`'s `MESSAGE_MEDIA_TOO_LARGE | 413` row is now accurate (no doc change needed).