### PR TITLE
feat(chats): mark a chat as unread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Mark a chat as unread: `POST /sessions/:id/chats/unread` (and `sessionApi.markChatUnread` on the dashboard client), the inverse of mark-as-read, supported on both the whatsapp-web.js and Baileys engines. (#432)
+
 ### Fixed
 
 - Sandboxed plugins now receive `onConfigChange` (config updates reach the worker instead of being silently ignored until disable + re-enable) and have their real `healthCheck` run — `GET /plugins/:id/health` previously always returned the default "healthy" for sandboxed plugins. (#430)

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -347,6 +347,11 @@ export const sessionApi = {
       method: 'POST',
       body: JSON.stringify({ chatId }),
     }),
+  markChatUnread: (id: string, chatId: string) =>
+    request<{ success: boolean }>(`/sessions/${id}/chats/unread`, {
+      method: 'POST',
+      body: JSON.stringify({ chatId }),
+    }),
   getChatMessages: (id: string, chatId: string, limit = 100) =>
     request<{ messages: ChatMessage[]; total: number }>(
       `/sessions/${id}/messages?chatId=${encodeURIComponent(chatId)}&limit=${limit}`,

--- a/src/engine/adapters/baileys.adapter.spec.ts
+++ b/src/engine/adapters/baileys.adapter.spec.ts
@@ -1409,7 +1409,7 @@ describe('BaileysAdapter contact + chat reads', () => {
   });
 });
 
