### PR TITLE
fix: infra-status storage path + SDK timestamp/PHP type accuracy

### DIFF
--- a/sdk/javascript/src/types.ts
+++ b/sdk/javascript/src/types.ts
@@ -87,7 +87,7 @@ export interface SessionStatsOverview {
 /** Returned by every send operation. */
 export interface MessageResponse {
   messageId: string;
-  /** Unix timestamp in milliseconds. */
+  /** Unix timestamp in seconds. */
   timestamp: number;
 }
 
@@ -191,7 +191,7 @@ export interface MessageRecord {
   body?: string | null;
   type: string;
   direction: MessageDirection;
-  /** Unix timestamp in milliseconds. */
+  /** Unix timestamp in seconds. */
   timestamp?: number | null;
   metadata?: Record<string, unknown> | null;
   status: DeliveryStatus;

--- a/sdk/php/src/Client.php
+++ b/sdk/php/src/Client.php
@@ -118,7 +118,7 @@ class Client
      * @param mixed|null          $body   JSON-serializable request body.
      * @return mixed Decoded JSON, or null for empty/204 responses.
      */
-    public function request(string $method, string $path, array $query = [], $body = null)
+    public function request(string $method, string $path, array $query = [], mixed $body = null): mixed
     {
         return $this->http->request($method, $path, $query, $body);
     }

--- a/src/modules/infra/infra.controller.spec.ts
+++ b/src/modules/infra/infra.controller.spec.ts
@@ -618,6 +618,39 @@ describe('InfraController.getStatus engine (F7 — reads the real engine.puppete
   });
 });
 
+describe('InfraController.getStatus storage (reads the real storage.localPath key)', () => {
+  const buildController = (map: Record<string, unknown>) => {
+    const config = { get: (key: string, def?: unknown) => (key in map ? map[key] : def) };
+    const cache = { isAvailable: () => Promise.resolve(false) };
+    const ds = { isInitialized: true };
+    return new InfraController(
+      config as never,
+      ds as never,
+      ds as never,
+      {} as never,
+      {} as never,
+      cache as never,
+      {} as never,
+      {} as never,
+    );
+  };
+
+  it('reports the configured storage.localPath, not the ./uploads fallback', async () => {
+    // The bug: status read the non-existent `storage.path` key, so it always reported the
+    // `./uploads` fallback instead of the real path StorageService uses (`storage.localPath`).
+    const status = await buildController({
+      'storage.type': 'local',
+      'storage.localPath': '/srv/openwa/media',
+    }).getStatus();
+    expect(status.storage.path).toBe('/srv/openwa/media');
+  });
+
+  it('falls back to ./data/media (matching StorageService) when storage.localPath is unset', async () => {
+    const status = await buildController({ 'storage.type': 'local' }).getStatus();
+    expect(status.storage.path).toBe('./data/media');
+  });
+});
+
 describe('InfraController.exportStorage keeps the export import-able and sweeps it', () => {
   function buildController(storage: Partial<{ createExportStream: jest.Mock }>) {
     return new InfraController(

--- a/src/modules/infra/infra.controller.ts
+++ b/src/modules/infra/infra.controller.ts
@@ -237,7 +237,9 @@ export class InfraController {
     const redisConnected = await this.cacheService.isAvailable();
 
     const storageType = this.configService.get<'local' | 's3'>('storage.type', 'local');
-    const storagePath = this.configService.get<string>('storage.path', './uploads');
+    // Read the key StorageService actually uses (`storage.localPath`, default `./data/media`).
+    // The old `storage.path` key never existed, so status always reported the `./uploads` fallback.
+    const storagePath = this.configService.get<string>('storage.localPath', './data/media');
 
     const engineType = this.configService.get<string>('engine.type', 'whatsapp-web.js');
     // configuration.ts nests these under engine.puppeteer.{headless,args}; the old flat


### PR DESCRIPTION
## Summary

Three small bugs surfaced while self-reviewing the documentation reconciliation (#471). Code-only; each is independently verified against source.

## Fixes

1. **infra: `GET /api/infra/status` reports the wrong storage path.** The handler read `configService.get('storage.path', './uploads')`, but no `storage.path` key exists — `StorageService` uses `storage.localPath` (default `./data/media`). So the status endpoint (shown in the dashboard Infrastructure tile) **always** reported `./uploads`, never the real configured path. Now reads `storage.localPath`. Adds a regression test (fails on the old key, passes on the new).
2. **sdk(js): `timestamp` JSDoc said "milliseconds" but the value is epoch seconds.** `MessageResponse.timestamp` and `MessageRecord.timestamp` carry the engine's message timestamp (Unix **seconds**), passed through unchanged — and the SDK's own `ChatHistoryMessage`/`ReactionRecord`/`GroupInfo` types already document "seconds". Corrected the two stray "milliseconds" comments. (Comment-only; no behavior change.)
3. **sdk(php): `Client::request()` lacked type hints.** Added `mixed $body` and a `: mixed` return type, consistent with `declare(strict_types=1)` and the rest of the client.

## Verification

- Backend: `build` ✓, `lint` ✓, `jest` **1374/1374** ✓ (incl. 2 new infra-status storage tests).
- JS SDK: dual CJS/ESM `build` ✓, `vitest` **42/42** ✓.
- PHP SDK: `php -l` ✓, `phpunit` **39/39** ✓.

## Note

Pairs with the docs PR **#471**: the infra-status path and the PHP `request()` signature are documented there to match these fixes (`./data/media`; typed signature). Merging this PR first (or together) keeps docs and code aligned; if #471 lands first, those two doc lines describe the post-fix behavior.
