### PR TITLE
fix(engine): honour an environment ENGINE_TYPE after the compose change

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,7 +47,10 @@ CORS_ORIGINS=*
 # =============================================================================
 # Which WhatsApp engine to use (plugin-based)
 # Options: whatsapp-web.js, baileys
-ENGINE_TYPE=whatsapp-web.js
+# Left unset by default so the dashboard (Infrastructure > Engine) governs the active engine via
+# data/.env.generated (defaults to whatsapp-web.js). Uncomment to pin an engine from the environment;
+# a value set here always wins over the dashboard selection.
+# ENGINE_TYPE=whatsapp-web.js
 
 # Engine-specific settings
 SESSION_DATA_PATH=./data/sessions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Infrastructure: configuration values saved from the dashboard are now rejected if they contain a line break, which could otherwise write an extra `KEY=value` line into `data/.env.generated` and inject an arbitrary environment variable on the next boot.
 - Infrastructure: data export/import (the documented backup and SQLite↔PostgreSQL migration flow) is now complete. It previously exported and restored only sessions, webhooks, messages, and message batches — so a restore silently lost all message templates and stored Baileys messages (cascade-deleted with the old sessions and never re-imported) and dropped every webhook's filters, causing a filtered webhook to come back firing on all events. Templates, stored Baileys messages, and webhook filters now round-trip intact.
+- Engine selection: pinning the engine from the environment works again after the v0.7.1 compose change. The bundled compose files forward `ENGINE_TYPE` into the container again (`- ENGINE_TYPE=${ENGINE_TYPE:-}`) and the app treats a blank value as unset, so an `.env`/host `ENGINE_TYPE=baileys` is honoured while the dashboard's Infrastructure > Engine selection still wins when no engine is pinned. `.env.example` no longer ships `ENGINE_TYPE` pre-pinned. **Upgrade note:** if you relied on `ENGINE_TYPE=baileys` in your `.env`, confirm the active engine after upgrading. (#453 — thanks @ulises2k)
 
 ## [0.7.1] - 2026-06-24
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -51,9 +51,11 @@ services:
       - DATABASE_TYPE=${DATABASE_TYPE:-sqlite}
       - DATABASE_NAME=${DATABASE_NAME:-/app/data/openwa.sqlite}
       - DATABASE_SYNCHRONIZE=${DATABASE_SYNCHRONIZE:-true}
-      # ENGINE_TYPE not pinned: the dashboard (Infrastructure > Engine) selects the active engine via
-      # data/.env.generated (default whatsapp-web.js). main.ts loads it with override:false, so a real
-      # env here would override the dashboard choice.
+      # Engine. Forwarded empty by default so the dashboard (Infrastructure > Engine) selects the
+      # active engine via data/.env.generated (default whatsapp-web.js); main.ts treats a blank
+      # ENGINE_TYPE as unset, so .env.generated wins. Set ENGINE_TYPE in your .env/host to pin an
+      # engine (e.g. baileys) — a real value flows through here and keeps top precedence.
+      - ENGINE_TYPE=${ENGINE_TYPE:-}
       - SESSION_DATA_PATH=${SESSION_DATA_PATH:-/app/data/sessions}
       - PUPPETEER_HEADLESS=${PUPPETEER_HEADLESS:-true}
       - PUPPETEER_ARGS=${PUPPETEER_ARGS:---no-sandbox,--disable-setuid-sandbox,--disable-dev-shm-usage,--disable-gpu}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,10 +88,11 @@ services:
       # postgres service requires it (:?) when that profile is active.
       - DATABASE_PASSWORD=${DATABASE_PASSWORD:-}
       - DATABASE_SYNCHRONIZE=${DATABASE_SYNCHRONIZE:-false}
-      # Engine. ENGINE_TYPE is intentionally NOT pinned here so the dashboard
-      # (Infrastructure > Engine) can select the active engine via data/.env.generated
-      # (defaults to whatsapp-web.js). main.ts loads .env.generated with override:false, so a
-      # real container env here would silently win over the dashboard selection.
+      # Engine. Forwarded empty by default so the dashboard (Infrastructure > Engine) selects the
+      # active engine via data/.env.generated (defaults to whatsapp-web.js); main.ts treats a blank
+      # ENGINE_TYPE as unset, so .env.generated wins. Set ENGINE_TYPE in your .env/host to pin an
+      # engine (e.g. baileys) — a real value flows through here and keeps top precedence.
+      - ENGINE_TYPE=${ENGINE_TYPE:-}
       - SESSION_DATA_PATH=${SESSION_DATA_PATH:-/app/data/sessions}
       - PUPPETEER_HEADLESS=${PUPPETEER_HEADLESS:-true}
       - PUPPETEER_ARGS=${PUPPETEER_ARGS:---no-sandbox,--disable-setuid-sandbox,--disable-dev-shm-usage,--disable-gpu}