-describe('BaileysAdapter sendSeen + deleteChat', () => {
+describe('BaileysAdapter sendSeen + markUnread + deleteChat', () => {
   beforeEach(() => {
     fakeSock.user = { id: '628999:1@s.whatsapp.net', name: 'Me' };
     fakeSock.resetEmitter();
@@ -1449,6 +1449,29 @@ describe('BaileysAdapter sendSeen + deleteChat', () => {
     fakeSock.fire('connection.update', { connection: 'open' });
     expect(await adapter.sendSeen('628999@s.whatsapp.net')).toBe(false);
     expect(fakeSock.readMessages).not.toHaveBeenCalled();
+  });
+
+  it('markUnread marks the chat unread via chatModify with the last message', async () => {
+    const adapter = await readyWithMessage();
+    const ok = await adapter.markUnread('628111@s.whatsapp.net');
+    expect(ok).toBe(true);
+    expect(fakeSock.chatModify).toHaveBeenCalledWith(
+      {
+        markRead: false,
+        lastMessages: [
+          { key: { remoteJid: '628111@s.whatsapp.net', fromMe: false, id: 'M1' }, messageTimestamp: 1700000020 },
+        ],
+      },
+      '628111@s.whatsapp.net',
+    );
+  });
+
+  it('markUnread returns false when no last message is known', async () => {
+    const adapter = newAdapter();
+    await adapter.initialize({});
+    fakeSock.fire('connection.update', { connection: 'open' });
+    expect(await adapter.markUnread('628999@s.whatsapp.net')).toBe(false);
+    expect(fakeSock.chatModify).not.toHaveBeenCalled();
   });
 
   it('deleteChat revokes the chat via chatModify with the last message', async () => {

--- a/src/engine/adapters/baileys.adapter.ts
+++ b/src/engine/adapters/baileys.adapter.ts
@@ -688,6 +688,19 @@ export class BaileysAdapter implements IWhatsAppEngine {
     return true;
   }
 
+  async markUnread(chatId: string): Promise<boolean> {
+    this.ensureReady();
+    const last = this.sessionStore.lastMessage(chatId);
+    if (!last) {
+      return false; // Baileys' unread toggle needs the last message; can't synthesize it
+    }
+    await this.sock!.chatModify(
+      { markRead: false, lastMessages: [{ key: last.key, messageTimestamp: last.timestamp }] },
+      chatId,
+    );
+    return true;
+  }
+
   async deleteChat(chatId: string): Promise<boolean> {
     this.ensureReady();
     const last = this.sessionStore.lastMessage(chatId);

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -1319,6 +1319,19 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     }
   }
 
+  async markUnread(chatId: string): Promise<boolean> {
+    this.ensureReady();
+    try {
+      const chat = await this.client!.getChatById(chatId);
+      // Chat.markUnread() resolves void, so synthesize the boolean from a clean call.
+      await chat.markUnread();
+      return true;
+    } catch (error) {
+      this.logger.error(`Error marking chat ${chatId} as unread`, String(error));
+      return false;
+    }
+  }
+
   async deleteChat(chatId: string): Promise<boolean> {
     this.ensureReady();
     try {

--- a/src/engine/interfaces/whatsapp-engine.interface.ts
+++ b/src/engine/interfaces/whatsapp-engine.interface.ts
@@ -456,6 +456,7 @@ export interface IWhatsAppEngine {
   // Chats
   getChats(): Promise<ChatSummary[]>;
   sendSeen(chatId: string): Promise<boolean>;
+  markUnread(chatId: string): Promise<boolean>;
   deleteChat(chatId: string): Promise<boolean>;
   /**
    * Send a typing/recording presence indicator to a chat, or clear it (`paused`).

--- a/src/modules/session/session.controller.ts
+++ b/src/modules/session/session.controller.ts
@@ -256,6 +256,18 @@ export class SessionController {
     return { success };
   }
 
+  @Post(':id/chats/unread')
+  @RequireRole(ApiKeyRole.OPERATOR)
+  @ApiOperation({ summary: 'Mark a chat as unread' })
+  @ApiParam({ name: 'id', description: 'Session ID' })
+  @ApiResponse({ status: 200, description: 'Chat marked as unread successfully' })
+  @ApiResponse({ status: 400, description: 'Session not ready' })
+  @ApiResponse({ status: 404, description: 'Session not found' })
+  async markChatUnread(@Param('id') id: string, @Body() dto: MarkChatReadDto): Promise<{ success: boolean }> {
+    const success = await this.sessionService.markUnread(id, dto.chatId);
+    return { success };
+  }
+
   @Post(':id/chats/delete')
   @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Delete a chat from the chat list (e.g. a group you have left)' })

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -78,6 +78,7 @@ describe('SessionService', () => {
       getGroups: jest.fn().mockResolvedValue([]),
       getChats: jest.fn().mockResolvedValue([]),
       sendSeen: jest.fn().mockResolvedValue(true),
+      markUnread: jest.fn().mockResolvedValue(true),
       deleteChat: jest.fn().mockResolvedValue(true),
       sendChatState: jest.fn().mockResolvedValue(undefined),
       resolveContactPhone: jest.fn().mockResolvedValue('628111222333'),
@@ -1356,6 +1357,31 @@ describe('SessionService', () => {
       (repository.findOne as jest.Mock).mockResolvedValue(session);
 
       await expect(service.sendSeen('sess-uuid-1', '123@c.us')).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  // ── markUnread (markChatUnread) ───────────────────────────────────
+
+  describe('markUnread', () => {
+    it('should delegate to engine.markUnread with the chatId', async () => {
+      const session = createMockSession();
+      (repository.findOne as jest.Mock).mockResolvedValue(session);
+      (repository.update as jest.Mock).mockResolvedValue({ affected: 1 });
+
+      await service.start('sess-uuid-1');
+      mockEngine.markUnread.mockResolvedValue(true);
+
+      const result = await service.markUnread('sess-uuid-1', '123@c.us');
+
+      expect(mockEngine.markUnread).toHaveBeenCalledWith('123@c.us');
+      expect(result).toBe(true);
+    });
+
+    it('should throw BadRequestException when session is not started', async () => {
+      const session = createMockSession();
+      (repository.findOne as jest.Mock).mockResolvedValue(session);
+
+      await expect(service.markUnread('sess-uuid-1', '123@c.us')).rejects.toThrow(BadRequestException);
     });
   });
 

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -1123,6 +1123,17 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
     return engine.sendSeen(chatId);
   }
 
+  async markUnread(id: string, chatId: string): Promise<boolean> {
+    await this.findOne(id); // Verify session exists
+    const engine = this.engines.get(id);
+
+    if (!engine) {
+      throw new BadRequestException('Session is not started');
+    }
+
+    return engine.markUnread(chatId);
+  }
+
   async deleteChat(id: string, chatId: string): Promise<boolean> {
     await this.findOne(id); // Verify session exists
     const engine = this.engines.get(id);


### PR DESCRIPTION
Closes #428.

Adds a mark-chat-as-unread capability — the inverse of the existing mark-chat-as-read — across the full stack. Both engines support it natively, so it's a near-mechanical mirror of the `markChatRead` slice.

## What's added

- **Engine port**: `markUnread(chatId): Promise<boolean>` on `IWhatsAppEngine` (forces both adapters to implement it).
- **whatsapp-web.js adapter**: `Chat.markUnread()`. That call resolves `void`, so the adapter synthesizes the boolean (returns `true` on success, `false` on error) rather than leaking `undefined` into the `{ success }` payload.
- **Baileys adapter**: `chatModify({ markRead: false, lastMessages: [last] }, chatId)` — mirrors `deleteChat`. Returns `false` when no last message is known for the chat (the in-memory session store has nothing to anchor the toggle to), same as `sendSeen`/`deleteChat`.
- **Service**: `SessionService.markUnread(id, chatId)` — 404 for an unknown session, 400 when the session isn't started.
- **HTTP**: `POST /sessions/:id/chats/unread` (`@RequireRole(OPERATOR)`), reusing `MarkChatReadDto` (identical `{ chatId }` shape — no duplicate DTO).
- **Dashboard API client**: `sessionApi.markChatUnread(id, chatId)`.

## Notes for the requester (@estmi)

Thanks for the sketch — it was the right direction. The pasted diff was just the two ends (the dashboard client + a Baileys spec), so on its own the endpoint would 404; this PR fills in the middle (interface, both adapters, service, controller) and synthesizes the wwebjs boolean it would otherwise drop.

## Tests

- Baileys adapter: `markUnread` calls `chatModify({ markRead: false, … })` with the last message; returns `false` when no last message is known.
- Service: delegates to `engine.markUnread`; throws `BadRequestException` when the session isn't started.

Full backend suite green (1184), dashboard build + lint clean. Non-breaking, additive, no migration.