### PR TITLE
chore(release): v0.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.8] - 2026-06-21
+
+A maintenance release — no breaking changes; everything is a fix or internal hardening.
+**Reliability:** the configurable whatsapp-web.js first-boot timeout (`WWEBJS_AUTH_TIMEOUT_MS`) now
+actually takes effect in Docker (it was never forwarded into the container) and is validated as a safe
+integer; the dashboard now collapses duplicate connection-lost toasts during a reverse-proxy outage.
+**Resource limits:** outbound base64 media is now size-capped (`413` when too large) on a par with the
+remote-URL and inbound media caps, and bulk-send media payloads are validated as typed objects.
+**Release & tooling:** a published GitHub Release now waits for the container image build, and the data
+migration CLI is scoped to the data-owned tables. Note: bulk-send media validation is now stricter — a
+bulk request carrying unknown or malformed fields inside a media object is now rejected with `400`.
+
 ### Changed
 
 - **A published GitHub Release now waits for the container image build.** The release workflow's

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/rmyndharis/OpenWA/actions/workflows/ci.yml"><img src="https://github.com/rmyndharis/OpenWA/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"/></a>
-  <img src="https://img.shields.io/badge/version-0.4.7-blue.svg" alt="Version"/>
+  <img src="https://img.shields.io/badge/version-0.4.8-blue.svg" alt="Version"/>
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"/>
   <img src="https://img.shields.io/badge/node-22_LTS-brightgreen.svg" alt="Node"/>
   <img src="https://img.shields.io/badge/NestJS-11.x-red.svg" alt="NestJS"/>

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashboard",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashboard",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "dependencies": {
         "@tanstack/react-query": "^5.101.0",
         "@tanstack/react-table": "^8.21.3",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboard",
   "private": true,
-  "version": "0.4.7",
+  "version": "0.4.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openwa",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openwa",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwa",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API for WhatsApp",
   "author": "Yudhi Armyndharis & OpenWA Contributors",
   "private": true,


### PR DESCRIPTION
Release **v0.4.8** — a maintenance release (no breaking changes).

Bundles the following merged changes:

- `fix(dashboard)`: collapse duplicate connection-lost toasts during a reverse-proxy outage (#388)
- `ci(release)`: publish the GitHub Release only after the container image build (#389)
- `chore(db)`: scope the data migration CLI to the data-owned entities (#391)
- `fix(engine)`: make `WWEBJS_AUTH_TIMEOUT_MS` effective in Docker and bound its parsing (#393)
- `fix(media)`: enforce an outbound base64 media size limit + bulk DTO hardening (#394)
- `fix(media)`: return `413` for an oversized base64 media payload, matching the documented contract (#395)

Version bumped (root + dashboard), CHANGELOG `[Unreleased]` rolled into `[0.4.8]`, README badge updated.

After merge: tag `v0.4.8` on main → the release workflow publishes the GitHub Release (now gated on the image build) and the multi-arch GHCR image.