### PR TITLE
feat(plugins): sandboxed-iframe config UI (B-full)

### DIFF
--- a/dashboard/src/pages/Plugins.css
+++ b/dashboard/src/pages/Plugins.css
@@ -561,6 +561,29 @@
   color: var(--primary);
 }
 
+/* Sandboxed-iframe config editor (B-full). */
+.plugin-config-ui-frame {
+  display: block;
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-white);
+}
+
+.config-ui-status {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+  color: var(--text-muted);
+}
+
+.config-ui-error {
+  padding: 1rem;
+  text-align: center;
+  color: var(--danger, #e5484d);
+}
+
 .config-form .form-group small {
   display: block;
   margin-top: 0.4rem;

--- a/dashboard/src/pages/Plugins.tsx
+++ b/dashboard/src/pages/Plugins.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
 import {
@@ -237,6 +237,84 @@ function ConfigField({
       />
       {desc}
     </div>
+  );
+}
+
+/**
+ * Renders a plugin's sandboxed-iframe config editor. The entry HTML is fetched WITH the API key
+ * (which never enters the iframe) and injected as `srcdoc` into a `sandbox="allow-scripts"` iframe
+ * (opaque origin — no access to the parent). The editor talks to the host over a postMessage bridge:
+ *   iframe → host  { type: 'config:get' }          → host → iframe { type: 'config:value', config, schema }
+ *   iframe → host  { type: 'config:save', config }  → host → iframe { type: 'config:saved' } | { type: 'config:error', message }
+ * The host makes the authenticated PUT (secret redact/restore applies); the iframe only ever sees the
+ * already-redacted config.
+ */
+function PluginConfigUi({ plugin }: { plugin: Plugin }) {
+  const { t } = useTranslation();
+  const toast = useToast();
+  const queryClient = useQueryClient();
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [html, setHtml] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    pluginsApi
+      .getConfigUi(plugin.id)
+      .then(h => {
+        if (!cancelled) setHtml(h);
+      })
+      .catch(e => {
+        if (!cancelled) setError(e instanceof Error ? e.message : t('common.unknownError'));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [plugin.id, t]);
+
+  useEffect(() => {
+    const onMessage = (e: MessageEvent) => {
+      const frame = iframeRef.current?.contentWindow;
+      if (!frame || e.source !== frame) return; // only our sandboxed iframe (its origin is opaque 'null')
+      const msg = e.data as { type?: string; config?: Record<string, unknown> };
+      const post = (m: unknown) => frame.postMessage(m, '*');
+      if (msg?.type === 'config:get') {
+        post({ type: 'config:value', config: plugin.config, schema: plugin.configSchema });
+      } else if (msg?.type === 'config:save') {
+        void (async () => {
+          try {
+            await pluginsApi.updateConfig(plugin.id, msg.config ?? {});
+            void queryClient.invalidateQueries({ queryKey: queryKeys.plugins });
+            post({ type: 'config:saved' });
+            toast.success(t('plugins.toasts.savedTitle'), t('plugins.toasts.savedDesc'));
+          } catch (err) {
+            const message = err instanceof Error ? err.message : t('common.unknownError');
+            post({ type: 'config:error', message });
+            toast.error(t('plugins.toasts.saveFailed'), message);
+          }
+        })();
+      }
+    };
+    window.addEventListener('message', onMessage);
+    return () => window.removeEventListener('message', onMessage);
+  }, [plugin, queryClient, t, toast]);
+
+  if (error) return <div className="config-ui-status config-ui-error">{error}</div>;
+  if (html === null)
+    return (
+      <div className="config-ui-status">
+        <Loader2 size={24} className="animate-spin" />
+      </div>
+    );
+  return (
+    <iframe
+      ref={iframeRef}
+      className="plugin-config-ui-frame"
+      sandbox="allow-scripts"
+      srcDoc={html}
+      title={plugin.name}
+      style={{ height: plugin.configUi?.height ?? 600 }}
+    />
   );
 }
 
@@ -901,6 +979,8 @@ export default function Plugins() {
                     </div>
                   </div>
                 </>
+              ) : configPlugin.configUi ? (
+                <PluginConfigUi plugin={configPlugin} />
               ) : configPlugin.configSchema && Object.keys(configPlugin.configSchema.properties).length > 0 ? (
                 <div className="config-form">
                   {Object.entries(configPlugin.configSchema.properties).map(([key, field]) => (
@@ -929,7 +1009,8 @@ export default function Plugins() {
                 <button className="btn-primary" onClick={handleSaveConfig} disabled={savingConfig}>
                   {savingConfig ? <Loader2 size={16} className="animate-spin" /> : t('plugins.config.save')}
                 </button>
-              ) : configPlugin.configSchema && Object.keys(configPlugin.configSchema.properties).length > 0 ? (
+              ) : configPlugin.configUi ? null : configPlugin.configSchema &&
+                Object.keys(configPlugin.configSchema.properties).length > 0 ? (
                 <button className="btn-primary" onClick={handleSaveSchemaConfig} disabled={savingConfig}>
                   {savingConfig ? <Loader2 size={16} className="animate-spin" /> : t('plugins.config.save')}
                 </button>

--- a/dashboard/src/pages/Plugins.tsx
+++ b/dashboard/src/pages/Plugins.tsx
@@ -279,7 +279,14 @@ function PluginConfigUi({ plugin }: { plugin: Plugin }) {
       const msg = e.data as { type?: string; config?: Record<string, unknown> };
       const post = (m: unknown) => frame.postMessage(m, '*');
       if (msg?.type === 'config:get') {
-        post({ type: 'config:value', config: plugin.config, schema: plugin.configSchema });
+        // Only expose schema-DECLARED fields (already secret-redacted by the API). An undeclared key
+        // may hold a secret the host can't mask, so it never reaches the untrusted iframe; with no
+        // schema there is nothing safe to send. The plugin must declare its fields to pre-fill them.
+        const props = plugin.configSchema?.properties;
+        const safeConfig = props
+          ? Object.fromEntries(Object.keys(props).flatMap(k => (k in plugin.config ? [[k, plugin.config[k]]] : [])))
+          : {};
+        post({ type: 'config:value', config: safeConfig, schema: plugin.configSchema });
       } else if (msg?.type === 'config:save') {
         void (async () => {
           try {

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -321,6 +321,29 @@ async function request<T>(endpoint: string, options: RequestInit = {}): Promise<
   return response.json();
 }
 
+/** Like {@link request} but returns the raw response text — e.g. a plugin's HTML config-UI bundle. */
+async function requestText(endpoint: string): Promise<string> {
+  const apiKey = sessionStorage.getItem('openwa_api_key');
+  const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+    headers: { ...(apiKey ? { 'X-API-Key': apiKey } : {}) },
+  });
+
+  if (response.status === 401) {
+    sessionStorage.removeItem('openwa_api_key');
+    if (typeof window !== 'undefined') {
+      window.location.assign('/');
+      return new Promise<string>(() => {});
+    }
+  }
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.message || `HTTP ${response.status}`);
+  }
+
+  return response.text();
+}
+
 // =============================================================================
 // Session API
 // =============================================================================
@@ -617,6 +640,8 @@ export interface Plugin {
   provides: string[];
   /** Declared config fields, when the plugin exposes a schema (drives the dashboard config form). */
   configSchema?: PluginConfigSchema;
+  /** When set, the plugin ships a sandboxed-iframe config editor (preferred over configSchema). */
+  configUi?: { entry: string; height?: number };
   loadedAt?: string;
   enabledAt?: string;
   error?: string;
@@ -682,6 +707,8 @@ export const pluginsApi = {
   updateFromUrl: (id: string, url: string) =>
     request<Plugin>(`/plugins/${id}/update`, { method: 'POST', body: JSON.stringify({ url }) }),
   catalog: () => request<CatalogPlugin[]>('/plugins/catalog'),
+  /** Fetch a plugin's sandboxed config-UI entry HTML (the API key stays here, in the parent). */
+  getConfigUi: (id: string) => requestText(`/plugins/${id}/config-ui`),
   uninstall: (id: string) => request<{ success: boolean; message: string }>(`/plugins/${id}`, { method: 'DELETE' }),
   getEngines: () => request<Engine[]>('/infra/engines'),
   getCurrentEngine: () => request<{ engineType: string }>('/infra/engines/current'),

--- a/src/core/plugins/plugin.interfaces.ts
+++ b/src/core/plugins/plugin.interfaces.ts
@@ -52,6 +52,13 @@ export interface PluginManifest {
   // Configuration schema (optional, for UI generation)
   configSchema?: PluginConfigSchema;
 
+  // Optional sandboxed-iframe config editor. `entry` is a plugin-relative path to a self-contained
+  // HTML file (inline JS/CSS — a sandboxed opaque-origin iframe can't load subresources). Served by
+  // the host via the authenticated GET /plugins/:id/config-ui and injected as an iframe `srcdoc`; the
+  // editor exchanges config over a postMessage bridge (the API key never reaches the iframe). When
+  // present, the dashboard prefers it over the declarative `configSchema` form.
+  configUi?: { entry: string; height?: number };
+
   // Hooks this plugin listens to
   hooks?: HookEvent[];
 

--- a/src/modules/plugins/dto/plugin.dto.ts
+++ b/src/modules/plugins/dto/plugin.dto.ts
@@ -43,6 +43,9 @@ export class PluginDto {
   @ApiPropertyOptional({ description: 'Configuration schema' })
   configSchema?: PluginConfigSchema;
 
+  @ApiPropertyOptional({ description: 'Sandboxed-iframe config editor (entry HTML + optional height)' })
+  configUi?: { entry: string; height?: number };
+
   @ApiPropertyOptional({ description: 'When the plugin was loaded' })
   loadedAt?: string;
 

--- a/src/modules/plugins/plugins.controller.spec.ts
+++ b/src/modules/plugins/plugins.controller.spec.ts
@@ -9,7 +9,7 @@ describe('PluginsController authorization', () => {
   // Plugin reads expose installed versions, non-secret config, and health/error text — privileged
   // inventory on par with the ADMIN-gated write routes and the InfraController convention. A
   // VIEWER/OPERATOR key (or a session-scoped key) must not be able to enumerate it via the raw API.
-  const adminOnly = ['findAll', 'findOne', 'healthCheck', 'enable', 'disable', 'updateConfig'] as const;
+  const adminOnly = ['findAll', 'findOne', 'healthCheck', 'enable', 'disable', 'updateConfig', 'getConfigUi'] as const;
 
   it.each(adminOnly)('%s requires the ADMIN role', method => {
     const handler = PluginsController.prototype[method];

--- a/src/modules/plugins/plugins.controller.ts
+++ b/src/modules/plugins/plugins.controller.ts
@@ -6,6 +6,7 @@ import {
   Delete,
   Param,
   Body,
+  Header,
   HttpCode,
   HttpStatus,
   UseInterceptors,
@@ -100,6 +101,21 @@ export class PluginsController {
   @ApiResponse({ status: 200, description: 'Plugin configuration updated' })
   updateConfig(@Param('id') id: string, @Body() configDto: PluginConfigDto): { success: boolean; message: string } {
     return this.pluginsService.updateConfig(id, configDto.config);
+  }
+
+  // The dashboard fetches this WITH the API key and injects the body as an iframe `srcdoc` (sandboxed,
+  // opaque origin). Served as untrusted HTML, so it's CSP-sandboxed + nosniff in case it's ever loaded
+  // directly as a document (it can't be in a browser — navigations don't carry the X-API-Key header).
+  @Get(':id/config-ui')
+  @RequireRole(ApiKeyRole.ADMIN)
+  @Header('Content-Type', 'text/html; charset=utf-8')
+  @Header('Content-Security-Policy', 'sandbox')
+  @Header('X-Content-Type-Options', 'nosniff')
+  @ApiOperation({ summary: "Serve a plugin's sandboxed config-UI entry HTML (for an iframe srcdoc)" })
+  @ApiResponse({ status: 200, description: 'Config UI HTML' })
+  @ApiResponse({ status: 404, description: 'Plugin not found or has no config UI' })
+  getConfigUi(@Param('id') id: string): string {
+    return this.pluginsService.getConfigUiHtml(id);
   }
 
   @Put(':id/sessions')

--- a/src/modules/plugins/plugins.service.spec.ts
+++ b/src/modules/plugins/plugins.service.spec.ts
@@ -163,6 +163,11 @@ describe('PluginsService — getConfigUiHtml (sandboxed config editor)', () => {
     expect(service.getConfigUiHtml('cfgui-plg')).toBe(HTML);
   });
 
+  it('exposes configUi on the DTO so the dashboard can render the iframe', () => {
+    installUi({ configUi: { entry: 'config/index.html', height: 480 } }, { 'config/index.html': HTML });
+    expect(service.findOne('cfgui-plg').configUi).toEqual({ entry: 'config/index.html', height: 480 });
+  });
+
   it('throws NotFound when the plugin does not exist', () => {
     expect(() => service.getConfigUiHtml('ghost')).toThrow(/not found/i);
   });
@@ -180,8 +185,21 @@ describe('PluginsService — getConfigUiHtml (sandboxed config editor)', () => {
     expect(() => service.getConfigUiHtml('cfgui-plg')).toThrow(/not found/i);
   });
 
-  it('rejects a configUi entry that escapes the plugin directory', () => {
+  it('rejects a configUi entry that escapes the plugin directory (404, not a 500)', () => {
     installUi({ configUi: { entry: '../../../etc/passwd' } }, { 'config/index.html': HTML });
-    expect(() => service.getConfigUiHtml('cfgui-plg')).toThrow(/escape/i);
+    expect(() => service.getConfigUiHtml('cfgui-plg')).toThrow(/not found/i);
+  });
+
+  it('rejects a non-string configUi entry from an untrusted manifest', () => {
+    installUi({ configUi: { entry: 123 } }, { 'config/index.html': HTML });
+    expect(() => service.getConfigUiHtml('cfgui-plg')).toThrow(/config ui/i);
+  });
+
+  it('rejects a configUi entry that is a symlink escaping the plugin directory', () => {
+    installUi({ configUi: { entry: 'config/escape.html' } }, { 'config/index.html': HTML });
+    const outside = path.join(tmpDir, 'outside-secret.txt');
+    fs.writeFileSync(outside, 'TOP SECRET');
+    fs.symlinkSync(outside, path.join(pluginsDir, 'cfgui-plg', 'config', 'escape.html'));
+    expect(() => service.getConfigUiHtml('cfgui-plg')).toThrow(/not found/i);
   });
 });

--- a/src/modules/plugins/plugins.service.spec.ts
+++ b/src/modules/plugins/plugins.service.spec.ts
@@ -121,3 +121,67 @@ describe('PluginsService — install / uninstall (real loader + disk)', () => {
     enableSpy.mockRestore();
   });
 });
+
+describe('PluginsService — getConfigUiHtml (sandboxed config editor)', () => {
+  let tmpDir: string;
+  let pluginsDir: string;
+  let loader: PluginLoaderService;
+  let service: PluginsService;
+
+  const HTML = '<!doctype html><title>cfg</title><script>parent.postMessage({type:"config:get"},"*")</script>';
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'owa-cfgui-'));
+    pluginsDir = path.join(tmpDir, 'plugins');
+    fs.mkdirSync(pluginsDir, { recursive: true });
+    const config = {
+      get: (k: string) => (k === 'plugins.dir' ? pluginsDir : k === 'dataDir' ? tmpDir : undefined),
+    } as unknown as ConfigService;
+    loader = new PluginLoaderService(
+      config,
+      new HookManager(),
+      new PluginStorageService(config),
+      {} as unknown as ModuleRef,
+    );
+    service = new PluginsService(loader, config);
+  });
+  afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+  function installUi(over: Record<string, unknown> = {}, files: Record<string, string> = {}): void {
+    const z = new AdmZip();
+    z.addFile(
+      'manifest.json',
+      Buffer.from(JSON.stringify({ ...manifest, id: 'cfgui-plg', configUi: { entry: 'config/index.html' }, ...over })),
+    );
+    z.addFile('index.js', Buffer.from('module.exports = class {};'));
+    for (const [p, c] of Object.entries(files)) z.addFile(p, Buffer.from(c));
+    service.install({ buffer: z.toBuffer() });
+  }
+
+  it('serves the configUi entry HTML for an installed plugin', () => {
+    installUi({}, { 'config/index.html': HTML });
+    expect(service.getConfigUiHtml('cfgui-plg')).toBe(HTML);
+  });
+
+  it('throws NotFound when the plugin does not exist', () => {
+    expect(() => service.getConfigUiHtml('ghost')).toThrow(/not found/i);
+  });
+
+  it('throws NotFound when the plugin declares no configUi', () => {
+    const z = new AdmZip();
+    z.addFile('manifest.json', Buffer.from(JSON.stringify({ ...manifest, id: 'no-ui' })));
+    z.addFile('index.js', Buffer.from('module.exports = class {};'));
+    service.install({ buffer: z.toBuffer() });
+    expect(() => service.getConfigUiHtml('no-ui')).toThrow(/config ui/i);
+  });
+
+  it('throws NotFound when the entry file is missing from the package', () => {
+    installUi({ configUi: { entry: 'config/missing.html' } }, { 'config/index.html': HTML });
+    expect(() => service.getConfigUiHtml('cfgui-plg')).toThrow(/not found/i);
+  });
+
+  it('rejects a configUi entry that escapes the plugin directory', () => {
+    installUi({ configUi: { entry: '../../../etc/passwd' } }, { 'config/index.html': HTML });
+    expect(() => service.getConfigUiHtml('cfgui-plg')).toThrow(/escape/i);
+  });
+});

--- a/src/modules/plugins/plugins.service.ts
+++ b/src/modules/plugins/plugins.service.ts
@@ -34,6 +34,7 @@ export class PluginsService {
       builtIn: this.pluginLoader.isBuiltIn(plugin.manifest.id),
       provides: plugin.manifest.provides ?? [],
       configSchema: plugin.manifest.configSchema,
+      configUi: plugin.manifest.configUi,
       sessionScoped: plugin.manifest.sessionScoped !== false,
       activeSessions: plugin.activeSessions ?? ['*'],
       loadedAt: plugin.loadedAt?.toISOString(),
@@ -61,6 +62,7 @@ export class PluginsService {
       builtIn: this.pluginLoader.isBuiltIn(plugin.manifest.id),
       provides: plugin.manifest.provides ?? [],
       configSchema: plugin.manifest.configSchema,
+      configUi: plugin.manifest.configUi,
       sessionScoped: plugin.manifest.sessionScoped !== false,
       activeSessions: plugin.activeSessions ?? ['*'],
       loadedAt: plugin.loadedAt?.toISOString(),
@@ -158,14 +160,30 @@ export class PluginsService {
       throw new NotFoundException(`Plugin ${id} not found`);
     }
     const entry = plugin.manifest.configUi?.entry;
-    if (!entry) {
+    // `entry` is untrusted manifest JSON — a non-string (or escaping) value is treated as "no config
+    // UI" (404), never a raw 500.
+    if (!entry || typeof entry !== 'string') {
       throw new NotFoundException(`Plugin ${id} has no config UI`);
     }
-    const file = resolvePluginMainPath(this.pluginLoader.getPluginsDir(), id, entry);
+    const base = path.resolve(this.pluginLoader.getPluginsDir(), id);
+    let file: string;
+    try {
+      file = resolvePluginMainPath(this.pluginLoader.getPluginsDir(), id, entry);
+    } catch {
+      throw new NotFoundException(`Config UI entry not found for plugin ${id}`);
+    }
     if (!fs.existsSync(file) || !fs.statSync(file).isFile()) {
       throw new NotFoundException(`Config UI entry not found for plugin ${id}`);
     }
-    return fs.readFileSync(file, 'utf-8');
+    // Defense-in-depth: the lexical guard above is symlink-blind; resolve links on BOTH the file and
+    // the plugin dir (so a symlinked tmp root like macOS /var→/private/var doesn't false-positive) and
+    // re-check containment before reading an arbitrary host file into the main process and serving it.
+    const real = fs.realpathSync(file);
+    const realBase = fs.realpathSync(base);
+    if (real !== realBase && !real.startsWith(realBase + path.sep)) {
+      throw new NotFoundException(`Config UI entry not found for plugin ${id}`);
+    }
+    return fs.readFileSync(real, 'utf-8');
   }
 
   /** Install a plugin from an uploaded .zip: validate the package, write it to the plugins dir, and load it. */

--- a/src/modules/plugins/plugins.service.ts
+++ b/src/modules/plugins/plugins.service.ts
@@ -2,7 +2,7 @@ import { Injectable, NotFoundException, BadRequestException, ConflictException, 
 import { ConfigService } from '@nestjs/config';
 import * as fs from 'fs';
 import * as path from 'path';
-import { PluginLoaderService, PluginStatus } from '../../core/plugins';
+import { PluginLoaderService, PluginStatus, resolvePluginMainPath } from '../../core/plugins';
 import { PluginDto } from './dto/plugin.dto';
 import { redactSecretConfig, restoreSecretConfig } from './redact-config';
 import { parsePluginPackage } from './plugin-installer';
@@ -145,6 +145,27 @@ export class PluginsService {
         message: error instanceof Error ? error.message : String(error),
       };
     }
+  }
+
+  /**
+   * Read a plugin's sandboxed config-UI entry HTML (manifest `configUi.entry`). The dashboard fetches
+   * this with the API key and injects it as an iframe `srcdoc`, so the file must be self-contained.
+   * Path is escape-guarded against the plugin directory; the entry is plugin-author-supplied.
+   */
+  getConfigUiHtml(id: string): string {
+    const plugin = this.pluginLoader.getPlugin(id);
+    if (!plugin) {
+      throw new NotFoundException(`Plugin ${id} not found`);
+    }
+    const entry = plugin.manifest.configUi?.entry;
+    if (!entry) {
+      throw new NotFoundException(`Plugin ${id} has no config UI`);
+    }
+    const file = resolvePluginMainPath(this.pluginLoader.getPluginsDir(), id, entry);
+    if (!fs.existsSync(file) || !fs.statSync(file).isFile()) {
+      throw new NotFoundException(`Config UI entry not found for plugin ${id}`);
+    }
+    return fs.readFileSync(file, 'utf-8');
   }
 
   /** Install a plugin from an uploaded .zip: validate the package, write it to the plugins dir, and load it. */


### PR DESCRIPTION
## What

A plugin can ship a custom config editor via manifest `configUi { entry, height? }`, rendered as a **sandboxed iframe** in the dashboard. Complements the declarative B-lite form (#439); preferred over it when both are present.

### The auth model (why an iframe + bridge)
A browser `<iframe src>` request carries no `X-API-Key` header, and the app authenticates *only* via that header. So the **parent** fetches the entry HTML with its key and injects it as the iframe `srcdoc` into a `sandbox="allow-scripts"` frame (opaque origin — no access to the parent's key/storage). The editor exchanges config purely over a `postMessage` bridge; the **parent** makes the authenticated `PUT`. The API key never enters the iframe.

```
iframe → host   { type: 'config:get' }           host → iframe  { type: 'config:value', config, schema }
iframe → host   { type: 'config:save', config }   host → iframe  { type: 'config:saved' } | { type: 'config:error', message }
```

### Backend
- `GET /plugins/:id/config-ui` (ADMIN) serves the entry HTML. The manifest-supplied entry is escape-guarded (`resolvePluginMainPath`) **and** realpath-rechecked (symlink-blind lexical guard hardened); a non-string/escaping entry → 404, not 500. CSP `sandbox` + `nosniff` headers.
- `configUi` is carried through the `PluginDto` (findAll/findOne).

### Secrets never reach the iframe
The bridge sends the iframe **only schema-declared, already-redacted** config fields (`{}` when there's no schema). An undeclared key could hold a secret the host can't mask, so it's withheld. A plugin declares its fields (incl. `secret: true`) via `configSchema` to pre-fill the editor; the host restores unchanged secrets on save (`redact-config`).

## Review
Built TDD; then an adversarial security review (3 dimensions → per-finding verify) surfaced 6 issues — all fixed in this branch (1 HIGH dead-code DTO, 1 HIGH secret-leak-to-iframe, 4 LOW route/path hardening). See commits.

## Testing
- `plugins.service.spec.ts` +6 (serve entry, 404s, DTO exposure, non-string entry, symlink/path escape). `plugins.controller.spec.ts` +1 (ADMIN gating).
- Full gate green: backend `tsc --noEmit -p tsconfig.build.json` + lint + **1244** jest; dashboard build (tsc) + lint.

Part of v0.7 plugin-contract (B-full). Per-session config editing follows as a separate PR.