### PR TITLE
ci(release): gate releases on tag↔package.json match + version guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,24 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Fail fast (before tests, image build, or the GitHub Release) if the release is inconsistent:
+      # the tag must match package.json, and the docs/CHANGELOG version guard must pass. This stops a
+      # mis-tagged or under-documented release from ever publishing an image or a GitHub Release.
+      - name: Verify tag matches package.json version
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          TAG_VERSION="${TAG#v}"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag '$TAG' (version '$TAG_VERSION') does not match package.json version '$PKG_VERSION'. Bump package.json or fix the tag before releasing."
+            exit 1
+          fi
+          echo "Tag $TAG matches package.json $PKG_VERSION"
+
+      - name: Check doc version consistency
+        run: npm run check:versions
+
       - name: Run tests
         run: npm test -- --coverage
 


### PR DESCRIPTION
## What
Adds two fail-fast steps to the **Release** workflow's test gate (runs on `v*` tag push, before tests / image build / GitHub Release):

1. **Tag ↔ package.json match** — fails if e.g. tag `v0.6.0` is pushed while `package.json` is still `0.5.0` (a mis-tag). Tag is read via `env: TAG` and quoted (no shell injection).
2. **`npm run check:versions`** — the same doc-version guard from the lint job, now also enforced at release time, so a release missing its `CHANGELOG.md` entry (or with a hardcoded badge/Swagger version) is blocked.

Release notes are already auto-generated from `CHANGELOG.md` (existing steps 55–67) — unchanged.

## Why
Completes the version-drift prevention started in #407: nothing can publish an image or a GitHub Release if the tag, `package.json`, docs, and CHANGELOG aren't consistent.

## Note
These steps only execute on a real `v*` tag push, so PR CI here can't exercise them. Verified locally: YAML parses; the tag-match shell logic blocks `v0.6.0`/`v0.5.0-rc1` against `package.json 0.5.0` and passes `v0.5.0`.