### PR TITLE
fix(session): de-duplicate inbound messages so each WhatsApp message is delivered once

### DIFF
--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -1324,6 +1324,19 @@ GET /api/health/live
 
 OpenWA provides an idempotency mechanism to prevent duplicate processing on the client side.
 
+#### Delivery Semantics
+
+Webhook delivery is **at-least-once**. WhatsApp engines can re-fire an event for a single message, and
+failed deliveries are retried, so a consumer can receive the same event more than once. **Design your
+handler to be idempotent**, keyed on the `X-OpenWA-Idempotency-Key` header (or the `idempotencyKey`
+field) — that key is content-based, so every duplicate of the same message carries the identical value;
+prefer it over hashing the payload yourself.
+
+As a safety net, OpenWA de-duplicates inbound `message.received` **server-side**: a re-fired event for a
+message already persisted is dropped before dispatch, so one registered webhook normally receives each
+inbound message once. This guard is best-effort defense-in-depth and does not remove the need for
+consumer-side idempotency on the key above.
+
 #### Idempotency Headers & Fields
 
 | Field/Header | Description |

--- a/src/common/utils/unique-constraint.util.spec.ts
+++ b/src/common/utils/unique-constraint.util.spec.ts
@@ -10,9 +10,9 @@ describe('isUniqueConstraintError', () => {
   });
 
   it('recognizes a SQLite constraint error by message', () => {
-    expect(
-      isUniqueConstraintError(new Error('SQLITE_CONSTRAINT: UNIQUE constraint failed: messages.sessionId')),
-    ).toBe(true);
+    expect(isUniqueConstraintError(new Error('SQLITE_CONSTRAINT: UNIQUE constraint failed: messages.sessionId'))).toBe(
+      true,
+    );
   });
 
   it('returns false for a non-unique DB error (e.g. FK violation 23503)', () => {
@@ -25,6 +25,8 @@ describe('isUniqueConstraintError', () => {
   });
 
   it('does not false-positive on a non-unique code whose message contains the unique phrase', () => {
-    expect(isUniqueConstraintError({ driverError: { code: '23503', message: 'UNIQUE constraint failed: x' } })).toBe(false);
+    expect(isUniqueConstraintError({ driverError: { code: '23503', message: 'UNIQUE constraint failed: x' } })).toBe(
+      false,
+    );
   });
 });

--- a/src/common/utils/unique-constraint.util.spec.ts
+++ b/src/common/utils/unique-constraint.util.spec.ts
@@ -1,0 +1,26 @@
+import { isUniqueConstraintError } from './unique-constraint.util';
+
+describe('isUniqueConstraintError', () => {
+  it('recognizes a PostgreSQL unique_violation (code 23505)', () => {
+    expect(isUniqueConstraintError({ driverError: { code: '23505' } })).toBe(true);
+  });
+
+  it('recognizes a SQLite constraint error by code', () => {
+    expect(isUniqueConstraintError({ driverError: { code: 'SQLITE_CONSTRAINT_UNIQUE' } })).toBe(true);
+  });
+
+  it('recognizes a SQLite constraint error by message', () => {
+    expect(
+      isUniqueConstraintError(new Error('SQLITE_CONSTRAINT: UNIQUE constraint failed: messages.sessionId')),
+    ).toBe(true);
+  });
+
+  it('returns false for a non-unique DB error (e.g. FK violation 23503)', () => {
+    expect(isUniqueConstraintError({ driverError: { code: '23503' } })).toBe(false);
+  });
+
+  it('returns false for an unrelated error and for null', () => {
+    expect(isUniqueConstraintError(new Error('boom'))).toBe(false);
+    expect(isUniqueConstraintError(null)).toBe(false);
+  });
+});

--- a/src/common/utils/unique-constraint.util.spec.ts
+++ b/src/common/utils/unique-constraint.util.spec.ts
@@ -23,4 +23,8 @@ describe('isUniqueConstraintError', () => {
     expect(isUniqueConstraintError(new Error('boom'))).toBe(false);
     expect(isUniqueConstraintError(null)).toBe(false);
   });
