### PR TITLE
fix(compose): parameterize data-path env vars in production compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,7 @@ services:
       - DATABASE_SYNCHRONIZE=${DATABASE_SYNCHRONIZE:-false}
       # Engine
       - ENGINE_TYPE=${ENGINE_TYPE:-whatsapp-web.js}
-      - SESSION_DATA_PATH=/app/data/sessions
+      - SESSION_DATA_PATH=${SESSION_DATA_PATH:-/app/data/sessions}
       - PUPPETEER_HEADLESS=${PUPPETEER_HEADLESS:-true}
       - PUPPETEER_ARGS=${PUPPETEER_ARGS:---no-sandbox,--disable-setuid-sandbox,--disable-dev-shm-usage,--disable-gpu}
       # Optional WhatsApp Web version override. Leave empty for whatsapp-web.js auto-selection.
@@ -104,7 +104,7 @@ services:
       - WWEBJS_AUTH_TIMEOUT_MS=${WWEBJS_AUTH_TIMEOUT_MS:-}
       # Storage
       - STORAGE_TYPE=${STORAGE_TYPE:-local}
-      - STORAGE_LOCAL_PATH=/app/data/media
+      - STORAGE_LOCAL_PATH=${STORAGE_LOCAL_PATH:-/app/data/media}
       - S3_ENDPOINT=${S3_ENDPOINT:-http://minio:9000}
       - S3_ACCESS_KEY=${S3_ACCESS_KEY:-}
       - S3_SECRET_KEY=${S3_SECRET_KEY:-}
@@ -122,7 +122,7 @@ services:
       - RATE_LIMIT_MAX=${RATE_LIMIT_MAX:-100}
       # Plugins
       - PLUGINS_ENABLED=${PLUGINS_ENABLED:-true}
-      - PLUGINS_DIR=/app/data/plugins
+      - PLUGINS_DIR=${PLUGINS_DIR:-/app/data/plugins}
       # Security
       - API_MASTER_KEY=${API_MASTER_KEY:-}
       # Docker socket proxy (openwa-api never touches /var/run/docker.sock directly)


### PR DESCRIPTION
## Summary

In `docker-compose.yml`, three documented user-facing data-path settings were hardcoded while their sibling `DATABASE_NAME` was already overridable:

| Var | In `.env.example`? | Before | After |
|---|---|---|---|
| `DATABASE_NAME` | yes | `${DATABASE_NAME:-/app/data/openwa.sqlite}` | (unchanged) |
| `SESSION_DATA_PATH` | yes | `/app/data/sessions` | `${SESSION_DATA_PATH:-/app/data/sessions}` |
| `STORAGE_LOCAL_PATH` | yes | `/app/data/media` | `${STORAGE_LOCAL_PATH:-/app/data/media}` |
| `PLUGINS_DIR` | yes | `/app/data/plugins` | `${PLUGINS_DIR:-/app/data/plugins}` |

All three are read from the environment in the app (`src/config/configuration.ts`) and documented in `.env.example`, so hardcoding them in the compose file was an inconsistency. This converts them to the `${VAR:-default}` pattern, matching `DATABASE_NAME` and the rest of the file.

## Safety / behavior

- **Defaults are identical** and stay under `/app/data` (the `openwa-data` volume that the entrypoint chowns), so persistence and the `read_only` rootfs posture are unchanged out of the box.
- Overriding to a path **outside** `/app/data` is an advanced, opt-in action — the same caveat that already applies to `DATABASE_NAME`.

## Intentionally left fixed

`HOME`, `XDG_CONFIG_HOME`, `XDG_CACHE_HOME`, `PORT`, `DOCKER_HOST` — genuinely container-internal values tied to the image/entrypoint, `EXPOSE`/healthcheck, and the docker-proxy service topology.

## Test plan

- [x] `docker compose -f docker-compose.yml config` parses successfully
- [ ] `docker compose up` with no overrides uses the prior `/app/data/*` defaults
- [ ] Setting e.g. `PLUGINS_DIR` in `.env` is reflected in the container env

---
Companion to the dev-compose change in #450 (keeps the two files consistent).

Made with [Cursor](https://cursor.com)