### PR TITLE
fix(webhook): return 400 (not 500) when a webhook URL's DNS lookup rejects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Sessions (Baileys): when a session is logged out — unlinked from the phone or via the API — the now-invalid on-disk auth state is cleared, so re-linking shows a fresh QR instead of getting stuck silently reloading the dead credentials. (#453 — thanks @ulises2k)
+- Webhooks: registering a webhook (`POST /sessions/:id/webhooks`) to a host whose DNS lookup *rejects* (NXDOMAIN, or a transient `EAI_AGAIN`/`ESERVFAIL` under resolver pressure) now returns `400 Could not resolve host: <host> (<code>)` instead of a generic `500 Internal server error`. The SSRF guard's DNS deadline already mapped resolution *timeouts* and empty results to a 4xx; a rejected lookup leaked the raw DNS error, which surfaced as an intermittent 500 during back-to-back session-create → webhook-register flows.
 
 ## [0.7.1] - 2026-06-24
 

--- a/src/common/security/ssrf-guard.spec.ts
+++ b/src/common/security/ssrf-guard.spec.ts
@@ -199,9 +199,14 @@ describe('resolveSafeFetchTarget', () => {
     await expect(resolveSafeFetchTarget('https://rebind.example/hook')).rejects.toThrow(SsrfBlockedError);
   });
 
-  it('propagates a DNS lookup failure (rejection) rather than hanging', async () => {
-    (dnsPromises.lookup as jest.Mock).mockRejectedValueOnce(new Error('ENOTFOUND'));
-    await expect(resolveSafeFetchTarget('https://nxdomain.example/hook')).rejects.toThrow(/ENOTFOUND/);
+  it('maps a DNS lookup failure (rejection) to SsrfBlockedError instead of leaking a raw error', async () => {
+    // A rejected lookup (NXDOMAIN, or a transient EAI_AGAIN under resolver pressure) must become a
+    // typed SsrfBlockedError so callers map it to a 4xx. A raw error here leaks as a generic 500 —
+    // the intermittent failure seen at webhook registration (POST /sessions/:id/webhooks).
+    (dnsPromises.lookup as jest.Mock).mockRejectedValueOnce(
+      Object.assign(new Error('getaddrinfo ENOTFOUND nxdomain.example'), { code: 'ENOTFOUND' }),
+    );
+    await expect(resolveSafeFetchTarget('https://nxdomain.example/hook')).rejects.toThrow(SsrfBlockedError);
   });
 
   it('rejects when DNS resolution exceeds the deadline (a hanging resolver cannot pin a worker)', async () => {

--- a/src/common/security/ssrf-guard.ts
+++ b/src/common/security/ssrf-guard.ts
@@ -182,8 +182,10 @@ function resolveDnsTimeoutMs(): number {
 /**
  * Resolve a host with `{ all: true }`, bounded by a deadline so a hanging/slow DNS resolver cannot
  * pin a worker indefinitely (the lookup is otherwise unbounded). The default deadline is generous
- * and overridable via SSRF_DNS_TIMEOUT_MS. On expiry it throws SsrfBlockedError; the in-flight lookup
- * is left to settle with its late result swallowed (no unhandledRejection).
+ * and overridable via SSRF_DNS_TIMEOUT_MS. On expiry — or on a rejected lookup (NXDOMAIN, transient
+ * EAI_AGAIN, ESERVFAIL, …) — it throws SsrfBlockedError; the in-flight lookup is left to settle with
+ * its late result swallowed (no unhandledRejection). Wrapping the rejection keeps every resolution
+ * failure typed, so callers map it to a 4xx instead of leaking a raw DNS error as a generic 500.
  */
 async function lookupWithDeadline(host: string): Promise<LookupAddress[]> {
   const lookupPromise = lookup(host, { all: true });
@@ -194,6 +196,10 @@ async function lookupWithDeadline(host: string): Promise<LookupAddress[]> {
   });
   try {
     return await Promise.race([lookupPromise, deadline]);
+  } catch (err) {
+    if (err instanceof SsrfBlockedError) throw err; // deadline already produced a typed error
+    const code = (err as NodeJS.ErrnoException)?.code;
+    throw new SsrfBlockedError(`Could not resolve host: ${host}${code ? ` (${code})` : ''}`);
   } finally {
     if (timer) clearTimeout(timer);
   }


### PR DESCRIPTION
## Summary

Registering a webhook to a host whose DNS lookup **rejects** returns a generic `500 Internal server error` instead of a `4xx`. This shows up as an **intermittent 500** on `POST /sessions/:id/webhooks` during back-to-back `create session → register webhook` flows, because a transient resolver failure (`EAI_AGAIN`) takes the same path as a hard `ENOTFOUND`.

## Root cause

`assertSafeFetchUrl` → `resolveSafeFetchTarget` → `lookupWithDeadline` (`src/common/security/ssrf-guard.ts`) resolves the host before delivery/registration. `lookupWithDeadline` mapped two failure modes to a typed `SsrfBlockedError` (which `WebhookService.validateWebhookUrl` turns into a `400`):

- DNS **timeout** (deadline) → `SsrfBlockedError`
- **empty** resolution (`resolved.length === 0`) → `SsrfBlockedError`

But a **rejected** `lookup()` (NXDOMAIN `ENOTFOUND`, or a transient `EAI_AGAIN`/`ESERVFAIL` under resolver pressure) won the `Promise.race` with a **raw Node DNS error**. `validateWebhookUrl` only maps `SsrfBlockedError → 400` and re-throws anything else; with no global exception filter, the raw error surfaces as a generic `500`.

Observed stack (reproduced deterministically with a non-existent domain):

```
Error: getaddrinfo ENOTFOUND <host>
    at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:internal/dns/promises:102:17)
  code: 'ENOTFOUND', syscall: 'getaddrinfo'
```

## Fix

Wrap the lookup rejection in `lookupWithDeadline` so **every** resolution failure is typed, consistent with the timeout/empty-result paths:

```ts
} catch (err) {
  if (err instanceof SsrfBlockedError) throw err; // deadline already produced a typed error
  const code = (err as NodeJS.ErrnoException)?.code;
  throw new SsrfBlockedError(`Could not resolve host: ${host}${code ? ` (${code})` : ''}`);
}
```

Callers now get a `400 Could not resolve host: <host> (<code>)` with the DNS code, instead of an opaque `500`.

## On the public-contract note

Per `CONTRIBUTING.md`, status-code changes warrant discussion. This is **not** a documented-contract change: an unresolvable webhook host is already a `400` when resolution times out or returns empty — this only stops the *rejection* sub-case from leaking an uncaught `500`. No success-path shape or status changes; auth is untouched.

## Test plan

- New/updated unit test in `ssrf-guard.spec.ts`: a rejected `lookup()` now maps to `SsrfBlockedError` (previously asserted raw propagation — that test encoded the bug).
- `npm run build` ✓ · `npm test` → **1285/1285** ✓ · `npm run lint` ✓ · `npm run format` (no changes) ✓
- Manual repro against a running instance: `POST /sessions/:id/webhooks` to a non-existent domain returned `500` before, `400` after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
