### PR TITLE
fix(dashboard): keep the appearance popover inside the sidebar

### DIFF
--- a/dashboard/src/components/Layout.css
+++ b/dashboard/src/components/Layout.css
@@ -285,7 +285,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.85rem;
-  min-width: 254px;
+  max-width: 100%;
   padding: 0.85rem;
   background: var(--bg-white);
   border: 1px solid var(--border);
@@ -379,8 +379,8 @@
 }
 
 .palette-grid {
-  display: grid;
-  grid-template-columns: repeat(7, 1fr);
+  display: flex;
+  flex-wrap: wrap;
   gap: 0.45rem;
 }
 
@@ -391,6 +391,7 @@
   justify-content: center;
   width: 30px;
   height: 30px;
+  flex: 0 0 auto;
   padding: 0;
   border: 1px solid var(--border);
   border-radius: 999px;


### PR DESCRIPTION
The Appearance popover (theme + palette, opened from the sidebar's System button) spilled out past the sidebar into the page content.

**Cause:** the palette was a fixed 7-column grid (~253px) which forced `.appearance-menu-list` to `min-width: 254px` — wider than the sidebar footer it's anchored to, so it overflowed to the right.

**Fix:** wrap the palette swatches (flex-wrap) and drop the forced min-width so the popover fits its container. Verified the popover now stays within the sidebar (swatches wrap to two rows).