### PR TITLE
fix(docs): self-updating version badges + Swagger, with a CI drift guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Check formatting
         run: npm run format -- --check
 
+      - name: Check version consistency (docs track package.json)
+        run: npm run check:versions
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/rmyndharis/OpenWA/actions/workflows/ci.yml"><img src="https://github.com/rmyndharis/OpenWA/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"/></a>
-  <img src="https://img.shields.io/badge/version-0.4.8-blue.svg" alt="Version"/>
+  <img src="https://img.shields.io/github/package-json/v/rmyndharis/OpenWA?label=version&color=blue" alt="Version"/>
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"/>
   <img src="https://img.shields.io/badge/node-22_LTS-brightgreen.svg" alt="Node"/>
   <img src="https://img.shields.io/badge/NestJS-11.x-red.svg" alt="NestJS"/>

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.4.6-blue.svg" alt="Version"/>
+  <img src="https://img.shields.io/github/package-json/v/rmyndharis/OpenWA?label=version&color=blue" alt="Version"/>
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"/>
   <img src="https://img.shields.io/badge/node-22_LTS-brightgreen.svg" alt="Node"/>
   <img src="https://img.shields.io/badge/NestJS-11.x-red.svg" alt="NestJS"/>

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "dashboard:dev": "cd dashboard && npm run dev",
     "dashboard:build": "cd dashboard && npm run build",
     "postinstall": "node -e \"if (require('fs').existsSync('dashboard')) require('child_process').spawnSync('npm', ['run', 'dashboard:install'], { stdio: 'inherit', shell: true });\"",
+    "check:versions": "node scripts/check-doc-versions.mjs",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\"",
     "lint:fix": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",

--- a/scripts/check-doc-versions.mjs
+++ b/scripts/check-doc-versions.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/**
+ * Version-consistency guard.
+ *
+ * Stops the recurring "we cut a release but a doc still shows the old version" problem by failing
+ * CI when a *current-version* reference drifts from package.json. It does NOT touch historical
+ * version mentions (CHANGELOG history, roadmap milestones, example image tags) — only the three
+ * places that must always reflect the shipped version:
+ *
+ *   1. The README version badges (root + docs/) must be the DYNAMIC shields endpoint that reads
+ *      package.json automatically — never a hardcoded `badge/version-x.y.z`.
+ *   2. src/config/swagger.config.ts must source the version from package.json — never `setVersion('x.y.z')`.
+ *   3. CHANGELOG.md must carry a `## [<current version>]` entry (the release notes exist).
+ *
+ * Run locally: `npm run check:versions`. Runs in CI (lint job).
+ */
+import { readFileSync } from 'node:fs';
+
+const root = new URL('../', import.meta.url);
+const read = (rel) => readFileSync(new URL(rel, root), 'utf8');
+
+const version = JSON.parse(read('package.json')).version;
+const errors = [];
+
+// 1) README badges must be dynamic, not a pinned `badge/version-x`.
+for (const f of ['README.md', 'docs/README.md']) {
+  if (/shields\.io\/badge\/version-\d/.test(read(f))) {
+    errors.push(`${f}: hardcoded version badge — use the dynamic shields "github/package-json/v" badge so it tracks package.json.`);
+  }
+}
+
+// 2) Swagger version must come from package.json, not a literal.
+if (/setVersion\(\s*['"]\d/.test(read('src/config/swagger.config.ts'))) {
+  errors.push("src/config/swagger.config.ts: hardcoded setVersion('x.y.z') — use require('../../package.json').version.");
+}
+
+// 3) CHANGELOG must have an entry for the current version.
+if (!read('CHANGELOG.md').includes(`## [${version}]`)) {
+  errors.push(`CHANGELOG.md: missing a "## [${version}]" entry for the current package.json version — add the release notes before tagging.`);
+}
+
+if (errors.length) {
+  console.error(`\n✖ Version consistency check failed (package.json = ${version}):`);
+  for (const e of errors) console.error(`  - ${e}`);
+  console.error('\nFix the above so docs track the release automatically, then re-run `npm run check:versions`.\n');
+  process.exit(1);
+}
+console.log(`✓ Version consistency OK (package.json = ${version}).`);

--- a/src/config/swagger.config.ts
+++ b/src/config/swagger.config.ts
@@ -10,11 +10,14 @@ export const API_KEY_SECURITY_SCHEME = 'X-API-Key';
  * Builds the OpenAPI document configuration for the OpenWA API.
  */
 export function createSwaggerConfig(): Omit<OpenAPIObject, 'paths'> {
+  // Source the API version from package.json so it tracks releases automatically — no manual bump, no drift.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { version } = require('../../package.json') as { version: string };
   return (
     new DocumentBuilder()
       .setTitle('OpenWA API')
       .setDescription('Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API')
-      .setVersion('0.4.6')
+      .setVersion(version)
       .addApiKey({ type: 'apiKey', name: 'X-API-Key', in: 'header' }, API_KEY_SECURITY_SCHEME)
       // Apply the scheme globally so Swagger UI sends the key with every request
       // (mirrors the global ApiKeyGuard). Without this, "Authorize" is cosmetic.


### PR DESCRIPTION
## Problem
The "current version" was hardcoded in several places, so it drifted after releases. At v0.5.0 the public README badge still showed **0.4.8**, `docs/README.md` showed **0.4.6**, and the Swagger API version was **0.4.6** — unprofessional and recurring.

## Fix (make it self-updating)
- **README + `docs/README.md` version badges** → dynamic shields endpoint `github/package-json/v/rmyndharis/OpenWA`, which reads `package.json` on `main` automatically.
- **`src/config/swagger.config.ts`** → `setVersion(require('../../package.json').version)` (matches the existing baileys/wwjs adapter pattern).

A single `package.json` bump (already done by the release PR) now propagates everywhere — these can't drift again.

## Prevent recurrence (CI guard)
- New `scripts/check-doc-versions.mjs` + `npm run check:versions`, wired into the CI **lint** job. It fails if:
  1. a README badge is a hardcoded `badge/version-x.y.z`,
  2. Swagger hardcodes `setVersion('x.y.z')`,
  3. `CHANGELOG.md` lacks a `## [<current version>]` entry.
- It deliberately ignores historical version mentions (CHANGELOG history, roadmap, example image tags).

## Verification
- `npm run check:versions` → passes clean; fails on a planted drift (exit 1); restored → passes.
- `npm run lint`, `npm run build` → OK. Swagger now resolves version `0.5.0` at runtime.
- `npm test` → **1083 passed / 95 suites**.