### PR TITLE
feat(dashboard): chats UX — reliable scroll, lazy pagination, on-demand media, call/location rendering

### DIFF
--- a/dashboard/src/components/chats/LazyMediaPlaceholder.tsx
+++ b/dashboard/src/components/chats/LazyMediaPlaceholder.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from 'react';
+import { Loader2 } from 'lucide-react';
+
+interface Props {
+  /** Label shown while the media loads (e.g. "📷 Photo"). */
+  label: string;
+  /** Called once when the placeholder approaches the viewport, to start downloading the media. */
+  onVisible: () => void;
+}
+
+/**
+ * Placeholder for an older media message whose payload isn't loaded yet. When it nears the viewport it
+ * fires `onVisible` once to lazily download the media. The IntersectionObserver `rootMargin` doubles as
+ * a soft prefetch — it starts the fetch a bit before the bubble is actually on screen.
+ */
+export default function LazyMediaPlaceholder({ label, onVisible }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  const firedRef = useRef(false);
+  // Keep the latest onVisible in a ref so the observer can mount once (the prop is a fresh closure each
+  // render; without this the observer would tear down and re-create on every parent re-render).
+  const onVisibleRef = useRef(onVisible);
+  useEffect(() => {
+    onVisibleRef.current = onVisible;
+  }, [onVisible]);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      entries => {
+        if (entries[0]?.isIntersecting && !firedRef.current) {
+          firedRef.current = true;
+          onVisibleRef.current();
+          observer.disconnect();
+        }
+      },
+      { rootMargin: '300px' },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div ref={ref} className="message-media-placeholder message-media-placeholder--loading">
+      <Loader2 className="animate-spin" size={14} />
+      <span>{label}</span>
+    </div>
+  );
+}

--- a/dashboard/src/components/chats/MessageBody.tsx
+++ b/dashboard/src/components/chats/MessageBody.tsx
@@ -13,6 +13,12 @@ const linkifyOptions = {
   rel: 'noopener noreferrer',
   defaultProtocol: 'https',
   ignoreTags: ['code', 'pre'],
+  validate: {
+    // Only linkify web URLs. A scheme'd match that isn't http(s) — e.g. file://… — is left as inert
+    // text. Bare domains and www.* have no '://' here and still resolve to https via defaultProtocol;
+    // emails are a separate token type and remain linkified.
+    url: (value: string) => !value.includes('://') || /^https?:\/\//i.test(value),
+  },
   attributes: {
     onClick: (e: React.MouseEvent) => e.stopPropagation(),
   },

--- a/dashboard/src/hooks/useChatMessages.ts
+++ b/dashboard/src/hooks/useChatMessages.ts
@@ -73,5 +73,21 @@ export function useChatMessagesActions() {
         (old = []) => removeMessageById(old, id),
       );
     },
+    /**
+     * Load older messages by fetching a deeper slice of the engine history (both directions, metadata
+     * only — no media for the deeper portion) and merging it into the cached thread. `limit` is the new,
+     * larger ceiling; the engine returns the most-recent `limit`, so a bigger limit reveals older ones.
+     * Returns how many genuinely-new (older) messages were added, so the caller knows whether more remain.
+     */
+    async loadOlderHistory(sessionId: string, chatId: string, limit: number): Promise<number> {
+      const history = await sessionApi.getChatHistory(sessionId, chatId, limit, false, true);
+      const older = history.map(mapEngineHistoryMessage);
+      const key = messagesQueryKey(sessionId, chatId);
+      const before = qc.getQueryData<ChatMessageView[]>(key) ?? [];
+      // `before` second so existing rows (with real status + any media) win over the metadata-only copies.
+      const merged = mergeChatMessages(older, before);
+      qc.setQueryData<ChatMessageView[]>(key, merged);
+      return merged.length - before.length;
+    },
   };
 }

--- a/dashboard/src/hooks/useChatMessages.ts
+++ b/dashboard/src/hooks/useChatMessages.ts
@@ -35,7 +35,17 @@ export function useChatMessages(
       if (dbRes.status === 'rejected' && historyRes.status === 'rejected') throw dbRes.reason;
       const dbMessages = dbRes.status === 'fulfilled' ? dbRes.value.messages : [];
       const history = historyRes.status === 'fulfilled' ? historyRes.value.map(mapEngineHistoryMessage) : [];
-      return mergeChatMessages(dbMessages, history);
+      const merged = mergeChatMessages(dbMessages, history);
+      // The DB stores ONLY incoming messages, and its page can reach further back than the engine
+      // history page (which carries both directions). Those extra older DB rows render as a confusing
+      // "only the other person" band at the top of the thread. Trim the thread to the history's range
+      // so the initial view is balanced; older messages (both directions) lazy-load via deep history on
+      // scroll-up. (When there's no history — e.g. a fresh session — keep the DB rows as-is.)
+      if (history.length === 0) return merged;
+      const ts = (m: { timestamp?: number; createdAt: string }): number =>
+        m.timestamp ?? (Math.floor(Date.parse(m.createdAt) / 1000) || 0);
+      const oldestHistoryTs = Math.min(...history.map(ts));
+      return merged.filter(m => ts(m) >= oldestHistoryTs);
     },
     enabled: Boolean(sessionId && chatId),
     staleTime: Infinity,

--- a/dashboard/src/hooks/useChatMessages.ts
+++ b/dashboard/src/hooks/useChatMessages.ts
@@ -84,8 +84,10 @@ export function useChatMessagesActions() {
       const older = history.map(mapEngineHistoryMessage);
       const key = messagesQueryKey(sessionId, chatId);
       const before = qc.getQueryData<ChatMessageView[]>(key) ?? [];
-      // `before` second so existing rows (with real status + any media) win over the metadata-only copies.
-      const merged = mergeChatMessages(older, before);
+      // `before` FIRST so the already-loaded rows win the dedup — mergeChatMessages lets the first arg
+      // overwrite the second, and the cached rows carry real delivery status + media that the
+      // metadata-only deep copies lack. The deep rows only contribute the genuinely-older messages.
+      const merged = mergeChatMessages(before, older);
       qc.setQueryData<ChatMessageView[]>(key, merged);
       return merged.length - before.length;
     },

--- a/dashboard/src/hooks/useChatScrollPosition.test.ts
+++ b/dashboard/src/hooks/useChatScrollPosition.test.ts
@@ -2,71 +2,27 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { decideRestoreTarget } from './useChatScrollPosition.ts';
 