+
+  it('does not false-positive on a non-unique code whose message contains the unique phrase', () => {
+    expect(isUniqueConstraintError({ driverError: { code: '23503', message: 'UNIQUE constraint failed: x' } })).toBe(false);
+  });
 });

--- a/src/common/utils/unique-constraint.util.ts
+++ b/src/common/utils/unique-constraint.util.ts
@@ -10,5 +10,6 @@ export function isUniqueConstraintError(err: unknown): boolean {
   const message = e.driverError?.message ?? e.message ?? '';
   if (code === '23505') return true; // PostgreSQL unique_violation
   if (typeof code === 'string' && code.startsWith('SQLITE_CONSTRAINT')) return true; // SQLite
+  if (code != null) return false; // a decisive non-unique code wins over a misleading message
   return /UNIQUE constraint failed/i.test(message); // SQLite fallback (message only)
 }

--- a/src/common/utils/unique-constraint.util.ts
+++ b/src/common/utils/unique-constraint.util.ts
@@ -1,0 +1,14 @@
+/**
+ * True when `err` is a unique-constraint violation, across SQLite and PostgreSQL. TypeORM wraps
+ * driver errors in QueryFailedError; the dialect-specific detail sits on `driverError`. Used to tell
+ * a duplicate-key insert (skip it) apart from a genuine persistence failure (must not be swallowed).
+ */
+export function isUniqueConstraintError(err: unknown): boolean {
+  if (err == null || typeof err !== 'object') return false;
+  const e = err as { code?: string; message?: string; driverError?: { code?: string; message?: string } };
+  const code = e.driverError?.code ?? e.code;
+  const message = e.driverError?.message ?? e.message ?? '';
+  if (code === '23505') return true; // PostgreSQL unique_violation
+  if (typeof code === 'string' && code.startsWith('SQLITE_CONSTRAINT')) return true; // SQLite
+  return /UNIQUE constraint failed/i.test(message); // SQLite fallback (message only)
+}

--- a/src/database/migrations/1781300000000-AddMessagesWaMessageIdUnique.ts
+++ b/src/database/migrations/1781300000000-AddMessagesWaMessageIdUnique.ts
@@ -1,0 +1,38 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Enforces one row per (sessionId, waMessageId) on `messages` (issue #464): the engine can re-fire
+ * the inbound `message` event, and the old blind insert persisted the same WhatsApp message twice.
+ *
+ * Pre-existing duplicates are removed losslessly — a duplicate (sessionId, waMessageId) IS the same
+ * message, so the earliest row (createdAt ASC, id ASC) is kept and the rest deleted. Rows with a NULL
+ * waMessageId are exempt (SQL treats NULLs as distinct), preserving transient outgoing PENDING rows.
+ *
+ * Hand-authored because `synchronize` is off for the `data` connection. Idempotent + cross-dialect.
+ */
+export class AddMessagesWaMessageIdUnique1781300000000 implements MigrationInterface {
+  name = 'AddMessagesWaMessageIdUnique1781300000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    if (!(await queryRunner.hasTable('messages'))) return;
+
+    await queryRunner.query(
+      `DELETE FROM "messages" WHERE "waMessageId" IS NOT NULL AND "id" <> (` +
+        `SELECT m2."id" FROM "messages" m2 ` +
+        `WHERE m2."sessionId" = "messages"."sessionId" AND m2."waMessageId" = "messages"."waMessageId" ` +
+        `ORDER BY m2."createdAt" ASC, m2."id" ASC LIMIT 1)`,
+    );
+
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_messages_sessionId_waMessageId"`);
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX IF NOT EXISTS "UQ_messages_sessionId_waMessageId" ON "messages" ("sessionId", "waMessageId")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "UQ_messages_sessionId_waMessageId"`);
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_messages_sessionId_waMessageId" ON "messages" ("sessionId", "waMessageId")`,
+    );
+  }
+}

