### PR TITLE
fix(compose): make dev compose environment variables overridable

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -34,21 +34,27 @@ services:
     ports:
       # Bind to localhost by default; set BIND_HOST=0.0.0.0 in .env to reach it from another host.
       - '${BIND_HOST:-127.0.0.1}:2785:2785'
+    # User-facing settings read from the environment (or .env) with a sane default fallback
+    # (${VAR:-default}); override any of them without editing this file. The data paths default
+    # under /app/data (the ./data bind mount) so they persist out of the box — override only if you
+    # also mount that target. Truly container-internal values (HOME, XDG_*, PORT) stay fixed: they
+    # must match the image/entrypoint. Same convention as the production docker-compose.yml.
     environment:
-      - NODE_ENV=development
+      - NODE_ENV=${NODE_ENV:-development}
       - PORT=2785
       - HOME=/tmp
       # Chromium reads its home from the passwd entry (no /home/openwa), so it needs writable, existing
       # config/cache dirs on the tmpfs or it hard-crashes at launch; the entrypoint pre-creates them. (#254)
       - XDG_CONFIG_HOME=/tmp/.config
       - XDG_CACHE_HOME=/tmp/.cache
-      - DATABASE_TYPE=sqlite
-      - DATABASE_NAME=/app/data/openwa.sqlite
-      - DATABASE_SYNCHRONIZE=true
-      - ENGINE_TYPE=whatsapp-web.js
-      - SESSION_DATA_PATH=/app/data/sessions
-      - PUPPETEER_HEADLESS=true
-      - PUPPETEER_ARGS=--no-sandbox,--disable-setuid-sandbox,--disable-dev-shm-usage,--disable-gpu
+      - LOG_LEVEL=${LOG_LEVEL:-info}
+      - DATABASE_TYPE=${DATABASE_TYPE:-sqlite}
+      - DATABASE_NAME=${DATABASE_NAME:-/app/data/openwa.sqlite}
+      - DATABASE_SYNCHRONIZE=${DATABASE_SYNCHRONIZE:-true}
+      - ENGINE_TYPE=${ENGINE_TYPE:-whatsapp-web.js}
+      - SESSION_DATA_PATH=${SESSION_DATA_PATH:-/app/data/sessions}
+      - PUPPETEER_HEADLESS=${PUPPETEER_HEADLESS:-true}
+      - PUPPETEER_ARGS=${PUPPETEER_ARGS:---no-sandbox,--disable-setuid-sandbox,--disable-dev-shm-usage,--disable-gpu}
       # Optional WhatsApp Web version override. Leave empty for whatsapp-web.js auto-selection.
       # If a session hangs at "authenticating", set WWEBJS_WEB_VERSION to a known-good cached build
       # from wppconnect-team/wa-version; latest|auto|off also forces auto-selection.
@@ -56,11 +62,11 @@ services:
       - WWEBJS_WEB_VERSION_REMOTE_PATH=${WWEBJS_WEB_VERSION_REMOTE_PATH:-}
       # Raise whatsapp-web.js's first-boot init wait (default 30000ms) on slow boots. Empty = default.
       - WWEBJS_AUTH_TIMEOUT_MS=${WWEBJS_AUTH_TIMEOUT_MS:-}
-      - STORAGE_TYPE=local
-      - STORAGE_LOCAL_PATH=/app/data/media
-      - WEBHOOK_TIMEOUT=10000
-      - WEBHOOK_MAX_RETRIES=3
-      - QUEUE_ENABLED=false
+      - STORAGE_TYPE=${STORAGE_TYPE:-local}
+      - STORAGE_LOCAL_PATH=${STORAGE_LOCAL_PATH:-/app/data/media}
+      - WEBHOOK_TIMEOUT=${WEBHOOK_TIMEOUT:-10000}
+      - WEBHOOK_MAX_RETRIES=${WEBHOOK_MAX_RETRIES:-3}
+      - QUEUE_ENABLED=${QUEUE_ENABLED:-false}
     volumes:
       - ./data:/app/data
     restart: unless-stopped


### PR DESCRIPTION
## Summary

`docker-compose.dev.yml` hardcoded most environment variables to fixed literal values (e.g. `NODE_ENV=development`, `DATABASE_TYPE=sqlite`, `PUPPETEER_HEADLESS=true`, `WEBHOOK_TIMEOUT=10000`, ...). There was no way to override them from the shell environment or an `.env` file without editing the compose file.

This converts the **user-facing** settings to the `${VAR:-default}` pattern — same defaults as before, but now overridable — bringing the dev compose in line with the production `docker-compose.yml`.

### Made overridable (default unchanged)
`NODE_ENV`, `DATABASE_TYPE`, `DATABASE_NAME`, `DATABASE_SYNCHRONIZE`, `ENGINE_TYPE`, `PUPPETEER_HEADLESS`, `PUPPETEER_ARGS`, `STORAGE_TYPE`, `WEBHOOK_TIMEOUT`, `WEBHOOK_MAX_RETRIES`, `QUEUE_ENABLED`, plus the data-path settings documented in `.env.example`: `SESSION_DATA_PATH`, `STORAGE_LOCAL_PATH`. Also added `LOG_LEVEL=${LOG_LEVEL:-info}` for parity with production.

The data-path defaults stay under `/app/data` (the `./data` bind mount), so persistence is unchanged out of the box; override only if you mount that target elsewhere.

### Intentionally kept fixed
`PORT`, `HOME`, `XDG_CONFIG_HOME`, `XDG_CACHE_HOME` — container-internal values that must match the image/entrypoint. Production keeps these fixed for the same reason.

## Notes

- `WWEBJS_*` were already parameterized; unchanged.
- Defaults are identical to the previous literals, so existing `docker compose -f docker-compose.dev.yml up` behavior is unchanged when no env is set.

## Test plan

- [x] `docker compose -f docker-compose.dev.yml config` parses successfully
- [ ] `docker compose -f docker-compose.dev.yml up` with no env uses the prior defaults
- [ ] Setting e.g. `LOG_LEVEL=debug` / `PUPPETEER_HEADLESS=false` in `.env` overrides the defaults