### PR TITLE
test(e2e): isolate the e2e data DB so suites don't pollute the dev database

### DIFF
--- a/src/engine/adapters/baileys.adapter.ts
+++ b/src/engine/adapters/baileys.adapter.ts
@@ -381,7 +381,7 @@ export class BaileysAdapter implements IWhatsAppEngine {
     this.sock = null;
     this.setStatus(EngineStatus.DISCONNECTED);
     await this.config.messageStore?.clearSession(this.config.sessionId).catch(() => undefined);
-    // ponytail: leaves the multi-file auth dir on disk; a fresh link overwrites it. Add fs cleanup if
+    // leaves the multi-file auth dir on disk; a fresh link overwrites it. Add fs cleanup if
     // stale creds ever block re-linking.
   }
 

--- a/test/setup-e2e.ts
+++ b/test/setup-e2e.ts
@@ -1,7 +1,17 @@
 // e2e boot environment. Set BEFORE AppModule is imported (setupFiles phase) so the
 // app boots against local SQLite with no Redis/queue and no production boot guard.
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { rmSync } from 'fs';
+
 process.env.NODE_ENV = 'test';
 process.env.DATABASE_TYPE = 'sqlite';
+// Isolate the e2e data DB to a throwaway temp file so suites never pollute the developer's
+// ./data/openwa.sqlite. e2e creates sessions/webhooks and doesn't self-clean, so without this they
+// pile up across runs. Start each run from a fresh file.
+const e2eDataDb = join(tmpdir(), `openwa-e2e-${process.pid}.sqlite`);
+rmSync(e2eDataDb, { force: true });
+process.env.DATABASE_NAME = e2eDataDb;
 process.env.QUEUE_ENABLED = 'false';
 process.env.AUTO_START_SESSIONS = 'false';
 // Keep the auth/audit + data schema zero-config for the test boot.


### PR DESCRIPTION
## Problem

Running the e2e suite (`npm run test:e2e`) accumulates test data in the **developer's** `./data/openwa.sqlite`. `test/webhooks.e2e-spec.ts` creates sessions (`e2e-webhooks-<ts>`) + webhooks pointing at a throwaway local receiver (`http://127.0.0.1:<port>/hook`), and `afterAll` only restores env vars — it never deletes them. Because `setup-e2e.ts` set `DATABASE_TYPE=sqlite` but **not** `DATABASE_NAME`, the suites fell back to the same data DB the dev app uses, so they piled up across runs (observed live: **151 sessions / 111 webhooks**, cluttering the dashboard).

## Fix

`setup-e2e.ts` now points `DATABASE_NAME` at a fresh per-run temp file (`<tmpdir>/openwa-e2e-<pid>.sqlite`, removed at the start of each run), so e2e never touches `./data/openwa.sqlite`.

**Verified:** ran `webhooks.e2e-spec.ts` (15/15 pass) — it created the temp DB and the dev `./data/openwa.sqlite` stayed at 0 sessions.

Also a one-line comment tidy in `baileys.adapter.ts` (separate commit).

Note: the auth/audit *main* DB path is hardcoded (`./data/main.sqlite`), so e2e api-keys still land there — far less impactful (few rows, not shown in the dashboard) and out of scope here.