### PR TITLE
fix(docker): build arch-independent assets on $BUILDPLATFORM (fix arm64 image build)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Plugins: an operator's per-session activation (and now per-session config) was silently dropped from the on-disk registry on the second restart, because the registry entry was rebuilt on each load without carrying those fields. Both are now preserved across restarts. (#441)
+- Docker: the multi-arch image build failed on `linux/arm64` (`Cannot find module lightningcss.linux-arm64-gnu.node`) — the builder stage was QEMU-emulated per target and the emulated arm64 install couldn't fetch lightningcss's (Vite's native CSS minifier) arm64 binary. The builder, which only produces arch-independent artifacts, is now pinned to `$BUILDPLATFORM` so it runs natively; per-arch runtime deps still install in the target-platform stage. Restores `linux/arm64` GHCR publishing.
 
 ## [0.6.2] - 2026-06-23
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,14 @@
 # Multi-stage build for production-ready image
 
 # ===== Stage 1: Builder =====
-FROM docker.io/node:22-slim AS builder
+# Pin the builder to the BUILD host's platform (not the target's). It only produces arch-INDEPENDENT
+# artifacts (the NestJS dist/ JS and the static dashboard SPA), so it never needs to run emulated for
+# the non-native target. On a multi-arch buildx build this avoids QEMU emulating the whole npm ci +
+# Vite build for arm64 — which is slow AND is where the arm64 lightningcss (Vite 8's native CSS
+# minifier) optional dependency fails to install ("Cannot find module lightningcss.linux-arm64-gnu.node").
+# The per-arch runtime deps are installed natively in the target-platform production stage below.
+# NOTE: $BUILDPLATFORM requires BuildKit (CI uses buildx; modern `docker build`/compose default to it).
+FROM --platform=$BUILDPLATFORM docker.io/node:22-slim AS builder
 
 WORKDIR /app
 

--- a/scripts/smoke-test-non-root.sh
+++ b/scripts/smoke-test-non-root.sh
@@ -4,6 +4,10 @@
 # Requires Docker to be running locally.
 set -e
 
+# The Dockerfile pins the builder to $BUILDPLATFORM (BuildKit-injected) for multi-arch correctness,
+# so the build requires BuildKit. It's the modern default, but force it on in case the host disabled it.
+export DOCKER_BUILDKIT=1
+
 IMAGE_TAG="openwa-test-non-root:smoke"
 
 echo "==> Building test image..."


### PR DESCRIPTION
## Problem
The multi-arch image build (CI/release, buildx + QEMU) **fails on `linux/arm64`**:
```
Error: [lightningcss minify] Cannot find module '../lightningcss.linux-arm64-gnu.node'
```
The builder stage was QEMU-**emulated** per target arch. The emulated arm64 `npm ci` can't fetch lightningcss's (Vite 8's native CSS minifier) `linux-arm64-gnu` optional binary, so the dashboard `vite build` dies. All *code* CI jobs pass; only the push-only **Docker Build** job fails, so GHCR `linux/arm64` publishing has been broken since the dashboard moved to Vite 8.

## Fix
The builder stage only produces **arch-independent** artifacts (NestJS `dist/` JS + the static dashboard SPA), so it never needs to run emulated. Pin it to the native build host:
```dockerfile
FROM --platform=$BUILDPLATFORM docker.io/node:22-slim AS builder
```
The arm64 leg no longer emulates the whole `npm ci` + Vite build (eliminating the lightningcss failure **and** speeding the build); per-arch **runtime** deps still install natively in the target-platform production stage (unchanged).

`$BUILDPLATFORM` requires BuildKit (CI uses buildx; modern `docker build`/`docker compose` default to it). The non-root smoke-test script uses plain `docker build`, so it now forces `DOCKER_BUILDKIT=1`.

## Verification
- **Empirical:** `docker buildx build --platform linux/amd64,linux/arm64 .` completes for **both** arches with **zero** lightningcss errors (previously the arm64 dashboard build failed here).
- Adversarial review (correctness/completeness + gotchas): fix confirmed correct; the one surfaced item (legacy non-BuildKit `docker build` needs BuildKit) is mitigated in the smoke-test + documented.
- Builder output confirmed arch-independent (no `.node` files in `dist/` or `dashboard/dist/`); production stage installs runtime deps per-arch.

Note: the Docker Build job is push-gated, so it doesn't run on this PR — it validates on the post-merge `main` push. CHANGELOG `[Unreleased] → Fixed` updated.