--- a/src/config/env-precedence.spec.ts
+++ b/src/config/env-precedence.spec.ts
@@ -1,0 +1,58 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as dotenv from 'dotenv';
+import { clearBlankEnv } from './env-precedence';
+
+describe('clearBlankEnv', () => {
+  it('deletes a key whose value is empty or whitespace-only', () => {
+    const env: NodeJS.ProcessEnv = { A: '', B: '   ', C: 'keep' };
+    clearBlankEnv(env, ['A', 'B', 'C']);
+    expect('A' in env).toBe(false);
+    expect('B' in env).toBe(false);
+    expect(env.C).toBe('keep');
+  });
+
+  it('leaves an unset key untouched and does not create it', () => {
+    const env: NodeJS.ProcessEnv = {};
+    clearBlankEnv(env, ['MISSING']);
+    expect('MISSING' in env).toBe(false);
+  });
+});
+
+describe('engine-selection env precedence (ENGINE_TYPE)', () => {
+  // Mirrors main.ts: process.env > .env > data/.env.generated. A compose `- ENGINE_TYPE=${ENGINE_TYPE:-}`
+  // line forwards a blank value when the operator sets nothing; that blank must be treated as unset so
+  // the dashboard's .env.generated selection is honoured, while a real operator value still wins.
+  const KEY = 'ENGINE_TYPE';
+  let saved: string | undefined;
+  let genDir: string;
+  let genPath: string;
+
+  beforeEach(() => {
+    saved = process.env[KEY];
+    genDir = fs.mkdtempSync(path.join(os.tmpdir(), 'owa-env-'));
+    genPath = path.join(genDir, '.env.generated');
+    fs.writeFileSync(genPath, 'ENGINE_TYPE=baileys\n');
+  });
+
+  afterEach(() => {
+    if (saved === undefined) delete process.env[KEY];
+    else process.env[KEY] = saved;
+    fs.rmSync(genDir, { recursive: true, force: true });
+  });
+
+  it('lets .env.generated select the engine when the forwarded ENGINE_TYPE is blank', () => {
+    process.env[KEY] = ''; // compose `${ENGINE_TYPE:-}` with nothing set on the host
+    clearBlankEnv(process.env, [KEY]);
+    dotenv.config({ path: genPath, override: false });
+    expect(process.env[KEY]).toBe('baileys');
+  });
+
+  it('keeps a real operator ENGINE_TYPE and ignores the .env.generated default', () => {
+    process.env[KEY] = 'whatsapp-web.js'; // real operator/host value forwarded by compose
+    clearBlankEnv(process.env, [KEY]);
+    dotenv.config({ path: genPath, override: false });
+    expect(process.env[KEY]).toBe('whatsapp-web.js');
+  });
+});

--- a/src/config/env-precedence.ts
+++ b/src/config/env-precedence.ts
@@ -1,0 +1,19 @@
+/**
+ * Treat a blank (empty or whitespace-only) value for each given key as if the variable were unset,
+ * by deleting it from `env`.
+ *
+ * Why: the bundled compose files forward an operator's engine choice with `- ENGINE_TYPE=${ENGINE_TYPE:-}`
+ * so a real `.env`/host value reaches the container. When the operator sets nothing, that line renders
+ * an *empty* value, which would still sit in `process.env` and block the lower-priority `.env` /
+ * `data/.env.generated` layers (loaded with dotenv `override: false`) from supplying one — silently
+ * pinning the default and ignoring the dashboard's selection. Clearing the blank lets the lower layers
+ * provide the value, while a real (non-empty) value is preserved and keeps its top precedence.
+ */
+export function clearBlankEnv(env: NodeJS.ProcessEnv, keys: string[]): void {
+  for (const key of keys) {
+    const value = env[key];
+    if (value !== undefined && value.trim() === '') {
+      delete env[key];
+    }
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import { BullBoardAuthMiddleware } from './common/security/bull-board-auth.middl
 import { AuthService } from './modules/auth/auth.service';
 import { Request, Response, NextFunction, json, urlencoded } from 'express';
 import { writeSecretFile } from './common/utils/secret-file';
+import { clearBlankEnv } from './config/env-precedence';
 import * as dotenv from 'dotenv';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -49,6 +50,12 @@ for (const secret of [generatedEnvPath, path.resolve(dataDir, '.api-key')]) {
     }
   }
 }
+
+// A compose `- ENGINE_TYPE=${ENGINE_TYPE:-}` line forwards a real operator engine choice into the
+// container, but renders an empty value when none is set. An empty process.env.ENGINE_TYPE would
+// still block .env / .env.generated (loaded below with override:false) from supplying one, silently
+// pinning the default and ignoring the dashboard's selection — so treat a blank value as unset.
+clearBlankEnv(process.env, ['ENGINE_TYPE']);
 
 // 2. User-managed .env (does not override real process env)
 if (fs.existsSync(userEnvPath)) {


### PR DESCRIPTION
## Summary

v0.7.1 dropped the compose `ENGINE_TYPE` pass-through so the dashboard could govern engine selection via `data/.env.generated`. A side effect: an operator's `.env`/host `ENGINE_TYPE=baileys` was no longer forwarded into the container, so a Baileys deployment **silently reverted to whatsapp-web.js on upgrade** (reported in #453).

## Changes

- Forward `ENGINE_TYPE` into the container again with an empty default in both compose files (`- ENGINE_TYPE=${ENGINE_TYPE:-}`).
- Treat a blank `ENGINE_TYPE` as unset at boot (new `src/config/env-precedence.ts` `clearBlankEnv`, called in `main.ts` before the `.env`/`.env.generated` load). A blank forwarded value would otherwise sit in `process.env` and block the lower layers (dotenv `override: false`), pinning the default and ignoring the dashboard selection.
- Stop shipping `ENGINE_TYPE` pre-pinned in `.env.example`.

Net effect: the dashboard's Infrastructure > Engine selection still wins when nothing is pinned, while a real `.env`/host `ENGINE_TYPE` is honoured again and keeps top precedence.

## Tests

- New tests assert the 3-layer precedence (`process.env` > `.env` > `.env.generated`) and the blank-as-unset behaviour.
- Verified `docker compose config` renders an empty value when unset and the real value when set.
- `npm test` (full backend) and `npm run build`: clean.

## Upgrade note

If you relied on `ENGINE_TYPE=baileys` in your `.env`, confirm the active engine after upgrading.