### PR TITLE
chore(release): v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-21
+
+A security & reliability hardening release. **One behavior change** (the reason for the minor bump):
+the contact / group / chat list endpoints now paginate with a default cap of 1000 items — opt into
+`limit`/`offset`; accounts with fewer than 1000 items are unaffected. Everything else is hardening and
+correctness: time-bounded SSRF DNS resolution, validated webhook custom headers (blocks CR/LF
+injection), Swagger off by default in production, boot-time validation of numeric env vars and of a
+SQLite data/main path collision, plugin reads gated to ADMIN, a session-scoped key no longer denied on
+non-session routes, no resurrection of a session stopped mid-startup, a hardened dashboard config-save
+path (browser-flag parsing + `0600` secret file), and cleaner fresh-install schema.
+
 ### Changed
 
 - **The contact, group, and chat list endpoints are now paginated (default cap 1000).** ⚠️ Behavior

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashboard",
-  "version": "0.4.8",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashboard",
-      "version": "0.4.8",
+      "version": "0.5.0",
       "dependencies": {
         "@tanstack/react-query": "^5.101.0",
         "@tanstack/react-table": "^8.21.3",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboard",
   "private": true,
-  "version": "0.4.8",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openwa",
-  "version": "0.4.8",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openwa",
-      "version": "0.4.8",
+      "version": "0.5.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwa",
-  "version": "0.4.8",
+  "version": "0.5.0",
   "description": "Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API for WhatsApp",
   "author": "Yudhi Armyndharis & OpenWA Contributors",
   "private": true,


### PR DESCRIPTION
Release **v0.5.0** — a security & reliability hardening release.

**One behavior change** (the reason for the minor bump): the contact / group / chat list endpoints now paginate with a default cap of **1000** items. Opt into `limit`/`offset` to page; accounts with fewer than 1000 items see no change. Chats are returned most-recent-first.

Everything else is hardening and correctness:
- **Security:** time-bounded SSRF DNS resolution; webhook custom headers validated (blocks CR/LF header injection); Swagger off by default in production; plugin reads gated to ADMIN; dashboard-generated env file written `0600`.
- **Reliability/correctness:** boot-time validation of numeric env vars and of a SQLite data/main DB path collision; a session-scoped API key no longer wrongly denied on non-session routes; a session stopped mid-startup is no longer resurrected; browser-launch flags from the dashboard parse correctly; case-insensitive remote-media URL detection; fresh databases no longer create unused auth/audit tables.

Bundles #397–#405. Full release notes in `CHANGELOG.md` (`## [0.5.0]`).

This PR: rename `[Unreleased]` → `[0.5.0]`, bump root + dashboard to `0.5.0`. Tagging `v0.5.0` after merge publishes the GitHub Release + multi-arch GHCR image.
