### PR TITLE
fix(infra): harden the dashboard config-save path (browser flags + owner-only env file)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   split on commas — collapsing every flag into a single malformed argv token, so `--no-sandbox` (and
   any other flag) was silently never applied. In a hardened/containerized environment that can wedge
   session startup. The parser now accepts either delimiter, and an already-saved space-separated value
-  is repaired on the next boot.
+  is repaired on the next boot. (#397)
 
 ### Security
 
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   configuration wrote `data/.env.generated` — which can hold the database, S3, and Redis credentials —
   with default permissions (world-readable `0644`) until the next restart re-tightened it. It is now
   written `0600` at save time through the same owner-only helper used for the generated env at first
-  boot, closing the exposure window on shared or bind-mounted hosts.
+  boot, closing the exposure window on shared or bind-mounted hosts. (#397)
 
 ## [0.4.8] - 2026-06-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Browser launch flags saved from the dashboard are now applied correctly.** The Infrastructure
+  form persists the Puppeteer/Chromium arguments space-separated, but the engine config parser only
+  split on commas — collapsing every flag into a single malformed argv token, so `--no-sandbox` (and
+  any other flag) was silently never applied. In a hardened/containerized environment that can wedge
+  session startup. The parser now accepts either delimiter, and an already-saved space-separated value
+  is repaired on the next boot.
+
+### Security
+
+- **The dashboard-generated env file is now written owner-only (`0600`).** Saving Infrastructure
+  configuration wrote `data/.env.generated` — which can hold the database, S3, and Redis credentials —
+  with default permissions (world-readable `0644`) until the next restart re-tightened it. It is now
+  written `0600` at save time through the same owner-only helper used for the generated env at first
+  boot, closing the exposure window on shared or bind-mounted hosts.
+
 ## [0.4.8] - 2026-06-21
 
 A maintenance release — no breaking changes; everything is a fix or internal hardening.

--- a/src/config/configuration.spec.ts
+++ b/src/config/configuration.spec.ts
@@ -35,3 +35,29 @@ describe('configuration — Postgres database name', () => {
     expect(configuration().dataDatabase.name).toBe('prod_db');
   });
 });
