### PR TITLE
chore(docker): fix dashboard build by using npm install instead of np…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,9 @@ COPY . .
 
 # Build the API (dist/) and the dashboard SPA (dashboard/dist/). The root `npm ci` above
 # ran before the dashboard source was copied, so its postinstall hook skipped the dashboard
-# deps - install them explicitly here (npm ci, reproducible from dashboard/package-lock.json).
-RUN npm run build && npm run dashboard:ci && npm run dashboard:build
+# deps — install them explicitly here. We use `npm install` (not ci) so that npm correctly
+# resolves transitive native bindings (e.g. @rolldown/binding-linux-x64-gnu).
+RUN npm run build && cd dashboard && npm install && npm run build
 
 # ===== Stage 2: Production =====
 FROM docker.io/node:22-slim AS production

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -22,6 +22,9 @@
     "react-router-dom": "^7.17.0",
     "socket.io-client": "^4.8.3"
   },
+  "optionalDependencies": {
+    "@rolldown/binding-linux-x64-gnu": "^1.0.3"
+  },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/node": "^25.9.3",


### PR DESCRIPTION
## Description

This PR fixes the Docker build failure occurring in the `dashboard` stage. 

**The problem:** 
Using `npm ci` in the Dockerfile for the dashboard dependencies was too strict. Since `npm ci` relies strictly on the lockfile and cannot reliably resolve or skip platform-specific optional native bindings (such as `@rolldown/binding-linux-x64-gnu`) during the Docker layer build, the installation was failing.

**The solution:**
- Replaced `npm run dashboard:ci` with `cd dashboard && npm install` inside the Dockerfile. This allows npm to dynamically resolve the correct native binary for the container's architecture (`linux-x64-gnu`) instead of being blocked by lockfile mismatches.
- Explicitly added `@rolldown/binding-linux-x64-gnu` to `optionalDependencies` in `dashboard/package.json` to ensure that if this binary fails to install on other platforms, it won't break the entire build process.

**Impact:** 
The Docker image now builds successfully without altering the actual runtime behavior of the dashboard.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] Lint passes
- [x] Self-reviewed

## Screenshots (if applicable)

## Related Issues
Closes #