### PR TITLE
chore(release): v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-06-22
+
+A small correctness & consistency patch — **no breaking changes**. Session engine callbacks no longer
+mutate a session after it has been stopped or its engine replaced; bulk-message variables now use the
+same `{{name}}` syntax as message templates (single-brace `{name}` deprecated but still honored); and
+a plugin's declared capability permissions are now actually enforced at the capability boundary.
+
 ### Changed
 
 - **Plugin capability permissions are now enforced.** A plugin may use a capability — `ctx.messages.*`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwa",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API for WhatsApp",
   "author": "Yudhi Armyndharis & OpenWA Contributors",
   "private": true,


### PR DESCRIPTION
Release **v0.5.1** — a small correctness & consistency patch. **No breaking changes** (patch bump).

Bundles three already-merged enhancements now promoted from `[Unreleased]`:

- **#410** — engine callbacks no longer mutate a session after it's been stopped or its engine replaced (stale-callback guard).
- **#411** — bulk-message variables unified onto the shared `{{name}}` template syntax; legacy single-brace `{name}` deprecated but still honored. (#69)
- **#412** — plugin capability permissions declared in a manifest are now actually enforced at the boundary.

### Changes in this PR
- `package.json` → `0.5.1`
- `CHANGELOG.md` → promote `[Unreleased]` to `## [0.5.1] - 2026-06-22`

Verified locally: `check:versions` ✓, build ✓, lint ✓, **1104 tests** ✓. After merge, tag `v0.5.1` triggers the release workflow (multi-arch image + GitHub Release).