-test('first render with no previous chat: no save, restore to bottom if loaded', () => {
-  assert.deepEqual(
-    decideRestoreTarget(null, 'A', false, true, undefined),
-    { save: null, restore: 'bottom' },
-  );
+test('no chat selected → no restore', () => {
+  assert.equal(decideRestoreTarget(null, true, undefined), null);
 });
 
-test('first render still loading: no save, no restore', () => {
-  assert.deepEqual(
-    decideRestoreTarget(null, 'A', false, false, undefined),
-    { save: null, restore: null },
-  );
+test('chat selected but content not loaded yet → no restore', () => {
+  assert.equal(decideRestoreTarget('A', false, undefined), null);
 });
 
-test('first-visit cold open: enter A while loading, then loaded transition restores to bottom', () => {
-  // First effect run: enter A, not yet loaded → no save (no prev), no restore.
-  assert.deepEqual(
-    decideRestoreTarget(null, 'A', false, false, undefined),
-    { save: null, restore: null },
-  );
-  // Second effect run after data lands: same chat, becomes loaded → restore to bottom.
-  assert.deepEqual(
-    decideRestoreTarget('A', 'A', false, true, undefined),
-    { save: null, restore: 'bottom' },
-  );
+test('first visit (loaded, no remembered position) → jump to bottom', () => {
+  assert.equal(decideRestoreTarget('A', true, undefined), 'bottom');
 });
 
-test('switch from loaded chat A to loaded cached chat B: save A, restore B saved', () => {
-  assert.deepEqual(
-    decideRestoreTarget('A', 'B', true, true, 250),
-    { save: 'previous', restore: 'saved' },
-  );
+test('return visit (loaded, remembered position exists) → restore saved', () => {
+  assert.equal(decideRestoreTarget('A', true, 250), 'saved');
 });
 
-test('switch from loaded A to uncached B (still loading): save A, no restore yet', () => {
-  assert.deepEqual(
-    decideRestoreTarget('A', 'B', true, false, undefined),
-    { save: 'previous', restore: null },
-  );
+test('a remembered position of 0 is real (user was at the top) → restore saved, not bottom', () => {
+  assert.equal(decideRestoreTarget('A', true, 0), 'saved');
 });
 
-test('switch from loaded A to uncached B, then B finishes loading: do not double-save A', () => {
-  // Step 1: switch A → B, B loading → save A, no restore.
-  assert.deepEqual(
-    decideRestoreTarget('A', 'B', true, false, undefined),
-    { save: 'previous', restore: null },
-  );
-  // Step 2: same chat B, transitions to loaded → no save (prev === next), restore B to bottom (first visit).
-  assert.deepEqual(
-    decideRestoreTarget('B', 'B', false, true, undefined),
-    { save: null, restore: 'bottom' },
-  );
-});
-
-test('switch B → A where A was unloaded when last left: do not save B against a spinner-snapshot of A', () => {
-  // prevLoaded=false signals B was on the spinner branch → do NOT save its zero scrollTop.
-  assert.deepEqual(
-    decideRestoreTarget('B', 'A', false, true, 320),
-    { save: null, restore: 'saved' },
-  );
-});
-
-test('deselect chat (next is null): no save (cant write null key), no restore', () => {
-  assert.deepEqual(
-    decideRestoreTarget('A', null, true, false, undefined),
-    { save: null, restore: null },
-  );
+test('cold open: loading first (null), then loaded transition restores to bottom on first visit', () => {
+  assert.equal(decideRestoreTarget('A', false, undefined), null);
+  assert.equal(decideRestoreTarget('A', true, undefined), 'bottom');
 });

--- a/dashboard/src/hooks/useChatScrollPosition.ts
+++ b/dashboard/src/hooks/useChatScrollPosition.ts
@@ -1,114 +1,106 @@
-import { useCallback, useLayoutEffect, useRef, type RefObject } from 'react';
-import { decideScroll, type ScrollDirection } from '../utils/scrollDecision.ts';
+import { useCallback, useLayoutEffect, useRef, useState, type RefObject } from 'react';
+import { decideScroll, isAwayFromBottom, type ScrollDirection } from '../utils/scrollDecision.ts';
 
 /**
- * Decide what to do with the scroll container on a chat switch or load-resolve.
+ * Decide where to place the scroll when entering a chat (or when its content first loads):
+ *   - 'saved'  → a remembered scrollTop exists for this chat: restore it
+ *   - 'bottom' → first visit (no saved position): jump to the latest message
+ *   - null     → nothing to do yet (no chat selected, or content not loaded)
  *
- * Inputs:
- *   - prevChatId: chat we are LEAVING (or null if first render)
- *   - nextChatId: chat we are ENTERING (or null if no chat selected)
- *   - prevLoaded: was the previous chat's content rendered when we last ran?
- *   - isLoaded:   is the next chat's content rendered now?
- *   - savedScrollTop: previously-saved scrollTop for nextChatId (or undefined)
+ * Note: this no longer decides whether to SAVE the leaving chat's position. That position is
+ * captured continuously by the hook's scroll handler, so it never depends on reading scrollTop
+ * after the DOM has already swapped to the next chat — the bug that left returned-to chats stuck
+ * at the top (the old layout-effect save read the incoming chat's / spinner's scrollTop ≈ 0).
  *
- * Output: { save: 'previous' | null, restore: 'saved' | 'bottom' | null }
- *   - save:    instructs the hook to write the CURRENT scrollTop into the
- *              map under prevChatId BEFORE doing the restore
- *   - restore: instructs the hook to write scrollTop = (the saved value)
- *              or = scrollHeight (bottom); null means do nothing
- *
- * This is a pure function so it can be unit-tested without React.
+ * Pure function so it can be unit-tested without React.
  */
-export interface RestoreDecision {
-  save: 'previous' | null;
-  restore: 'saved' | 'bottom' | null;
-}
+export type RestoreTarget = 'saved' | 'bottom' | null;
 
 export function decideRestoreTarget(
-  prevChatId: string | null,
   nextChatId: string | null,
-  prevLoaded: boolean,
   isLoaded: boolean,
   savedScrollTop: number | undefined,
-): RestoreDecision {
-  // Only save the previous chat's scrollTop when we're switching to ANOTHER
-  // chat (not when deselecting back to nothing) and when its content was
-  // actually rendered (not a spinner snapshot).
-  const save: 'previous' | null =
-    prevChatId !== null &&
-    nextChatId !== null &&
-    prevChatId !== nextChatId &&
-    prevLoaded
-      ? 'previous'
-      : null;
-
-  const restore: 'saved' | 'bottom' | null =
-    nextChatId !== null && isLoaded
-      ? savedScrollTop !== undefined ? 'saved' : 'bottom'
-      : null;
-
-  return { save, restore };
+): RestoreTarget {
+  if (nextChatId === null || !isLoaded) return null;
+  // A saved value of 0 is a real position (user was at the top) — only `undefined` means "first visit".
+  return savedScrollTop !== undefined ? 'saved' : 'bottom';
 }
 
 /**
- * Per-chat scroll-position memory + auto-scroll heuristic.
+ * Per-chat scroll-position memory + auto-scroll heuristic + "jump to bottom" affordance.
  *
- * - On chat switch (and once content for the new chat has actually rendered):
- *   saves the leaving chat's scrollTop, restores the entering chat's saved
- *   scrollTop, or jumps to bottom on first visit. All synchronously, before
- *   paint, via useLayoutEffect — no visible "jump" or smooth-scroll animation.
- * - The hook depends on BOTH activeChatId AND isLoaded so that a cold-open
- *   (spinner first, then data) correctly waits to restore until the messages
- *   list is mounted with non-zero scrollHeight.
- * - On message append: `onMessageAppended(direction)` snapshots the geometry
- *   BEFORE the new message is committed, then defers the scroll-to-bottom (if
- *   any) to the next frame so the new message is already in the DOM.
+ * - `onScroll` (attach to the scroll container) records the active chat's scrollTop on every scroll,
+ *   so switching away always has an accurate position to restore later, and toggles the jump button
+ *   based on how far the user has scrolled up.
+ * - On chat switch / first load: restores the entering chat's remembered scrollTop, or jumps to
+ *   bottom on first visit — synchronously before paint via useLayoutEffect.
+ * - `onMessageAppended(direction)`: scrolls to bottom when appropriate (the user's own message, or an
+ *   arrival while they were already near the bottom), deferred to the next frame so the new node is
+ *   in the DOM. Preserves position when the user has scrolled up to read history.
+ * - `scrollToBottom()`: smooth-scrolls to the latest message (the jump button's action).
  *
- * Mount the returned `containerRef` on the scroll container (the `.room-messages`
- * div in Chats.tsx). The Map of saved positions lives in a ref so it doesn't
- * trigger renders and is garbage-collected when the host component unmounts.
+ * Mount `containerRef` on the scroll container (`.room-messages`). The Map of saved positions lives
+ * in a ref so it doesn't trigger renders and is garbage-collected when the host component unmounts.
  */
 export function useChatScrollPosition(
   activeChatId: string | null,
   isLoaded: boolean,
 ): {
   containerRef: RefObject<HTMLDivElement | null>;
+  onScroll: () => void;
   onMessageAppended: (direction: ScrollDirection) => void;
+  showJumpToBottom: boolean;
+  scrollToBottom: () => void;
 } {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const scrollMap = useRef<Map<string, number>>(new Map());
-  const prevChatIdRef = useRef<string | null>(null);
-  const prevLoadedRef = useRef<boolean>(false);
+
+  const [showJumpToBottom, setShowJumpToBottom] = useState(false);
+
+  const syncJumpButton = useCallback((el: HTMLDivElement) => {
+    setShowJumpToBottom(
+      isAwayFromBottom({
+        scrollTop: el.scrollTop,
+        scrollHeight: el.scrollHeight,
+        clientHeight: el.clientHeight,
+      }),
+    );
+  }, []);
+
+  // Recreated whenever the active chat changes, so the position is always recorded under the chat
+  // currently on screen — React swaps the listener on the container, never leaving a stale closure.
+  const onScroll = useCallback(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    if (activeChatId !== null) scrollMap.current.set(activeChatId, el.scrollTop);
+    syncJumpButton(el);
+  }, [activeChatId, syncJumpButton]);
 
   useLayoutEffect(() => {
-    const prev = prevChatIdRef.current;
-    const next = activeChatId;
     const el = containerRef.current;
-    const prevLoaded = prevLoadedRef.current;
-
-    const decision = decideRestoreTarget(
-      prev,
+    const next = activeChatId;
+    const target = decideRestoreTarget(
       next,
-      prevLoaded,
       isLoaded,
       next !== null ? scrollMap.current.get(next) : undefined,
     );
 
-    if (el) {
-      if (decision.save === 'previous' && prev !== null) {
-        scrollMap.current.set(prev, el.scrollTop);
-      }
-      if (decision.restore === 'saved' && next !== null) {
+    if (el && next !== null) {
+      if (target === 'saved') {
         const saved = scrollMap.current.get(next);
         if (saved !== undefined) el.scrollTop = saved;
-      } else if (decision.restore === 'bottom') {
+      } else if (target === 'bottom') {
         el.scrollTop = el.scrollHeight;
+        // Media can grow the content a frame after open; re-pin to the bottom next frame so the chat
+        // reliably lands on the latest message instead of mid-thread.
+        requestAnimationFrame(() => {
+          const cur = containerRef.current;
+          if (cur) cur.scrollTop = cur.scrollHeight;
+        });
       }
+      if (target !== null) syncJumpButton(el);
     }
-
-    prevChatIdRef.current = next;
-    prevLoadedRef.current = isLoaded;
-  }, [activeChatId, isLoaded]);
+  }, [activeChatId, isLoaded, syncJumpButton]);
 
   const onMessageAppended = useCallback((direction: ScrollDirection) => {
     const el = containerRef.current;
@@ -125,5 +117,11 @@ export function useChatScrollPosition(
     });
   }, []);
 
-  return { containerRef, onMessageAppended };
+  const scrollToBottom = useCallback(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+  }, []);
+
+  return { containerRef, onScroll, onMessageAppended, showJumpToBottom, scrollToBottom };
 }

--- a/dashboard/src/i18n/locales/en.json
+++ b/dashboard/src/i18n/locales/en.json
@@ -90,6 +90,14 @@
     "noMessagesInChat": "No messages yet. Send the first message to get started!",
     "scrollToBottom": "Scroll to latest messages",
     "downloadDocument": "Download document",
+    "media": {
+      "photo": "Photo",
+      "video": "Video",
+      "voice": "Voice message",
+      "sticker": "Sticker",
+      "document": "Document",
+      "attachment": "Attachment"
+    },
     "actions": {
       "reply": "Reply",
       "react": "React",

--- a/dashboard/src/i18n/locales/en.json
+++ b/dashboard/src/i18n/locales/en.json
@@ -102,6 +102,7 @@
       "call": "Call",
       "callMissed": "Missed call",
       "callVideo": "Video call",
+      "callVideoMissed": "Missed video call",
       "unsupported": "Unsupported message"
     },
     "actions": {

--- a/dashboard/src/i18n/locales/en.json
+++ b/dashboard/src/i18n/locales/en.json
@@ -99,6 +99,9 @@
       "attachment": "Attachment",
       "location": "Location",
       "contact": "Contact",
+      "call": "Call",
+      "callMissed": "Missed call",
+      "callVideo": "Video call",
       "unsupported": "Unsupported message"
     },
     "actions": {

--- a/dashboard/src/i18n/locales/en.json
+++ b/dashboard/src/i18n/locales/en.json
@@ -96,7 +96,10 @@
       "voice": "Voice message",
       "sticker": "Sticker",
       "document": "Document",
-      "attachment": "Attachment"
+      "attachment": "Attachment",
+      "location": "Location",
+      "contact": "Contact",
+      "unsupported": "Unsupported message"
     },
     "actions": {
       "reply": "Reply",

--- a/dashboard/src/i18n/locales/en.json
+++ b/dashboard/src/i18n/locales/en.json
@@ -88,6 +88,7 @@
     "noMessageYet": "No messages yet",
     "loadingMessages": "Loading messages...",
     "noMessagesInChat": "No messages yet. Send the first message to get started!",
+    "scrollToBottom": "Scroll to latest messages",
     "downloadDocument": "Download document",
     "actions": {
       "reply": "Reply",

--- a/dashboard/src/i18n/locales/es.json
+++ b/dashboard/src/i18n/locales/es.json
@@ -88,6 +88,7 @@
     "noMessageYet": "Aún sin mensajes",
     "loadingMessages": "Cargando mensajes...",
     "noMessagesInChat": "Aún no hay mensajes. ¡Envía el primero para empezar!",
+    "scrollToBottom": "Ir al último mensaje",
     "downloadDocument": "Descargar documento",
     "actions": {
       "reply": "Responder",

--- a/dashboard/src/i18n/locales/es.json
+++ b/dashboard/src/i18n/locales/es.json
@@ -90,6 +90,14 @@
     "noMessagesInChat": "Aún no hay mensajes. ¡Envía el primero para empezar!",
     "scrollToBottom": "Ir al último mensaje",
     "downloadDocument": "Descargar documento",
+    "media": {
+      "photo": "Foto",
+      "video": "Video",
+      "voice": "Nota de voz",
+      "sticker": "Sticker",
+      "document": "Documento",
+      "attachment": "Adjunto"
+    },
     "actions": {
       "reply": "Responder",
       "react": "Reaccionar",

--- a/dashboard/src/i18n/locales/es.json
+++ b/dashboard/src/i18n/locales/es.json
@@ -99,6 +99,9 @@
       "attachment": "Adjunto",
       "location": "Ubicación",
       "contact": "Contacto",
+      "call": "Llamada",
+      "callMissed": "Llamada perdida",
+      "callVideo": "Videollamada",
       "unsupported": "Mensaje no soportado"
     },
     "actions": {

--- a/dashboard/src/i18n/locales/es.json
+++ b/dashboard/src/i18n/locales/es.json
@@ -96,7 +96,10 @@
       "voice": "Nota de voz",
       "sticker": "Sticker",
       "document": "Documento",
-      "attachment": "Adjunto"
+      "attachment": "Adjunto",
+      "location": "Ubicación",
+      "contact": "Contacto",
+      "unsupported": "Mensaje no soportado"
     },
     "actions": {
       "reply": "Responder",

--- a/dashboard/src/i18n/locales/es.json
+++ b/dashboard/src/i18n/locales/es.json
@@ -102,6 +102,7 @@
       "call": "Llamada",
       "callMissed": "Llamada perdida",
       "callVideo": "Videollamada",
+      "callVideoMissed": "Videollamada perdida",
       "unsupported": "Mensaje no soportado"
     },
     "actions": {

--- a/dashboard/src/pages/Chats.css
+++ b/dashboard/src/pages/Chats.css
@@ -821,6 +821,14 @@
   margin-bottom: 0.5rem;
 }
 
+/* Placeholder for a media message whose payload isn't loaded (older deep-history messages are
+   metadata-only). Keeps the bubble visible and labeled instead of rendering empty. */
+.chats-page .message-media-placeholder{
+  font-style: italic;
+  opacity: 0.75;
+  font-size: 0.9375rem;
+}
+
 .chats-page .chat-document-media{
   display: inline-flex;
   align-items: center;

--- a/dashboard/src/pages/Chats.css
+++ b/dashboard/src/pages/Chats.css
@@ -835,6 +835,19 @@
   gap: 0.4rem;
 }
 
+/* Location message: base64 map thumbnail (from the message body) + a label. */
+.chats-page .message-location{
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.chats-page .chat-location-thumb{
+  max-width: 100%;
+  max-height: 200px;
+  border-radius: 8px;
+  display: block;
+}
+
 .chats-page .chat-document-media{
   display: inline-flex;
   align-items: center;

--- a/dashboard/src/pages/Chats.css
+++ b/dashboard/src/pages/Chats.css
@@ -330,8 +330,19 @@
   font-family: monospace;
 }
 
+/* Non-scrolling positioned wrapper around the thread so the jump-to-bottom button can anchor to the
+   bottom-right of the visible scroll area (an absolute child of the scroller itself would scroll). */
+.chats-page .room-messages-area{
+  flex: 1;
+  min-height: 0;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
 .chats-page .room-messages{
   flex: 1;
+  min-height: 0;
   padding: 1.5rem;
   overflow-y: auto;
   display: flex;
@@ -339,6 +350,42 @@
   gap: 0.75rem;
   background-image: radial-gradient(var(--border) 1px, transparent 0);
   background-size: 24px 24px;
+}
+
+/* WhatsApp-style floating "jump to latest" button — shown only once scrolled up past a threshold.
+   Filled primary (green) circle with an explicit white chevron: colors are literal, not inherited
+   via currentColor, so the icon is guaranteed visible regardless of theme/cascade quirks. */
+.chats-page .jump-to-bottom-btn{
+  position: absolute;
+  right: 1.25rem;
+  bottom: 1rem;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--primary, #25d366);
+  color: #ffffff;
+  border: none;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.22);
+  cursor: pointer;
+  z-index: 5;
+  transition: background 0.15s ease, transform 0.15s ease;
+}
+
+/* Force the lucide chevron to a fixed size and an explicit white stroke (lucide paths inherit the
+   svg stroke), so it can never collapse to 0 or pick up an invisible inherited color. */
+.chats-page .jump-to-bottom-btn svg{
+  display: block;
+  width: 22px;
+  height: 22px;
+  stroke: #ffffff;
+}
+
+.chats-page .jump-to-bottom-btn:hover{
+  background: var(--primary-hover, #1da851);
+  transform: translateY(-1px);
 }
 
 .chats-page .messages-loading{

--- a/dashboard/src/pages/Chats.css
+++ b/dashboard/src/pages/Chats.css
@@ -388,6 +388,26 @@
   transform: translateY(-1px);
 }
 
+/* "Loading older messages" spinner — absolutely positioned over the top of the thread so it never
+   shifts scrollHeight (which would break the prepend anchoring). */
+.chats-page .messages-loading-older{
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 4;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--bg-white, #ffffff);
+  color: var(--text-secondary, #475569);
+  border: 1px solid var(--border, #e2e8f0);
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.15);
+}
+
 .chats-page .messages-loading{
   display: flex;
   flex-direction: column;

--- a/dashboard/src/pages/Chats.css
+++ b/dashboard/src/pages/Chats.css
@@ -829,6 +829,12 @@
   font-size: 0.9375rem;
 }
 
+.chats-page .message-media-placeholder--loading{
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
 .chats-page .chat-document-media{
   display: inline-flex;
   align-items: center;

--- a/dashboard/src/pages/Chats.tsx
+++ b/dashboard/src/pages/Chats.tsx
@@ -1034,6 +1034,15 @@ export function Chats() {
                               <LazyMediaPlaceholder label={label} onVisible={() => ensureMessageMedia(msg)} />
                             );
                           }
+                          if (msg.type === 'call') {
+                            const call = msg.metadata?.call;
+                            const callLabel = call?.video
+                              ? `📹 ${t('chats.media.callVideo')}`
+                              : call?.missed
+                                ? `📞 ${t('chats.media.callMissed')}`
+                                : `📞 ${t('chats.media.call')}`;
+                            return <div className="message-media-placeholder">{callLabel}</div>;
+                          }
                           if (msg.type === 'contact') {
                             return <div className="message-media-placeholder">👤 {t('chats.media.contact')}</div>;
                           }

--- a/dashboard/src/pages/Chats.tsx
+++ b/dashboard/src/pages/Chats.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import { useState, useEffect, useLayoutEffect, useCallback, useRef, useMemo } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { Trans, useTranslation } from 'react-i18next';
 import {
@@ -15,6 +15,7 @@ import {
   X,
   CornerUpLeft,
   Trash2,
+  ChevronDown,
 } from 'lucide-react';
 import {
   sessionApi,
@@ -36,9 +37,15 @@ import {
   messagesQueryKey,
 } from '../hooks/useChatMessages';
 import { useChatScrollPosition } from '../hooks/useChatScrollPosition';
+import { isNearTop, anchorScrollTopAfterPrepend } from '../utils/scrollDecision';
 import MessageBody from '../components/chats/MessageBody';
 import MediaLightbox, { type LightboxItem } from '../components/chats/MediaLightbox';
 import './Chats.css';
+
+// Client-side render windowing: how many of the most-recent loaded messages to render on open, and how
+// many more to reveal each time the user scrolls near the top. Keeps the DOM small on large chats.
+const MESSAGES_WINDOW_SIZE = 30;
+const MESSAGES_WINDOW_STEP = 30;
 
 type MessageMedia = { mimetype: string; filename?: string; data?: string };
 
@@ -143,8 +150,60 @@ export function Chats() {
   // chat has any message (doesn't toggle per append) and covers both the
   // first-fetch resolution and a WS-driven first message on a previously-empty
   // chat. `loadingMessages` alone would miss the latter case.
-  const { containerRef: messagesContainerRef, onMessageAppended } =
-    useChatScrollPosition(activeChat?.id ?? null, messages.length > 0);
+  const {
+    containerRef: messagesContainerRef,
+    onScroll: onScrollSavePosition,
+    onMessageAppended,
+    showJumpToBottom,
+    scrollToBottom,
+  } = useChatScrollPosition(activeChat?.id ?? null, messages.length > 0);
+
+  // Client-side windowing. useChatMessages already loads the full recent thread (DB + engine history,
+  // BOTH directions). To keep large chats fast we only RENDER the most recent `visibleCount` messages
+  // and reveal older ones as the user scrolls near the top — no extra fetches, with scroll anchoring so
+  // the view doesn't jump. (Reaching back beyond the loaded thread is a future backend-paging concern;
+  // the DB stores only incoming messages, so older outgoing must keep coming from the engine history.)
+  const [visibleCount, setVisibleCount] = useState<number>(MESSAGES_WINDOW_SIZE);
+  const pendingAnchorRef = useRef<{ prevTop: number; prevHeight: number } | null>(null);
+
+  // Reset the render window when the active chat changes.
+  useEffect(() => {
+    setVisibleCount(MESSAGES_WINDOW_SIZE);
+    pendingAnchorRef.current = null;
+  }, [activeChat?.id]);
+
+  const visibleMessages = useMemo(
+    () => messages.slice(Math.max(0, messages.length - visibleCount)),
+    [messages, visibleCount],
+  );
+
+  // Reveal an older slice when the user nears the top. Arm the anchor first so the layout effect below
+  // keeps the reading position once the older messages mount (content grows above the viewport).
+  const revealOlder = useCallback(() => {
+    if (visibleCount >= messages.length) return;
+    const el = messagesContainerRef.current;
+    pendingAnchorRef.current = { prevTop: el?.scrollTop ?? 0, prevHeight: el?.scrollHeight ?? 0 };
+    setVisibleCount(c => Math.min(c + MESSAGES_WINDOW_STEP, messages.length));
+  }, [visibleCount, messages.length, messagesContainerRef]);
+
+  // Compose the container's scroll handler: keep the hook's position-save + jump-button logic, and
+  // reveal the next older slice when the user nears the top.
+  const onMessagesScroll = useCallback(() => {
+    onScrollSavePosition();
+    const el = messagesContainerRef.current;
+    if (el && isNearTop(el.scrollTop)) revealOlder();
+  }, [onScrollSavePosition, revealOlder, messagesContainerRef]);
+
+  // After the window grows, restore the reading position — content grew above the viewport, so shift
+  // scrollTop by the same amount. Keyed on `visibleCount` so realtime appends (which grow `messages` at
+  // the bottom) don't trigger it.
+  useLayoutEffect(() => {
+    const anchor = pendingAnchorRef.current;
+    if (!anchor) return;
+    pendingAnchorRef.current = null;
+    const el = messagesContainerRef.current;
+    if (el) el.scrollTop = anchorScrollTopAfterPrepend(anchor.prevTop, anchor.prevHeight, el.scrollHeight);
+  }, [visibleCount, messagesContainerRef]);
 
   // Popular emojis
   const popularEmojis = ['😀', '😂', '👍', '❤️', '🔥', '👏', '🙏', '🎉', '💡', '🤔', '😅', '😍', '😊', '😭', '😎', '😜', '🚀', '✨'];
@@ -231,9 +290,17 @@ export function Chats() {
         },
       };
 
-      // Always write to the React Query cache for this message's session — keeps non-active chats
-      // up to date so re-opening them shows fresh data without a refetch.
-      appendMessage(event.sessionId, newMsg.chatId, mappedMessage);
+      // Only update the cache for chats already loaded into it. Seeding a brand-new slice from a
+      // single live message would — with staleTime:Infinity in useChatMessages — make the next open
+      // of that chat treat the 1-message slice as fresh and skip fetching its real DB/engine history,
+      // truncating the thread until gcTime evicts it. For never-opened chats we skip the write; the
+      // next open runs queryFn and backfills the full thread. (The sidebar list still updates below.)
+      const cached = queryClient.getQueryData<ChatMessageView[]>(
+        messagesQueryKey(event.sessionId, newMsg.chatId),
+      );
+      if (cached !== undefined) {
+        appendMessage(event.sessionId, newMsg.chatId, mappedMessage);
+      }
 
       // If the message belongs to the currently visible chat, mark-as-read and run the scroll heuristic.
       if (activeChat && newMsg.chatId === activeChat.id) {
@@ -263,7 +330,7 @@ export function Chats() {
         return updatedChats;
       });
     },
-    [selectedSessionId, activeChat, loadChats, markChatRead, appendMessage, onMessageAppended],
+    [selectedSessionId, activeChat, loadChats, markChatRead, appendMessage, onMessageAppended, queryClient],
   );
 
   const handleIncomingMessageAck = useCallback(
@@ -635,7 +702,9 @@ export function Chats() {
   const imageMedia = useMemo<LightboxItem[]>(
     () =>
       messages
-        .filter(m => m.type === 'image' && Boolean(getMediaSrc(m.metadata?.media)))
+        // Stickers render with the same zoom-in image affordance + lightbox onClick as images, so
+        // include them here too — otherwise the findIndex below misses and the click is a no-op.
+        .filter(m => (m.type === 'image' || m.type === 'sticker') && Boolean(getMediaSrc(m.metadata?.media)))
         .map(m => ({
           id: m.id,
           url: getMediaSrc(m.metadata?.media),
@@ -780,8 +849,10 @@ export function Chats() {
                   </div>
                 </header>
 
-                {/* Messages body */}
-                <div className="room-messages" ref={messagesContainerRef}>
+                {/* Messages body. Wrapped so the floating jump-to-bottom button anchors to the
+                    bottom-right of the scroll area instead of scrolling with the thread. */}
+                <div className="room-messages-area">
+                <div className="room-messages" ref={messagesContainerRef} onScroll={onMessagesScroll}>
                   {loadingMessages ? (
                     <div className="messages-loading">
                       <Loader2 className="animate-spin" size={32} />
@@ -798,7 +869,7 @@ export function Chats() {
                       <span>{t('chats.noMessagesInChat')}</span>
                     </div>
                   ) : (
-                    messages.map(msg => {
+                    visibleMessages.map(msg => {
                       const isMe = msg.direction === 'outgoing';
                       const formattedTime = formatTime(
                         msg.timestamp || Math.floor(new Date(msg.createdAt).getTime() / 1000),
@@ -976,6 +1047,18 @@ export function Chats() {
                       );
                     })
                   )}
+                </div>
+                {showJumpToBottom && (
+                  <button
+                    type="button"
+                    className="jump-to-bottom-btn"
+                    onClick={scrollToBottom}
+                    aria-label={t('chats.scrollToBottom')}
+                    title={t('chats.scrollToBottom')}
+                  >
+                    <ChevronDown size={22} />
+                  </button>
+                )}
                 </div>
 
                 {/* Attachment preview banner */}

--- a/dashboard/src/pages/Chats.tsx
+++ b/dashboard/src/pages/Chats.tsx
@@ -40,6 +40,7 @@ import { useChatScrollPosition } from '../hooks/useChatScrollPosition';
 import { isNearTop, anchorScrollTopAfterPrepend } from '../utils/scrollDecision';
 import MessageBody from '../components/chats/MessageBody';
 import MediaLightbox, { type LightboxItem } from '../components/chats/MediaLightbox';
+import LazyMediaPlaceholder from '../components/chats/LazyMediaPlaceholder';
 import './Chats.css';
 
 // Client-side render windowing: how many of the most-recent loaded messages to render on open, and how
@@ -173,14 +174,46 @@ export function Chats() {
   const historyLimitRef = useRef<number>(HISTORY_INITIAL_LIMIT);
   const pendingAnchorRef = useRef<{ prevTop: number; prevHeight: number } | null>(null);
 
-  // Reset windowing + pagination when the active chat changes.
+  // Lazy on-demand media for older (metadata-only) messages: ids with an in-flight download, and ids
+  // whose download failed (render a static label for those, don't keep retrying).
+  const mediaFetchRef = useRef<Set<string>>(new Set());
+  const [mediaFailed, setMediaFailed] = useState<Set<string>>(new Set());
+
+  // Reset windowing + pagination + media state when the active chat changes.
   useEffect(() => {
     setVisibleCount(MESSAGES_WINDOW_SIZE);
     setLoadingOlder(false);
     setHasMoreToFetch(true);
     historyLimitRef.current = HISTORY_INITIAL_LIMIT;
     pendingAnchorRef.current = null;
+    mediaFetchRef.current.clear();
+    setMediaFailed(new Set());
   }, [activeChat?.id]);
+
+  // Download (and server-side cache) the media payload for one older message, then patch it into the
+  // cached thread so the real photo/audio replaces the placeholder. The backend persists it, so a later
+  // visit is instant. Deduped per message; failures are remembered to avoid hammering.
+  const ensureMessageMedia = useCallback(
+    (msg: ChatMessageView) => {
+      if (!selectedSessionId || !activeChat) return;
+      if (msg.metadata?.media?.data) return;
+      if (mediaFetchRef.current.has(msg.id)) return;
+      mediaFetchRef.current.add(msg.id);
+      const waId = msg.waMessageId || msg.id;
+      sessionApi
+        .getMessageMedia(selectedSessionId, activeChat.id, waId)
+        .then(media => {
+          queryClient.setQueryData<ChatMessageView[]>(
+            messagesQueryKey(selectedSessionId, activeChat.id),
+            (old = []) =>
+              old.map(m => (m.id === msg.id ? { ...m, metadata: { ...m.metadata, media } } : m)),
+          );
+        })
+        .catch(() => setMediaFailed(prev => new Set(prev).add(msg.id)))
+        .finally(() => mediaFetchRef.current.delete(msg.id));
+    },
+    [selectedSessionId, activeChat, queryClient],
+  );
 
   const visibleMessages = useMemo(
     () => messages.slice(Math.max(0, messages.length - visibleCount)),
@@ -934,8 +967,9 @@ export function Chats() {
                         const mediaSrc = mediaInfo ? getMediaSrc(mediaInfo) : '';
                         if (!mediaSrc) {
                           // Media message with no payload — e.g. older messages from the deep-history
-                          // backfill, which is metadata-only. Show a labeled placeholder so the bubble is
-                          // visible (notably the user's own sent photos/voice) instead of empty.
+                          // backfill, which is metadata-only. Lazily fetch the real media when the bubble
+                          // nears the viewport; until then (or on failure) show a labeled placeholder so
+                          // the bubble is visible instead of empty.
                           if (!isMediaMessage) return null;
                           const label =
                             msg.type === 'image' ? `📷 ${t('chats.media.photo')}`
@@ -944,7 +978,12 @@ export function Chats() {
                             : msg.type === 'sticker' ? `🏷️ ${t('chats.media.sticker')}`
                             : msg.type === 'document' ? `📄 ${t('chats.media.document')}`
                             : `📎 ${t('chats.media.attachment')}`;
-                          return <div className="message-media-placeholder">{label}</div>;
+                          if (mediaFailed.has(msg.id)) {
+                            return <div className="message-media-placeholder">{label}</div>;
+                          }
+                          return (
+                            <LazyMediaPlaceholder label={label} onVisible={() => ensureMessageMedia(msg)} />
+                          );
                         }
                         if (!mediaInfo) return null; // unreachable (mediaSrc implies mediaInfo) — narrows the type
 

--- a/dashboard/src/pages/Chats.tsx
+++ b/dashboard/src/pages/Chats.tsx
@@ -1036,11 +1036,10 @@ export function Chats() {
                           }
                           if (msg.type === 'call') {
                             const call = msg.metadata?.call;
-                            const callLabel = call?.video
-                              ? `📹 ${t('chats.media.callVideo')}`
-                              : call?.missed
-                                ? `📞 ${t('chats.media.callMissed')}`
-                                : `📞 ${t('chats.media.call')}`;
+                            const callKey = call?.video
+                              ? call.missed ? 'callVideoMissed' : 'callVideo'
+                              : call?.missed ? 'callMissed' : 'call';
+                            const callLabel = `${call?.video ? '📹' : '📞'} ${t(`chats.media.${callKey}`)}`;
                             return <div className="message-media-placeholder">{callLabel}</div>;
                           }
                           if (msg.type === 'contact') {

--- a/dashboard/src/pages/Chats.tsx
+++ b/dashboard/src/pages/Chats.tsx
@@ -931,9 +931,22 @@ export function Chats() {
 
                       const renderMedia = () => {
                         if (msg.type === 'revoked') return null;
-                        if (!mediaInfo) return null;
-                        const mediaSrc = getMediaSrc(mediaInfo);
-                        if (!mediaSrc) return null;
+                        const mediaSrc = mediaInfo ? getMediaSrc(mediaInfo) : '';
+                        if (!mediaSrc) {
+                          // Media message with no payload — e.g. older messages from the deep-history
+                          // backfill, which is metadata-only. Show a labeled placeholder so the bubble is
+                          // visible (notably the user's own sent photos/voice) instead of empty.
+                          if (!isMediaMessage) return null;
+                          const label =
+                            msg.type === 'image' ? `📷 ${t('chats.media.photo')}`
+                            : msg.type === 'video' ? `🎥 ${t('chats.media.video')}`
+                            : msg.type === 'voice' || msg.type === 'audio' ? `🎤 ${t('chats.media.voice')}`
+                            : msg.type === 'sticker' ? `🏷️ ${t('chats.media.sticker')}`
+                            : msg.type === 'document' ? `📄 ${t('chats.media.document')}`
+                            : `📎 ${t('chats.media.attachment')}`;
+                          return <div className="message-media-placeholder">{label}</div>;
+                        }
+                        if (!mediaInfo) return null; // unreachable (mediaSrc implies mediaInfo) — narrows the type
 
                         switch (msg.type) {
                           case 'image':

--- a/dashboard/src/pages/Chats.tsx
+++ b/dashboard/src/pages/Chats.tsx
@@ -53,6 +53,14 @@ const HISTORY_INITIAL_LIMIT = 100;
 const HISTORY_FETCH_STEP = 300;
 const HISTORY_MAX_LIMIT = 2000;
 
+// Message types that have a downloadable media payload (so an empty one is lazily fetched). Other
+// non-text types (location, contact, call logs reported as `unknown`) are NOT downloadable media.
+const DOWNLOADABLE_MEDIA_TYPES = new Set<MessageType>(['image', 'video', 'audio', 'voice', 'sticker', 'document']);
+// Bound concurrent on-demand media downloads and retry transient failures (notably HTTP 429 when many
+// placeholders become visible while scrolling fast), so media isn't dropped under load.
+const MEDIA_DOWNLOAD_CONCURRENCY = 3;
+const MEDIA_DOWNLOAD_RETRIES = 4;
+
 type MessageMedia = { mimetype: string; filename?: string; data?: string };
 
 // Delivery acks must only ADVANCE the tick, never regress it. The backend DB update is forward-only
@@ -174,10 +182,16 @@ export function Chats() {
   const historyLimitRef = useRef<number>(HISTORY_INITIAL_LIMIT);
   const pendingAnchorRef = useRef<{ prevTop: number; prevHeight: number } | null>(null);
 
-  // Lazy on-demand media for older (metadata-only) messages: ids with an in-flight download, and ids
-  // whose download failed (render a static label for those, don't keep retrying).
+  // Lazy on-demand media for older (metadata-only) messages, throttled through a small queue. `mediaFetchRef`
+  // holds enqueued/in-flight ids (dedup); `mediaFailed` holds ids whose download failed after retries
+  // (render a static label, stop retrying); `mediaQueueRef`/`mediaActiveRef` bound concurrency.
   const mediaFetchRef = useRef<Set<string>>(new Set());
   const [mediaFailed, setMediaFailed] = useState<Set<string>>(new Set());
+  const mediaQueueRef = useRef<{ msg: ChatMessageView; sessionId: string; chatId: string }[]>([]);
+  const mediaActiveRef = useRef<number>(0);
+  // Holds the latest queue pump so a finished task can trigger the next one without the callback
+  // referencing itself before it's declared.
+  const runMediaQueueRef = useRef<() => void>(() => {});
 
   // Reset windowing + pagination + media state when the active chat changes.
   useEffect(() => {
@@ -187,32 +201,56 @@ export function Chats() {
     historyLimitRef.current = HISTORY_INITIAL_LIMIT;
     pendingAnchorRef.current = null;
     mediaFetchRef.current.clear();
+    mediaQueueRef.current = [];
     setMediaFailed(new Set());
   }, [activeChat?.id]);
 
-  // Download (and server-side cache) the media payload for one older message, then patch it into the
-  // cached thread so the real photo/audio replaces the placeholder. The backend persists it, so a later
-  // visit is instant. Deduped per message; failures are remembered to avoid hammering.
+  // Drain the media-download queue up to the concurrency cap. Each task downloads (server-persisted) the
+  // message's media, patches it into the cached thread, and retries transient failures with backoff (so a
+  // 429 burst recovers instead of dropping). Stable callback — operates on refs.
+  const runMediaQueue = useCallback(() => {
+    while (mediaActiveRef.current < MEDIA_DOWNLOAD_CONCURRENCY && mediaQueueRef.current.length > 0) {
+      const { msg, sessionId, chatId } = mediaQueueRef.current.shift()!;
+      mediaActiveRef.current++;
+      const waId = msg.waMessageId || msg.id;
+      void (async () => {
+        for (let attempt = 1; attempt <= MEDIA_DOWNLOAD_RETRIES; attempt++) {
+          try {
+            const media = await sessionApi.getMessageMedia(sessionId, chatId, waId);
+            queryClient.setQueryData<ChatMessageView[]>(messagesQueryKey(sessionId, chatId), (old = []) =>
+              old.map(m => (m.id === msg.id ? { ...m, metadata: { ...m.metadata, media } } : m)),
+            );
+            return;
+          } catch {
+            if (attempt === MEDIA_DOWNLOAD_RETRIES) {
+              setMediaFailed(prev => new Set(prev).add(msg.id));
+              return;
+            }
+            await new Promise(resolve => setTimeout(resolve, 500 * attempt + Math.floor(Math.random() * 250)));
+          }
+        }
+      })().finally(() => {
+        mediaFetchRef.current.delete(msg.id);
+        mediaActiveRef.current--;
+        runMediaQueueRef.current();
+      });
+    }
+  }, [queryClient]);
+  useEffect(() => {
+    runMediaQueueRef.current = runMediaQueue;
+  }, [runMediaQueue]);
+
+  // Enqueue a one-shot media download for a message (called when its placeholder nears the viewport).
   const ensureMessageMedia = useCallback(
     (msg: ChatMessageView) => {
       if (!selectedSessionId || !activeChat) return;
       if (msg.metadata?.media?.data) return;
       if (mediaFetchRef.current.has(msg.id)) return;
       mediaFetchRef.current.add(msg.id);
-      const waId = msg.waMessageId || msg.id;
-      sessionApi
-        .getMessageMedia(selectedSessionId, activeChat.id, waId)
-        .then(media => {
-          queryClient.setQueryData<ChatMessageView[]>(
-            messagesQueryKey(selectedSessionId, activeChat.id),
-            (old = []) =>
-              old.map(m => (m.id === msg.id ? { ...m, metadata: { ...m.metadata, media } } : m)),
-          );
-        })
-        .catch(() => setMediaFailed(prev => new Set(prev).add(msg.id)))
-        .finally(() => mediaFetchRef.current.delete(msg.id));
+      mediaQueueRef.current.push({ msg, sessionId: selectedSessionId, chatId: activeChat.id });
+      runMediaQueue();
     },
-    [selectedSessionId, activeChat, queryClient],
+    [selectedSessionId, activeChat, runMediaQueue],
   );
 
   const visibleMessages = useMemo(
@@ -964,26 +1002,45 @@ export function Chats() {
 
                       const renderMedia = () => {
                         if (msg.type === 'revoked') return null;
+                        if (msg.type === 'location') {
+                          // WhatsApp location messages carry a base64 JPEG map-preview thumbnail in `body`
+                          // (there's no separate media payload to download). Render the thumbnail + a label
+                          // instead of dumping the base64 string as text. The body is suppressed below.
+                          const thumb =
+                            msg.body && msg.body.length > 100 ? `data:image/jpeg;base64,${msg.body}` : '';
+                          return (
+                            <div className="message-location">
+                              {thumb && <img src={thumb} alt="" className="chat-location-thumb" />}
+                              <span className="message-media-placeholder">📍 {t('chats.media.location')}</span>
+                            </div>
+                          );
+                        }
                         const mediaSrc = mediaInfo ? getMediaSrc(mediaInfo) : '';
                         if (!mediaSrc) {
-                          // Media message with no payload — e.g. older messages from the deep-history
-                          // backfill, which is metadata-only. Lazily fetch the real media when the bubble
-                          // nears the viewport; until then (or on failure) show a labeled placeholder so
-                          // the bubble is visible instead of empty.
-                          if (!isMediaMessage) return null;
-                          const label =
-                            msg.type === 'image' ? `📷 ${t('chats.media.photo')}`
-                            : msg.type === 'video' ? `🎥 ${t('chats.media.video')}`
-                            : msg.type === 'voice' || msg.type === 'audio' ? `🎤 ${t('chats.media.voice')}`
-                            : msg.type === 'sticker' ? `🏷️ ${t('chats.media.sticker')}`
-                            : msg.type === 'document' ? `📄 ${t('chats.media.document')}`
-                            : `📎 ${t('chats.media.attachment')}`;
-                          if (mediaFailed.has(msg.id)) {
-                            return <div className="message-media-placeholder">{label}</div>;
+                          // Real media type with no payload yet (older deep-history messages are metadata-only):
+                          // lazily fetch the media when the bubble nears the viewport; until then (or on failure)
+                          // show a labeled placeholder so the bubble is visible instead of empty.
+                          if (DOWNLOADABLE_MEDIA_TYPES.has(msg.type)) {
+                            const label =
+                              msg.type === 'image' ? `📷 ${t('chats.media.photo')}`
+                              : msg.type === 'video' ? `🎥 ${t('chats.media.video')}`
+                              : msg.type === 'voice' || msg.type === 'audio' ? `🎤 ${t('chats.media.voice')}`
+                              : msg.type === 'sticker' ? `🏷️ ${t('chats.media.sticker')}`
+                              : `📄 ${t('chats.media.document')}`;
+                            if (mediaFailed.has(msg.id)) {
+                              return <div className="message-media-placeholder">{label}</div>;
+                            }
+                            return (
+                              <LazyMediaPlaceholder label={label} onVisible={() => ensureMessageMedia(msg)} />
+                            );
                           }
-                          return (
-                            <LazyMediaPlaceholder label={label} onVisible={() => ensureMessageMedia(msg)} />
-                          );
+                          if (msg.type === 'contact') {
+                            return <div className="message-media-placeholder">👤 {t('chats.media.contact')}</div>;
+                          }
+                          // Anything else non-text (e.g. call logs the engine reports as `unknown`) isn't a
+                          // downloadable attachment — show a neutral label instead of a misleading "attachment".
+                          if (!isMediaMessage) return null;
+                          return <div className="message-media-placeholder">ℹ️ {t('chats.media.unsupported')}</div>;
                         }
                         if (!mediaInfo) return null; // unreachable (mediaSrc implies mediaInfo) — narrows the type
 
@@ -1062,6 +1119,10 @@ export function Chats() {
                               {isRevoked ? (
                                 <div className="message-text">{t('chats.messageDeleted')}</div>
                               ) : (
+                                // `location` bodies hold a base64 thumbnail and `contact` bodies hold a vcard
+                                // (both rendered/labeled by renderMedia), so don't dump them as text.
+                                msg.type !== 'location' &&
+                                msg.type !== 'contact' &&
                                 msg.body &&
                                 (!mediaInfo || msg.body !== mediaInfo.filename) && (
                                   <MessageBody text={msg.body} className="message-text" />

--- a/dashboard/src/pages/Chats.tsx
+++ b/dashboard/src/pages/Chats.tsx
@@ -46,6 +46,11 @@ import './Chats.css';
 // many more to reveal each time the user scrolls near the top. Keeps the DOM small on large chats.
 const MESSAGES_WINDOW_SIZE = 30;
 const MESSAGES_WINDOW_STEP = 30;
+// Lazy "load older": once the window reaches the top of what's loaded, fetch a deeper slice of the engine
+// history (both directions, text-only) by growing this ceiling each time, up to the engine's max.
+const HISTORY_INITIAL_LIMIT = 100;
+const HISTORY_FETCH_STEP = 300;
+const HISTORY_MAX_LIMIT = 2000;
 
 type MessageMedia = { mimetype: string; filename?: string; data?: string };
 
@@ -123,7 +128,7 @@ export function Chats() {
     isLoading: loadingMessages,
     isError: messagesError,
   } = useChatMessages(selectedSessionId, activeChat?.id ?? null);
-  const { appendMessage, updateMessage } = useChatMessagesActions();
+  const { appendMessage, updateMessage, loadOlderHistory } = useChatMessagesActions();
   const queryClient = useQueryClient();
   const [messageInput, setMessageInput] = useState<string>('');
   const [sending, setSending] = useState<boolean>(false);
@@ -158,17 +163,22 @@ export function Chats() {
     scrollToBottom,
   } = useChatScrollPosition(activeChat?.id ?? null, messages.length > 0);
 
-  // Client-side windowing. useChatMessages already loads the full recent thread (DB + engine history,
-  // BOTH directions). To keep large chats fast we only RENDER the most recent `visibleCount` messages
-  // and reveal older ones as the user scrolls near the top — no extra fetches, with scroll anchoring so
-  // the view doesn't jump. (Reaching back beyond the loaded thread is a future backend-paging concern;
-  // the DB stores only incoming messages, so older outgoing must keep coming from the engine history.)
+  // Render windowing + lazy "load older". useChatMessages loads the recent thread (DB + engine history,
+  // BOTH directions). We render only the most recent `visibleCount` messages and reveal more as the user
+  // scrolls up: first the already-loaded older ones (instant), then — once the window reaches the top of
+  // what's loaded — fetch a deeper slice of the engine history (text-only for the deeper portion).
   const [visibleCount, setVisibleCount] = useState<number>(MESSAGES_WINDOW_SIZE);
+  const [loadingOlder, setLoadingOlder] = useState<boolean>(false);
+  const [hasMoreToFetch, setHasMoreToFetch] = useState<boolean>(true);
+  const historyLimitRef = useRef<number>(HISTORY_INITIAL_LIMIT);
   const pendingAnchorRef = useRef<{ prevTop: number; prevHeight: number } | null>(null);
 
-  // Reset the render window when the active chat changes.
+  // Reset windowing + pagination when the active chat changes.
   useEffect(() => {
     setVisibleCount(MESSAGES_WINDOW_SIZE);
+    setLoadingOlder(false);
+    setHasMoreToFetch(true);
+    historyLimitRef.current = HISTORY_INITIAL_LIMIT;
     pendingAnchorRef.current = null;
   }, [activeChat?.id]);
 
@@ -177,26 +187,67 @@ export function Chats() {
     [messages, visibleCount],
   );
 
-  // Reveal an older slice when the user nears the top. Arm the anchor first so the layout effect below
-  // keeps the reading position once the older messages mount (content grows above the viewport).
-  const revealOlder = useCallback(() => {
-    if (visibleCount >= messages.length) return;
+  // Capture the current geometry so the layout effect below keeps the reading position once older
+  // content mounts above the viewport.
+  const armAnchor = useCallback(() => {
     const el = messagesContainerRef.current;
     pendingAnchorRef.current = { prevTop: el?.scrollTop ?? 0, prevHeight: el?.scrollHeight ?? 0 };
-    setVisibleCount(c => Math.min(c + MESSAGES_WINDOW_STEP, messages.length));
-  }, [visibleCount, messages.length, messagesContainerRef]);
+  }, [messagesContainerRef]);
+
+  const revealOlder = useCallback(async () => {
+    if (loadingOlder) return;
+    // 1) Reveal already-loaded older messages — instant, no fetch.
+    if (visibleCount < messages.length) {
+      armAnchor();
+      setVisibleCount(c => Math.min(c + MESSAGES_WINDOW_STEP, messages.length));
+      return;
+    }
+    // 2) Window covers everything loaded → fetch a deeper slice of engine history (both directions).
+    if (!hasMoreToFetch || !selectedSessionId || !activeChat) return;
+    // The loaded thread already being shorter than the last ceiling means there's nothing older to fetch.
+    if (messages.length < historyLimitRef.current || historyLimitRef.current >= HISTORY_MAX_LIMIT) {
+      setHasMoreToFetch(false);
+      return;
+    }
+    setLoadingOlder(true);
+    armAnchor();
+    try {
+      const nextLimit = Math.min(historyLimitRef.current + HISTORY_FETCH_STEP, HISTORY_MAX_LIMIT);
+      const added = await loadOlderHistory(selectedSessionId, activeChat.id, nextLimit);
+      historyLimitRef.current = nextLimit;
+      setHasMoreToFetch(added > 0 && nextLimit < HISTORY_MAX_LIMIT);
+      if (added > 0) setVisibleCount(c => c + added); // reveal the newly fetched older messages
+      else pendingAnchorRef.current = null;
+    } catch (err) {
+      pendingAnchorRef.current = null;
+      showWarningToast(t('chats.errors.loadMessages'), err instanceof Error ? err.message : undefined);
+    } finally {
+      setLoadingOlder(false);
+    }
+  }, [
+    loadingOlder,
+    visibleCount,
+    messages.length,
+    hasMoreToFetch,
+    selectedSessionId,
+    activeChat,
+    armAnchor,
+    loadOlderHistory,
+    t,
+    showWarningToast,
+  ]);
 
   // Compose the container's scroll handler: keep the hook's position-save + jump-button logic, and
-  // reveal the next older slice when the user nears the top.
+  // reveal/fetch older messages when the user nears the top.
   const onMessagesScroll = useCallback(() => {
     onScrollSavePosition();
     const el = messagesContainerRef.current;
-    if (el && isNearTop(el.scrollTop)) revealOlder();
+    if (el && isNearTop(el.scrollTop)) void revealOlder();
   }, [onScrollSavePosition, revealOlder, messagesContainerRef]);
 
-  // After the window grows, restore the reading position — content grew above the viewport, so shift
-  // scrollTop by the same amount. Keyed on `visibleCount` so realtime appends (which grow `messages` at
-  // the bottom) don't trigger it.
+  // After older content mounts (window grew, or older was fetched + revealed), restore the reading
+  // position — content grew above the viewport, so shift scrollTop by the same amount. Keyed on
+  // `visibleCount` so realtime appends (which grow `messages` at the bottom) don't trigger it.
   useLayoutEffect(() => {
     const anchor = pendingAnchorRef.current;
     if (!anchor) return;
@@ -1048,6 +1099,11 @@ export function Chats() {
                     })
                   )}
                 </div>
+                {loadingOlder && (
+                  <div className="messages-loading-older" aria-hidden="true">
+                    <Loader2 className="animate-spin" size={18} />
+                  </div>
+                )}
                 {showJumpToBottom && (
                   <button
                     type="button"

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -413,11 +413,14 @@ export const sessionApi = {
   // captured, e.g. a freshly paired session whose persisted store is still empty.
   // includeMedia downloads the media payload (base64) for history messages so stickers/images/
   // video/voice render instead of collapsing to an empty timestamp-only bubble.
-  getChatHistory: (id: string, chatId: string, limit = 100, includeMedia = false) =>
+  // `deep` raises the engine's limit ceiling (100 → 2000) to reach further back in the conversation,
+  // loading earlier messages on demand. It forces metadata-only (includeMedia is ignored when deep),
+  // so older scrollback comes back as text without media payloads. Used for "load older" pagination.
+  getChatHistory: (id: string, chatId: string, limit = 100, includeMedia = false, deep = false) =>
     request<EngineHistoryMessage[]>(
       `/sessions/${id}/messages/${encodeURIComponent(chatId)}/history?limit=${limit}${
         includeMedia ? '&includeMedia=true' : ''
-      }`,
+      }${deep ? '&deep=true' : ''}`,
     ),
 };
 

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -140,6 +140,7 @@ export const MESSAGE_TYPES = [
   'sticker',
   'location',
   'contact',
+  'call',
   'revoked',
   'unknown',
 ] as const;
@@ -166,6 +167,7 @@ export interface ChatMessage {
     media?: { mimetype: string; filename?: string; data?: string };
     quotedMessage?: { id: string; body: string };
     reactions?: Record<string, string>;
+    call?: { video: boolean; missed: boolean };
   };
 }
 
@@ -181,6 +183,8 @@ export interface EngineHistoryMessage {
   timestamp: number;
   fromMe?: boolean;
   media?: { mimetype: string; filename?: string; data?: string };
+  /** For `call` messages: video vs voice, and whether an incoming call went unanswered. */
+  call?: { video: boolean; missed: boolean };
 }
 
 export interface SendMediaPayload {

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -413,6 +413,13 @@ export const sessionApi = {
   // captured, e.g. a freshly paired session whose persisted store is still empty.
   // includeMedia downloads the media payload (base64) for history messages so stickers/images/
   // video/voice render instead of collapsing to an empty timestamp-only bubble.
+  // Lazily fetch (and server-side cache) the media payload for ONE message — for older messages that
+  // were backfilled metadata-only via getChatHistory(deep). Returns base64 media; persisted by the
+  // backend so a later request is instant.
+  getMessageMedia: (id: string, chatId: string, messageId: string) =>
+    request<{ mimetype: string; data: string; filename?: string }>(
+      `/sessions/${id}/messages/${encodeURIComponent(chatId)}/${encodeURIComponent(messageId)}/media`,
+    ),
   // `deep` raises the engine's limit ceiling (100 → 2000) to reach further back in the conversation,
   // loading earlier messages on demand. It forces metadata-only (includeMedia is ignored when deep),
   // so older scrollback comes back as text without media payloads. Used for "load older" pagination.

--- a/dashboard/src/utils/chatMessages.test.ts
+++ b/dashboard/src/utils/chatMessages.test.ts
@@ -96,15 +96,15 @@ const msg = (over: Partial<ChatMessageView> = {}): ChatMessageView => ({
 });
 
 test('mergeOrAppend appends when id is new', () => {
-  const before = [msg({ id: 'm-1' })];
-  const after = mergeOrAppend(before, msg({ id: 'm-2', body: 'world' }));
+  const before = [msg({ id: 'm-1', waMessageId: 'wa-1' })];
+  const after = mergeOrAppend(before, msg({ id: 'm-2', waMessageId: 'wa-2', body: 'world' }));
   assert.equal(after.length, 2);
   assert.equal(after[1].body, 'world');
 });
 
 test('mergeOrAppend replaces in place when id matches', () => {
-  const before = [msg({ id: 'm-1', body: 'old' }), msg({ id: 'm-2' })];
-  const after = mergeOrAppend(before, msg({ id: 'm-1', body: 'new' }));
+  const before = [msg({ id: 'm-1', waMessageId: 'wa-1', body: 'old' }), msg({ id: 'm-2', waMessageId: 'wa-2' })];
+  const after = mergeOrAppend(before, msg({ id: 'm-1', waMessageId: 'wa-1', body: 'new' }));
   assert.equal(after.length, 2);
   assert.equal(after[0].body, 'new');
   assert.equal(after[1].id, 'm-2');
@@ -120,9 +120,16 @@ test('mergeOrAppend dedupes a live WS message against its DB copy (id != id but 
   assert.equal(after[0].body, 'live');
 });
 
+test('mergeOrAppend keeps two distinct optimistic temps (no waMessageId) separate', () => {
+  // Temp placeholders have no waMessageId; they must not collapse into each other.
+  const before = [msg({ id: 'temp_1', waMessageId: undefined })];
+  const after = mergeOrAppend(before, msg({ id: 'temp_2', waMessageId: undefined }));
+  assert.equal(after.length, 2);
+});
+
 test('mergeOrAppend does not mutate the input array', () => {
-  const before = [msg({ id: 'm-1' })];
-  const after = mergeOrAppend(before, msg({ id: 'm-2' }));
+  const before = [msg({ id: 'm-1', waMessageId: 'wa-1' })];
+  const after = mergeOrAppend(before, msg({ id: 'm-2', waMessageId: 'wa-2' }));
   assert.notEqual(after, before);
   assert.equal(before.length, 1);
 });

--- a/dashboard/src/utils/chatMessages.ts
+++ b/dashboard/src/utils/chatMessages.ts
@@ -18,7 +18,10 @@ export function mapEngineHistoryMessage(h: EngineHistoryMessage): ChatMessage {
     status: 'read',
     timestamp: h.timestamp,
     createdAt: new Date((h.timestamp ?? 0) * 1000).toISOString(),
-    metadata: h.media ? { media: h.media } : undefined,
+    metadata:
+      h.media || h.call
+        ? { ...(h.media ? { media: h.media } : {}), ...(h.call ? { call: h.call } : {}) }
+        : undefined,
   };
 }
 
@@ -45,6 +48,7 @@ export interface ChatMessageView extends ChatMessage {
     media?: MessageMedia;
     quotedMessage?: { id: string; body: string };
     reactions?: Record<string, string>;
+    call?: { video: boolean; missed: boolean };
   };
 }
 

--- a/dashboard/src/utils/messageFormatter.test.ts
+++ b/dashboard/src/utils/messageFormatter.test.ts
@@ -92,3 +92,27 @@ test('marker without outside boundary stays literal (no over-formatting)', () =>
     { type: 'text', value: 'word*bold*end' },
   ]);
 });
+
+// XSS inertness: this formatter is the one place untrusted, attacker-controlled message bodies are
+// rendered. It must only ever emit text/code *values* (which React escapes) and format containers —
+// never markup. These pin that invariant so a future refactor can't silently start interpreting HTML.
+test('HTML in a body is a single literal text node, never markup', () => {
+  assert.deepEqual(parseMessageBody('<script>alert(1)</script>'), [
+    text('<script>alert(1)</script>'),
+  ]);
+});
+
+test('formatting markers wrap raw HTML as literal text, not parsed markup', () => {
+  // The bold node carries the literal '<b onmouseover=x>' as its text child — no attributes escape.
+  assert.deepEqual(parseMessageBody('*<b onmouseover=x>*'), [
+    { type: 'bold', children: [text('<b onmouseover=x>')] },
+  ]);
+});
+
+test('a javascript: URL body stays a plain text node (no link node emitted)', () => {
+  // The formatter never produces link nodes — link rendering is linkify's job, and it ignores the
+  // javascript: scheme. Pin that the parser leaves it as inert text.
+  assert.deepEqual(parseMessageBody('javascript:alert(1)'), [
+    text('javascript:alert(1)'),
+  ]);
+});

--- a/dashboard/src/utils/scrollDecision.test.ts
+++ b/dashboard/src/utils/scrollDecision.test.ts
@@ -1,6 +1,12 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { decideScroll, type ScrollGeometry } from './scrollDecision.ts';
+import {
+  decideScroll,
+  isAwayFromBottom,
+  isNearTop,
+  anchorScrollTopAfterPrepend,
+  type ScrollGeometry,
+} from './scrollDecision.ts';
 
 const at = (scrollTop: number, scrollHeight = 1000, clientHeight = 500): ScrollGeometry => ({
   scrollTop, scrollHeight, clientHeight,
@@ -34,4 +40,52 @@ test('incoming message exactly at threshold preserves (gap = 100 is NOT < 100)',
 test('custom threshold overrides default', () => {
   // gap = 200, threshold 300 → bottom
   assert.equal(decideScroll('incoming', at(300), 300), 'bottom');
+});
+
+// isAwayFromBottom drives the "jump to bottom" button visibility.
+test('isAwayFromBottom: false when pinned to the bottom (gap = 0)', () => {
+  assert.equal(isAwayFromBottom(at(500)), false);
+});
+
+test('isAwayFromBottom: true when scrolled up past the default threshold', () => {
+  // gap = 1000 - 100 - 500 = 400 > 240
+  assert.equal(isAwayFromBottom(at(100)), true);
+});
+
+test('isAwayFromBottom: false within the threshold band (gap just under 240)', () => {
+  // gap = 1000 - 270 - 500 = 230, not > 240
+  assert.equal(isAwayFromBottom(at(270)), false);
+});
+
+test('isAwayFromBottom: custom threshold is honored', () => {
+  // gap = 1000 - 400 - 500 = 100; with threshold 50 → away
+  assert.equal(isAwayFromBottom(at(400), 50), true);
+});
+
+// isNearTop triggers loading older messages when the user scrolls up to the top of the thread.
+test('isNearTop: true at the very top (scrollTop 0)', () => {
+  assert.equal(isNearTop(0), true);
+});
+
+test('isNearTop: true within the default threshold (120)', () => {
+  assert.equal(isNearTop(80), true);
+});
+
+test('isNearTop: false once scrolled down past the threshold', () => {
+  assert.equal(isNearTop(200), false);
+});
+
+test('isNearTop: honors a custom threshold', () => {
+  assert.equal(isNearTop(40, 30), false);
+});
+
+// anchorScrollTopAfterPrepend keeps the same messages in view after older ones are prepended:
+// the content above grew by (newHeight - prevHeight), so scrollTop must grow by the same delta.
+test('anchorScrollTopAfterPrepend: shifts scrollTop by the height added on top', () => {
+  // was at 300, content grew 1000 -> 1600 (added 600 above) → 300 + 600 = 900
+  assert.equal(anchorScrollTopAfterPrepend(300, 1000, 1600), 900);
+});
+
+test('anchorScrollTopAfterPrepend: no growth leaves scrollTop unchanged', () => {
+  assert.equal(anchorScrollTopAfterPrepend(300, 1000, 1000), 300);
 });

--- a/dashboard/src/utils/scrollDecision.ts
+++ b/dashboard/src/utils/scrollDecision.ts
@@ -30,3 +30,40 @@ export function decideScroll(
   const gap = geometry.scrollHeight - geometry.scrollTop - geometry.clientHeight;
   return gap < nearBottomThreshold ? 'bottom' : 'preserve';
 }
+
+// Larger than the near-bottom auto-scroll threshold: the "jump to bottom" affordance should appear
+// only once the user has deliberately scrolled up a meaningful amount, not on tiny offsets.
+export const DEFAULT_JUMP_VISIBILITY_THRESHOLD = 240;
+
+/**
+ * Whether the user has scrolled far enough from the bottom to warrant showing a "jump to bottom"
+ * button. `gap` is the distance (px) between the current viewport bottom and the content bottom.
+ */
+export function isAwayFromBottom(
+  geometry: ScrollGeometry,
+  threshold: number = DEFAULT_JUMP_VISIBILITY_THRESHOLD,
+): boolean {
+  const gap = geometry.scrollHeight - geometry.scrollTop - geometry.clientHeight;
+  return gap > threshold;
+}
+
+// How close to the top (px) the user must scroll before we fetch the next older page.
+export const DEFAULT_NEAR_TOP_THRESHOLD = 120;
+
+/** Whether the user has scrolled near the top of the thread — the cue to load older messages. */
+export function isNearTop(scrollTop: number, threshold: number = DEFAULT_NEAR_TOP_THRESHOLD): boolean {
+  return scrollTop <= threshold;
+}
+
+/**
+ * New scrollTop that keeps the currently-visible messages in place after older ones are prepended.
+ * Prepending grows the content above the viewport by (newScrollHeight - prevScrollHeight), so the
+ * scroll offset must grow by the same amount — otherwise the view jumps up to the new top.
+ */
+export function anchorScrollTopAfterPrepend(
+  prevScrollTop: number,
+  prevScrollHeight: number,
+  newScrollHeight: number,
+): number {
+  return prevScrollTop + (newScrollHeight - prevScrollHeight);
+}

--- a/src/engine/adapters/baileys.adapter.ts
+++ b/src/engine/adapters/baileys.adapter.ts
@@ -760,6 +760,11 @@ export class BaileysAdapter implements IWhatsAppEngine {
   getChatHistory(_chatId: string, _limit?: number, _includeMedia?: boolean): Promise<IncomingMessage[]> {
     return this.unsupported('getChatHistory');
   }
+  downloadMessageMedia(
+    _messageId: string,
+  ): Promise<{ mimetype: string; data: string; filename?: string } | null> {
+    return this.unsupported('downloadMessageMedia');
+  }
   getLabels(): Promise<Label[]> {
     return this.unsupported('getLabels');
   }

--- a/src/engine/adapters/baileys.adapter.ts
+++ b/src/engine/adapters/baileys.adapter.ts
@@ -760,9 +760,7 @@ export class BaileysAdapter implements IWhatsAppEngine {
   getChatHistory(_chatId: string, _limit?: number, _includeMedia?: boolean): Promise<IncomingMessage[]> {
     return this.unsupported('getChatHistory');
   }
-  downloadMessageMedia(
-    _messageId: string,
-  ): Promise<{ mimetype: string; data: string; filename?: string } | null> {
+  downloadMessageMedia(_messageId: string): Promise<{ mimetype: string; data: string; filename?: string } | null> {
     return this.unsupported('downloadMessageMedia');
   }
   getLabels(): Promise<Label[]> {

--- a/src/engine/adapters/message-mapper.spec.ts
+++ b/src/engine/adapters/message-mapper.spec.ts
@@ -102,6 +102,7 @@ describe('mapWwebjsMessageType (engine type-token -> neutral MessageType boundar
     ['location', 'location'],
     ['vcard', 'contact'],
     ['multi_vcard', 'contact'],
+    ['call_log', 'call'],
     ['revoked', 'revoked'],
     ['e2e_notification', 'unknown'], // any unmapped wwebjs type
   ])('maps wwebjs type %s -> %s', (raw, expected) => {

--- a/src/engine/adapters/message-mapper.ts
+++ b/src/engine/adapters/message-mapper.ts
@@ -27,6 +27,8 @@ export function mapWwebjsMessageType(raw: string): MessageType {
     case 'vcard':
     case 'multi_vcard':
       return 'contact';
+    case 'call_log':
+      return 'call';
     case 'revoked':
       return 'revoked';
     default:

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -1282,6 +1282,24 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
 
   // ========== Gap Quick Wins Implementation ==========
 
+  async downloadMessageMedia(
+    messageId: string,
+  ): Promise<{ mimetype: string; data: string; filename?: string } | null> {
+    this.ensureReady();
+    // getMessageById resolves from the engine's message store (populated when chat history was loaded),
+    // so it reaches older messages that chat.fetchMessages({limit}) would miss.
+    const message = await this.client!.getMessageById(messageId).catch(() => null);
+    if (!message || !message.hasMedia) return null;
+    const media = await this.inboundLimiter.run(() => message.downloadMedia());
+    if (!media || !media.data) return null;
+    const sizeBytes = Buffer.byteLength(media.data, 'base64');
+    if (sizeBytes > inboundMediaMaxBytes()) {
+      this.logger.warn('On-demand media exceeds MEDIA_DOWNLOAD_MAX_BYTES; skipped', { messageId, sizeBytes });
+      return null;
+    }
+    return { mimetype: media.mimetype, data: media.data, filename: media.filename || undefined };
+  }
+
   async getChatHistory(chatId: string, limit: number = 50, includeMedia: boolean = false): Promise<IncomingMessage[]> {
     this.ensureReady();
     const chat = await this.client!.getChatById(chatId);

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -1315,6 +1315,15 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
       out.chatId = chatId;
       out.isGroup = chatId.endsWith('@g.us');
       out.isStatusBroadcast = chatId === 'status@broadcast';
+      if (msg.type === 'call_log') {
+        // The public Message wrapper doesn't surface call details; read them off the raw _data.
+        const d = (msg as unknown as { _data?: { isVideoCall?: boolean; callDuration?: number } })._data ?? {};
+        out.call = {
+          video: Boolean(d.isVideoCall),
+          // An incoming call with no recorded duration was never answered → a missed call.
+          missed: !out.fromMe && !d.callDuration,
+        };
+      }
       if (includeMedia && msg.hasMedia) {
         try {
           // Same pre-gate + limiter as live media: a large historical blob shouldn't bloat the response/heap.

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -1282,9 +1282,7 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
 
   // ========== Gap Quick Wins Implementation ==========
 
-  async downloadMessageMedia(
-    messageId: string,
-  ): Promise<{ mimetype: string; data: string; filename?: string } | null> {
+  async downloadMessageMedia(messageId: string): Promise<{ mimetype: string; data: string; filename?: string } | null> {
     this.ensureReady();
     // getMessageById resolves from the engine's message store (populated when chat history was loaded),
     // so it reaches older messages that chat.fetchMessages({limit}) would miss.
@@ -1315,7 +1313,7 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
       out.chatId = chatId;
       out.isGroup = chatId.endsWith('@g.us');
       out.isStatusBroadcast = chatId === 'status@broadcast';
-      if (msg.type === 'call_log') {
+      if ((msg.type as string) === 'call_log') {
         // The public Message wrapper doesn't surface call details; read them off the raw _data.
         const d = (msg as unknown as { _data?: { isVideoCall?: boolean; callDuration?: number } })._data ?? {};
         out.call = {

--- a/src/engine/interfaces/whatsapp-engine.interface.ts
+++ b/src/engine/interfaces/whatsapp-engine.interface.ts
@@ -453,6 +453,13 @@ export interface IWhatsAppEngine {
   deleteMessage(chatId: string, messageId: string, forEveryone?: boolean): Promise<void>;
   getChatHistory(chatId: string, limit?: number, includeMedia?: boolean): Promise<IncomingMessage[]>;
 
+  /**
+   * Download the media payload for a single message by its (serialized) id — used to lazily fetch
+   * media for older messages that were backfilled metadata-only via getChatHistory(deep). Returns null
+   * when the message can't be resolved (e.g. no longer in the engine store) or has no media.
+   */
+  downloadMessageMedia(messageId: string): Promise<{ mimetype: string; data: string; filename?: string } | null>;
+
   // Contact Extended Operations
   getProfilePicture(contactId: string): Promise<string | null>;
   blockContact(contactId: string): Promise<void>;

--- a/src/engine/interfaces/whatsapp-engine.interface.ts
+++ b/src/engine/interfaces/whatsapp-engine.interface.ts
@@ -51,6 +51,7 @@ export type MessageType =
   | 'sticker'
   | 'location'
   | 'contact'
+  | 'call'
   | 'revoked'
   | 'unknown';
 
@@ -87,6 +88,8 @@ export interface IncomingMessage {
   senderPhone?: string | null;
   /** Sender contact info, best-effort from the WhatsApp Web cache. Sync fields only (no network). */
   contact?: MessageContact;
+  /** Set for `call` (call_log) messages: video vs voice, and whether an incoming call went unanswered. */
+  call?: { video: boolean; missed: boolean };
   media?: {
     mimetype: string;
     filename?: string;

--- a/src/modules/message/message.controller.ts
+++ b/src/modules/message/message.controller.ts
@@ -308,6 +308,23 @@ export class MessageController {
     );
   }
 
+  @Get(':chatId/:messageId/media')
+  @ApiOperation({
+    summary: 'Download (and cache) the media payload for a single message',
+    description:
+      'Lazily fetches the media for one message — for older messages backfilled metadata-only via ' +
+      'history(deep). Served from the storage cache when already downloaded, otherwise downloaded from ' +
+      'the engine and persisted so subsequent requests are instant.',
+  })
+  @ApiParam({ name: 'sessionId', description: 'Session ID' })
+  @ApiParam({ name: 'chatId', description: 'Chat ID' })
+  @ApiParam({ name: 'messageId', description: 'Serialized message id' })
+  @ApiResponse({ status: 200, description: 'Media payload (mimetype + base64 data)' })
+  @ApiResponse({ status: 404, description: 'Media not available (message not in store or no media)' })
+  async getMessageMedia(@Param('sessionId') sessionId: string, @Param('messageId') messageId: string) {
+    return this.messageService.getMessageMedia(sessionId, messageId);
+  }
+
   @Get(':chatId/:messageId/reactions')
   @ApiOperation({ summary: 'Get reactions for a specific message' })
   @ApiParam({ name: 'sessionId', description: 'Session ID' })

--- a/src/modules/message/message.service.ts
+++ b/src/modules/message/message.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, BadRequestException } from '@nestjs/common';
+import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
+import { StorageService } from '../../common/storage/storage.service';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { SessionService } from '../session/session.service';
@@ -34,7 +35,37 @@ export class MessageService {
     private readonly hookManager: HookManager,
     private readonly templateService: TemplateService,
     private readonly lidMappingStore: LidMappingStoreService,
+    private readonly storage: StorageService,
   ) {}
+
+  /**
+   * Lazily fetch (and persist) the media payload for one message — used for older messages that were
+   * backfilled metadata-only via getChatHistory(deep). Serves from the storage layer when already
+   * downloaded (so a media fetched yesterday is instant today), otherwise downloads it from the engine
+   * and caches it. The message id is sanitized into a safe per-session storage key.
+   */
+  async getMessageMedia(
+    sessionId: string,
+    messageId: string,
+  ): Promise<{ mimetype: string; data: string; filename?: string }> {
+    const safeId = messageId.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 200);
+    const key = `media-cache/${sessionId}/${safeId}.json`;
+    try {
+      const cached = await this.storage.getFile(key);
+      return JSON.parse(cached.toString('utf8'));
+    } catch {
+      // not cached yet — fall through to download
+    }
+    const engine = this.getEngine(sessionId);
+    const media = await engine.downloadMessageMedia(messageId);
+    if (!media) {
+      throw new NotFoundException(`Media not available for message ${messageId}`);
+    }
+    await this.storage
+      .putFile(key, Buffer.from(JSON.stringify(media), 'utf8'))
+      .catch(err => this.logger.warn(`Failed to persist media cache for ${messageId}: ${String(err)}`));
+    return media;
+  }
 
   async sendText(sessionId: string, dto: SendTextMessageDto): Promise<MessageResponseDto> {
     // Execute hook before sending - plugins can modify or block

--- a/src/modules/message/message.service.ts
+++ b/src/modules/message/message.service.ts
@@ -52,7 +52,7 @@ export class MessageService {
     const key = `media-cache/${sessionId}/${safeId}.json`;
     try {
       const cached = await this.storage.getFile(key);
-      return JSON.parse(cached.toString('utf8'));
+      return JSON.parse(cached.toString('utf8')) as { mimetype: string; data: string; filename?: string };
     } catch {
       // not cached yet — fall through to download
     }


### PR DESCRIPTION
## Description

Follow-up to #484, hardening the `/chats` experience after testing on live sessions. Grouped:

**Scroll & layout**
- Fix reopened chats jumping to the top — scroll position is recorded continuously via `onScroll` (not read after the DOM already swapped to the next chat), so returning restores where you were.
- Reliable open-at-bottom (re-pin on the next frame for late media layout).
- WhatsApp-style jump-to-bottom FAB.

**Loading & pagination**
- Render windowing: render the recent ~30 messages and reveal more on scroll-up, keeping the DOM light on large chats.
- Lazy "load older" via the engine deep-history (both directions, up to 2000) once the window reaches the top — older messages, including the user's own, are reachable again.
- Drop the incoming-only band at the top of the initial thread (the DB stores only incoming and its page reached further back than the both-directions history page, so the top looked one-sided).

**Media**
- On-demand media for older (metadata-only) messages with **server-side persistence**: new `GET /sessions/:id/messages/:chatId/:messageId/media` resolves the message via the engine, downloads its media, and caches it through `StorageService` — so a media fetched once is instant next time. Client downloads are concurrency-limited with retry/backoff (no dropped media under a 429 burst).
- Payload-less media renders a labeled placeholder; the lazy loader (IntersectionObserver) swaps in the real photo/audio as the bubble nears the viewport.

**Message types**
- Render location messages (the base64 map thumbnail) instead of dumping the base64 as text.
- Map WhatsApp `call_log` → a new `call` MessageType with missed/video detection (from the raw `_data`), rendering "📞 Missed call" / "📹 Video call" etc. instead of a misleading "attachment".
- Precise non-media handling: only real media types attempt a download; contacts and unsupported types get neutral labels.

**Hardening**
- linkify blocks non-http(s) schemes (e.g. `file://`); stickers open in the lightbox; formatter XSS-inertness tests; dedup test for optimistic temps.

Aligned with `main` (#484 already merged): the cache-seed-truncation, dedup, and load-error handling are main's — this PR builds on top.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] Tests added/updated (dashboard pure logic: scroll/window/pagination, formatter XSS, dedup; backend: `call_log`→`call` mapper case)
- [ ] Documentation updated
- [x] Lint passes (backend + dashboard)
- [x] Self-reviewed

## Screenshots (if applicable)
N/A — behavioral; verified against live sessions (scroll restore, old-message pagination, on-demand media, location/call rendering).

## Related Issues
Follow-up to #484.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
