### PR TITLE
test(e2e): isolate the auth/audit DB so e2e api-keys don't pollute the dev database

### DIFF
--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -21,7 +21,9 @@ export default () => ({
   // Main Database configuration (always SQLite for boot config)
   database: {
     type: 'sqlite' as const,
-    database: './data/main.sqlite',
+    // SQLite file for the auth/audit DB. Overridable (e.g. e2e points it at a temp file) so tests
+    // never write api keys into the developer's ./data/main.sqlite.
+    database: process.env.MAIN_DATABASE_NAME || './data/main.sqlite',
     // Schema management for the auth/audit DB. Default ON (zero-config first boot).
     // Set MAIN_DATABASE_SYNCHRONIZE=false to manage schema via the main-owned migrations
     // instead (migrationsRun then creates api_keys/audit_logs). When disabled, run the

--- a/test/setup-e2e.ts
+++ b/test/setup-e2e.ts
@@ -12,6 +12,10 @@ process.env.DATABASE_TYPE = 'sqlite';
 const e2eDataDb = join(tmpdir(), `openwa-e2e-${process.pid}.sqlite`);
 rmSync(e2eDataDb, { force: true });
 process.env.DATABASE_NAME = e2eDataDb;
+// Likewise isolate the auth/audit (main) DB, so e2e api-keys don't accumulate in ./data/main.sqlite.
+const e2eMainDb = join(tmpdir(), `openwa-e2e-main-${process.pid}.sqlite`);
+rmSync(e2eMainDb, { force: true });
+process.env.MAIN_DATABASE_NAME = e2eMainDb;
 process.env.QUEUE_ENABLED = 'false';
 process.env.AUTO_START_SESSIONS = 'false';
 // Keep the auth/audit + data schema zero-config for the test boot.


### PR DESCRIPTION
Follow-up to #416. That PR isolated the **data** DB (`DATABASE_NAME`), but the **auth/audit (main)** DB path was hardcoded (`./data/main.sqlite`), so the e2e suite kept creating `e2e-admin` / `e2e-viewer` api-keys in the developer's main DB — they piled up across runs (24 observed in the dashboard's API Keys page).

## Fix
- `configuration.ts`: main DB path is now `process.env.MAIN_DATABASE_NAME || './data/main.sqlite'`.
- `setup-e2e.ts`: points `MAIN_DATABASE_NAME` at a fresh per-run temp file (mirrors the data-DB isolation).

**Verified:** `webhooks.e2e-spec.ts` runs (15/15) and `./data/main.sqlite` stays unchanged — the e2e api-keys land in the temp DB instead.