### PR TITLE
chore: remove internal review-reference codes from comments and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -118,14 +118,14 @@ DATABASE_HOST=localhost
 DATABASE_PORT=5432
 DATABASE_NAME=openwa
 DATABASE_USERNAME=openwa
-# MUST set a strong, unique value before using Postgres — no default is shipped (M16).
+# MUST set a strong, unique value before using Postgres — no default is shipped.
 # Production refuses to start if this is empty or a known placeholder when DATABASE_TYPE=postgres.
 DATABASE_PASSWORD=
 DATABASE_SYNCHRONIZE=false          # WARNING: Set false in production! (data DB)
 DATABASE_LOGGING=false
 # Auth/audit (main) DB schema management. Default ON (zero-config first boot).
 # Set to "false" to manage the api_keys/audit_logs schema via the bundled main-owned
-# migration instead of synchronize (migrationsRun creates them at boot). Finding H12/M18.
+# migration instead of synchronize (migrationsRun creates them at boot).
 MAIN_DATABASE_SYNCHRONIZE=true
 DATABASE_SSL=false                   # Set true for managed Postgres (Supabase, Heroku, Render, Railway)
 DATABASE_SSL_REJECT_UNAUTHORIZED=true # Set false to allow self-signed certs (only when DATABASE_SSL=true)
@@ -155,7 +155,7 @@ STORAGE_LOCAL_PATH=./data/media
 S3_ENDPOINT=http://localhost:9000
 S3_BUCKET=openwa
 S3_REGION=us-east-1
-# MUST set strong, unique values before using S3/MinIO — no defaults shipped (M16).
+# MUST set strong, unique values before using S3/MinIO — no defaults shipped.
 # Production refuses to start if these are empty/placeholder when STORAGE_TYPE=s3.
 S3_ACCESS_KEY=
 S3_SECRET_KEY=

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,4 +1,4 @@
-# OpenWA - Local smoke / quick-start compose (L22)
+# OpenWA - Local smoke / quick-start compose
 #
 # This builds and runs the PRODUCTION image (same Dockerfile) against a local SQLite DB
 # with a bind-mounted ./data — it is a single-container local smoke test, NOT a
@@ -15,7 +15,7 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: openwa-api
-    # Container hardening (finding H7) — same posture as production (same Dockerfile/entrypoint).
+    # Container hardening — same posture as production (same Dockerfile/entrypoint).
     security_opt:
       - 'no-new-privileges:true'
     cap_drop:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: openwa-docker-proxy
     restart: unless-stopped
     # Only on the isolated internal network — reachable solely by openwa-api, NOT the
-    # dashboard or any other peer (finding H6). `internal: true` also denies the proxy
+    # dashboard or any other peer. `internal: true` also denies the proxy
     # outbound access; it only needs the locally-mounted docker socket.
     networks:
       - internal-docker
@@ -40,7 +40,7 @@ services:
     networks:
       - openwa-network
       - internal-docker
-    # Container hardening (finding H7): Chromium runs with --no-sandbox, so the
+    # Container hardening: Chromium runs with --no-sandbox, so the
     # container itself is the confinement boundary. cap_drop ALL + a minimal re-add
     # ONLY for the root entrypoint's chown + gosu privilege-drop; once gosu setuids to
     # the openwa user the node/Chromium process keeps NO effective capabilities.
@@ -84,7 +84,7 @@ services:
       - DATABASE_HOST=${DATABASE_HOST:-postgres}
       - DATABASE_PORT=${DATABASE_PORT:-5432}
       - DATABASE_USERNAME=${DATABASE_USERNAME:-openwa}
-      # No committed default secret (M16). Empty for the default sqlite setup; the
+      # No committed default secret. Empty for the default sqlite setup; the
       # postgres service requires it (:?) when that profile is active.
       - DATABASE_PASSWORD=${DATABASE_PASSWORD:-}
       - DATABASE_SYNCHRONIZE=${DATABASE_SYNCHRONIZE:-false}

--- a/docs/10-devops-infrastructure.md
+++ b/docs/10-devops-infrastructure.md
@@ -1,6 +1,6 @@
 # 10 - DevOps & Infrastructure
 
-> **⚠️ Conceptual reference (M9).** Some examples here predate the shipped runtime and may not
+> **⚠️ Conceptual reference.** Some examples here predate the shipped runtime and may not
 > match it exactly. The **authoritative** sources are the repo's `Dockerfile`, `docker-compose.yml`
 > (Docker socket-proxy threat model, gosu non-root drop, loopback-bound datastores, container
 > hardening), and `.env.example` (canonical env var names). Where this doc and those disagree,
