### PR TITLE
test(security): verify undici honors the SSRF connect.lookup pin (real connection)

### DIFF
--- a/src/common/security/ssrf-undici-pin.spec.ts
+++ b/src/common/security/ssrf-undici-pin.spec.ts
@@ -1,0 +1,45 @@
+import * as http from 'http';
+import type { AddressInfo } from 'net';
+import { Agent, fetch } from 'undici';
+import { pinnedLookup } from './ssrf-guard';
+
+// Real-connection invariant for the SSRF guard: the *installed* undici must honor an Agent's
+// `connect.lookup` AND the per-request `dispatcher` option on fetch — that pairing is the whole
+// DNS-rebind defense (ssrf-guard.ts pins the resolved IPs into a dispatcher). The unit spec mocks
+// undici's fetch, so it can't see a silent break across an undici upgrade; this test makes a real
+// loopback connection so a future bump that drops/renames either feature fails loudly here instead
+// of leaving the SSRF pin a no-op.
+describe('undici honors the SSRF connect.lookup pin (real connection)', () => {
+  let server: http.Server;
+  let port: number;
+
+  beforeAll(
+    () =>
+      new Promise<void>(resolve => {
+        server = http.createServer((_req, res) => res.end('pinned-ok'));
+        server.listen(0, '127.0.0.1', () => {
+          port = (server.address() as AddressInfo).port;
+          resolve();
+        });
+      }),
+  );
+  afterAll(() => new Promise<void>(resolve => server.close(() => resolve())));
+
+  it('routes the connection to the pinned IP for a host that does not resolve via DNS', async () => {
+    // `.invalid` (RFC 2606) never resolves, so the request can ONLY reach the server if undici used
+    // our pinned lookup → 127.0.0.1.
+    const dispatcher = new Agent({ connect: { lookup: pinnedLookup([{ address: '127.0.0.1', family: 4 }]) } });
+    try {
+      const res = await fetch(`http://pinned.invalid:${port}/`, { dispatcher });
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe('pinned-ok');
+    } finally {
+      await dispatcher.destroy();
+    }
+  });
+
+  it('control: the same host is genuinely unresolvable without the pin', async () => {
+    // Proves the test above succeeds because of the pin, not because the host happens to resolve.
+    await expect(fetch(`http://pinned.invalid:${port}/`)).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
Follow-up to the undici 6→8 bump (#422). The unit `ssrf-guard.spec` mocks undici's `fetch`, so it proves the pinning *logic* but can't see a silent break in the actual DNS-rebind defense across an undici upgrade.

This adds a **real-connection** test: it fetches a non-resolvable `pinned.invalid` host through an `Agent` pinned to `127.0.0.1` and asserts the request reaches a local server. That can only succeed if the installed undici honors **both** `connect.lookup` **and** the per-request `dispatcher` option on `fetch` — the exact pairing the SSRF guard relies on. A control case asserts the host is genuinely unresolvable without the pin.

**Verified green against undici 8.5.0** (now on main). Guards the SSRF pin in CI going forward.