### PR TITLE
feat: add MEDIA_DOWNLOAD_ENABLED env var to skip inbound media download

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -192,6 +192,8 @@ WEBHOOK_SSRF_PROTECT=true
 # store or a sidecar webhook receiver).
 # SSRF_ALLOWED_HOSTS=localhost,minio
 # Server-side media size/time limits:
+# MEDIA_DOWNLOAD_ENABLED=true          # Set to false to skip downloading inbound media entirely
+#                                     # (no decryption, no memory allocation, no storage).
 # MEDIA_DOWNLOAD_MAX_BYTES=52428800   # cap remote-URL sends, inbound media, AND outbound base64 sends (default 50 MiB; oversized inbound media is dropped, message kept; oversized base64 is rejected with 400)
 # MEDIA_DOWNLOAD_TIMEOUT_MS=30000     # abort a slow media download (default 30s)
 # Storage import/export limits (ADMIN /infra/storage/* endpoints):

--- a/.env.example
+++ b/.env.example
@@ -194,6 +194,8 @@ WEBHOOK_SSRF_PROTECT=true
 # Server-side media size/time limits:
 # MEDIA_DOWNLOAD_ENABLED=true          # Set to false to skip downloading inbound media entirely
 #                                     # (no decryption, no memory allocation, no storage).
+#                                     # NOTE: disabling also makes hasMedia report false and removes the
+#                                     # media field from webhooks and the dashboard.
 # MEDIA_DOWNLOAD_MAX_BYTES=52428800   # cap remote-URL sends, inbound media, AND outbound base64 sends (default 50 MiB; oversized inbound media is dropped, message kept; oversized base64 is rejected with 400)
 # MEDIA_DOWNLOAD_TIMEOUT_MS=30000     # abort a slow media download (default 30s)
 # Storage import/export limits (ADMIN /infra/storage/* endpoints):

--- a/src/engine/adapters/baileys.adapter.spec.ts
+++ b/src/engine/adapters/baileys.adapter.spec.ts
@@ -874,6 +874,44 @@ describe('BaileysAdapter inbound fan-out', () => {
     }
   });
 