+
+describe('configuration — Puppeteer args delimiter', () => {
+  const orig = process.env.PUPPETEER_ARGS;
+  afterEach(() => {
+    if (orig === undefined) delete process.env.PUPPETEER_ARGS;
+    else process.env.PUPPETEER_ARGS = orig;
+  });
+
+  // The dashboard Infrastructure form persists browser args space-separated, while .env/compose
+  // use commas. The parser must accept both so each flag reaches Chromium as a discrete argv token
+  // (a single glued token like "--no-sandbox --disable-gpu" silently neuters --no-sandbox).
+  it('splits space-separated PUPPETEER_ARGS into discrete flags (dashboard-written form)', () => {
+    process.env.PUPPETEER_ARGS = '--no-sandbox --disable-gpu';
+    expect(configuration().engine.puppeteer.args).toEqual(['--no-sandbox', '--disable-gpu']);
+  });
+
+  it('still splits comma-separated PUPPETEER_ARGS (.env / docker-compose form)', () => {
+    process.env.PUPPETEER_ARGS = '--no-sandbox,--disable-setuid-sandbox';
+    expect(configuration().engine.puppeteer.args).toEqual(['--no-sandbox', '--disable-setuid-sandbox']);
+  });
+
+  it('defaults to discrete sandbox flags when unset', () => {
+    delete process.env.PUPPETEER_ARGS;
+    expect(configuration().engine.puppeteer.args).toEqual(['--no-sandbox', '--disable-setuid-sandbox']);
+  });
+});

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -60,7 +60,10 @@ export default () => ({
     type: process.env.ENGINE_TYPE || 'whatsapp-web.js',
     puppeteer: {
       headless: process.env.PUPPETEER_HEADLESS !== 'false',
-      args: (process.env.PUPPETEER_ARGS || '--no-sandbox,--disable-setuid-sandbox').split(','),
+      // Accept either delimiter: .env/compose use commas, the dashboard Infrastructure form
+      // persists space-separated. Splitting on both keeps each flag a discrete argv token —
+      // a single glued token like "--no-sandbox --disable-gpu" silently neuters --no-sandbox.
+      args: (process.env.PUPPETEER_ARGS || '--no-sandbox,--disable-setuid-sandbox').split(/[\s,]+/).filter(Boolean),
       // Optional path to a system Chromium/Chrome binary. When unset, whatsapp-web.js
       // uses Puppeteer's bundled Chromium. Required on hosts where the bundled binary
       // is missing or incompatible (Alpine, ARM, custom base images).

--- a/src/modules/infra/infra.controller.spec.ts
+++ b/src/modules/infra/infra.controller.spec.ts
@@ -18,6 +18,9 @@ jest.mock('fs', () => {
   return {
     ...actual,
     writeFileSync: jest.fn(),
+    // saveConfig now writes the generated env via writeSecretFile, which chmods 0600 — mock it
+    // so the secret-hygiene path never touches the real filesystem.
+    chmodSync: jest.fn(),
     existsSync: jest.fn().mockReturnValue(false),
     readFileSync: jest.fn().mockReturnValue(''),
   };
@@ -118,6 +121,29 @@ describe('InfraController.saveConfig SSL reject-unauthorized', () => {
   it('omits DATABASE_SSL_REJECT_UNAUTHORIZED when SSL is disabled', () => {
     const env = writtenEnv({ database: { type: 'postgres', sslEnabled: false } });
     expect(env).not.toContain('DATABASE_SSL_REJECT_UNAUTHORIZED');
+  });
+});
+
+describe('InfraController.saveConfig writes the generated env owner-only', () => {
+  // data/.env.generated holds DB/S3/Redis credentials, so it must be written 0600 — not the
+  // default 0644 (world-readable). The write must go through the same owner-only path the
+  // first-run boot uses, closing the gap between a dashboard save and the next restart.
+  it('persists data/.env.generated with mode 0600, not world-readable', () => {
+    const writeSpy = jest.spyOn(fs, 'writeFileSync').mockImplementation(() => undefined);
+    const controller = new InfraController(
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+    );
+    controller.saveConfig({ database: { type: 'postgres', sslEnabled: true, password: 'pw' } } as never);
+    const opts = writeSpy.mock.calls[0][2];
+    expect(opts).toEqual({ mode: 0o600 });
+    writeSpy.mockRestore();
   });
 });
 

--- a/src/modules/infra/infra.controller.ts
+++ b/src/modules/infra/infra.controller.ts
@@ -6,6 +6,7 @@ import { InjectDataSource } from '@nestjs/typeorm';
 import { Public, RequireRole } from '../auth/decorators/auth.decorators';
 import { ApiKeyRole } from '../auth/entities/api-key.entity';
 import { isPathWithin } from '../../common/utils/path-safety';
+import { writeSecretFile } from '../../common/utils/secret-file';
 import { EngineFactory } from '../../engine/engine.factory';
 import { DockerService } from '../docker';
 import { CacheService } from '../../common/cache/cache.service';
@@ -450,8 +451,9 @@ export class InfraController {
         '',
       ].join('\n');
 
-      // Write to data/ so it persists across container restarts.
-      fs.writeFileSync(envPath, contents, 'utf8');
+      // Write to data/ so it persists across container restarts. Owner-only (0600): this file holds
+      // the DB/S3/Redis credentials, so it must not be world-readable between save and next restart.
+      writeSecretFile(envPath, contents);
       this.logger.log('Configuration saved', { envPath });
 
       const profileMsg = profiles.length > 0 ? ` Docker profiles required: ${profiles.join(', ')}.` : '';


### PR DESCRIPTION
## Summary

Two hardening fixes on the dashboard **Infrastructure → Save config** path.

### Browser launch flags are now applied correctly (reliability)
The Infrastructure form persists the Puppeteer/Chromium args **space-separated**, but the engine config parser (`configuration.ts`) only split on commas — so the saved value collapsed into a single malformed argv token and `--no-sandbox` (or any flag) was never actually applied to Chromium. In a hardened/containerized environment where the sandbox can't initialize, that can wedge session startup at FAILED after an otherwise innocuous config save + restart.

The parser now splits on either delimiter (`/[\s,]+/`), so each flag reaches Chromium as a discrete token. Fixing the **parser** (rather than the writer) also repairs an already-saved space-separated `data/.env.generated` on the next boot. Comma-separated `.env`/compose values parse identically.

### Generated env file is written owner-only (security)
`saveConfig()` wrote `data/.env.generated` — which can contain the database, S3, and Redis credentials — with `fs.writeFileSync(..., 'utf8')`, i.e. the default `0644` (world-readable), until the next restart re-tightened it to `0600`. On a shared host or a bind-mounted `data/`, another local user could read the credentials during that window.

It now goes through `writeSecretFile()` — the same helper `main.ts` uses for the generated env at first boot — which chmods `0600` before and after the write. Byte-identical content; only the mode changes.

## Tests
- `configuration.spec.ts`: space-separated, comma-separated, and default `PUPPETEER_ARGS` each parse to discrete flags.
- `infra.controller.spec.ts`: `saveConfig` writes the generated env with mode `0600`.
- Full backend gate: lint 0 · build OK · 1043 tests pass. Dashboard build + lint clean.

## Risk
Low and surgical. No API/contract change; env-file content is unchanged. The only behavioral deltas are (a) browser flags now parse into the correct array and (b) the generated env is `0600` instead of `0644`.