### PR TITLE
feat(plugins): enforce declared capability permissions at the boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Plugin capability permissions are now enforced.** A plugin may use a capability — `ctx.messages.*`
+  (send/reply) or `ctx.engine.*` (read-only group/contact/chat queries) — only if its manifest
+  declares the matching permission (`messages:send` / `engine:read`); a plugin that doesn't declare
+  it, or declares none, is denied with a clear `PluginCapabilityError`. Previously `manifest.permissions`
+  was advisory and unenforced. The built-in extensions declare exactly what they use (auto-reply:
+  `messages:send`; translation: `messages:send` + `engine:read`) and are unaffected; custom plugins
+  must declare the permissions for the capabilities they call.
+
 ### Fixed
 
 - **A session is no longer mutated by callbacks from an engine it has already replaced or torn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it, or declares none, is denied with a clear `PluginCapabilityError`. Previously `manifest.permissions`
   was advisory and unenforced. The built-in extensions declare exactly what they use (auto-reply:
   `messages:send`; translation: `messages:send` + `engine:read`) and are unaffected; custom plugins
-  must declare the permissions for the capabilities they call.
+  must declare the permissions for the capabilities they call. (#412)
 
 ### Fixed
 

--- a/src/core/plugins/plugin-capability.spec.ts
+++ b/src/core/plugins/plugin-capability.spec.ts
@@ -14,7 +14,7 @@ import {
 import { MessageService } from '../../modules/message/message.service';
 import { SessionService } from '../../modules/session/session.service';
 
-function makePlugin(sessions?: string[]): PluginInstance {
+function makePlugin(sessions?: string[], permissions: string[] = ['messages:send', 'engine:read']): PluginInstance {
   const manifest: PluginManifest = {
     id: 'test-ext',
     name: 'Test Extension',
@@ -22,6 +22,7 @@ function makePlugin(sessions?: string[]): PluginInstance {
     type: PluginType.EXTENSION,
     main: 'index.ts',
     sessions,
+    permissions,
   };
   return { manifest, status: PluginStatus.INSTALLED, config: {}, instance: null };
 }
@@ -100,6 +101,19 @@ describe('PluginLoaderService capability facade — ctx.messages', () => {
     await expect(ctx.messages.sendText('dead-session', '628@c.us', 'hi')).rejects.toBeInstanceOf(PluginCapabilityError);
     expect(messageService.sendText).not.toHaveBeenCalled();
   });
+
+  it('denies sendText when the plugin does not declare the messages:send permission', async () => {
+    const ctx = contextFor(makePlugin(['*'], [])); // no permissions
+    await expect(ctx.messages.sendText('sess-1', '628@c.us', 'hi')).rejects.toBeInstanceOf(PluginCapabilityError);
+    expect(moduleRef.get).not.toHaveBeenCalled();
+    expect(messageService.sendText).not.toHaveBeenCalled();
+  });
+
+  it('denies reply when the plugin does not declare the messages:send permission', async () => {
+    const ctx = contextFor(makePlugin(['*'], []));
+    await expect(ctx.messages.reply('sess-1', '628@c.us', 'q', 'hi')).rejects.toBeInstanceOf(PluginCapabilityError);
+    expect(messageService.reply).not.toHaveBeenCalled();
+  });
 });
 
 describe('PluginLoaderService capability facade — ctx.engine', () => {
@@ -149,5 +163,20 @@ describe('PluginLoaderService capability facade — ctx.engine', () => {
     const ctx = contextFor(makePlugin(['allowed']));
     await expect(ctx.engine.getChats('other')).rejects.toBeInstanceOf(PluginCapabilityError);
     expect(sessionService.getEngine).not.toHaveBeenCalled();
+  });
+
+  it('denies engine.getGroupInfo when the plugin does not declare the engine:read permission', async () => {
+    const { sessionService } = build({ getGroupInfo: jest.fn() });
+    const ctx = contextFor(makePlugin(['*'], ['messages:send'])); // has messages, lacks engine:read
+    await expect(ctx.engine.getGroupInfo('sess-1', 'g@g.us')).rejects.toBeInstanceOf(PluginCapabilityError);
+    expect(sessionService.getEngine).not.toHaveBeenCalled();
+  });
+
+  it('allows engine.getGroupInfo when the plugin declares engine:read', async () => {
+    const engine = { getGroupInfo: jest.fn().mockResolvedValue({ id: 'g@g.us' }) };
+    build(engine);
+    const ctx = contextFor(makePlugin(['*'], ['engine:read']));
+    await ctx.engine.getGroupInfo('sess-1', 'g@g.us');
+    expect(engine.getGroupInfo).toHaveBeenCalledWith('g@g.us');
   });
 });

--- a/src/core/plugins/plugin-loader.service.ts
+++ b/src/core/plugins/plugin-loader.service.ts
@@ -7,6 +7,7 @@ import { createLogger } from '../../common/services/logger.service';
 import { HookManager } from '../hooks';
 import {
   PluginCapabilityError,
+  PluginCapabilityPermission,
   PluginEngineReadCapability,
   PluginManifest,
   PluginMessagingCapability,
@@ -336,6 +337,20 @@ export class PluginLoaderService implements OnModuleInit {
   }
 
   /**
+   * Enforce a plugin's declared manifest permissions at the capability boundary. A plugin may only
+   * use a capability whose permission string it declares in `manifest.permissions`; anything else
+   * (including a manifest with no permissions) is denied. Runs first in each capability verb so a
+   * missing grant fails fast and uniformly as a PluginCapabilityError.
+   */
+  private assertPermission(manifest: PluginManifest, permission: PluginCapabilityPermission): void {
+    if (!(manifest.permissions ?? []).includes(permission)) {
+      throw new PluginCapabilityError(
+        `Plugin ${manifest.id} is missing the '${permission}' permission required for this capability`,
+      );
+    }
+  }
+
+  /**
    * Enforce a plugin's manifest session scope. Runs BEFORE any engine/message resolution —
    * sessionId is supplied by the plugin, so this is the security boundary. Absent = ['*'].
    */
@@ -358,6 +373,12 @@ export class PluginLoaderService implements OnModuleInit {
       throw new PluginCapabilityError(`Session ${sessionId} has no active engine (unknown or not started)`);
     }
     return engine;
+  }
+
+  /** Engine read capabilities: require the `engine:read` permission, then resolve the live engine. */
+  private resolveEngineRead(manifest: PluginManifest, sessionId: string): IWhatsAppEngine {
+    this.assertPermission(manifest, PluginCapabilityPermission.ENGINE_READ);
+    return this.resolveEngine(manifest, sessionId);
   }
 
   private createPluginContext(plugin: PluginInstance): PluginContext {
@@ -388,26 +409,29 @@ export class PluginLoaderService implements OnModuleInit {
       },
       messages: {
         sendText: async (sessionId, chatId, text) => {
-          // Validate scope + that the session has a live engine BEFORE MessageService persists a
-          // pending row: a dead/unstarted session must fail with PluginCapabilityError, not a raw
-          // TypeError + orphaned row. resolveEngine also runs assertSessionAllowed.
+          // Validate permission + scope + that the session has a live engine BEFORE MessageService
+          // persists a pending row: a missing grant / dead session must fail with
+          // PluginCapabilityError, not a raw TypeError + orphaned row. resolveEngine also runs
+          // assertSessionAllowed.
+          this.assertPermission(plugin.manifest, PluginCapabilityPermission.MESSAGES_SEND);
           this.resolveEngine(plugin.manifest, sessionId);
           return this.getMessageService().sendText(sessionId, { chatId, text });
         },
         reply: async (sessionId, chatId, quotedMessageId, text) => {
+          this.assertPermission(plugin.manifest, PluginCapabilityPermission.MESSAGES_SEND);
           this.resolveEngine(plugin.manifest, sessionId);
           return this.getMessageService().reply(sessionId, { chatId, quotedMessageId, text });
         },
       } satisfies PluginMessagingCapability,
       engine: {
         getGroupInfo: async (sessionId, groupId) =>
-          this.resolveEngine(plugin.manifest, sessionId).getGroupInfo(groupId),
-        getContacts: async sessionId => this.resolveEngine(plugin.manifest, sessionId).getContacts(),
+          this.resolveEngineRead(plugin.manifest, sessionId).getGroupInfo(groupId),
+        getContacts: async sessionId => this.resolveEngineRead(plugin.manifest, sessionId).getContacts(),
         getContactById: async (sessionId, contactId) =>
-          this.resolveEngine(plugin.manifest, sessionId).getContactById(contactId),
+          this.resolveEngineRead(plugin.manifest, sessionId).getContactById(contactId),
         checkNumberExists: async (sessionId, phone) =>
-          this.resolveEngine(plugin.manifest, sessionId).checkNumberExists(phone),
-        getChats: async sessionId => this.resolveEngine(plugin.manifest, sessionId).getChats(),
+          this.resolveEngineRead(plugin.manifest, sessionId).checkNumberExists(phone),
+        getChats: async sessionId => this.resolveEngineRead(plugin.manifest, sessionId).getChats(),
       } satisfies PluginEngineReadCapability,
     };
   }

--- a/src/core/plugins/plugin.interfaces.ts
+++ b/src/core/plugins/plugin.interfaces.ts
@@ -60,7 +60,9 @@ export interface PluginManifest {
   // Required features from other plugins
   requires?: string[];
 
-  // Capabilities this plugin declares (informational at this tier; not per-verb enforced)
+  // Capability permissions this plugin declares; the loader enforces them at the capability
+  // boundary (see PluginCapabilityPermission). A capability call whose permission is not declared
+  // here is denied with a PluginCapabilityError. Absent / empty = no capability access.
   permissions?: string[];
 
   // Session ids this plugin may act on, or ['*']. Absent = ['*'] (all). Enforced by the
@@ -89,7 +91,20 @@ export interface PluginConfigSchema {
 // ============================================================================
 
 /**
- * Thrown by a plugin capability when a call is rejected (out-of-scope session,
+ * Capability permissions a plugin declares in its manifest `permissions` and that the loader
+ * enforces at the capability boundary. A plugin may only use a capability whose permission it
+ * declares; an undeclared (or missing-permission) plugin is denied with a PluginCapabilityError.
+ */
+export const PluginCapabilityPermission = {
+  /** `ctx.messages.*` — send / reply on a session. */
+  MESSAGES_SEND: 'messages:send',
+  /** `ctx.engine.*` — read-only engine queries (group info, contacts, chats, number check). */
+  ENGINE_READ: 'engine:read',
+} as const;
+export type PluginCapabilityPermission = (typeof PluginCapabilityPermission)[keyof typeof PluginCapabilityPermission];
+
+/**
+ * Thrown by a plugin capability when a call is rejected (missing permission, out-of-scope session,
  * unstarted session, etc.). Gives plugins a predictable failure instead of a raw TypeError.
  */
 export class PluginCapabilityError extends Error {

--- a/src/plugins/extensions/extensions.module.ts
+++ b/src/plugins/extensions/extensions.module.ts
@@ -38,7 +38,8 @@ export class ExtensionsRegistrar implements OnModuleInit {
       description:
         "Auto-translates group messages between participants' languages via LibreTranslate. Configure in-group with /tr commands. Disabled by default.",
       main: 'index.ts',
-      permissions: ['messages:send'],
+      // Sends translations (messages:send) and reads group admins via ctx.engine.getGroupInfo (engine:read).
+      permissions: ['messages:send', 'engine:read'],
       sessions: ['*'],
       // Exposed via GET /plugins so the dashboard renders an editable config form (URL + API key, etc.).
       configSchema: {


### PR DESCRIPTION
## Problem

A plugin's `manifest.permissions` was **declared but not enforced** — the comment in the interface even said "informational at this tier; not per-verb enforced." Any enabled plugin could call any capability (`ctx.messages.sendText`/`reply`, `ctx.engine.getGroupInfo`/`getContacts`/…) regardless of what it declared. The only capability guard was session scope.

## Fix

Enforce declared permissions at the capability boundary:

- Define the vocabulary `PluginCapabilityPermission`: `messages:send` (write verbs) and `engine:read` (read verbs).
- `assertPermission(manifest, permission)` denies a verb whose permission the manifest doesn't declare, with a clear `PluginCapabilityError`. It runs **first** in each verb (before session-scope / engine resolution) so a missing grant fails fast and uniformly.
- Read verbs go through a small `resolveEngineRead` helper (`engine:read` + resolve).

**Model:** *declared = allowed; undeclared (or no permissions) = denied.* This is the secure default and is safe to adopt now — there is no external plugin ecosystem yet (the marketplace is still planned).

## Built-ins updated (the one real migration)

The `translation` extension declared only `messages:send` but its chat gateway calls `ctx.engine.getGroupInfo` — so it now declares `messages:send` + `engine:read`. Without this, enabling enforcement would have broken translation at runtime. `auto-reply` uses only `ctx.messages.reply`, so it keeps `messages:send`.

## Tests

`plugin-capability.spec.ts`: the test harness now grants both permissions by default (existing delegation/scope tests unchanged), plus new cases — deny `sendText`/`reply` without `messages:send`, deny `engine.getGroupInfo` without `engine:read`, and allow it with `engine:read`.

Full suite: **1091 passed / 95 suites**; build + project lint clean.

## Note
This is the first half of the plugin-hardening work. Process isolation / sandboxing of untrusted plugin code is tracked separately as a design RFC — until it lands, the guidance remains: load only trusted plugins.