### PR TITLE
[codex] Fix whatsapp-web.js authenticating hang

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,10 +93,9 @@ services:
       - SESSION_DATA_PATH=/app/data/sessions
       - PUPPETEER_HEADLESS=${PUPPETEER_HEADLESS:-true}
       - PUPPETEER_ARGS=${PUPPETEER_ARGS:---no-sandbox,--disable-setuid-sandbox,--disable-dev-shm-usage,--disable-gpu}
-      # Pin the WhatsApp Web version if a session hangs at "authenticating" after scanning the QR
-      # (whatsapp-web.js 1.34.x can stall on an incompatible auto-selected WA-Web version, #251/#273).
-      # Empty = auto-select (default). Set WWEBJS_WEB_VERSION in .env to a known-good version — see
-      # docs/12-troubleshooting-faq.md. (Without this line the var in .env never reaches the container.)
+      # Optional WhatsApp Web version override. The adapter defaults to a validated cached version
+      # because whatsapp-web.js 1.34.x can stall at "authenticating" with auto-selected WA-Web builds
+      # (#251/#273). Set WWEBJS_WEB_VERSION=latest|auto|off to restore auto-selection.
       - WWEBJS_WEB_VERSION=${WWEBJS_WEB_VERSION:-}
       - WWEBJS_WEB_VERSION_REMOTE_PATH=${WWEBJS_WEB_VERSION_REMOTE_PATH:-}
       # Raise whatsapp-web.js's first-boot init wait (default 30000ms) on slow boots — e.g. WSL2 or

--- a/docs/12-troubleshooting-faq.md
+++ b/docs/12-troubleshooting-faq.md
@@ -209,16 +209,18 @@ stuck. Often seen on ARM64 (e.g. Raspberry Pi) after upgrading to v0.2.x.
 stalls the post-link sync. (If you also see `chrome_crashpad_handler: --database is required` *and the
 session never starts at all*, that is a different problem — see "Session fails to launch …" below.)
 
-**Fix:** pin a known-good WhatsApp Web version with `WWEBJS_WEB_VERSION`:
+**Default behavior:** OpenWA pins a validated WhatsApp Web version for `whatsapp-web.js` by default
+because auto-selecting the latest web client can break the post-link injection step. To override the
+default, set `WWEBJS_WEB_VERSION`:
 
 ```bash
-# Confirmed to reach "ready" (incl. ARM64 / Raspberry Pi 5):
-WWEBJS_WEB_VERSION=2.3000.1023204257
+# Current default, confirmed to reach "ready":
+WWEBJS_WEB_VERSION=2.3000.1040641150-alpha
 ```
 