@@ -113,7 +113,7 @@ services:
       - DATABASE_URL=postgresql://openwa:openwa@postgres:5432/openwa
       - REDIS_URL=redis://redis:6379
       # The env var is API_MASTER_KEY (not API_KEY_MASTER); never hardcode a key — set a
-      # strong secret. Production refuses to boot with a placeholder/default (M9/M16).
+      # strong secret. Production refuses to boot with a placeholder/default.
       - API_MASTER_KEY=
     volumes:
       - ./:/app

--- a/docs/11-operational-runbooks.md
+++ b/docs/11-operational-runbooks.md
@@ -418,7 +418,7 @@ docker compose pull
 
 # 7. Run database migrations (if any)
 # Use migration:run:prod in the production image — `migration:run` needs ts-node + the TS
-# source, both stripped from the prod image by `npm ci --omit=dev` (M13).
+# source, both stripped from the prod image by `npm ci --omit=dev`.
 docker compose run --rm openwa npm run migration:run:prod
 
 # 8. Start services

--- a/docs/13-horizontal-scaling.md
+++ b/docs/13-horizontal-scaling.md
@@ -5,7 +5,7 @@
 > **OpenWA is currently a single-process, single-instance application.** Live WhatsApp
 > engine state (browser + WebSocket + reconnect/error state) lives in an in-memory `Map`
 > in `SessionService`; there is **no** DB-backed session registry, **no** node-claim/lease,
-> and **no** Socket.IO Redis adapter (findings H1/H11).
+> and **no** Socket.IO Redis adapter.
 >
 > **Supported topology:** exactly **one** API instance per session-data volume. Running
 > multiple replicas against a shared session volume — as the multi-node examples below
@@ -107,7 +107,7 @@ services:
   openwa:
     image: ghcr.io/rmyndharis/openwa:0.4.6
     deploy:
-      replicas: 1 # MUST stay 1 until session-claim is implemented — multiple replicas on one session volume corrupt WhatsApp auth (H1/H11)
+      replicas: 1 # MUST stay 1 until session-claim is implemented — multiple replicas on one session volume corrupt WhatsApp auth
       update_config:
         parallelism: 1
         delay: 30s
@@ -252,7 +252,7 @@ metadata:
   namespace: openwa
 spec:
   serviceName: openwa
-  replicas: 1 # MUST stay 1 until session-claim is implemented (H1/H11) — see the warning at the top of this guide
+  replicas: 1 # MUST stay 1 until session-claim is implemented — see the warning at the top of this guide
   selector:
     matchLabels:
       app: openwa

--- a/docs/14-migration-guide.md
+++ b/docs/14-migration-guide.md
@@ -752,7 +752,7 @@ docker run --rm \
   -v $(pwd)/data:/app/data \
   -e DATABASE_URL=sqlite:///app/data/openwa.db \
   ghcr.io/rmyndharis/openwa:0.2.0 \
-  npm run migration:run:prod   # the prod image strips ts-node/TS source — use :prod (M13)
+  npm run migration:run:prod   # the prod image strips ts-node/TS source — use :prod
 
 # 4. Migrate configuration
 echo "⚙️ Migrating configuration..."

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,7 +33,7 @@ export default tseslint.config(
     },
   },
   {
-    // Architecture guard (M1): HTTP controllers must go through a per-capability service and
+    // Architecture guard: HTTP controllers must go through a per-capability service and
     // never reach for the raw WhatsApp engine. This keeps the "session not started" guard,
     // error mapping, and business rules behind the service boundary instead of leaking into
     // controllers. `.getEngine(` (not `.getEngines()`) and the `IWhatsAppEngine` type are banned.
@@ -44,7 +44,7 @@ export default tseslint.config(
         {
           selector: "CallExpression[callee.property.name='getEngine']",
           message:
-            'Controllers must not call getEngine(). Add a method to the capability service (e.g. GroupService) and call that instead (M1).',
+            'Controllers must not call getEngine(). Add a method to the capability service (e.g. GroupService) and call that instead.',
         },
       ],
       'no-restricted-imports': [
@@ -57,7 +57,7 @@ export default tseslint.config(
               group: ['**/engine/interfaces/whatsapp-engine.interface'],
               importNames: ['IWhatsAppEngine'],
               message:
-                'Controllers must not import IWhatsAppEngine. Keep engine types behind a capability service (M1).',
+                'Controllers must not import IWhatsAppEngine. Keep engine types behind a capability service.',
             },
           ],
         },

