### PR TITLE
fix(hooks): emit the message:ack hook (declared but never fired)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-06-22
+
+A patch closing a plugin-hook gap.
+
+### Fixed
+
+- The `message:ack` hook event was declared in the `HookEvent` union but never emitted, so a plugin registered for it (e.g. a delivery-status logger) silently never fired. It now fires for every delivery/read receipt with `{ messageId, status, ack }` (`source: 'Engine'`, scoped to the session), consistent with `message:received`/`message:sent`. Delivery failures surface as `message:ack` with `status: 'failed'`; the send-time `message:failed` hook is unchanged.
+
 ## [0.6.0] - 2026-06-22
 
 The **plugin platform** release: untrusted plugins now run sandboxed, and you can install and uninstall them from the dashboard. One breaking change for plugin authors (the sandbox context), so this is a minor bump.

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboard",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwa",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API for WhatsApp",
   "author": "Yudhi Armyndharis & OpenWA Contributors",
   "private": true,

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -751,6 +751,34 @@ describe('SessionService', () => {
       expect(dispatchedEvents('message.failed')).toHaveLength(1);
     });
 
+    it('emits the message:ack hook for every ack so plugins (e.g. a delivery logger) can react', async () => {
+      const callbacks = await startAndCaptureCallbacks();
+
+      callbacks.onMessageAck!('wa-out-1', 'delivered');
+      await flush();
+
+      expect(hookManager.execute).toHaveBeenCalledWith(
+        'message:ack',
+        expect.objectContaining({ messageId: 'wa-out-1', status: 'delivered' }),
+        expect.objectContaining({ source: 'Engine' }),
+      );
+    });
+
+    it("surfaces delivery failures via message:ack with status 'failed' (not the send-time message:failed hook)", async () => {
+      const callbacks = await startAndCaptureCallbacks();
+
+      callbacks.onMessageAck!('wa-out-1', 'failed');
+      await flush();
+
+      expect(hookManager.execute).toHaveBeenCalledWith(
+        'message:ack',
+        expect.objectContaining({ messageId: 'wa-out-1', status: 'failed' }),
+        expect.objectContaining({ source: 'Engine' }),
+      );
+      // message:failed stays reserved for send-time failures (a distinct {error,input} payload).
+      expect(hookManager.execute).not.toHaveBeenCalledWith('message:failed', expect.anything(), expect.anything());
+    });
+
     it("does not upgrade the stored status (or emit message.failed) for a 'sent' status", async () => {
       const callbacks = await startAndCaptureCallbacks();
 

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -713,6 +713,17 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
             ack: deliveryStatusToAck(status),
           });
         }
+
+        // Notify plugins of the delivery/read receipt. The `message:ack` hook event was declared in
+        // the HookEvent union but never emitted, so any plugin registered for it silently never fired.
+        // Fire-and-forget: an ack is a notification with nothing downstream to cancel, so the hook's
+        // `continue` flag is moot. Delivery failures surface here as status `failed` — `message:failed`
+        // stays reserved for send-time send failures, which carry a distinct `{ error, input }` payload.
+        void this.hookManager.execute(
+          'message:ack',
+          { messageId, status, ack: deliveryStatusToAck(status) },
+          { sessionId: id, source: 'Engine' },
+        );
       },
       onMessageRevoked: (message): void => {
         if (!this.isLiveEngine(id, engine)) return;


### PR DESCRIPTION
## Bug
`message:ack` is in the `HookEvent` union (`hook.interfaces.ts:20`) but **nothing ever calls `hookManager.execute('message:ack', …)`** — `grep` returns zero emitters. So a plugin registered for it silently never fires. `onMessageAck` (`session.service.ts`) advances the stored status, emits the websocket tick, and dispatches the `message.ack` webhook — but skips the plugin hook.

## Fix
Emit `message:ack` at the end of `onMessageAck`, consistent with the other emitters (`message:received` `:534`, `message:sent` `:614`): fire-and-forget, `source: 'Engine'`, scoped `sessionId`, payload `{ messageId, status, ack }`.

## The `message:failed` question (decided)
The report flagged that delivery-`failed` acks emit the `message.failed` **webhook** but not the `message:failed` **hook**. **Decision: keep `message:failed` send-time-only.** Send failures carry `{ sessionId, error, input }` (the send threw — there's no WA message id); delivery failures carry `{ messageId, status, ack }`. Folding delivery failures into `message:failed` would give that one hook two incompatible payload shapes — worse for plugin authors. Delivery failures are cleanly observable as `message:ack` with `status: 'failed'`.

## Tests
TDD — two new cases in `session.service.spec.ts` (emits `message:ack` on a normal ack; surfaces a delivery failure as `message:ack[status=failed]` and does **not** fire `message:failed`). Full suite green.