--- a/src/database/migrations/__tests__/1781300000000-AddMessagesWaMessageIdUnique.spec.ts
+++ b/src/database/migrations/__tests__/1781300000000-AddMessagesWaMessageIdUnique.spec.ts
@@ -1,0 +1,67 @@
+import { DataSource } from 'typeorm';
+import { AddMessagesWaMessageIdUnique1781300000000 } from '../1781300000000-AddMessagesWaMessageIdUnique';
+
+describe('AddMessagesWaMessageIdUnique migration', () => {
+  let ds: DataSource;
+
+  beforeEach(async () => {
+    ds = new DataSource({ type: 'sqlite', database: ':memory:' });
+    await ds.initialize();
+    await ds.query(
+      `CREATE TABLE "messages" ("id" varchar PRIMARY KEY NOT NULL, "sessionId" varchar NOT NULL, ` +
+        `"waMessageId" varchar, "chatId" varchar NOT NULL, "from" varchar NOT NULL, "to" varchar NOT NULL, ` +
+        `"body" text, "type" varchar NOT NULL DEFAULT ('text'), "direction" varchar NOT NULL DEFAULT ('outgoing'), ` +
+        `"timestamp" bigint, "metadata" text, "status" varchar NOT NULL DEFAULT ('sent'), ` +
+        `"createdAt" datetime NOT NULL DEFAULT (datetime('now')))`,
+    );
+    await ds.query(`CREATE INDEX "IDX_messages_sessionId_waMessageId" ON "messages" ("sessionId", "waMessageId")`);
+  });
+
+  afterEach(async () => {
+    await ds.destroy();
+  });
+
+  const insert = (id: string, sessionId: string, waMessageId: string | null, createdAt: string): Promise<unknown> =>
+    ds.query(
+      `INSERT INTO "messages" ("id","sessionId","waMessageId","chatId","from","to","body","type","direction","timestamp","status","createdAt") ` +
+        `VALUES (?,?,?,'c@c.us','c@c.us','me@c.us','hi','text','incoming',1,'sent',?)`,
+      [id, sessionId, waMessageId, createdAt],
+    );
+
+  it('deletes duplicate (sessionId, waMessageId) rows keeping the earliest, then enforces uniqueness', async () => {
+    await insert('id-early', 'sess-1', 'wa-1', '2026-01-01T00:00:00.000Z');
+    await insert('id-late', 'sess-1', 'wa-1', '2026-02-01T00:00:00.000Z');
+    await insert('id-other', 'sess-1', 'wa-2', '2026-01-01T00:00:00.000Z');
+
+    const runner = ds.createQueryRunner();
+    await new AddMessagesWaMessageIdUnique1781300000000().up(runner);
+
+    const rows = (await runner.query(`SELECT id FROM "messages" ORDER BY id`)) as { id: string }[];
+    expect(rows.map(r => r.id).sort()).toEqual(['id-early', 'id-other']); // later dup deleted, earliest kept
+
+    await expect(insert('id-new', 'sess-1', 'wa-1', '2026-03-01T00:00:00.000Z')).rejects.toThrow();
+    await runner.release();
+  });
+
+  it('keeps multiple NULL-waMessageId rows (NULLs are distinct under the unique index)', async () => {
+    await insert('p1', 'sess-1', null, '2026-01-01T00:00:00.000Z');
+    await insert('p2', 'sess-1', null, '2026-01-01T00:00:01.000Z');
+
+    const runner = ds.createQueryRunner();
+    await new AddMessagesWaMessageIdUnique1781300000000().up(runner);
+
+    const rows = (await runner.query(`SELECT id FROM "messages" WHERE "waMessageId" IS NULL`)) as unknown[];
+    expect(rows).toHaveLength(2);
+    await runner.release();
+  });
+
+  it('is idempotent and a no-op when the table is absent', async () => {
+    const runner = ds.createQueryRunner();
+    const migration = new AddMessagesWaMessageIdUnique1781300000000();
+    await migration.up(runner);
+    await expect(migration.up(runner)).resolves.toBeUndefined(); // re-run: index already exists
+    await ds.query(`DROP TABLE "messages"`);
+    await expect(migration.up(runner)).resolves.toBeUndefined(); // absent table
+    await runner.release();
+  });
+});

