### PR TITLE
chore(db): stop the data baseline from creating the unused auth/audit tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the data-connection baseline migration also created them (with a stale `keyPrefix` width), leaving
   dead, unused tables on the data database. New installs are now clean. Existing installs are
   unaffected — an already-applied migration is never re-run, so their harmless leftover tables remain
-  and no destructive drop is performed.
+  and no destructive drop is performed. (#400)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Fresh databases no longer create the unused `api_keys`/`audit_logs` tables on the data
+  connection.** Those auth/audit tables belong solely to the separate "main" SQLite connection, but
+  the data-connection baseline migration also created them (with a stale `keyPrefix` width), leaving
+  dead, unused tables on the data database. New installs are now clean. Existing installs are
+  unaffected — an already-applied migration is never re-run, so their harmless leftover tables remain
+  and no destructive drop is performed.
+
 ### Fixed
 
 - **Browser launch flags saved from the dashboard are now applied correctly.** The Infrastructure

--- a/src/database/add-uuid-defaults-migration.spec.ts
+++ b/src/database/add-uuid-defaults-migration.spec.ts
@@ -4,7 +4,7 @@
 import { QueryRunner } from 'typeorm';
 import { AddUuidDefaultsForPostgres1779235200000 } from './migrations/1779235200000-AddUuidDefaultsForPostgres';
 
-const ALL_TABLES = ['sessions', 'webhooks', 'messages', 'api_keys', 'audit_logs', 'message_batches'];
+const ALL_TABLES = ['sessions', 'webhooks', 'messages', 'message_batches'];
 
 function makeQueryRunner(type: string, existingTables: Set<string>) {
   return {
@@ -46,6 +46,6 @@ describe('AddUuidDefaultsForPostgres migration', () => {
     await migration.down(qr as unknown as QueryRunner);
 
     expect(qr.query).toHaveBeenCalledTimes(ALL_TABLES.length);
-    expect(qr.query).toHaveBeenCalledWith('ALTER TABLE "api_keys" ALTER COLUMN "id" DROP DEFAULT');
+    expect(qr.query).toHaveBeenCalledWith('ALTER TABLE "message_batches" ALTER COLUMN "id" DROP DEFAULT');
   });
 });

--- a/src/database/migrations/1770108659848-AddMessageStatus.ts
+++ b/src/database/migrations/1770108659848-AddMessageStatus.ts
@@ -55,17 +55,6 @@ export class AddMessageStatus1770108659848 implements MigrationInterface {
       `CREATE TABLE "message_batches" ("id" varchar PRIMARY KEY NOT NULL, "batch_id" varchar NOT NULL, "session_id" varchar NOT NULL, "status" varchar NOT NULL DEFAULT ('pending'), "messages" text NOT NULL, "options" text, "progress" text, "results" text, "current_index" integer NOT NULL DEFAULT (0), "created_at" datetime NOT NULL DEFAULT (datetime('now')), "updated_at" datetime NOT NULL DEFAULT (datetime('now')), "started_at" datetime, "completed_at" datetime, CONSTRAINT "UQ_ff274470c0dbaff6c7d1f9795f5" UNIQUE ("batch_id"))`,
     );
     await queryRunner.query(
-      `CREATE TABLE "api_keys" ("id" varchar PRIMARY KEY NOT NULL, "name" varchar(100) NOT NULL, "keyHash" varchar(64) NOT NULL, "keyPrefix" varchar(8) NOT NULL, "role" varchar(20) NOT NULL DEFAULT ('operator'), "allowedIps" text, "allowedSessions" text, "isActive" boolean NOT NULL DEFAULT (1), "expiresAt" datetime, "lastUsedAt" datetime, "usageCount" integer NOT NULL DEFAULT (0), "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "updatedAt" datetime NOT NULL DEFAULT (datetime('now')))`,
-    );
-    await queryRunner.query(`CREATE UNIQUE INDEX "IDX_df3b25181df0b4b59bd93f16e1" ON "api_keys" ("keyHash") `);
-    await queryRunner.query(
-      `CREATE TABLE "audit_logs" ("id" varchar PRIMARY KEY NOT NULL, "action" varchar(50) NOT NULL, "severity" varchar(10) NOT NULL DEFAULT ('info'), "apiKeyId" varchar(36), "apiKeyName" varchar(100), "sessionId" varchar(36), "sessionName" varchar(100), "ipAddress" varchar(45), "userAgent" varchar(500), "method" varchar(10), "path" varchar(500), "statusCode" integer, "metadata" text, "errorMessage" text, "createdAt" datetime NOT NULL DEFAULT (datetime('now')))`,
-    );
-    await queryRunner.query(`CREATE INDEX "IDX_cee5459245f652b75eb2759b4c" ON "audit_logs" ("action") `);
-    await queryRunner.query(`CREATE INDEX "IDX_741fa976d1e04e695f3aa23cb8" ON "audit_logs" ("apiKeyId") `);
-    await queryRunner.query(`CREATE INDEX "IDX_dd2b6e43c767b6b5b2bb227ace" ON "audit_logs" ("sessionId") `);
-    await queryRunner.query(`CREATE INDEX "IDX_c69efb19bf127c97e6740ad530" ON "audit_logs" ("createdAt") `);
-    await queryRunner.query(
       `CREATE TABLE "temporary_webhooks" ("id" varchar PRIMARY KEY NOT NULL, "sessionId" varchar NOT NULL, "url" varchar(2048) NOT NULL, "events" text NOT NULL DEFAULT ('["message.received"]'), "secret" varchar(255), "headers" text NOT NULL DEFAULT ('{}'), "active" boolean NOT NULL DEFAULT (1), "retryCount" integer NOT NULL DEFAULT (3), "lastTriggeredAt" datetime, "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "updatedAt" datetime NOT NULL DEFAULT (datetime('now')), CONSTRAINT "FK_d209715bb62b12255e825580af6" FOREIGN KEY ("sessionId") REFERENCES "sessions" ("id") ON DELETE CASCADE ON UPDATE NO ACTION)`,
     );
     await queryRunner.query(
@@ -84,13 +73,6 @@ export class AddMessageStatus1770108659848 implements MigrationInterface {
       `INSERT INTO "webhooks"("id", "sessionId", "url", "events", "secret", "headers", "active", "retryCount", "lastTriggeredAt", "createdAt", "updatedAt") SELECT "id", "sessionId", "url", "events", "secret", "headers", "active", "retryCount", "lastTriggeredAt", "createdAt", "updatedAt" FROM "temporary_webhooks"`,
     );
     await queryRunner.query(`DROP TABLE "temporary_webhooks"`);
-    await queryRunner.query(`DROP INDEX "IDX_c69efb19bf127c97e6740ad530"`);
-    await queryRunner.query(`DROP INDEX "IDX_dd2b6e43c767b6b5b2bb227ace"`);
-    await queryRunner.query(`DROP INDEX "IDX_741fa976d1e04e695f3aa23cb8"`);
-    await queryRunner.query(`DROP INDEX "IDX_cee5459245f652b75eb2759b4c"`);
-    await queryRunner.query(`DROP TABLE "audit_logs"`);
-    await queryRunner.query(`DROP INDEX "IDX_df3b25181df0b4b59bd93f16e1"`);
-    await queryRunner.query(`DROP TABLE "api_keys"`);
     await queryRunner.query(`DROP TABLE "message_batches"`);
     await queryRunner.query(`DROP INDEX "IDX_399833392126349ef0b04b9bed"`);
     await queryRunner.query(`DROP INDEX "IDX_36bc604c820bb9adc4c75cd411"`);
@@ -122,27 +104,9 @@ export class AddMessageStatus1770108659848 implements MigrationInterface {
     await queryRunner.query(
       `CREATE TABLE "message_batches" ("id" varchar PRIMARY KEY NOT NULL, "batch_id" varchar NOT NULL, "session_id" varchar NOT NULL, "status" varchar NOT NULL DEFAULT 'pending', "messages" text NOT NULL, "options" text, "progress" text, "results" text, "current_index" integer NOT NULL DEFAULT 0, "created_at" timestamp NOT NULL DEFAULT NOW(), "updated_at" timestamp NOT NULL DEFAULT NOW(), "started_at" timestamp, "completed_at" timestamp, CONSTRAINT "UQ_ff274470c0dbaff6c7d1f9795f5" UNIQUE ("batch_id"))`,
     );
-    await queryRunner.query(
-      `CREATE TABLE "api_keys" ("id" varchar PRIMARY KEY NOT NULL, "name" varchar(100) NOT NULL, "keyHash" varchar(64) NOT NULL, "keyPrefix" varchar(8) NOT NULL, "role" varchar(20) NOT NULL DEFAULT 'operator', "allowedIps" text, "allowedSessions" text, "isActive" boolean NOT NULL DEFAULT true, "expiresAt" timestamp, "lastUsedAt" timestamp, "usageCount" integer NOT NULL DEFAULT 0, "createdAt" timestamp NOT NULL DEFAULT NOW(), "updatedAt" timestamp NOT NULL DEFAULT NOW())`,
-    );
-    await queryRunner.query(`CREATE UNIQUE INDEX "IDX_df3b25181df0b4b59bd93f16e1" ON "api_keys" ("keyHash")`);
-    await queryRunner.query(
-      `CREATE TABLE "audit_logs" ("id" varchar PRIMARY KEY NOT NULL, "action" varchar(50) NOT NULL, "severity" varchar(10) NOT NULL DEFAULT 'info', "apiKeyId" varchar(36), "apiKeyName" varchar(100), "sessionId" varchar(36), "sessionName" varchar(100), "ipAddress" varchar(45), "userAgent" varchar(500), "method" varchar(10), "path" varchar(500), "statusCode" integer, "metadata" text, "errorMessage" text, "createdAt" timestamp NOT NULL DEFAULT NOW())`,
-    );
-    await queryRunner.query(`CREATE INDEX "IDX_cee5459245f652b75eb2759b4c" ON "audit_logs" ("action")`);
-    await queryRunner.query(`CREATE INDEX "IDX_741fa976d1e04e695f3aa23cb8" ON "audit_logs" ("apiKeyId")`);
-    await queryRunner.query(`CREATE INDEX "IDX_dd2b6e43c767b6b5b2bb227ace" ON "audit_logs" ("sessionId")`);
-    await queryRunner.query(`CREATE INDEX "IDX_c69efb19bf127c97e6740ad530" ON "audit_logs" ("createdAt")`);
   }
 
   private async downPostgres(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`DROP INDEX "IDX_c69efb19bf127c97e6740ad530"`);
-    await queryRunner.query(`DROP INDEX "IDX_dd2b6e43c767b6b5b2bb227ace"`);
-    await queryRunner.query(`DROP INDEX "IDX_741fa976d1e04e695f3aa23cb8"`);
-    await queryRunner.query(`DROP INDEX "IDX_cee5459245f652b75eb2759b4c"`);
-    await queryRunner.query(`DROP TABLE "audit_logs"`);
-    await queryRunner.query(`DROP INDEX "IDX_df3b25181df0b4b59bd93f16e1"`);
-    await queryRunner.query(`DROP TABLE "api_keys"`);
     await queryRunner.query(`DROP TABLE "message_batches"`);
     await queryRunner.query(`DROP INDEX "IDX_399833392126349ef0b04b9bed"`);
     await queryRunner.query(`DROP INDEX "IDX_36bc604c820bb9adc4c75cd411"`);

--- a/src/database/migrations/1779235200000-AddUuidDefaultsForPostgres.ts
+++ b/src/database/migrations/1779235200000-AddUuidDefaultsForPostgres.ts
@@ -19,7 +19,8 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
 export class AddUuidDefaultsForPostgres1779235200000 implements MigrationInterface {
   name = 'AddUuidDefaultsForPostgres1779235200000';
 
-  private readonly tables = ['sessions', 'webhooks', 'messages', 'api_keys', 'audit_logs', 'message_batches'];
+  // Data-connection tables only — api_keys/audit_logs live on the separate 'main' connection.
+  private readonly tables = ['sessions', 'webhooks', 'messages', 'message_batches'];
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     if (queryRunner.connection.options.type !== 'postgres') return;

--- a/src/database/migrations/__tests__/1770108659848-AddMessageStatus.spec.ts
+++ b/src/database/migrations/__tests__/1770108659848-AddMessageStatus.spec.ts
@@ -22,6 +22,11 @@ describe('AddMessageStatus baseline migration', () => {
     expect(await runner.hasTable('messages')).toBe(true);
     expect(await runner.hasTable('message_batches')).toBe(true);
 
+    // api_keys / audit_logs belong to the separate 'main' (auth/audit) connection. The data
+    // baseline must NOT create them here — they were dead, unused tables on the data DB.
+    expect(await runner.hasTable('api_keys')).toBe(false);
+    expect(await runner.hasTable('audit_logs')).toBe(false);
+
     await runner.release();
   });
 


### PR DESCRIPTION
## Summary

`api_keys` and `audit_logs` belong to the separate **main** SQLite connection (auth + audit). But the **data**-connection baseline migration (`1770108659848-AddMessageStatus`) also created them — with a stale `keyPrefix varchar(8)` (the entity and the main migration use `varchar(12)`) — leaving two dead, never-read tables on the data database, and a latent Postgres truncation hazard if auth were ever re-pointed at the data connection.

This removes the `api_keys`/`audit_logs` `CREATE`/index statements from the baseline (both SQLite and Postgres `up()`), the matching `DROP`s from `down()` (kept symmetric), and drops the two from the `AddUuidDefaultsForPostgres` table list. Fresh data DBs no longer carry them.

### Existing installs are not touched
TypeORM never re-runs an applied migration, so an existing install keeps its (harmless) leftover tables — this change only affects what a **fresh** database builds. **No `DROP` migration is added on purpose:** an unconditional drop could destroy a shared-file install's live auth tables, and the path-collision guard added in #399 already prevents that misconfiguration going forward.

## Tests
- `__tests__/1770108659848-AddMessageStatus.spec.ts` (real in-memory SQLite): after `up()` on a fresh DB, `api_keys`/`audit_logs` are now asserted **absent** (sessions/webhooks/messages/message_batches still present); the synchronize-adoption no-op test is unchanged.
- `add-uuid-defaults-migration.spec.ts`: table list updated to the four data-owned tables.
- Full gate: lint 0 · build OK · 1052 unit · 26 e2e · dashboard build + lint clean.

## Risk
Low, and scoped to fresh installs. No data is dropped or migrated on existing deployments; `up`/`down` stay symmetric so a fresh-DB rollback still succeeds.