### PR TITLE
fix(config): reject a SQLite data path that collides with the main database file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pointing `DATABASE_NAME` at `./data/main.sqlite` ran two connections — each with its own migration
   ledger and synchronize policy — against one file, risking schema divergence and lock contention.
   Startup validation now fails fast with a clear message (paths are normalized, so relative spellings
-  of the same file are caught). Postgres is unaffected (its `DATABASE_NAME` is a bare db name).
+  of the same file are caught). Postgres is unaffected (its `DATABASE_NAME` is a bare db name). (#399)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   also the resource id on unrelated routes (e.g. `auth/api-keys/:id`, `plugins/:id`) — so a
   session-scoped key got a spurious `401` there. Session scoping is now applied only where `:id`
   actually denotes a session; enforcement on the real `sessions/:id/...` routes is unchanged. (#398)
+- **Boot is now rejected when the SQLite `DATABASE_NAME` collides with the internal main database
+  file.** The auth/audit ("main") and application ("data") connections must be separate SQLite files;
+  pointing `DATABASE_NAME` at `./data/main.sqlite` ran two connections — each with its own migration
+  ledger and synchronize policy — against one file, risking schema divergence and lock contention.
+  Startup validation now fails fast with a clear message (paths are normalized, so relative spellings
+  of the same file are caught). Postgres is unaffected (its `DATABASE_NAME` is a bare db name).
 
 ### Security
 

--- a/src/config/env.validation.spec.ts
+++ b/src/config/env.validation.spec.ts
@@ -35,4 +35,28 @@ describe('validateEnv', () => {
     expect(() => validateEnv({ STORAGE_TYPE: 'local' })).not.toThrow();
     expect(() => validateEnv({ STORAGE_TYPE: 's3' })).not.toThrow();
   });
+
+  it('rejects a sqlite data DB path that collides with the internal main database file', () => {
+    // The 'main' (auth/audit) and 'data' connections must be separate SQLite files; sharing one
+    // file means two migration ledgers + synchronize policies on the same tables.
+    expect(() => validateEnv({ DATABASE_TYPE: 'sqlite', DATABASE_NAME: './data/main.sqlite' })).toThrow(
+      /DATABASE_NAME/,
+    );
+    // Relative spellings of the same file are caught (path normalization).
+    expect(() => validateEnv({ DATABASE_TYPE: 'sqlite', DATABASE_NAME: './data/../data/main.sqlite' })).toThrow(
+      /DATABASE_NAME/,
+    );
+    // The default data path is fine.
+    expect(() => validateEnv({ DATABASE_TYPE: 'sqlite', DATABASE_NAME: './data/openwa.sqlite' })).not.toThrow();
+    // Postgres uses a bare DB name, never a file path — must not false-positive.
+    expect(() =>
+      validateEnv({
+        DATABASE_TYPE: 'postgres',
+        DATABASE_HOST: 'db',
+        DATABASE_USERNAME: 'u',
+        DATABASE_PASSWORD: 'p',
+        DATABASE_NAME: 'main.sqlite',
+      }),
+    ).not.toThrow();
+  });
 });

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -1,4 +1,9 @@
+import { resolve } from 'path';
+
 type EnvConfig = Record<string, unknown>;
+
+// The 'main' (auth/audit) connection is always this fixed SQLite file (not env-overridable).
+const MAIN_DB_PATH = './data/main.sqlite';
 
 /**
  * Fail-fast environment validation. Wired as ConfigModule's `validate`
@@ -39,6 +44,15 @@ export function validateEnv(config: EnvConfig): EnvConfig {
       if (!str(key)) {
         errors.push(`${key} is required when DATABASE_TYPE=postgres`);
       }
+    }
+  } else {
+    // SQLite (explicit or default): DATABASE_NAME is a file path for the 'data' connection. It must
+    // not resolve to the 'main' DB file — two TypeORM connections on one SQLite file run separate
+    // migration ledgers + synchronize policies against the same tables, risking schema divergence and
+    // lock contention. (Postgres DATABASE_NAME is a bare db name, so this never applies there.)
+    const dataDbName = str('DATABASE_NAME');
+    if (dataDbName && resolve(dataDbName) === resolve(MAIN_DB_PATH)) {
+      errors.push(`DATABASE_NAME must not point at the main database file (${MAIN_DB_PATH}); use a separate file`);
     }
   }
 


### PR DESCRIPTION
## Summary

The app runs **two** TypeORM connections: `main` (auth + audit) is a fixed SQLite file at `./data/main.sqlite`, and `data` (sessions/messages/webhooks/…) uses `DATABASE_NAME`. The whole two-connection split relies on those two paths being different — but that invariant was enforced only by distinct *defaults*, never validated.

If an operator sets `DATABASE_TYPE=sqlite` and `DATABASE_NAME=./data/main.sqlite` (a plausible "I just want one database file" misstep), both connections open the **same** SQLite file, each with its own migration ledger and its own `synchronize` policy. That's the exact corruption class the split was designed to avoid — schema divergence, `SQLITE_BUSY` lock contention, and one connection's synchronize pass mutating the other's migration-managed tables.

This adds a fail-fast boot check: when the effective DB type is SQLite, `DATABASE_NAME` must not resolve to the main DB file. Paths are normalized with `path.resolve`, so `./data/../data/main.sqlite` is caught too. **Postgres is unaffected** — its `DATABASE_NAME` is a bare database name, not a file path, so the guard is gated on SQLite and can't false-positive (the infra UI also deletes `DATABASE_NAME` when switching to SQLite).

## Tests
- `env.validation.spec.ts`: rejects `./data/main.sqlite` and the un-normalized `./data/../data/main.sqlite`; accepts the default `./data/openwa.sqlite`; does not false-positive on a Postgres config with `DATABASE_NAME=main.sqlite`.
- Full gate: lint 0 · build OK · 1052 unit pass · dashboard build + lint clean.

## Risk
Very low. The only configurations this newly rejects are ones already running in the unsupported, corruption-prone shared-file mode — which is the intended outcome. No default, existing test, or supported flow is affected.