--- a/src/modules/message/entities/message.entity.ts
+++ b/src/modules/message/entities/message.entity.ts
@@ -36,7 +36,7 @@ export enum MessageStatus {
 @Index(['chatId'])
 // Composite index for the ack-driven status UPDATE (scoped by sessionId + waMessageId).
 // Without it every ack does a full table scan of a hot table.
-@Index(['sessionId', 'waMessageId'])
+@Index('UQ_messages_sessionId_waMessageId', ['sessionId', 'waMessageId'], { unique: true })
 export class Message {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -1205,6 +1205,28 @@ describe('SessionService', () => {
 
       expect((webhookService.dispatch as jest.Mock).mock.calls.filter(c => c[1] === 'message.received')).toHaveLength(1);
     });
+
+    // ── persistHistoryMessages collision tolerance ───────────────────
+    describe('persistHistoryMessages collision tolerance', () => {
+      it('uses an insert-or-ignore bulk insert so a colliding history row cannot abort the batch', async () => {
+        const callbacks = await startAndCaptureCallbacks();
+        const execute = jest.fn().mockResolvedValue({ identifiers: [] });
+        const qb = { insert: jest.fn().mockReturnThis(), values: jest.fn().mockReturnThis(), orIgnore: jest.fn().mockReturnThis(), execute };
+        (messageRepository.createQueryBuilder as jest.Mock) = jest.fn().mockReturnValue(qb);
+        (messageRepository.find as jest.Mock).mockResolvedValue([]); // nothing pre-seen
+        (messageRepository.create as jest.Mock).mockImplementation((data: Record<string, unknown>) => ({ ...data }));
+        (messageRepository.save as jest.Mock).mockClear();
+
+        callbacks.onHistoryMessages?.([
+          { id: 'h1', from: 'peer@c.us', to: 'me@c.us', chatId: 'peer@c.us', body: 'old', type: 'text', timestamp: 1, fromMe: false, isGroup: false },
+        ]);
+        await flush();
+
+        expect(qb.orIgnore).toHaveBeenCalled();
+        expect(execute).toHaveBeenCalled();
+        expect(messageRepository.save).not.toHaveBeenCalled(); // no longer the throwing path
+      });
+    });
   });
 
   // ── stop ──────────────────────────────────────────────────────────

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -1182,16 +1182,30 @@ describe('SessionService', () => {
       (webhookService.dispatch as jest.Mock).mockClear();
       (messageRepository.insert as jest.Mock)
         .mockResolvedValueOnce(undefined) // first delivery: new row
-        .mockRejectedValueOnce({ driverError: { code: 'SQLITE_CONSTRAINT_UNIQUE', message: 'UNIQUE constraint failed' } }); // re-fire
+        .mockRejectedValueOnce({
+          driverError: { code: 'SQLITE_CONSTRAINT_UNIQUE', message: 'UNIQUE constraint failed' },
+        }); // re-fire
 
-      const msg = { id: 'wa-1', from: 'peer@c.us', to: 'me@c.us', chatId: 'peer@c.us', body: 'hi', type: 'text', timestamp: 1, fromMe: false, isGroup: false };
+      const msg = {
+        id: 'wa-1',
+        from: 'peer@c.us',
+        to: 'me@c.us',
+        chatId: 'peer@c.us',
+        body: 'hi',
+        type: 'text',
+        timestamp: 1,
+        fromMe: false,
+        isGroup: false,
+      };
       callbacks.onMessage?.(msg);
       await flush();
       callbacks.onMessage?.(msg); // re-fired engine event
       await flush();
 
       expect(messageRepository.insert).toHaveBeenCalledTimes(2);
-      expect((webhookService.dispatch as jest.Mock).mock.calls.filter(c => c[1] === 'message.received')).toHaveLength(1);
+      expect(
+        ((webhookService.dispatch as jest.Mock).mock.calls as unknown[][]).filter(c => c[1] === 'message.received'),
+      ).toHaveLength(1);
     });
 
     it('still dispatches message.received when the insert fails with a non-constraint error (fail-open)', async () => {
@@ -1200,10 +1214,22 @@ describe('SessionService', () => {
       (webhookService.dispatch as jest.Mock).mockClear();
       (messageRepository.insert as jest.Mock).mockRejectedValueOnce(new Error('db down'));
 
-      callbacks.onMessage?.({ id: 'wa-2', from: 'peer@c.us', to: 'me@c.us', chatId: 'peer@c.us', body: 'hi', type: 'text', timestamp: 1, fromMe: false, isGroup: false });
+      callbacks.onMessage?.({
+        id: 'wa-2',
+        from: 'peer@c.us',
+        to: 'me@c.us',
+        chatId: 'peer@c.us',
+        body: 'hi',
+        type: 'text',
+        timestamp: 1,
+        fromMe: false,
+        isGroup: false,
+      });
       await flush();
 
-      expect((webhookService.dispatch as jest.Mock).mock.calls.filter(c => c[1] === 'message.received')).toHaveLength(1);
+      expect(
+        ((webhookService.dispatch as jest.Mock).mock.calls as unknown[][]).filter(c => c[1] === 'message.received'),
+      ).toHaveLength(1);
     });
 
     // ── persistHistoryMessages collision tolerance ───────────────────
@@ -1211,14 +1237,29 @@ describe('SessionService', () => {
       it('uses an insert-or-ignore bulk insert so a colliding history row cannot abort the batch', async () => {
         const callbacks = await startAndCaptureCallbacks();
         const execute = jest.fn().mockResolvedValue({ identifiers: [] });
-        const qb = { insert: jest.fn().mockReturnThis(), values: jest.fn().mockReturnThis(), orIgnore: jest.fn().mockReturnThis(), execute };
+        const qb = {
+          insert: jest.fn().mockReturnThis(),
+          values: jest.fn().mockReturnThis(),
+          orIgnore: jest.fn().mockReturnThis(),
+          execute,
+        };
         (messageRepository.createQueryBuilder as jest.Mock) = jest.fn().mockReturnValue(qb);
         (messageRepository.find as jest.Mock).mockResolvedValue([]); // nothing pre-seen
         (messageRepository.create as jest.Mock).mockImplementation((data: Record<string, unknown>) => ({ ...data }));
         (messageRepository.save as jest.Mock).mockClear();
 
         callbacks.onHistoryMessages?.([
-          { id: 'h1', from: 'peer@c.us', to: 'me@c.us', chatId: 'peer@c.us', body: 'old', type: 'text', timestamp: 1, fromMe: false, isGroup: false },
+          {
+            id: 'h1',
+            from: 'peer@c.us',
+            to: 'me@c.us',
+            chatId: 'peer@c.us',
+            body: 'old',
+            type: 'text',
+            timestamp: 1,
+            fromMe: false,
+            isGroup: false,
+          },
         ]);
         await flush();
 

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -57,6 +57,7 @@ describe('SessionService', () => {
       findOne: jest.fn().mockResolvedValue(null),
       create: jest.fn(),
       save: jest.fn().mockResolvedValue(undefined),
+      insert: jest.fn().mockResolvedValue(undefined),
       update: jest.fn().mockResolvedValue({ affected: 1 }),
     };
 
@@ -607,7 +608,7 @@ describe('SessionService', () => {
     it('ignores onMessage from a superseded engine (no persist, no webhook)', async () => {
       const callbacks = await startAndCapture();
       enginesOf().set('sess-uuid-1', { marker: 'engine-B' });
-      (messageRepository.save as jest.Mock).mockClear();
+      (messageRepository.insert as jest.Mock).mockClear();
       (webhookService.dispatch as jest.Mock).mockClear();
 
       callbacks.onMessage?.({
@@ -623,7 +624,7 @@ describe('SessionService', () => {
       });
       await new Promise(resolve => setImmediate(resolve));
 
-      expect(messageRepository.save).not.toHaveBeenCalled();
+      expect(messageRepository.insert).not.toHaveBeenCalled();
       expect(webhookService.dispatch).not.toHaveBeenCalled();
     });
   });
@@ -1173,6 +1174,36 @@ describe('SessionService', () => {
         c => (c[2] as { status?: string }).status === SessionStatus.QR_READY,
       );
       expect(qrStatus).toHaveLength(1);
+    });
+
+    it('persists and dispatches message.received only once when the engine re-fires the same message', async () => {
+      const callbacks = await startAndCaptureCallbacks();
+      (messageRepository.insert as jest.Mock).mockReset();
+      (webhookService.dispatch as jest.Mock).mockClear();
+      (messageRepository.insert as jest.Mock)
+        .mockResolvedValueOnce(undefined) // first delivery: new row
+        .mockRejectedValueOnce({ driverError: { code: 'SQLITE_CONSTRAINT_UNIQUE', message: 'UNIQUE constraint failed' } }); // re-fire
+
+      const msg = { id: 'wa-1', from: 'peer@c.us', to: 'me@c.us', chatId: 'peer@c.us', body: 'hi', type: 'text', timestamp: 1, fromMe: false, isGroup: false };
+      callbacks.onMessage?.(msg);
+      await flush();
+      callbacks.onMessage?.(msg); // re-fired engine event
+      await flush();
+
+      expect(messageRepository.insert).toHaveBeenCalledTimes(2);
+      expect((webhookService.dispatch as jest.Mock).mock.calls.filter(c => c[1] === 'message.received')).toHaveLength(1);
+    });
+
+    it('still dispatches message.received when the insert fails with a non-constraint error (fail-open)', async () => {
+      const callbacks = await startAndCaptureCallbacks();
+      (messageRepository.insert as jest.Mock).mockReset();
+      (webhookService.dispatch as jest.Mock).mockClear();
+      (messageRepository.insert as jest.Mock).mockRejectedValueOnce(new Error('db down'));
+
+      callbacks.onMessage?.({ id: 'wa-2', from: 'peer@c.us', to: 'me@c.us', chatId: 'peer@c.us', body: 'hi', type: 'text', timestamp: 1, fromMe: false, isGroup: false });
+      await flush();
+
+      expect((webhookService.dispatch as jest.Mock).mock.calls.filter(c => c[1] === 'message.received')).toHaveLength(1);
     });
   });
 

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -486,7 +486,10 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
           return row;
         });
       if (rows.length) {
-        await this.messageRepository.save(rows);
+        // Insert-or-ignore: a live onMessage insert can land between the `seen` SELECT above and this
+        // write, colliding on UNIQUE(sessionId, waMessageId). orIgnore skips the collision instead of
+        // throwing and aborting the whole batch (history is best-effort, persist-never-dispatch).
+        await this.messageRepository.createQueryBuilder().insert().values(rows).orIgnore().execute();
         inserted += rows.length;
       }
     }

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -9,6 +9,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository, InjectDataSource } from '@nestjs/typeorm';
 import { Repository, In, Not, IsNull, DataSource, FindManyOptions } from 'typeorm';
+import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 import { Session, SessionStatus } from './entities/session.entity';
 import { Message, MessageDirection, MessageStatus } from '../message/entities/message.entity';
 import { CreateSessionDto } from './dto';
@@ -489,7 +490,12 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
         // Insert-or-ignore: a live onMessage insert can land between the `seen` SELECT above and this
         // write, colliding on UNIQUE(sessionId, waMessageId). orIgnore skips the collision instead of
         // throwing and aborting the whole batch (history is best-effort, persist-never-dispatch).
-        await this.messageRepository.createQueryBuilder().insert().values(rows).orIgnore().execute();
+        await this.messageRepository
+          .createQueryBuilder()
+          .insert()
+          .values(rows as unknown as QueryDeepPartialEntity<Message>[])
+          .orIgnore()
+          .execute();
         inserted += rows.length;
       }
     }
