### PR TITLE
fix(docker): force devDependencies in builder stage (fixes "nest: not found" in production builds)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,14 @@ RUN apt-get update && apt-get install -y \
 # Copy package files
 COPY package*.json ./
 
-# Install all dependencies (including devDependencies for build)
-RUN npm ci
+# Install all dependencies INCLUDING devDependencies — the build needs them (`nest` from
+# @nestjs/cli, plus `vite`/`typescript` for the dashboard). `--include=dev` is REQUIRED, not
+# cosmetic: npm omits devDependencies whenever NODE_ENV=production is present in the build env.
+# Coolify (and similar PaaS) promote every ${VAR} referenced in the compose file to a build-time
+# variable, so docker-compose.yml's `NODE_ENV=${NODE_ENV:-production}` leaks NODE_ENV=production
+# into this stage and a bare `npm ci` would skip @nestjs/cli → `sh: 1: nest: not found` (exit 127).
+# (docker-compose.dev.yml hardcodes NODE_ENV=development, which is why the dev build never hit this.)
+RUN npm ci --include=dev
 
 # Copy source code
 COPY . .
@@ -32,7 +38,9 @@ COPY . .
 # Build the API (dist/) and the dashboard SPA (dashboard/dist/). The root `npm ci` above
 # ran before the dashboard source was copied, so its postinstall hook skipped the dashboard
 # deps - install them explicitly here (npm ci, reproducible from dashboard/package-lock.json).
-RUN npm run build && npm run dashboard:ci && npm run dashboard:build
+# `--include=dev` for the same reason as above: the dashboard build needs vite/typescript
+# (devDependencies), which a NODE_ENV=production build env would otherwise omit.
+RUN npm run build && npm run dashboard:ci -- --include=dev && npm run dashboard:build
 
 # ===== Stage 2: Production =====
 FROM docker.io/node:22-slim AS production


### PR DESCRIPTION
## Summary

Production image builds fail in the builder stage with:

```
> openwa@0.6.2 build
> nest build
sh: 1: nest: not found
ERROR: process "/bin/sh -c npm run build && npm run dashboard:ci && npm run dashboard:build" did not complete successfully: exit code: 127
```

**Root cause:** the builder ran a bare `npm ci`, which omits `devDependencies` whenever `NODE_ENV=production` is present in the build environment. `nest` (`@nestjs/cli`) and the dashboard's `vite`/`typescript` are devDependencies, so they were never installed and `nest build` failed (exit 127).

**Why it only hit production deploys (and not the dev compose):** Coolify (and similar PaaS) promote every `${VAR}` referenced in the compose file to a build-time variable. `docker-compose.yml` declares `NODE_ENV=${NODE_ENV:-production}`, so `NODE_ENV=production` leaks into the image build and `npm ci` drops dev deps. `docker-compose.dev.yml` hardcodes `NODE_ENV=development`, so the dev path never reproduced it. Both compose files use the same Dockerfile, so the difference is entirely the injected build env.

## Fix

Force dev dependencies in the **builder** stage so the build is independent of `NODE_ENV`:

- `npm ci` → `npm ci --include=dev`
- `npm run dashboard:ci` → `npm run dashboard:ci -- --include=dev`

The production runtime stage still uses `npm ci --omit=dev` (unchanged) — the final image stays slim.

## Test plan

- [ ] `docker compose -f docker-compose.yml build` with `NODE_ENV=production` in the build env succeeds (previously failed with `nest: not found`)
- [ ] `docker compose -f docker-compose.dev.yml build` still succeeds
- [ ] Deploy via Coolify with the non-dev compose completes the build
- [ ] Resulting runtime image still excludes devDependencies

Made with [Cursor](https://cursor.com)