### PR TITLE
fix(engine): clear Baileys auth state on logout so re-linking shows a fresh QR

### DIFF
--- a/src/engine/adapters/baileys.adapter.spec.ts
+++ b/src/engine/adapters/baileys.adapter.spec.ts
@@ -1,4 +1,6 @@
 import { EventEmitter } from 'events';
+import * as fs from 'fs';
+import * as path from 'path';
 
 jest.mock('../../common/media/load-remote-media', () => ({
   loadRemoteMediaBuffer: jest.fn(),
@@ -161,6 +163,43 @@ describe('BaileysAdapter lifecycle & status', () => {
     expect(adapter.getStatus()).toBe(EngineStatus.DISCONNECTED);
     expect(onDisconnected).toHaveBeenCalled();
     expect(makeWASocket).not.toHaveBeenCalled(); // no reconnect
+  });
+
+  it('on a logged-out close: clears the on-disk auth dir so a fresh connect shows a new QR', async () => {
+    // Root cause of the "QR never appears after logout" bug: the now-invalid multi-file auth dir was
+    // left on disk, so the next connect() reloaded the dead creds and Baileys retried them instead of
+    // emitting a QR. A terminal loggedOut MUST wipe the auth dir.
+    const rmSpy = jest.spyOn(fs.promises, 'rm').mockResolvedValue(undefined);
+    try {
+      const adapter = newAdapter();
+      await adapter.initialize(noopCallbacks({}));
+      fakeSock.fire('connection.update', {
+        connection: 'close',
+        lastDisconnect: { error: { output: { statusCode: 401 } } },
+      });
+      await new Promise(r => setImmediate(r)); // let the fire-and-forget clearAuthState() settle
+      expect(rmSpy).toHaveBeenCalledWith(
+        path.join('./data/baileys', 'sess-1'),
+        expect.objectContaining({ recursive: true, force: true }),
+      );
+    } finally {
+      rmSpy.mockRestore();
+    }
+  });
+
+  it('logout() clears the on-disk auth dir (stale creds would otherwise block re-linking)', async () => {
+    const rmSpy = jest.spyOn(fs.promises, 'rm').mockResolvedValue(undefined);
+    try {
+      const adapter = newAdapter();
+      await adapter.initialize(noopCallbacks({}));
+      await adapter.logout();
+      expect(rmSpy).toHaveBeenCalledWith(
+        path.join('./data/baileys', 'sess-1'),
+        expect.objectContaining({ recursive: true, force: true }),
+      );
+    } finally {
+      rmSpy.mockRestore();
+    }
   });
 
   it('on a recoverable close: reconnects (re-creates the socket) and does NOT fire onDisconnected', async () => {

--- a/src/engine/adapters/baileys.adapter.ts
+++ b/src/engine/adapters/baileys.adapter.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import * as path from 'path';
 import * as qrcode from 'qrcode';
 import type * as BaileysLib from '@whiskeysockets/baileys';
@@ -314,8 +315,12 @@ export class BaileysAdapter implements IWhatsAppEngine {
       }
 
       if (statusCode === this.lib?.DisconnectReason.loggedOut) {
-        // Credentials invalidated — terminal. Re-linking requires a fresh QR/pairing.
+        // Credentials invalidated — terminal. Re-linking requires a fresh QR/pairing, so the now-dead
+        // multi-file auth dir MUST be wiped: otherwise the next connect() reloads the stale creds and
+        // Baileys silently retries them instead of emitting a new QR, leaving the session stuck (no QR).
         this.setStatus(EngineStatus.DISCONNECTED);
+        this.sock = null;
+        void this.clearAuthState();
         this.callbacks.onDisconnected?.('logged out');
         return;
       }
@@ -390,8 +395,25 @@ export class BaileysAdapter implements IWhatsAppEngine {
     this.sock = null;
     this.setStatus(EngineStatus.DISCONNECTED);
     await this.config.messageStore?.clearSession(this.config.sessionId).catch(() => undefined);
-    // leaves the multi-file auth dir on disk; a fresh link overwrites it. Add fs cleanup if
-    // stale creds ever block re-linking.
+    // Wipe the multi-file auth dir so a fresh link starts clean — stale creds would otherwise be
+    // reloaded on the next connect() and block re-linking (Baileys retries them, no QR emitted).
+    await this.clearAuthState();
+  }
+
+  /**
+   * Delete this session's on-disk multi-file auth state (`authDir/sessionId`). Required after a terminal
+   * logout: Baileys would otherwise reload the now-invalid creds on the next connect() and retry them
+   * instead of emitting a fresh QR, leaving re-linking stuck. `force` makes a missing dir a no-op.
+   */
+  private async clearAuthState(): Promise<void> {
+    try {
+      await fs.promises.rm(this.authPath, { recursive: true, force: true });
+      this.logger.log('Cleared Baileys auth state', { authPath: this.authPath });
+    } catch (err) {
+      this.logger.warn('Failed to clear Baileys auth state', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
   destroy(): Promise<void> {


### PR DESCRIPTION
## Problem

When a Baileys session is terminated by WhatsApp (`DisconnectReason.loggedOut` — e.g. the device is unlinked from the phone) — or via the API `logout()` — `BaileysAdapter` leaves the multi-file auth directory (`authDir/sessionId`) on disk.

On the next `connect()`, `useMultiFileAuthState(this.authPath)` reloads those now-invalid credentials (`creds.json` with `registered: false`). Baileys then retries the dead identity instead of emitting a fresh QR, so the session gets stuck: the status churns but **no QR is ever produced**, and re-linking is impossible without manually deleting the auth folder.

This is exactly what the existing TODO in `logout()` anticipated:

> `// leaves the multi-file auth dir on disk; a fresh link overwrites it. Add fs cleanup if stale creds ever block re-linking.`

In practice a fresh link does **not** overwrite stale creds in the logged-out case — they are reloaded and reused.

## Fix

A small `clearAuthState()` helper removes `authDir/sessionId` (`fs.promises.rm`, `recursive: true, force: true`), called in the two terminal paths:

1. `handleConnectionUpdate` — on `DisconnectReason.loggedOut` (and null out the now-dead socket).
2. `logout()` — replacing the TODO.

`force: true` makes a missing dir a no-op; failures are logged and swallowed (best-effort cleanup must not throw on a teardown path). `disconnect()` / `destroy()` are intentionally untouched — those are non-terminal and must keep the session for reconnect. Only the session's own dir (`authDir/sessionId`) is removed, never the shared `authDir`.

## Tests

Two new cases in `baileys.adapter.spec.ts`:
- a `loggedOut` close wipes `authDir/sessionId`;
- `logout()` wipes `authDir/sessionId`.

`baileys.adapter.spec.ts` green (90/90); `npm run build` clean.