-Restart the container after setting it. Browse newer versions at
-[wppconnect-team/wa-version](https://github.com/wppconnect-team/wa-version) (the `html/` folder).
-Set `WWEBJS_WEB_VERSION=latest` (or leave it unset) to restore the default auto-version behavior.
+Restart the container after changing it. Browse newer versions at
+[wppconnect-team/wa-version](https://github.com/wppconnect-team/wa-version) (the `html/` folder). Set
+`WWEBJS_WEB_VERSION=latest`, `auto`, or `off` to restore whatsapp-web.js auto-version behavior.
 
 ### Issue: QR generation times out on slow first boot (WSL2 / low-resource)
 

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -1,5 +1,7 @@
 import { MessageMedia } from 'whatsapp-web.js';
+import { EventEmitter } from 'events';
 import {
+  DEFAULT_WWEBJS_WEB_VERSION,
   WhatsAppWebJsAdapter,
   extractLinkedParentJID,
   isHttpUrl,
@@ -292,6 +294,43 @@ describe('WhatsAppWebJsAdapter.forceDestroy (recover a wedged session, #351)', (
   });
 });
 
+describe('WhatsAppWebJsAdapter ready reconciliation (#251/#273)', () => {
+  const newAdapter = (): WhatsAppWebJsAdapter =>
+    new WhatsAppWebJsAdapter({ sessionId: 'sess-1', sessionDataPath: './data/sessions', puppeteer: {} });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('marks the adapter ready when authenticated runtime is connected but the ready event is missed', async () => {
+    jest.useFakeTimers();
+
+    const adapter = newAdapter();
+    const fakeClient = Object.assign(new EventEmitter(), {
+      info: { wid: { user: '628123' }, pushname: 'Tester' },
+      getState: jest.fn().mockResolvedValue('CONNECTED'),
+      pupPage: {
+        evaluate: jest.fn().mockResolvedValue(true),
+      },
+    });
+    const onReady = jest.fn();
+    const onStateChanged = jest.fn();
+
+    (adapter as unknown as { client: unknown }).client = fakeClient;
+    (adapter as unknown as { callbacks: unknown }).callbacks = { onReady, onStateChanged };
+    (adapter as unknown as { setupEventHandlers: () => void }).setupEventHandlers();
+
+    fakeClient.emit('authenticated');
+    expect(adapter.getStatus()).toBe(EngineStatus.AUTHENTICATING);
+
+    await jest.advanceTimersByTimeAsync(2100);
+
+    expect(adapter.getStatus()).toBe(EngineStatus.READY);
+    expect(onReady).toHaveBeenCalledWith('628123', 'Tester');
+    expect(onReady).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('WhatsAppWebJsAdapter.resolveContactPhone (@lid -> phone, #263)', () => {
   // Stub a "ready" adapter with a fake client so we exercise the mapping without a real browser.
   const readyAdapter = (getContactLidAndPhone: jest.Mock): WhatsAppWebJsAdapter => {
@@ -319,7 +358,7 @@ describe('WhatsAppWebJsAdapter.resolveContactPhone (@lid -> phone, #263)', () =>
   });
 });
 
-describe('resolveWebVersionPin (#251 — opt-in WA-Web version pin)', () => {
+describe('resolveWebVersionPin (#251 — default WA-Web version pin)', () => {
   const orig = { v: process.env.WWEBJS_WEB_VERSION, p: process.env.WWEBJS_WEB_VERSION_REMOTE_PATH };
   afterEach(() => {
     if (orig.v === undefined) delete process.env.WWEBJS_WEB_VERSION;
@@ -328,23 +367,34 @@ describe('resolveWebVersionPin (#251 — opt-in WA-Web version pin)', () => {
     else process.env.WWEBJS_WEB_VERSION_REMOTE_PATH = orig.p;
   });
 
-  it('returns undefined (default auto-version) when unset / "latest" / "off"', () => {
+  it('pins the validated cached WA-Web version by default', () => {
     delete process.env.WWEBJS_WEB_VERSION;
-    expect(resolveWebVersionPin()).toBeUndefined();
-    process.env.WWEBJS_WEB_VERSION = 'latest';
-    expect(resolveWebVersionPin()).toBeUndefined();
-    process.env.WWEBJS_WEB_VERSION = 'off';
-    expect(resolveWebVersionPin()).toBeUndefined();
+    delete process.env.WWEBJS_WEB_VERSION_REMOTE_PATH;
+    expect(resolveWebVersionPin()).toEqual({
+      webVersion: DEFAULT_WWEBJS_WEB_VERSION,
+      webVersionCache: {
+        type: 'remote',
+        remotePath: `https://raw.githubusercontent.com/wppconnect-team/wa-version/main/html/${DEFAULT_WWEBJS_WEB_VERSION}.html`,
+      },
+    });
+  });
+
+  it('returns undefined for explicit auto-version opt-outs', () => {
+    for (const value of ['latest', 'off', 'auto']) {
+      process.env.WWEBJS_WEB_VERSION = value;
+      expect(resolveWebVersionPin()).toBeUndefined();
+    }
   });
 
   it('pins a remote webVersionCache from the version when set', () => {
     delete process.env.WWEBJS_WEB_VERSION_REMOTE_PATH;
-    process.env.WWEBJS_WEB_VERSION = '2.3000.1023204257';
+    process.env.WWEBJS_WEB_VERSION = '2.3000.1041203030-alpha';
     expect(resolveWebVersionPin()).toEqual({
-      webVersion: '2.3000.1023204257',
+      webVersion: '2.3000.1041203030-alpha',
       webVersionCache: {
         type: 'remote',
-        remotePath: 'https://raw.githubusercontent.com/wppconnect-team/wa-version/main/html/2.3000.1023204257.html',
+        remotePath:
+          'https://raw.githubusercontent.com/wppconnect-team/wa-version/main/html/2.3000.1041203030-alpha.html',
       },
     });
   });

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -115,21 +115,23 @@ export interface WhatsAppWebJsConfig {
   };
 }
 
+export const DEFAULT_WWEBJS_WEB_VERSION = '2.3000.1040641150-alpha';
+const READY_RECONCILE_INTERVAL_MS = 2000;
+const READY_RECONCILE_TIMEOUT_MS = 90_000;
+
 /**
- * Optional pin for the WhatsApp Web client version. whatsapp-web.js 1.34.x can get stuck at
- * "authenticating" (the post-link sync never completes) when the auto-fetched WA-Web version is
- * incompatible (#251). Set WWEBJS_WEB_VERSION to a known-good version string (browse
- * https://github.com/wppconnect-team/wa-version) to pin it; WWEBJS_WEB_VERSION_REMOTE_PATH
- * overrides the URL template (use `{version}` as the placeholder) if you self-host the HTML.
- * Unset (or `latest`/`off`) keeps whatsapp-web.js's default auto-version behavior.
+ * WhatsApp Web client version pin. whatsapp-web.js 1.34.x can get stuck at "authenticating" when the
+ * auto-fetched WA-Web version is incompatible (#251/#273). Default to the currently validated cached
+ * build so first-run sessions work; set WWEBJS_WEB_VERSION=latest|off|auto to restore auto-selection.
  */
 export function resolveWebVersionPin():
   | { webVersion: string; webVersionCache: { type: 'remote'; remotePath: string } }
   | undefined {
-  const version = process.env.WWEBJS_WEB_VERSION?.trim();
-  if (!version || version.toLowerCase() === 'off' || version.toLowerCase() === 'latest') {
+  const rawVersion = process.env.WWEBJS_WEB_VERSION?.trim();
+  if (rawVersion && ['off', 'latest', 'auto'].includes(rawVersion.toLowerCase())) {
     return undefined;
   }
+  const version = rawVersion || DEFAULT_WWEBJS_WEB_VERSION;
   const template =
     process.env.WWEBJS_WEB_VERSION_REMOTE_PATH?.trim() ||
     'https://raw.githubusercontent.com/wppconnect-team/wa-version/main/html/{version}.html';
@@ -184,6 +186,8 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
   private phoneNumber: string | null = null;
   private pushName: string | null = null;
   private callbacks: EngineEventCallbacks = {};
+  private readyReconcileTimer: ReturnType<typeof setTimeout> | null = null;
+  private readyReconcileStartedAt = 0;
 
   constructor(private readonly config: WhatsAppWebJsConfig) {
     super();
@@ -277,20 +281,11 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     this.client.on('authenticated', () => {
       this.setStatus(EngineStatus.AUTHENTICATING);
       this.qrCode = null;
+      this.scheduleReadyReconcile();
     });
 
     this.client.on('ready', () => {
-      try {
-        const info = this.client?.info;
-        this.phoneNumber = info?.wid?.user || null;
-        this.pushName = info?.pushname || null;
-        this.setStatus(EngineStatus.READY);
-        this.callbacks.onReady?.(this.phoneNumber || '', this.pushName || '');
-      } catch (error) {
-        this.logger.error('Error getting client info', String(error));
-        this.setStatus(EngineStatus.READY);
-        this.callbacks.onReady?.('', '');
-      }
+      this.markReadyFromClientInfo();
     });
 
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
@@ -423,17 +418,93 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     });
 
     this.client.on('disconnected', reason => {
+      this.clearReadyReconcile();
       this.setStatus(EngineStatus.DISCONNECTED);
       this.callbacks.onDisconnected?.(reason);
     });
 
     this.client.on('auth_failure', (message?: string) => {
+      this.clearReadyReconcile();
       this.setStatus(EngineStatus.FAILED);
       // Authentication failure is terminal: the stored credentials are invalid and
       // reconnecting will not help — the operator must re-scan the QR code. Route it
       // through onError (FAILED, no reconnect) rather than onDisconnected (reconnect).
       this.callbacks.onError?.(message ? `Authentication failed: ${message}` : 'Authentication failed');
     });
+  }
+
+  private markReadyFromClientInfo(): void {
+    if (this.status === EngineStatus.READY) return;
+    this.clearReadyReconcile();
+    try {
+      const info = this.client?.info;
+      this.phoneNumber = info?.wid?.user || null;
+      this.pushName = info?.pushname || null;
+      this.setStatus(EngineStatus.READY);
+      this.callbacks.onReady?.(this.phoneNumber || '', this.pushName || '');
+    } catch (error) {
+      this.logger.error('Error getting client info', String(error));
+      this.setStatus(EngineStatus.READY);
+      this.callbacks.onReady?.('', '');
+    }
+  }
+
+  private scheduleReadyReconcile(): void {
+    this.clearReadyReconcile();
+    this.readyReconcileStartedAt = Date.now();
+
+    const tick = async (): Promise<void> => {
+      if (!this.client || this.status !== EngineStatus.AUTHENTICATING) {
+        this.clearReadyReconcile();
+        return;
+      }
+
+      try {
+        if (await this.isClientRuntimeReady()) {
+          this.logger.warn('WhatsApp Web ready event was missed; reconciling from connected runtime state');
+          this.markReadyFromClientInfo();
+          return;
+        }
+      } catch (error) {
+        this.logger.debug('Ready reconciliation probe failed', { error: String(error) });
+      }
+
+      if (Date.now() - this.readyReconcileStartedAt >= READY_RECONCILE_TIMEOUT_MS) {
+        this.logger.warn('Timed out waiting for WhatsApp Web runtime readiness after authentication');
+        this.clearReadyReconcile();
+        return;
+      }
+
+      this.readyReconcileTimer = setTimeout(() => {
+        void tick();
+      }, READY_RECONCILE_INTERVAL_MS);
+      this.readyReconcileTimer.unref?.();
+    };
+
+    this.readyReconcileTimer = setTimeout(() => {
+      void tick();
+    }, READY_RECONCILE_INTERVAL_MS);
+    this.readyReconcileTimer.unref?.();
+  }
+
+  private clearReadyReconcile(): void {
+    if (this.readyReconcileTimer) {
+      clearTimeout(this.readyReconcileTimer);
+      this.readyReconcileTimer = null;
+    }
+    this.readyReconcileStartedAt = 0;
+  }
+
+  private async isClientRuntimeReady(): Promise<boolean> {
+    if (!this.client) return false;
+    const state = await this.client.getState();
+    if (state !== 'CONNECTED') return false;
+
+    const page = (this.client as unknown as { pupPage?: { evaluate: <T>(fn: () => T) => Promise<T> } }).pupPage;
+    const hasWWebJS = await page?.evaluate(
+      () => typeof (window as unknown as { WWebJS?: unknown }).WWebJS !== 'undefined',
+    );
+    return hasWWebJS === true;
   }
 
   private setStatus(status: EngineStatus): void {
@@ -453,6 +524,7 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
         // Already destroyed or not initialized - ignore
       }
       this.client = null;
+      this.clearReadyReconcile();
       this.setStatus(EngineStatus.DISCONNECTED);
     }
   }
@@ -472,6 +544,7 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
         }
       }
       this.client = null;
+      this.clearReadyReconcile();
       this.setStatus(EngineStatus.DISCONNECTED);
     }
   }
@@ -480,6 +553,7 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     if (this.client) {
       await this.client.destroy();
       this.client = null;
+      this.clearReadyReconcile();
       this.setStatus(EngineStatus.DISCONNECTED);
     }
   }
@@ -511,6 +585,7 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     }
 
     this.client = null;
+    this.clearReadyReconcile();
     this.setStatus(EngineStatus.DISCONNECTED);
   }
 


### PR DESCRIPTION
## Summary

Fixes `whatsapp-web.js` sessions that remain stuck at `authenticating` after the phone has already linked the device and WhatsApp Web is active.

## Issue Encountered

A live Docker Compose session reached WhatsApp Web successfully, but the OpenWA dashboard and API stayed at `authenticating`. DevTools inspection showed the WhatsApp page was loaded and connected, with account info available, while `whatsapp-web.js` did not reliably finish its own `ready` event path. In the failing path, OpenWA only persisted `ready` from the library's `ready` callback, so the dashboard could remain stale indefinitely even after the underlying WhatsApp runtime was usable.

There was also an existing documented workaround to pin a known-good WhatsApp Web version, but the older documented cached version was no longer available upstream. Leaving the adapter on auto-selected WhatsApp Web builds made first-run sessions vulnerable to this recurring compatibility break.

## Why This Fix

This patch fixes the problem at the adapter boundary where the state mismatch is introduced:

- Defaults `whatsapp-web.js` to a validated cached WhatsApp Web build instead of relying on auto-selection.
- Keeps explicit opt-outs with `WWEBJS_WEB_VERSION=latest`, `auto`, or `off` for operators who want upstream auto-selection.
- Adds a bounded post-auth reconciliation loop: after `authenticated`, if the runtime reports `CONNECTED` and `window.WWebJS` is injected, the adapter promotes itself to `READY` even if the library missed the `ready` event.
- Clears the reconciliation timer on ready/disconnect/failure/teardown so it does not leak or mutate stopped sessions.
- Updates docs and compose comments so operator guidance matches runtime behavior.

This preserves the normal `ready` event path and only reconciles when the page proves it is actually connected and the injected helper layer exists.

## Validation

- `npm test -- --runInBand src/engine/adapters/whatsapp-web-js.adapter.spec.ts`
- `npm run build`
- `docker compose --profile full build openwa-api`
- Recreated the live `openwa-api` container from the patched image.
- Started the existing local session and verified it transitioned from `authenticating` to `ready` with phone/push name populated.
- Verified `GET /api/sessions/:id/chats?limit=1` returned `200`.
- Verified `/sessions` rendered the session as `Connected` in the dashboard.