--- a/src/engine/adapters/baileys-message-store.service.spec.ts
+++ b/src/engine/adapters/baileys-message-store.service.spec.ts
@@ -31,7 +31,7 @@ describe('BaileysMessageStoreService', () => {
       type: 'sqlite',
       database: ':memory:',
       // Session must be present so the @ManyToOne relation metadata resolves and synchronize
-      // can emit the CASCADE FK on the baileys_stored_messages table (I6).
+      // can emit the CASCADE FK on the baileys_stored_messages table.
       entities: [BaileysStoredMessage, Session],
       synchronize: true,
     });
@@ -75,7 +75,7 @@ describe('BaileysMessageStoreService', () => {
   });
 
   /**
-   * C1 regression test — drives eviction through the REAL put() path so the stored
+   * Regression test — drives eviction through the REAL put() path so the stored
    * createdAt value comes from the upsert payload (millisecond precision), not from
    * SQLite's datetime('now') (second precision). Without the `createdAt: new Date()`
    * fix in put(), the string comparison '…:XX' < '…:XX.000' evaluates TRUE for every
@@ -84,7 +84,7 @@ describe('BaileysMessageStoreService', () => {
    * This test MUST FAIL against the old code (no explicit createdAt in upsert) and
    * PASS with the fix.
    */
-  it('eviction via put() keeps exactly the cap — never wipes the store (C1)', async () => {
+  it('eviction via put() keeps exactly the cap — never wipes the store', async () => {
     process.env.BAILEYS_MESSAGE_STORE_LIMIT = '3';
     await seedSession('s_c1');
     const s = new BaileysMessageStoreService(repo);

--- a/src/engine/adapters/baileys-message-store.service.ts
+++ b/src/engine/adapters/baileys-message-store.service.ts
@@ -61,7 +61,7 @@ export class BaileysMessageStoreService implements BaileysMessageStore {
     // :createdAt bound param used in enforceLimit(). Without this, SQLite's datetime('now') stores
     // second-precision (e.g. '…:11') while the JS Date bound serializes as '…:11.000', and SQLite
     // string-compares '…:11' < '…:11.000' = TRUE, causing every same-second row to be over-evicted
-    // and the store to be wiped to ~0 (C1).
+    // and the store to be wiped to ~0.
     try {
       await this.repo.upsert({ sessionId, waMessageId, serializedMessage, createdAt: new Date() }, [
         'sessionId',

--- a/src/engine/adapters/baileys-stored-message.entity.ts
+++ b/src/engine/adapters/baileys-stored-message.entity.ts
@@ -7,7 +7,7 @@ import { Session } from '../../modules/session/entities/session.entity';
  * restarts. Engine-specific — lives in the engine layer, not the neutral `messages` table.
  *
  * The `session` relation declares the CASCADE FK so both the `synchronize:true` SQLite path and
- * the migration path clean up stored messages when the parent session row is deleted (I6).
+ * the migration path clean up stored messages when the parent session row is deleted.
  */
 @Entity('baileys_stored_messages')
 @Index(['sessionId', 'waMessageId'], { unique: true }) // lookup + dedup (send-return vs upsert echo)

--- a/src/modules/queue/queue.module.ts
+++ b/src/modules/queue/queue.module.ts
@@ -33,7 +33,7 @@ export { QUEUE_NAMES } from './queue-names';
     BullModule.registerQueue({
       name: QUEUE_NAMES.WEBHOOK,
       // Auto-evict finished jobs so completed/failed webhook payloads don't accumulate in Redis
-      // unbounded (M19). Keep a small recent window for debugging; cap age too.
+      // unbounded. Keep a small recent window for debugging; cap age too.
       defaultJobOptions: {
         removeOnComplete: { age: 3600, count: 1000 },
         removeOnFail: { age: 86400, count: 5000 },


### PR DESCRIPTION
Housekeeping. A handful of inline comments and docs carried short internal tracking codes (e.g. in `docker-compose*.yml`, `.env.example`, `eslint.config.mjs`, the queue/baileys modules, and a few `docs/` pages) that are meaningless to outside readers.

This drops the codes and keeps the explanatory text they annotated. No runtime behaviour changes — comments, docs, one ESLint message string, and one test title only.

12 files, symmetric edits (each removes a parenthetical, prose unchanged). Build + lint + full backend suite (1433) green.