### PR TITLE
fix(session): don't resurrect a session stopped/deleted during start()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   string was treated as a URL only with a lowercase `http://`/`https://` prefix, so a mixed-case
   scheme (e.g. `HTTPS://…`) was mistaken for base64 instead of being fetched through the SSRF-guarded
   path — diverging from the Baileys engine. Both engines now use the same case-insensitive check. (#404)
+- **A session stopped or deleted mid-startup is no longer resurrected to `READY`.** If `stop`/`delete`
+  landed while `start()` was awaiting the engine's `initialize()`, the freshly-created engine was left
+  registered and running. `start()` now re-checks the stopping flag after initialization and tears the
+  engine down (mirroring the existing reconnect guard), so a concurrent stop/delete wins. (#405)
 
 ### Security
 

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -1213,6 +1213,26 @@ describe('SessionService', () => {
     });
   });
 
+  describe('start() concurrent stop/delete guard', () => {
+    it('tears down the just-initialized engine if a stop/delete lands during start() (no resurrection to READY)', async () => {
+      const session = createMockSession();
+      (repository.findOne as jest.Mock).mockResolvedValue(session);
+      (repository.update as jest.Mock).mockResolvedValue({ affected: 1 });
+
+      // Simulate a concurrent stop()/delete() landing WHILE engine.initialize() is in flight.
+      mockEngine.initialize.mockImplementationOnce(() => {
+        (service as unknown as { stoppingSessions: Set<string> }).stoppingSessions.add('sess-uuid-1');
+        return Promise.resolve();
+      });
+
+      await service.start('sess-uuid-1');
+
+      // The engine registered during init must be torn down + removed, not left READY.
+      expect(mockEngine.destroy).toHaveBeenCalled();
+      expect(service.getEngine('sess-uuid-1')).toBeUndefined();
+    });
+  });
+
   // ── sendSeen (markChatRead) ───────────────────────────────────────
 
   describe('sendSeen', () => {

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -402,6 +402,17 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
       this.reconnectStates.set(id, { attempts: 0, timer: null, maxAttempts, baseDelay });
 
       await this.initializeEngine(id, session);
+
+      // A stop()/delete() may have landed while we awaited engine.initialize() — if so, tear down the
+      // engine we just registered so the session isn't resurrected to READY (mirrors the post-init
+      // guard in executeReconnect; initialize()'s callbacks can also fire async after this returns).
+      if (this.stoppingSessions.has(id)) {
+        const resurrected = this.engines.get(id);
+        if (resurrected) {
+          await this.teardownEngineSafely(id, resurrected, e => e.destroy(), 'destroy');
+          this.engines.delete(id);
+        }
+      }
       return this.findOne(id);
     } finally {
       this.initializingSessions.delete(id);


### PR DESCRIPTION
## Summary

`start()` reserves its slot, clears the stop flag, then `await`s `initializeEngine()` (which registers the engine and runs `engine.initialize()`). If a `stop()` or `delete()` lands **during** that await, it sets the stopping flag and tears down — but `start()` did not re-check afterward, so the freshly-created engine was left registered and driven to `READY`. The session came back up even though it was meant to be down (and could orphan a Chromium against a deleted session row).

`start()` now mirrors the **proven** post-init guard already used by `executeReconnect()`: after `initializeEngine()`, if the session is marked stopping, tear down the just-registered engine via `teardownEngineSafely` and remove it before returning. A concurrent stop/delete wins.

Scope note: the narrower window where `initialize()`'s async callbacks fire *after* `start()` returns is intentionally left unchanged — that matches the existing `executeReconnect` path, and the alternative (an engine-identity check inside the callbacks) is higher-risk (it could suppress a legitimate status write during a normal reconnect). This PR takes only the low-risk, proven guard.

## Tests
- `session.service.spec.ts`: a stop/delete simulated **during** `initialize()` now results in the engine being `destroy()`ed and removed (`getEngine` undefined) rather than left READY.
- Full gate: lint 0 · build OK · 1083 unit (incl. coverage thresholds) · 26 e2e pass.

## Risk
Low. The guard mirrors logic already in production on the reconnect path; it only fires when a stop/delete genuinely raced the start, and the safe outcome is "the session stays down" (what the operator asked for).