+  it('inbound media: skips download and omits media field when MEDIA_DOWNLOAD_ENABLED=false', async () => {
+    const prev = process.env.MEDIA_DOWNLOAD_ENABLED;
+    process.env.MEDIA_DOWNLOAD_ENABLED = 'false';
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+      const baileys = jest.requireMock('@whiskeysockets/baileys') as {
+        getContentType: jest.Mock;
+        downloadMediaMessage: jest.Mock;
+      };
+      baileys.getContentType.mockReturnValue('imageMessage');
+      baileys.downloadMediaMessage.mockClear();
+
+      const onMessage = jest.fn();
+      const adapter = newAdapter();
+      await adapter.initialize({ onMessage });
+      fakeSock.fire('messages.upsert', {
+        type: 'notify',
+        messages: [
+          {
+            key: { remoteJid: '628111@s.whatsapp.net', fromMe: false, id: 'DISABLED1' },
+            message: { imageMessage: { mimetype: 'image/png', caption: 'should not download' } },
+            messageTimestamp: 1700000040,
+          },
+        ],
+      });
+      await new Promise(r => setImmediate(r));
+      expect(onMessage).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const msg = onMessage.mock.calls[0][0] as { media?: unknown; type: string };
+      expect(msg.type).toBe('image');
+      expect(msg.media).toBeUndefined();
+      expect(baileys.downloadMediaMessage).not.toHaveBeenCalled();
+    } finally {
+      if (prev === undefined) delete process.env.MEDIA_DOWNLOAD_ENABLED;
+      else process.env.MEDIA_DOWNLOAD_ENABLED = prev;
+    }
+  });
+
   it('inbound documentWithCaption: normalizeMessageContent unwraps wrapper, yields non-empty mimetype', async () => {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     const baileys = jest.requireMock('@whiskeysockets/baileys') as {

--- a/src/engine/adapters/baileys.adapter.ts
+++ b/src/engine/adapters/baileys.adapter.ts
@@ -43,9 +43,10 @@ import { BaileysAdapterConfig, BaileysLogger } from '../types/baileys.types';
 import { BaileysSessionStore } from './baileys-session-store';
 import {
   capInboundMedia,
+  coerceDeclaredSize,
   inboundMediaConcurrency,
   inboundMediaMaxBytes,
-  coerceDeclaredSize,
+  isMediaDownloadEnabled,
 } from './inbound-media-cap';
 import { ConcurrencyLimiter } from './concurrency-limiter';
 
@@ -1013,53 +1014,58 @@ export class BaileysAdapter implements IWhatsAppEngine {
       contentType === 'documentWithCaptionMessage' ||
       contentType === 'stickerMessage';
     if (isMediaType) {
-      // normalizeMessageContent unwraps documentWithCaptionMessage / viewOnceMessage / ephemeralMessage
-      // so we reach the inner media sub-message — needed BEFORE download for the declared-size pre-gate.
-      const normalizedContent = b.normalizeMessageContent(content) ?? content;
-      const subMessage =
-        normalizedContent.imageMessage ??
-        normalizedContent.videoMessage ??
-        normalizedContent.audioMessage ??
-        normalizedContent.documentMessage ??
-        normalizedContent.stickerMessage;
-      const mimetype = subMessage?.mimetype ?? '';
-      const filename = normalizedContent.documentMessage?.fileName ?? undefined;
-      const maxBytes = inboundMediaMaxBytes();
-      const declared = coerceDeclaredSize(subMessage?.fileLength);
-
-      if (declared > maxBytes) {
-        // Pre-download gate: an honest over-cap sender's media is never decrypted into heap at all
-        // (Baileys integrity-checks content against the declared size, so this is a robust bound).
-        media = { mimetype, filename, omitted: true, sizeBytes: declared };
-        this.logger.warn('Inbound media declared size exceeds MEDIA_DOWNLOAD_MAX_BYTES; skipped download', {
-          msgId: msg.key.id,
-          sizeBytes: declared,
-        });
+      if (!isMediaDownloadEnabled()) {
+        // media stays undefined — Media download disabled entirely via MEDIA_DOWNLOAD_ENABLED=false.
+        // The message is emitted without a media field.
       } else {
-        try {
-          // Stream-download with a running-total abort so a sender who understates fileLength still
-          // can't materialise an over-cap blob. For under-cap media this yields the identical buffer.
-          const buf = await this.downloadInboundMediaCapped(msg, maxBytes);
-          if (buf === null) {
-            media = { mimetype, filename, omitted: true, sizeBytes: maxBytes };
-            this.logger.warn('Inbound media exceeded MEDIA_DOWNLOAD_MAX_BYTES mid-download; aborted', {
+        // normalizeMessageContent unwraps documentWithCaptionMessage / viewOnceMessage / ephemeralMessage
+        // so we reach the inner media sub-message — needed BEFORE download for the declared-size pre-gate.
+        const normalizedContent = b.normalizeMessageContent(content) ?? content;
+        const subMessage =
+          normalizedContent.imageMessage ??
+          normalizedContent.videoMessage ??
+          normalizedContent.audioMessage ??
+          normalizedContent.documentMessage ??
+          normalizedContent.stickerMessage;
+        const mimetype = subMessage?.mimetype ?? '';
+        const filename = normalizedContent.documentMessage?.fileName ?? undefined;
+        const maxBytes = inboundMediaMaxBytes();
+        const declared = coerceDeclaredSize(subMessage?.fileLength);
+
+        if (declared > maxBytes) {
+          // Pre-download gate: an honest over-cap sender's media is never decrypted into heap at all
+          // (Baileys integrity-checks content against the declared size, so this is a robust bound).
+          media = { mimetype, filename, omitted: true, sizeBytes: declared };
+          this.logger.warn('Inbound media declared size exceeds MEDIA_DOWNLOAD_MAX_BYTES; skipped download', {
+            msgId: msg.key.id,
+            sizeBytes: declared,
+          });
+        } else {
+          try {
+            // Stream-download with a running-total abort so a sender who understates fileLength still
+            // can't materialise an over-cap blob. For under-cap media this yields the identical buffer.
+            const buf = await this.downloadInboundMediaCapped(msg, maxBytes);
+            if (buf === null) {
+              media = { mimetype, filename, omitted: true, sizeBytes: maxBytes };
+              this.logger.warn('Inbound media exceeded MEDIA_DOWNLOAD_MAX_BYTES mid-download; aborted', {
+                msgId: msg.key.id,
+              });
+            } else {
+              // capInboundMedia is the last line (lazy base64, never persist/webhook/broadcast an over-cap
+              // blob); the real heap bound is the pre-gate + streaming abort + concurrency limiter.
+              media = capInboundMedia({
+                mimetype,
+                filename,
+                sizeBytes: buf.byteLength,
+                toBase64: () => buf.toString('base64'),
+              });
+            }
+          } catch (err) {
+            this.logger.debug('Failed to download inbound media; emitting message without media', {
+              error: err instanceof Error ? err.message : String(err),
               msgId: msg.key.id,
             });
-          } else {
-            // capInboundMedia is the last line (lazy base64, never persist/webhook/broadcast an over-cap
-            // blob); the real heap bound is the pre-gate + streaming abort + concurrency limiter.
-            media = capInboundMedia({
-              mimetype,
-              filename,
-              sizeBytes: buf.byteLength,
-              toBase64: () => buf.toString('base64'),
-            });
           }
-        } catch (err) {
-          this.logger.debug('Failed to download inbound media; emitting message without media', {
-            error: err instanceof Error ? err.message : String(err),
-            msgId: msg.key.id,
-          });
         }
       }
     }

--- a/src/engine/adapters/inbound-media-cap.spec.ts
+++ b/src/engine/adapters/inbound-media-cap.spec.ts
@@ -3,6 +3,7 @@ import {
   inboundMediaMaxBytes,
   inboundMediaConcurrency,
   coerceDeclaredSize,
+  isMediaDownloadEnabled,
 } from './inbound-media-cap';
 
 describe('inbound media cap', () => {
@@ -67,6 +68,46 @@ describe('inbound media cap', () => {
       expect(inboundMediaMaxBytes()).toBe(50 * 1024 * 1024);
       process.env[ENV] = 'abc';
       expect(inboundMediaMaxBytes()).toBe(50 * 1024 * 1024);
+    });
+  });
+
+  describe('isMediaDownloadEnabled', () => {
+    const ENV = 'MEDIA_DOWNLOAD_ENABLED';
+    const orig = process.env[ENV];
+    afterEach(() => {
+      if (orig === undefined) delete process.env[ENV];
+      else process.env[ENV] = orig;
+    });
+
+    it('defaults to true when unset', () => {
+      delete process.env[ENV];
+      expect(isMediaDownloadEnabled()).toBe(true);
+    });
+
+    it('returns false when set to "false"', () => {
+      process.env[ENV] = 'false';
+      expect(isMediaDownloadEnabled()).toBe(false);
+    });
+
+    it('returns false when set to "0"', () => {
+      process.env[ENV] = '0';
+      expect(isMediaDownloadEnabled()).toBe(false);
+    });
+
+    it('returns false when set to "no"', () => {
+      process.env[ENV] = 'no';
+      expect(isMediaDownloadEnabled()).toBe(false);
+    });
+
+    it('returns true for any other value', () => {
+      process.env[ENV] = 'true';
+      expect(isMediaDownloadEnabled()).toBe(true);
+      process.env[ENV] = '1';
+      expect(isMediaDownloadEnabled()).toBe(true);
+      process.env[ENV] = 'yes';
+      expect(isMediaDownloadEnabled()).toBe(true);
+      process.env[ENV] = 'whatever';
+      expect(isMediaDownloadEnabled()).toBe(true);
     });
   });
 

--- a/src/engine/adapters/inbound-media-cap.spec.ts
+++ b/src/engine/adapters/inbound-media-cap.spec.ts
@@ -89,6 +89,17 @@ describe('inbound media cap', () => {
       expect(isMediaDownloadEnabled()).toBe(false);
     });
 
+    it('returns false for case/whitespace variants of false', () => {
+      process.env[ENV] = 'FALSE';
+      expect(isMediaDownloadEnabled()).toBe(false);
+      process.env[ENV] = 'False';
+      expect(isMediaDownloadEnabled()).toBe(false);
+      process.env[ENV] = ' false ';
+      expect(isMediaDownloadEnabled()).toBe(false);
+      process.env[ENV] = ' FALSE ';
+      expect(isMediaDownloadEnabled()).toBe(false);
+    });
+
     it('returns false when set to "0"', () => {
       process.env[ENV] = '0';
       expect(isMediaDownloadEnabled()).toBe(false);

--- a/src/engine/adapters/inbound-media-cap.ts
+++ b/src/engine/adapters/inbound-media-cap.ts
@@ -28,10 +28,10 @@ const DEFAULT_MEDIA_DOWNLOAD_ENABLED = true;
 /**
  * Whether inbound media download is enabled. When false, the engine skips downloading media from
  * incoming messages entirely — no decryption, no memory allocation, no storage. Override via
- * MEDIA_DOWNLOAD_ENABLED; accepts 'false', '0', or 'no' (case-sensitive) to disable.
+ * MEDIA_DOWNLOAD_ENABLED; accepts 'false', '0', or 'no' (case-insensitive, whitespace-tolerant) to disable.
  */
 export function isMediaDownloadEnabled(): boolean {
-  const val = process.env.MEDIA_DOWNLOAD_ENABLED ?? '';
+  const val = (process.env.MEDIA_DOWNLOAD_ENABLED ?? '').trim().toLowerCase();
   return val !== 'false' && val !== '0' && val !== 'no';
 }
 

--- a/src/engine/adapters/inbound-media-cap.ts
+++ b/src/engine/adapters/inbound-media-cap.ts
@@ -22,9 +22,6 @@ export function inboundMediaConcurrency(): number {
   return Number.isInteger(parsed) && parsed > 0 ? parsed : DEFAULT_INBOUND_MEDIA_CONCURRENCY;
 }
 
-/** Default for inbound media download. */
-const DEFAULT_MEDIA_DOWNLOAD_ENABLED = true;
-
 /**
  * Whether inbound media download is enabled. When false, the engine skips downloading media from
  * incoming messages entirely — no decryption, no memory allocation, no storage. Override via

--- a/src/engine/adapters/inbound-media-cap.ts
+++ b/src/engine/adapters/inbound-media-cap.ts
@@ -22,6 +22,19 @@ export function inboundMediaConcurrency(): number {
   return Number.isInteger(parsed) && parsed > 0 ? parsed : DEFAULT_INBOUND_MEDIA_CONCURRENCY;
 }
 
+/** Default for inbound media download. */
+const DEFAULT_MEDIA_DOWNLOAD_ENABLED = true;
+
+/**
+ * Whether inbound media download is enabled. When false, the engine skips downloading media from
+ * incoming messages entirely — no decryption, no memory allocation, no storage. Override via
+ * MEDIA_DOWNLOAD_ENABLED; accepts 'false', '0', or 'no' (case-sensitive) to disable.
+ */
+export function isMediaDownloadEnabled(): boolean {
+  const val = process.env.MEDIA_DOWNLOAD_ENABLED ?? '';
+  return val !== 'false' && val !== '0' && val !== 'no';
+}
+
 /**
  * Coerce a sender-declared media size (a protobuf `fileLength`, which may be a number, a Long-like
  * `{ toNumber() }`, a numeric string, or absent) to a finite byte count. Unknown/garbage → 0, i.e.

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -787,3 +787,54 @@ describe('resolveAuthTimeoutMs (#353 — configurable first-boot init wait)', ()
     expect(resolveAuthTimeoutMs()).toBe(600000);
   });
 });
+
+describe('WhatsAppWebJsAdapter inbound media (MEDIA_DOWNLOAD_ENABLED=false)', () => {
+  const ENV = 'MEDIA_DOWNLOAD_ENABLED';
+  const orig = process.env[ENV];
+
+  afterEach(() => {
+    if (orig === undefined) delete process.env[ENV];
+    else process.env[ENV] = orig;
+  });
+
+  it('skips media download and omits the media field when disabled', async () => {
+    process.env[ENV] = 'false';
+
+    const adapter = new WhatsAppWebJsAdapter({
+      sessionId: 'sess-media-test',
+      sessionDataPath: './data/sessions',
+      puppeteer: {},
+    });
+    const client = Object.assign(new EventEmitter(), {
+      info: { wid: { user: '628123' }, pushname: 'Tester' },
+      getState: jest.fn().mockResolvedValue(WAState.CONNECTED),
+      pupPage: { evaluate: jest.fn().mockResolvedValue(true) },
+    });
+    (adapter as unknown as { client: unknown }).client = client;
+    const onMessage = jest.fn();
+    (adapter as unknown as { callbacks: unknown }).callbacks = { onMessage };
+    (adapter as unknown as { setupEventHandlers: () => void }).setupEventHandlers();
+
+    const mockMsg = {
+      id: { _serialized: 'MEDIA_OFF_1' },
+      from: '628111@c.us',
+      to: '628111@c.us',
+      body: '',
+      type: 'image',
+      timestamp: 1700000050,
+      fromMe: false,
+      hasMedia: true,
+      _data: { mimetype: 'image/png', size: 5000 },
+      getContact: jest.fn().mockResolvedValue(null),
+      hasQuotedMsg: false,
+    };
+
+    client.emit('message', mockMsg);
+    await new Promise(r => setImmediate(r));
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    const msg = onMessage.mock.calls[0][0] as { media?: unknown; type: string };
+    expect(msg.type).toBe('image');
+    expect(msg.media).toBeUndefined();
+  });
+});

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -833,6 +833,7 @@ describe('WhatsAppWebJsAdapter inbound media (MEDIA_DOWNLOAD_ENABLED=false)', ()
     await new Promise(r => setImmediate(r));
 
     expect(onMessage).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     const msg = onMessage.mock.calls[0][0] as { media?: unknown; type: string };
     expect(msg.type).toBe('image');
     expect(msg.media).toBeUndefined();

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -50,9 +50,10 @@ import {
 import { buildIncomingMessageBase, mapContactFields } from './message-mapper';
 import {
   capInboundMedia,
+  coerceDeclaredSize,
   inboundMediaConcurrency,
   inboundMediaMaxBytes,
-  coerceDeclaredSize,
+  isMediaDownloadEnabled,
 } from './inbound-media-cap';
 import { ConcurrencyLimiter } from './concurrency-limiter';
 
@@ -200,6 +201,9 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
    * download through the concurrency limiter for backpressure. Returns undefined when there's no media.
    */
   private async capInboundMediaFor(msg: Message): Promise<IncomingMessage['media'] | undefined> {
+    if (!isMediaDownloadEnabled()) {
+      return undefined;
+    }
     const maxBytes = inboundMediaMaxBytes();
     const data = (msg as unknown as { _data?: { size?: number; mimetype?: string; filename?: string } })._data;
     const declared = coerceDeclaredSize(data?.size);


### PR DESCRIPTION
## Summary

Adds a new environment variable MEDIA_DOWNLOAD_ENABLED (default: true) that lets operators disable inbound media download entirely.

When set to false, the engine skips downloading, decrypting, and processing media from incoming messages — no memory allocation, no storage, no base64 encoding, no Puppeteer/Chromium overhead. The message is emitted without a media field, which callers already handle correctly (they check for undefined).

## Motivation

Not every deployment needs to process inbound media. For setups that only care about text messages — alerts, notifications, simple chatbots — downloading every photo, video, and document that comes in is wasted CPU, memory, and bandwidth. On low-resource VPS or container environments, this can make a real difference.

The existing MEDIA_DOWNLOAD_MAX_BYTES cap only limits size; it doesn't let you turn media processing off at the source. This PR adds that toggle.

## Changes

| File | Change |
|------|--------|
| src/engine/adapters/inbound-media-cap.ts | Add isMediaDownloadEnabled() — reads MEDIA_DOWNLOAD_ENABLED env var, accepts false, 0, or no to disable |
| src/engine/adapters/whatsapp-web-js.adapter.ts | Guard in capInboundMediaFor() — returns undefined immediately when disabled |
| src/engine/adapters/baileys.adapter.ts | Guard in the inbound media handler — same approach, skips the entire media download path |
| .env.example | Document MEDIA_DOWNLOAD_ENABLED |
| src/engine/adapters/inbound-media-cap.spec.ts | Tests for the new function |

## Backward Compatibility

Fully backward compatible. Default is true — existing deployments keep downloading media as before. No code changes needed unless you want to disable it.

## Testing

- isMediaDownloadEnabled() defaults to true when MEDIA_DOWNLOAD_ENABLED is unset
- Returns false for false, 0, no
- Returns true for any other value (true, 1, yes, garbage)
- Both engine adapters handle undefined media correctly (verified in existing code paths)