@@ -654,7 +660,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
             // message is never dropped by a transient DB failure.
             let isNewMessage = true;
             try {
-              await this.messageRepository.insert(dbMessage);
+              await this.messageRepository.insert(dbMessage as unknown as QueryDeepPartialEntity<Message>);
             } catch (err) {
               if (isUniqueConstraintError(err)) {
                 isNewMessage = false;

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -14,6 +14,7 @@ import { Message, MessageDirection, MessageStatus } from '../message/entities/me
 import { CreateSessionDto } from './dto';
 import { EngineFactory } from '../../engine/engine.factory';
 import { paginate, ListOptions } from '../../common/utils/paginate';
+import { isUniqueConstraintError } from '../../common/utils/unique-constraint.util';
 import {
   IWhatsAppEngine,
   EngineStatus,
@@ -643,9 +644,24 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
               metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
             });
 
-            void this.messageRepository.save(dbMessage).catch(err => {
-              this.logger.error(`Failed to save incoming message ${incoming.id} to database`, String(err));
-            });
+            // De-duplicate at the source: the engine can re-fire `message` for one inbound message
+            // (#464). UNIQUE(sessionId, waMessageId) makes the insert the atomic dedup oracle — a
+            // near-simultaneous re-fire loses the race and is skipped here, so persist + webhook + WS
+            // happen exactly once. Fail-open: a non-conflict DB error still dispatches, so a real
+            // message is never dropped by a transient DB failure.
+            let isNewMessage = true;
+            try {
+              await this.messageRepository.insert(dbMessage);
+            } catch (err) {
+              if (isUniqueConstraintError(err)) {
+                isNewMessage = false;
+              } else {
+                this.logger.error(`Failed to save incoming message ${incoming.id} to database`, String(err));
+              }
+            }
+            if (!isNewMessage) {
+              return; // duplicate re-fire — the original already persisted and dispatched
+            }
 
             // Dispatch to webhooks with potentially modified message
             void this.webhookService.dispatch(id, 'message.received', finalMessage);


### PR DESCRIPTION
Closes #464.

A single inbound WhatsApp message could reach a registered webhook **more than once** — sometimes twice within the same second — producing duplicate downstream side effects (double replies, duplicate records).

## Root cause

Not a fan-out bug in the delivery layer (a single `dispatch()` delivers each webhook once). The WhatsApp engine (`whatsapp-web.js`) can **re-fire the `message` event** for one inbound message, and the live inbound handler did a *blind* `create` + `save` + `dispatch` with no de-duplication — so a re-fired event produced both a duplicate `message.received` webhook **and** a duplicate row in `messages` (the second, previously-unreported symptom: the dashboard chat view would show the message twice).

## Change

Make inbound `message.received` exactly-once, deterministically — the DB unique constraint is the atomic de-dup oracle, so persist + webhook + WebSocket fire only when the row is genuinely new:

- **`UNIQUE(sessionId, waMessageId)` on `messages`** via a migration that first deletes pre-existing duplicates losslessly (a duplicate `(sessionId, waMessageId)` *is* the same message — keep the earliest per pair; `NULL` `waMessageId` rows are exempt, so transient outgoing `PENDING` rows are untouched). Reversible, idempotent, SQLite + PostgreSQL.
- **Inbound handler** now does `insert` + catch the unique-violation: a re-fired event loses the insert race and is skipped; a non-conflict DB error **fails open** (still dispatches — a real message is never dropped by a transient failure).
- **History-merge** bulk insert switched to `INSERT OR IGNORE` / `ON CONFLICT DO NOTHING` so a live insert racing the history backfill can't abort the batch under the new constraint.
- **Docs:** the webhook delivery contract is now documented as **at-least-once**, pointing integrators at the existing `X-OpenWA-Idempotency-Key` header (content-based, identical across duplicates) — the server-side guard is best-effort defense-in-depth, not a replacement for consumer idempotency.

## Out of scope (deliberate)

Outgoing `message.sent` de-duplication is **not** included: it would require unifying how sent messages are persisted (today split between the REST send path — which also backs bulk sends — and the engine echo) and reworking the failed-send path — a large refactor of the entire outbound pipeline for an unreported symptom. Tracked as a separate follow-up. The at-least-once doc note covers all events regardless.

## Testing

- New unit tests for the cross-dialect unique-error predicate, the migration (keep-earliest + `NULL`-exempt + idempotent), the inbound dedup (re-fire → one webhook/row; non-constraint error → still dispatches), and the collision-tolerant history insert.
- Full backend suite: **1365 passing / 111 suites**, coverage thresholds met; `npm run build` + `npm run lint` clean; dashboard build + lint clean.