### PR TITLE
fix(infra): show only persisted config controls; reject env-injecting values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Sessions (Baileys): when a session is logged out — unlinked from the phone or via the API — the now-invalid on-disk auth state is cleared, so re-linking shows a fresh QR instead of getting stuck silently reloading the dead credentials. (#453 — thanks @ulises2k)
 - Webhooks: registering a webhook (`POST /sessions/:id/webhooks`) to a host whose DNS lookup *rejects* (NXDOMAIN, or a transient `EAI_AGAIN`/`ESERVFAIL` under resolver pressure) now returns `400 Could not resolve host: <host> (<code>)` instead of a generic `500 Internal server error`. The SSRF guard's DNS deadline already mapped resolution *timeouts* and empty results to a 4xx; a rejected lookup leaked the raw DNS error, which surfaced as an intermittent 500 during back-to-back session-create → webhook-register flows.
+- Infrastructure: the dashboard config form no longer shows Server, Webhook, and Rate-Limit sections that were never persisted — they returned a fake "saved" while silently discarding every value. The form now exposes only the settings it actually writes (Database, Redis/Queue, Storage, Engine); the removed settings remain configurable via environment variables.
+
+### Security
+
+- Infrastructure: configuration values saved from the dashboard are now rejected if they contain a line break, which could otherwise write an extra `KEY=value` line into `data/.env.generated` and inject an arbitrary environment variable on the next boot.
 
 ## [0.7.1] - 2026-06-24
 

--- a/dashboard/src/pages/Infrastructure.tsx
+++ b/dashboard/src/pages/Infrastructure.tsx
@@ -9,9 +9,6 @@ import {
   Loader2,
   CheckCircle,
   Trash2,
-  Globe,
-  Webhook,
-  Gauge,
   Cpu,
 } from 'lucide-react';
 import { infraApi, API_BASE_URL } from '../services/api';
@@ -76,27 +73,6 @@ interface QueueStats {
   failed: number;
 }
 
-interface ServerConfig {
-  port: string;
-  nodeEnv: 'production' | 'development';
-  domain: string;
-  dashboardPort: string;
-  baseUrl: string;
-  dashboardUrl: string;
-  corsOrigins: string;
-}
-
-interface WebhookConfig {
-  timeout: number;
-  maxRetries: number;
-  retryDelay: number;
-}
-
-interface RateLimitConfig {
-  ttl: number;
-  max: number;
-}
-
 export function Infrastructure() {
   const { t } = useTranslation();
   useDocumentTitle(t('infrastructure.title'));
@@ -159,27 +135,6 @@ export function Infrastructure() {
   const [queueEnabled, setQueueEnabled] = useState(false);
   const [pendingProfiles, setPendingProfiles] = useState<string[]>([]);
   const [previousProfiles, setPreviousProfiles] = useState<string[]>([]);
-
-  const [serverConfig, setServerConfig] = useState<ServerConfig>({
-    port: '2785',
-    nodeEnv: 'development',
-    domain: 'localhost',
-    dashboardPort: '2886',
-    baseUrl: '',
-    dashboardUrl: '',
-    corsOrigins: '*',
-  });
-
-  const [webhookConfig, setWebhookConfig] = useState<WebhookConfig>({
-    timeout: 10000,
-    maxRetries: 3,
-    retryDelay: 5000,
-  });
-
-  const [rateLimitConfig, setRateLimitConfig] = useState<RateLimitConfig>({
-    ttl: 60,
-    max: 100,
-  });
 
   useEffect(() => {
     if (!infraStatus) return;
@@ -278,12 +233,6 @@ export function Infrastructure() {
     setStorageConfig(prev => ({ ...prev, [key]: value }));
   const updateEngineConfig = (key: keyof EngineConfig, value: string | boolean) =>
     setEngineConfig(prev => ({ ...prev, [key]: value }));
-  const updateServerConfig = (key: keyof ServerConfig, value: string) =>
-    setServerConfig(prev => ({ ...prev, [key]: value }));
-  const updateWebhookConfig = (key: keyof WebhookConfig, value: number) =>
-    setWebhookConfig(prev => ({ ...prev, [key]: value }));
-  const updateRateLimitConfig = (key: keyof RateLimitConfig, value: number) =>
-    setRateLimitConfig(prev => ({ ...prev, [key]: value }));
 
   const handleSaveConfig = async () => {
     setSaving(true);
@@ -294,9 +243,6 @@ export function Infrastructure() {
         queue: { enabled: queueEnabled },
         storage: { ...storageConfig },
         engine: { ...engineConfig },
-        server: { ...serverConfig },
-        webhook: { ...webhookConfig },
-        rateLimit: { ...rateLimitConfig },
       };
 
       const result = await infraApi.saveConfig(payload);
@@ -375,156 +321,6 @@ export function Infrastructure() {
       <PageHeader title={t('infrastructure.title')} subtitle={t('infrastructure.subtitle')} />
 
       <div className="infra-sections">
-        {/* Server Configuration */}
-        <section className="infra-card">
-          <div className="card-header">
-            <div className="header-left">
-              <Globe size={20} />
-              <h2>{t('infrastructure.server.title')}</h2>
-            </div>
-            <span className={`status-indicator ${serverConfig.nodeEnv === 'production' ? 'connected' : 'sqlite'}`}>
-              ● {serverConfig.nodeEnv === 'production' ? t('infrastructure.server.production') : t('infrastructure.server.development')}
-            </span>
-          </div>
-
-          <div className="config-form">
-            <div className="form-row">
-              <div className="form-group">
-                <label>{t('infrastructure.server.environment')}</label>
-                <select
-                  value={serverConfig.nodeEnv}
-                  onChange={e => updateServerConfig('nodeEnv', e.target.value as 'production' | 'development')}
-                >
-                  <option value="production">{t('infrastructure.server.production')}</option>
-                  <option value="development">{t('infrastructure.server.development')}</option>
-                </select>
-              </div>
-              <div className="form-group">
-                <label>{t('infrastructure.server.domain')}</label>
-                <input
-                  type="text"
-                  value={serverConfig.domain}
-                  onChange={e => updateServerConfig('domain', e.target.value)}
-                  placeholder="localhost"
-                />
-              </div>
-            </div>
-            <div className="form-row">
-              <div className="form-group small">
-                <label>{t('infrastructure.server.apiPort')}</label>
-                <input type="text" value={serverConfig.port} onChange={e => updateServerConfig('port', e.target.value)} />
-              </div>
-              <div className="form-group small">
-                <label>{t('infrastructure.server.dashboardPort')}</label>
-                <input
-                  type="text"
-                  value={serverConfig.dashboardPort}
-                  onChange={e => updateServerConfig('dashboardPort', e.target.value)}
-                />
-              </div>
-              <div className="form-group">
-                <label>{t('infrastructure.server.corsOrigins')}</label>
-                <input
-                  type="text"
-                  value={serverConfig.corsOrigins}
-                  onChange={e => updateServerConfig('corsOrigins', e.target.value)}
-                  placeholder={t('infrastructure.server.corsPlaceholder')}
-                />
-              </div>
-            </div>
-            <div className="form-row">
-              <div className="form-group">
-                <label>{t('infrastructure.server.publicApiUrl')}</label>
-                <input
-                  type="text"
-                  value={serverConfig.baseUrl}
-                  onChange={e => updateServerConfig('baseUrl', e.target.value)}
-                  placeholder="https://api.yourdomain.com"
-                />
-              </div>
-              <div className="form-group">
-                <label>{t('infrastructure.server.publicDashboardUrl')}</label>
-                <input
-                  type="text"
-                  value={serverConfig.dashboardUrl}
-                  onChange={e => updateServerConfig('dashboardUrl', e.target.value)}
-                  placeholder="https://dashboard.yourdomain.com"
-                />
-              </div>
-            </div>
-          </div>
-        </section>
-
-        {/* Webhook & Rate Limiting */}
-        <section className="infra-card">
-          <div className="card-header">
-            <div className="header-left">
-              <Webhook size={20} />
-              <h2>{t('infrastructure.webhook.title')}</h2>
-            </div>
-          </div>
-
-          <div className="config-form">
-            <h3 style={{ margin: '0 0 1rem', fontSize: '0.9375rem', color: '#475569', fontWeight: 600 }}>
-              <Webhook size={16} style={{ marginInlineEnd: '0.5rem', verticalAlign: 'middle' }} />
-              {t('infrastructure.webhook.settings')}
-            </h3>
-            <div className="form-row">
-              <div className="form-group">
-                <label>{t('infrastructure.webhook.timeout')}</label>
-                <input
-                  type="number"
-                  value={webhookConfig.timeout}
-                  onChange={e => updateWebhookConfig('timeout', parseInt(e.target.value) || 10000)}
-                />
-              </div>
-              <div className="form-group small">
-                <label>{t('infrastructure.webhook.maxRetries')}</label>
-                <input
-                  type="number"
-                  min="0"
-                  max="10"
-                  value={webhookConfig.maxRetries}
-                  onChange={e => updateWebhookConfig('maxRetries', parseInt(e.target.value) || 3)}
-                />
-              </div>
-              <div className="form-group">
-                <label>{t('infrastructure.webhook.retryDelay')}</label>
-                <input
-                  type="number"
-                  value={webhookConfig.retryDelay}
-                  onChange={e => updateWebhookConfig('retryDelay', parseInt(e.target.value) || 5000)}
-                />
-              </div>
-            </div>
-
-            <div style={{ borderTop: '1px solid var(--border)', margin: '1.5rem 0', paddingTop: '1.5rem' }}>
-              <h3 style={{ margin: '0 0 1rem', fontSize: '0.9375rem', color: '#475569', fontWeight: 600 }}>
-                <Gauge size={16} style={{ marginInlineEnd: '0.5rem', verticalAlign: 'middle' }} />
-                {t('infrastructure.webhook.rateLimit')}
-              </h3>
-              <div className="form-row">
-                <div className="form-group">
-                  <label>{t('infrastructure.webhook.window')}</label>
-                  <input
-                    type="number"
-                    value={rateLimitConfig.ttl}
-                    onChange={e => updateRateLimitConfig('ttl', parseInt(e.target.value) || 60)}
-                  />
-                </div>
-                <div className="form-group">
-                  <label>{t('infrastructure.webhook.maxReq')}</label>
-                  <input
-                    type="number"
-                    value={rateLimitConfig.max}
-                    onChange={e => updateRateLimitConfig('max', parseInt(e.target.value) || 100)}
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </section>
-
         {/* Database */}
         <section className="infra-card">
           <div className="card-header">

--- a/src/modules/infra/infra.controller.spec.ts
+++ b/src/modules/infra/infra.controller.spec.ts
@@ -231,6 +231,46 @@ describe('InfraController.saveConfig env-name correctness and merge (#226)', () 
   });
 });
 
+describe('InfraController.saveConfig rejects values that would inject extra env vars', () => {
+  const newController = () =>
+    new InfraController(
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+    );
+
+  // .env.generated is one KEY=value per line and is loaded on the next boot. A value carrying a
+  // newline would write a second `KEY=value` line — injecting an arbitrary env var (e.g. an admin
+  // key) the operator never set. Such a value must be refused outright, with nothing written.
+  it.each([
+    ['linefeed', '--no-sandbox\nADMIN_MASTER_KEY=attacker'],
+    ['carriage return', '--no-sandbox\rADMIN_MASTER_KEY=attacker'],
+  ])('does not persist a config value containing a %s', (_label, malicious) => {
+    (fs.existsSync as jest.Mock).mockReturnValue(false);
+    (fs.writeFileSync as jest.Mock).mockClear();
+
+    const result = newController().saveConfig({ engine: { browserArgs: malicious } });
+
+    expect(result.saved).toBe(false);
+    expect(fs.writeFileSync as jest.Mock).not.toHaveBeenCalled();
+  });
+
+  it('still persists a normal value with the same key', () => {
+    (fs.existsSync as jest.Mock).mockReturnValue(false);
+    (fs.writeFileSync as jest.Mock).mockClear();
+
+    const result = newController().saveConfig({ engine: { browserArgs: '--no-sandbox --disable-gpu' } });
+
+    expect(result.saved).toBe(true);
+    expect(fs.writeFileSync as jest.Mock).toHaveBeenCalled();
+  });
+});
+
 describe('InfraController.saveConfig engine selection (persist ENGINE_TYPE — Infrastructure tile)', () => {
   const engineFactory = {
     getAvailableEngines: () => [{ id: 'whatsapp-web.js' }, { id: 'baileys' }],

--- a/src/modules/infra/infra.controller.ts
+++ b/src/modules/infra/infra.controller.ts
@@ -447,6 +447,15 @@ export class InfraController {
         updates.PUPPETEER_ARGS = config.engine.browserArgs || '--no-sandbox --disable-gpu';
       }
 
+      // .env.generated is one KEY=value per line, loaded on the next boot. A value carrying a
+      // line break would write a second line and inject an arbitrary env var the operator never
+      // set, so refuse any such value before writing anything.
+      for (const [key, value] of Object.entries(updates)) {
+        if (/[\r\n]/.test(value)) {
+          throw new BadRequestException(`Invalid configuration value for ${key}: line breaks are not allowed`);
+        }
+      }
+
       // Existing values are the base; this payload's values win (secrets handled above).
       const merged: Record<string, string> = { ...existing, ...updates };
       // Drop keys made obsolete by a mode switch (postgres->sqlite, s3->local).


### PR DESCRIPTION
## Summary

The Infrastructure dashboard form rendered editable **Server**, **Webhook**, and **Rate-Limit** sections that `saveConfig` never read — it only persists Database, Redis/Queue, Storage, and Engine. Those controls returned a `{ saved: true }` success and silently discarded every value the operator typed.

## Changes

- **Dashboard:** remove the three non-functional sections from `Infrastructure.tsx` (plus their now-unused state, handlers, interfaces, and icon imports) so the form only shows settings it actually writes. The removed settings remain configurable via environment variables.
- **Backend (hardening):** reject any saved config value containing a line break before writing `data/.env.generated`. A newline would otherwise write a second `KEY=value` line and inject an arbitrary environment variable on the next boot.

## Tests

- New unit tests assert a newline-bearing config value is refused and nothing is written, while a normal value still persists.
- `npm test` (full backend), `npm run build`, dashboard `npm run build` + `npm run lint`: clean.