### PR TITLE
feat(status): Baileys-only WhatsApp Status posting (#455)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **WhatsApp Status posting (Baileys only).** The three status `send-*` endpoints now post to the status feed on the Baileys engine: `POST /api/sessions/:id/status/send-text`, `/send-image`, and `/send-video` accept a required `recipients[]` body field (1–256 JIDs, each `@c.us` or `@lid`; passed to the engine as `statusJidList` — an empty array is rejected with `400`). Image/video take an optional `image.mimetype` / `video.mimetype`; the service defaults to `image/jpeg` / `video/mp4`. A whatsapp-web.js session returns `501`: WA Web removed `WAWebStatusGatingUtils.canCheckStatusRankingPosterGating` around 2026-04-30, so the wwebjs path is upstream-blocked. `@c.us` recipients are reliable; `@lid` is best-effort (unverified), and the posting account's own phone may briefly show a "waiting for this status update" notice while recipients view it normally. Thanks @CharlesLightjarvis for the report. (#455)
+
 - **Visible placeholder for skipped inbound media.** When `MEDIA_DOWNLOAD_ENABLED=false` (or a media item is over the byte cap), an incoming media message now carries an `omitted` marker and the dashboard chat renders a `📎 Media` placeholder instead of a bare timestamp. The marker reuses the existing `{ mimetype, omitted, sizeBytes }` shape on both the whatsapp-web.js and Baileys engines, so webhook/n8n/dashboard consumers see one consistent contract for "media was present but not downloaded." Thanks @spidgrou. (#501)
 
 ### Fixed
+
+- **Status image/video no longer hardcode `image/jpeg` / `video/mp4`.** The `SendImageStatusDto` / `SendVideoStatusDto` media input now accepts an optional `mimetype`; the service applies `mimetype ?? 'image/jpeg'` (or `'video/mp4'`) instead of always passing the hardcoded value to the engine. (#455)
 
 - **Clean install on Node 22+ / npm 11.** `@nestjs/websockets` is now declared as a direct dependency — it was only resolving transitively via `@nestjs/platform-socket.io`, so stricter installs failed with `TS2307: Cannot find module '@nestjs/websockets'`. The `postinstall` script also no longer triggers Node's `DEP0190` deprecation: `shell: true` is retained (so Windows still resolves `npm` via `npm.cmd`) but the command is now passed as a single string instead of an args array. Thanks @abdullah4tech. (#500)
 

--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -2685,7 +2685,7 @@ Same `{ statuses }` wrapper and `Status` shape as the list-all route.
 
 #### POST /api/sessions/:sessionId/status/send-text
 
-Post a text status (story) to the session's status feed.
+Post a text status (story) to the session's status feed. **Baileys engine only** — a whatsapp-web.js session returns `501` (see Errors).
 
 **Auth:** API key (OPERATOR)
 
@@ -2700,11 +2700,12 @@ Post a text status (story) to the session's status feed.
 | Field | Type | Required | Constraints | Description |
 | --- | --- | --- | --- | --- |
 | text | string | yes | — | Status text body |
+| recipients | string[] | yes | 1–256 items, each matching `^\d+@(c\.us\|lid)$` | JIDs of the contacts permitted to view the status (passed as `statusJidList` to the engine). Empty array → `400` |
 | backgroundColor | string | no | 6-digit hex color matching `^#[0-9A-Fa-f]{6}$` | e.g. `#25D366`; bad value → `backgroundColor must be a hex color (e.g., #25D366)` |
-| font | integer | no | integer `0`–`4` | Font index |
+| font | integer | no | integer `0`–`5` | Font index |
 
 ```json
-{ "text": "Hello from OpenWA!", "backgroundColor": "#25D366", "font": 2 }
+{ "text": "Hello from OpenWA!", "recipients": ["6281234567890@c.us"], "backgroundColor": "#25D366", "font": 2 }
 ```
 
 **Response** `201`
@@ -2719,11 +2720,15 @@ Post a text status (story) to the session's status feed.
 
 Returns the engine `StatusResult` directly (no wrapper). POST default status is `201`.
 
-**Errors:** `400` validation failure (unknown body field, bad `backgroundColor`/`font`), or session is not started · `401` missing/invalid API key · `403` key lacks `OPERATOR` role · `404` session not found / not connected
+**Recipient JIDs:** `@c.us` (regular phone) recipients are reliable. `@lid` (privacy-id) recipients are best-effort and unverified — WhatsApp may not deliver to an unresolved LID, so prefer `@c.us` where the phone number is known.
+
+**Sender-side caveat:** the posting account's own phone may display a "waiting for this status update" notice in its status feed; this is cosmetic — recipients view the status normally.
+
+**Errors:** `400` validation failure (unknown body field, missing/empty `recipients`, a JID not matching `@c.us`/`@lid`, or more than 256 recipients, bad `backgroundColor`/`font`), or session is not started · `401` missing/invalid API key · `403` key lacks `OPERATOR` role · `404` session not found / not connected · `501` the session is on the whatsapp-web.js engine (status posting is Baileys-only; WA Web removed `WAWebStatusGatingUtils.canCheckStatusRankingPosterGating` around 2026-04-30, so the wwebjs path is upstream-blocked — see #455)
 
 #### POST /api/sessions/:sessionId/status/send-image
 
-Post an image status (story) from a URL or base64 payload.
+Post an image status (story) from a URL or base64 payload. **Baileys engine only** — a whatsapp-web.js session returns `501` (see Errors).
 
 **Auth:** API key (OPERATOR)
 
@@ -2740,12 +2745,14 @@ Post an image status (story) from a URL or base64 payload.
 | image | object (`MediaInput`) | yes | validated nested object (an empty `{}` passes — there is no `@IsNotEmpty`) | Media source wrapper |
 | image.url | string | no | — | Media source URL |
 | image.base64 | string | no | — | Base64-encoded media data |
+| image.mimetype | string | no | — | Media MIME type; if omitted the service defaults to `image/jpeg` |
+| recipients | string[] | yes | 1–256 items, each matching `^\d+@(c\.us\|lid)$` | JIDs of the contacts permitted to view the status (`statusJidList`). Empty array → `400` |
 | caption | string | no | — | Optional caption |
 
-The service resolves the media as `image.url || image.base64 || ''` and hard-codes mimetype `image/jpeg`.
+The service resolves the media as `image.url || image.base64 || ''` and applies mimetype `image.mimetype ?? 'image/jpeg'`.
 
 ```json
-{ "image": { "url": "https://example.com/photo.jpg" }, "caption": "My status" }
+{ "image": { "url": "https://example.com/photo.jpg", "mimetype": "image/png" }, "recipients": ["6281234567890@c.us"], "caption": "My status" }
 ```
 
 **Response** `201`
@@ -2760,11 +2767,13 @@ The service resolves the media as `image.url || image.base64 || ''` and hard-cod
 
 Returns the engine `StatusResult` directly. POST default status is `201`.
 
-**Errors:** `400` unknown top-level body field (strict whitelist), or session is not started · `401` missing/invalid API key · `403` key lacks `OPERATOR` role · `404` session not found / not connected
+**Recipient JIDs:** `@c.us` (regular phone) recipients are reliable. `@lid` (privacy-id) recipients are best-effort and unverified — prefer `@c.us` where the phone number is known. **Sender-side caveat:** the posting account's own phone may show a "waiting for this status update" notice; recipients view it normally.
+
+**Errors:** `400` validation failure (unknown body field, missing/empty `recipients`, a JID not matching `@c.us`/`@lid`, or more than 256 recipients), or session is not started · `401` missing/invalid API key · `403` key lacks `OPERATOR` role · `404` session not found / not connected · `501` the session is on the whatsapp-web.js engine (status posting is Baileys-only; see `send-text` and #455)
 
 #### POST /api/sessions/:sessionId/status/send-video
 
-Post a video status (story) from a URL or base64 payload.
+Post a video status (story) from a URL or base64 payload. **Baileys engine only** — a whatsapp-web.js session returns `501` (see Errors).
 
 **Auth:** API key (OPERATOR)
 
@@ -2781,12 +2790,14 @@ Post a video status (story) from a URL or base64 payload.
 | video | object (`MediaInput`) | yes | validated nested object (an empty `{}` passes) | Media source wrapper |
 | video.url | string | no | — | Media source URL |
 | video.base64 | string | no | — | Base64-encoded media data |
+| video.mimetype | string | no | — | Media MIME type; if omitted the service defaults to `video/mp4` |
+| recipients | string[] | yes | 1–256 items, each matching `^\d+@(c\.us\|lid)$` | JIDs of the contacts permitted to view the status (`statusJidList`). Empty array → `400` |
 | caption | string | no | — | Optional caption |
 
-The service resolves the media as `video.url || video.base64 || ''` and hard-codes mimetype `video/mp4`.
+The service resolves the media as `video.url || video.base64 || ''` and applies mimetype `video.mimetype ?? 'video/mp4'`.
 
 ```json
-{ "video": { "url": "https://example.com/clip.mp4" }, "caption": "Watch this" }
+{ "video": { "url": "https://example.com/clip.mp4", "mimetype": "video/quicktime" }, "recipients": ["6281234567890@c.us"], "caption": "Watch this" }
 ```
 
 **Response** `201`
@@ -2801,7 +2812,9 @@ The service resolves the media as `video.url || video.base64 || ''` and hard-cod
 
 Returns the engine `StatusResult` directly. POST default status is `201`.
 
-**Errors:** `400` unknown top-level body field, or session is not started · `401` missing/invalid API key · `403` key lacks `OPERATOR` role · `404` session not found / not connected
+**Recipient JIDs:** `@c.us` (regular phone) recipients are reliable. `@lid` (privacy-id) recipients are best-effort and unverified — prefer `@c.us` where the phone number is known. **Sender-side caveat:** the posting account's own phone may show a "waiting for this status update" notice; recipients view it normally.
+
+**Errors:** `400` validation failure (unknown body field, missing/empty `recipients`, a JID not matching `@c.us`/`@lid`, or more than 256 recipients), or session is not started · `401` missing/invalid API key · `403` key lacks `OPERATOR` role · `404` session not found / not connected · `501` the session is on the whatsapp-web.js engine (status posting is Baileys-only; see `send-text` and #455)
 
 #### DELETE /api/sessions/:sessionId/status/:statusId
 

--- a/sdk/javascript/src/resources/status.ts
+++ b/sdk/javascript/src/resources/status.ts
@@ -8,7 +8,13 @@
 
 import { encodeSegment } from '../http.js';
 import type { OpenWAClient } from '../client.js';
-import type { SendImageStatusRequest, SendTextStatusRequest, SendVideoStatusRequest, StatusRecord } from '../types.js';
+import type {
+  SendImageStatusRequest,
+  SendTextStatusRequest,
+  SendVideoStatusRequest,
+  StatusRecord,
+  StatusResult,
+} from '../types.js';
 
 export class StatusResource {
   constructor(private readonly client: OpenWAClient) {}
@@ -30,8 +36,8 @@ export class StatusResource {
   }
 
   /** Post a text status update. */
-  sendText(sessionId: string, body: SendTextStatusRequest): Promise<StatusRecord> {
-    return this.client.request<StatusRecord>({
+  sendText(sessionId: string, body: SendTextStatusRequest): Promise<StatusResult> {
+    return this.client.request<StatusResult>({
       method: 'POST',
       path: `/api/sessions/${encodeSegment(sessionId)}/status/send-text`,
       body,
@@ -39,8 +45,8 @@ export class StatusResource {
   }
 
   /** Post an image status update. */
-  sendImage(sessionId: string, body: SendImageStatusRequest): Promise<StatusRecord> {
-    return this.client.request<StatusRecord>({
+  sendImage(sessionId: string, body: SendImageStatusRequest): Promise<StatusResult> {
+    return this.client.request<StatusResult>({
       method: 'POST',
       path: `/api/sessions/${encodeSegment(sessionId)}/status/send-image`,
       body,
@@ -48,8 +54,8 @@ export class StatusResource {
   }
 
   /** Post a video status update. */
-  sendVideo(sessionId: string, body: SendVideoStatusRequest): Promise<StatusRecord> {
-    return this.client.request<StatusRecord>({
+  sendVideo(sessionId: string, body: SendVideoStatusRequest): Promise<StatusResult> {
+    return this.client.request<StatusResult>({
       method: 'POST',
       path: `/api/sessions/${encodeSegment(sessionId)}/status/send-video`,
       body,

--- a/sdk/javascript/src/types.ts
+++ b/sdk/javascript/src/types.ts
@@ -500,6 +500,10 @@ export interface DeleteChatRequest {
 
 // ── Status / Stories ──────────────────────────────────────────────
 
+/**
+ * Weak shape returned by the GET status endpoints (`list`/`fromContact`).
+ * The server payload there is loose/different; fields are all optional.
+ */
 export interface StatusRecord {
   id?: string;
   statusId?: string;
@@ -508,8 +512,22 @@ export interface StatusRecord {
   timestamp?: string | number;
 }
 
+/**
+ * Result of a status POST (`send-text`/`send-image`/`send-video`).
+ * Mirrors the backend `StatusResult` exactly.
+ */
+export interface StatusResult {
+  statusId: string;
+  /** ISO 8601 timestamp of the post. */
+  timestamp: string;
+  /** ISO 8601 expiry timestamp. */
+  expiresAt: string;
+}
+
 export interface SendTextStatusRequest {
   text: string;
+  /** Recipient JIDs the status is addressed to (required by the server; empty → 400). */
+  recipients: string[];
   /** Hex background color, e.g. `#25D366`. */
   backgroundColor?: string;
   /** Font index supported by WhatsApp status. */
@@ -520,17 +538,23 @@ export interface SendTextStatusRequest {
 export interface StatusMediaInput {
   url?: string;
   base64?: string;
+  /** Optional explicit mimetype (inferred from URL/bytes when omitted). */
+  mimetype?: string;
 }
 
 /** Server expects a nested `{ image: { url|base64 } }` body, not flat media fields. */
 export interface SendImageStatusRequest {
   image: StatusMediaInput;
+  /** Recipient JIDs the status is addressed to (required by the server; empty → 400). */
+  recipients: string[];
   caption?: string;
 }
 
 /** Server expects a nested `{ video: { url|base64 } }` body, not flat media fields. */
 export interface SendVideoStatusRequest {
   video: StatusMediaInput;
+  /** Recipient JIDs the status is addressed to (required by the server; empty → 400). */
+  recipients: string[];
   caption?: string;
 }
 

--- a/sdk/javascript/test/resources.test.ts
+++ b/sdk/javascript/test/resources.test.ts
@@ -124,13 +124,13 @@ describe('WebhooksResource — exact paths', () => {
 describe('StatusResource — nested media bodies', () => {
   it('sendImage/sendVideo forward the server-required nested {image|video:{...}} shape', async () => {
     const t = new MockTransport()
-      .on('POST', /\/status\/send-image$/, { body: { statusId: 's1' } })
-      .on('POST', /\/status\/send-video$/, { body: { statusId: 's2' } });
+      .on('POST', /\/status\/send-image$/, { body: { statusId: 's1', timestamp: '2025-01-01T00:00:00.000Z', expiresAt: '2025-01-02T00:00:00.000Z' } })
+      .on('POST', /\/status\/send-video$/, { body: { statusId: 's2', timestamp: '2025-01-01T00:00:00.000Z', expiresAt: '2025-01-02T00:00:00.000Z' } });
     const c = client(t);
-    await c.status.sendImage('s', { image: { url: 'http://img' }, caption: 'hi' });
-    expect(t.lastCall!.body).toEqual({ image: { url: 'http://img' }, caption: 'hi' });
-    await c.status.sendVideo('s', { video: { url: 'http://vid' } });
-    expect(t.lastCall!.body).toEqual({ video: { url: 'http://vid' } });
+    await c.status.sendImage('s', { image: { url: 'http://img' }, recipients: ['a@c.us'], caption: 'hi' });
+    expect(t.lastCall!.body).toEqual({ image: { url: 'http://img' }, recipients: ['a@c.us'], caption: 'hi' });
+    await c.status.sendVideo('s', { video: { url: 'http://vid' }, recipients: ['a@c.us'] });
+    expect(t.lastCall!.body).toEqual({ video: { url: 'http://vid' }, recipients: ['a@c.us'] });
   });
 });
 

--- a/sdk/php/src/Resources/StatusResource.php
+++ b/sdk/php/src/Resources/StatusResource.php
@@ -34,7 +34,8 @@ class StatusResource
     }
 
     /**
-     * @param array<string,mixed> $body
+     * @param array<string,mixed> $body Body must include a required `recipients` key
+     *                                   (list<string> of recipient JIDs; empty -> 400).
      * @return array<string,mixed>
      */
     public function sendText(string $sessionId, array $body): array
@@ -42,13 +43,21 @@ class StatusResource
         return $this->http->request('POST', "/api/sessions/{$this->http->encodeSegment($sessionId)}/status/send-text", [], $body);
     }
 
-    /** @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body Body must include a required `recipients` key
+     *                                   (list<string> of recipient JIDs; empty -> 400).
+     * @return array<string,mixed>
+     */
     public function sendImage(string $sessionId, array $body): array
     {
         return $this->http->request('POST', "/api/sessions/{$this->http->encodeSegment($sessionId)}/status/send-image", [], $body);
     }
 
-    /** @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body Body must include a required `recipients` key
+     *                                   (list<string> of recipient JIDs; empty -> 400).
+     * @return array<string,mixed>
+     */
     public function sendVideo(string $sessionId, array $body): array
     {
         return $this->http->request('POST', "/api/sessions/{$this->http->encodeSegment($sessionId)}/status/send-video", [], $body);

--- a/sdk/php/tests/ResourcesTest.php
+++ b/sdk/php/tests/ResourcesTest.php
@@ -182,6 +182,24 @@ class ResourcesTest extends TestCase
         $this->assertStringContainsString('/chats/typing', $backend->calls()[4]['url']);
     }
 
+    // ── Status (Stories) ──────────────────────────────────────────────
+
+    public function testStatusSendForwardsRequiredRecipientsAndNestedMedia(): void
+    {
+        $backend = new MockBackend();
+        $backend->on(200, ['statusId' => 's1', 'timestamp' => '2025-01-01T00:00:00.000Z', 'expiresAt' => '2025-01-02T00:00:00.000Z']);
+        $backend->on(200, ['statusId' => 's2', 'timestamp' => '2025-01-01T00:00:00.000Z', 'expiresAt' => '2025-01-02T00:00:00.000Z']);
+        $backend->on(200, ['statusId' => 's3', 'timestamp' => '2025-01-01T00:00:00.000Z', 'expiresAt' => '2025-01-02T00:00:00.000Z']);
+        $client = $backend->makeClient();
+        // Server requires `recipients` on every status post; media posts use a nested {image|video:{...}} body.
+        $client->status->sendText('s', ['text' => 'hi', 'recipients' => ['a@c.us']]);
+        $this->assertSame(['text' => 'hi', 'recipients' => ['a@c.us']], $backend->lastCall()['body']);
+        $client->status->sendImage('s', ['image' => ['url' => 'http://img'], 'recipients' => ['a@c.us'], 'caption' => 'c']);
+        $this->assertSame(['image' => ['url' => 'http://img'], 'recipients' => ['a@c.us'], 'caption' => 'c'], $backend->lastCall()['body']);
+        $client->status->sendVideo('s', ['video' => ['url' => 'http://vid'], 'recipients' => ['a@c.us']]);
+        $this->assertSame(['video' => ['url' => 'http://vid'], 'recipients' => ['a@c.us']], $backend->lastCall()['body']);
+    }
+
     public function testHealthAndAuth(): void
     {
         $backend = new MockBackend();

--- a/sdk/python/openwa/types.py
+++ b/sdk/python/openwa/types.py
@@ -501,8 +501,10 @@ class StatusRecord(TypedDict, total=False):
 
 
 class SendTextStatusRequest(TypedDict, total=False):
-    # text required; backgroundColor (hex, e.g. #25D366) and font optional.
+    # text and recipients required; backgroundColor (hex, e.g. #25D366) and font optional.
     text: str
+    # Recipient JIDs the status is addressed to (required by the server; empty -> 400).
+    recipients: list[str]
     backgroundColor: str
     font: int
 
@@ -512,12 +514,15 @@ class StatusMediaInput(TypedDict, total=False):
 
     url: str
     base64: str
+    mimetype: str
 
 
 class SendImageStatusRequest(TypedDict, total=False):
     """Server expects a nested ``{ image: { url|base64 } }`` body."""
 
     image: StatusMediaInput
+    # Recipient JIDs the status is addressed to (required by the server; empty -> 400).
+    recipients: list[str]
     caption: str
 
 
@@ -525,6 +530,8 @@ class SendVideoStatusRequest(TypedDict, total=False):
     """Server expects a nested ``{ video: { url|base64 } }`` body."""
 
     video: StatusMediaInput
+    # Recipient JIDs the status is addressed to (required by the server; empty -> 400).
+    recipients: list[str]
     caption: str
 
 

--- a/sdk/python/tests/test_sdk.py
+++ b/sdk/python/tests/test_sdk.py
@@ -376,11 +376,12 @@ class TestStatus:
         backend.on("POST", "/status/send-image", body={"statusId": "s1"})
         backend.on("POST", "/status/send-video", body={"statusId": "s2"})
         client = make_client(backend)
-        # Server requires a nested {image|video:{...}} body, not flat media fields.
-        client.status.send_image("s", {"image": {"url": "http://img"}, "caption": "hi"})
-        assert backend.calls[-1].body == {"image": {"url": "http://img"}, "caption": "hi"}
-        client.status.send_video("s", {"video": {"url": "http://vid"}})
-        assert backend.calls[-1].body == {"video": {"url": "http://vid"}}
+        # Server requires a nested {image|video:{...}} body, not flat media fields,
+        # plus a required recipients list.
+        client.status.send_image("s", {"image": {"url": "http://img"}, "recipients": ["a@c.us"], "caption": "hi"})
+        assert backend.calls[-1].body == {"image": {"url": "http://img"}, "recipients": ["a@c.us"], "caption": "hi"}
+        client.status.send_video("s", {"video": {"url": "http://vid"}, "recipients": ["a@c.us"]})
+        assert backend.calls[-1].body == {"video": {"url": "http://vid"}, "recipients": ["a@c.us"]}
 
 
 class TestChatsAndHealth:

--- a/src/engine/adapters/baileys.adapter.spec.ts
+++ b/src/engine/adapters/baileys.adapter.spec.ts
@@ -1697,11 +1697,15 @@ describe('BaileysAdapter status posting', () => {
       backgroundColor: '#25D366',
       font: 2,
     });
-    expect(fakeSock.sendMessage).toHaveBeenCalledWith('status@broadcast', { text: 'hello' }, {
-      statusJidList: ['628111@s.whatsapp.net', '628222@lid'],
-      backgroundColor: '#25D366',
-      font: 2,
-    });
+    expect(fakeSock.sendMessage).toHaveBeenCalledWith(
+      'status@broadcast',
+      { text: 'hello' },
+      {
+        statusJidList: ['628111@s.whatsapp.net', '628222@lid'],
+        backgroundColor: '#25D366',
+        font: 2,
+      },
+    );
     expect(result.statusId).toBe('STATUS1');
     expect(result.expiresAt.getTime() - result.timestamp.getTime()).toBe(24 * 3_600_000);
     expect(fakeStore.put).not.toHaveBeenCalled();
@@ -1725,10 +1729,7 @@ describe('BaileysAdapter status posting', () => {
   it('postVideoStatus resolves media and threads recipients', async () => {
     fakeSock.sendMessage.mockResolvedValue({ key: { id: 'VID1' }, messageTimestamp: 1719600000 });
     const adapter = await ready();
-    await adapter.postVideoStatus(
-      { mimetype: 'video/mp4', data: 'AAAA' },
-      { recipients: ['628111@c.us'] },
-    );
+    await adapter.postVideoStatus({ mimetype: 'video/mp4', data: 'AAAA' }, { recipients: ['628111@c.us'] });
     expect(fakeSock.sendMessage).toHaveBeenCalledWith(
       'status@broadcast',
       { video: Buffer.from('AAAA', 'base64'), caption: undefined, mimetype: 'video/mp4' },

--- a/src/engine/adapters/baileys.adapter.ts
+++ b/src/engine/adapters/baileys.adapter.ts
@@ -1358,9 +1358,7 @@ export class BaileysAdapter implements IWhatsAppEngine {
 
   /** Shape a Baileys send result into a StatusResult; expiresAt is timestamp + 24h (WhatsApp status TTL). */
   private toStatusResult(sent: WAMessage | undefined): StatusResult {
-    const ts = sent?.messageTimestamp
-      ? new Date(this.toUnixSeconds(sent.messageTimestamp) * 1000)
-      : new Date();
+    const ts = sent?.messageTimestamp ? new Date(this.toUnixSeconds(sent.messageTimestamp) * 1000) : new Date();
     return {
       statusId: sent?.key?.id ?? '',
       timestamp: ts,

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -12,6 +12,7 @@ import {
 import { getEffectiveWebVersionInfo, resolveWebVersionPin, __resetWebVersionCache } from '../wa-web-version';
 import * as fs from 'fs';
 import { EngineNotReadyError } from '../../common/errors/engine-not-ready.error';
+import { EngineNotSupportedError } from '../../common/errors/engine-not-supported.error';
 import { EngineStatus } from '../interfaces/whatsapp-engine.interface';
 import { SsrfBlockedError } from '../../common/security/ssrf-guard';
 import { fetch as undiciFetch } from 'undici';
@@ -616,6 +617,33 @@ describe('WhatsAppWebJsAdapter.resolveContactPhone (@lid -> phone, #263)', () =>
   it('is best-effort: a thrown engine error resolves to null, not a rejection', async () => {
     const adapter = readyAdapter(jest.fn().mockRejectedValue(new Error('Evaluation failed')));
     await expect(adapter.resolveContactPhone('123@lid')).resolves.toBeNull();
+  });
+});
+
+describe('WhatsAppWebJsAdapter status methods (Baileys-only, surface HTTP 501, #455)', () => {
+  // The 4 status methods are Baileys-only; the wwebjs adapter stubs each to EngineNotSupportedError
+  // (which extends NestJS NotImplementedException -> HTTP 501). This locks the new-contract signatures
+  // (postTextStatus(text, options) / postImage|VideoStatus(media, options) / deleteStatus(statusId))
+  // so a future refactor that silently starts returning data instead of throwing is caught here.
+  const readyAdapter = (): WhatsAppWebJsAdapter => {
+    const adapter = new WhatsAppWebJsAdapter({ sessionId: 's', sessionDataPath: './data/sessions', puppeteer: {} });
+    (adapter as unknown as { status: EngineStatus }).status = EngineStatus.READY;
+    // ensureReady() requires both status === READY and a non-null client before the method body runs.
+    (adapter as unknown as { client: unknown }).client = {};
+    return adapter;
+  };
+  const media = { mimetype: 'image/png', data: 'iVBOR' };
+  const options = { recipients: ['628111@c.us'] };
+
+  it.each([
+    ['postTextStatus', ['hello', options]] as const,
+    ['postImageStatus', [media, options]] as const,
+    ['postVideoStatus', [media, options]] as const,
+    ['deleteStatus', ['STATUS1']] as const,
+  ])('%s rejects with EngineNotSupportedError (501)', async (method, args) => {
+    await expect(
+      (readyAdapter() as unknown as Record<string, (...a: unknown[]) => Promise<unknown>>)[method](...args),
+    ).rejects.toBeInstanceOf(EngineNotSupportedError);
   });
 });
 

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -1136,6 +1136,41 @@ describe('SessionService', () => {
       expect(dispatchedEvents('message.received')).toHaveLength(0);
     });
 
+    it('does not process an own-send status echo (type=append) — no dispatch, no WS emit, no DB write', async () => {
+      // Regression guard for the WhatsApp Status feature: posting a status produces an own-send echo
+      // that Baileys delivers as `messages.upsert` with `type: 'append'` (NOT 'notify'). The adapter's
+      // handleMessagesUpsert filters `type !== 'notify'` before processInboundMessage, so the echo never
+      // reaches the engine callbacks. This test pins the engine-neutral last-chance guard —
+      // `isStatusBroadcast` on both onMessageCreate and onMessage — so a future change can't silently
+      // leak a status echo to websockets, webhooks, or the message table. Asserts the full no-side-effect
+      // contract (webhook dispatch + WS emit + DB insert) for completeness, even though the existing
+      // isStatusBroadcast tests above already cover the dispatch-only slice.
+      const callbacks = await startAndCaptureCallbacks();
+      (webhookService.dispatch as jest.Mock).mockClear();
+      (eventsGateway.emitMessage as jest.Mock).mockClear();
+      (eventsGateway.emitMessageSent as jest.Mock).mockClear();
+      (messageRepository.insert as jest.Mock).mockClear();
+
+      const statusEcho = makeMessage({
+        id: 'wa-status-echo',
+        from: 'me@c.us',
+        to: 'status@broadcast',
+        chatId: 'status@broadcast',
+        fromMe: true,
+        isStatusBroadcast: true,
+      });
+
+      // An own-send echo could in principle surface via either callback path; assert neither dispatches.
+      callbacks.onMessageCreate!(statusEcho);
+      callbacks.onMessage!(statusEcho);
+      await flush();
+
+      expect(webhookService.dispatch).not.toHaveBeenCalled();
+      expect(eventsGateway.emitMessage).not.toHaveBeenCalled();
+      expect(eventsGateway.emitMessageSent).not.toHaveBeenCalled();
+      expect(messageRepository.insert).not.toHaveBeenCalled();
+    });
+
     // The default hookManager mock returns an empty `data: {}`; echo the message through so the
     // engine-set fields (isLidSender) survive the hook and reach the inline-resolution branch.
     const echoHook = () =>

--- a/src/modules/status/dto/send-media-status.dto.spec.ts
+++ b/src/modules/status/dto/send-media-status.dto.spec.ts
@@ -13,23 +13,23 @@ describe('SendImageStatusDto recipients validation', () => {
 
   it('rejects missing recipients', async () => {
     const errors = await validate(plainToInstance(SendImageStatusDto, { image: valid.image }));
-    expect(errors.some((e) => e.property === 'recipients')).toBe(true);
+    expect(errors.some(e => e.property === 'recipients')).toBe(true);
   });
 
   it('rejects an empty recipients array (-> 400)', async () => {
     const errors = await validate(plainToInstance(SendImageStatusDto, { image: valid.image, recipients: [] }));
-    expect(errors.some((e) => e.property === 'recipients')).toBe(true);
+    expect(errors.some(e => e.property === 'recipients')).toBe(true);
   });
 
   it('rejects non-string entries', async () => {
     const errors = await validate(plainToInstance(SendImageStatusDto, { image: valid.image, recipients: [123] }));
-    expect(errors.some((e) => e.property === 'recipients')).toBe(true);
+    expect(errors.some(e => e.property === 'recipients')).toBe(true);
   });
 
   it('rejects more than 256 recipients', async () => {
     const recipients = Array.from({ length: 257 }, (_, i) => `${i}@c.us`);
     const errors = await validate(plainToInstance(SendImageStatusDto, { image: valid.image, recipients }));
-    expect(errors.some((e) => e.property === 'recipients')).toBe(true);
+    expect(errors.some(e => e.property === 'recipients')).toBe(true);
   });
 
   it('rejects malformed JIDs', async () => {
@@ -39,11 +39,13 @@ describe('SendImageStatusDto recipients validation', () => {
         recipients: ['not-a-jid', '123@g.us', '@c.us', 'abc@lid'],
       }),
     );
-    expect(errors.some((e) => e.property === 'recipients')).toBe(true);
+    expect(errors.some(e => e.property === 'recipients')).toBe(true);
   });
 
   it('accepts @lid recipients', async () => {
-    const errors = await validate(plainToInstance(SendImageStatusDto, { image: valid.image, recipients: ['6281@lid'] }));
+    const errors = await validate(
+      plainToInstance(SendImageStatusDto, { image: valid.image, recipients: ['6281@lid'] }),
+    );
     expect(errors).toHaveLength(0);
   });
 });
@@ -58,23 +60,23 @@ describe('SendVideoStatusDto recipients validation', () => {
 
   it('rejects missing recipients', async () => {
     const errors = await validate(plainToInstance(SendVideoStatusDto, { video: valid.video }));
-    expect(errors.some((e) => e.property === 'recipients')).toBe(true);
+    expect(errors.some(e => e.property === 'recipients')).toBe(true);
   });
 
   it('rejects an empty recipients array (-> 400)', async () => {
     const errors = await validate(plainToInstance(SendVideoStatusDto, { video: valid.video, recipients: [] }));
-    expect(errors.some((e) => e.property === 'recipients')).toBe(true);
+    expect(errors.some(e => e.property === 'recipients')).toBe(true);
   });
 
   it('rejects non-string entries', async () => {
     const errors = await validate(plainToInstance(SendVideoStatusDto, { video: valid.video, recipients: [123] }));
-    expect(errors.some((e) => e.property === 'recipients')).toBe(true);
+    expect(errors.some(e => e.property === 'recipients')).toBe(true);
   });
 
   it('rejects more than 256 recipients', async () => {
     const recipients = Array.from({ length: 257 }, (_, i) => `${i}@c.us`);
     const errors = await validate(plainToInstance(SendVideoStatusDto, { video: valid.video, recipients }));
-    expect(errors.some((e) => e.property === 'recipients')).toBe(true);
+    expect(errors.some(e => e.property === 'recipients')).toBe(true);
   });
 
   it('rejects malformed JIDs', async () => {
@@ -84,11 +86,13 @@ describe('SendVideoStatusDto recipients validation', () => {
         recipients: ['not-a-jid', '123@g.us', '@c.us', 'abc@lid'],
       }),
     );
-    expect(errors.some((e) => e.property === 'recipients')).toBe(true);
+    expect(errors.some(e => e.property === 'recipients')).toBe(true);
   });
 
   it('accepts @lid recipients', async () => {
-    const errors = await validate(plainToInstance(SendVideoStatusDto, { video: valid.video, recipients: ['6281@lid'] }));
+    const errors = await validate(
+      plainToInstance(SendVideoStatusDto, { video: valid.video, recipients: ['6281@lid'] }),
+    );
     expect(errors).toHaveLength(0);
   });
 });

--- a/src/modules/status/dto/send-media-status.dto.ts
+++ b/src/modules/status/dto/send-media-status.dto.ts
@@ -1,12 +1,4 @@
-import {
-  IsString,
-  IsOptional,
-  ValidateNested,
-  IsArray,
-  ArrayMinSize,
-  ArrayMaxSize,
-  Matches,
-} from 'class-validator';
+import { IsString, IsOptional, ValidateNested, IsArray, ArrayMinSize, ArrayMaxSize, Matches } from 'class-validator';
 import { Type } from 'class-transformer';
 
 class StatusMediaInput {

--- a/src/modules/status/dto/send-text-status.dto.spec.ts
+++ b/src/modules/status/dto/send-text-status.dto.spec.ts
@@ -13,23 +13,23 @@ describe('SendTextStatusDto recipients validation', () => {
 
   it('rejects missing recipients', async () => {
     const errors = await validate(plainToInstance(SendTextStatusDto, { text: 'hi' }));
-    expect(errors.some((e) => e.property === 'recipients')).toBe(true);
+    expect(errors.some(e => e.property === 'recipients')).toBe(true);
   });
 
   it('rejects an empty recipients array (-> 400)', async () => {
     const errors = await validate(plainToInstance(SendTextStatusDto, { text: 'hi', recipients: [] }));
-    expect(errors.some((e) => e.property === 'recipients')).toBe(true);
+    expect(errors.some(e => e.property === 'recipients')).toBe(true);
   });
 
   it('rejects non-string entries', async () => {
     const errors = await validate(plainToInstance(SendTextStatusDto, { text: 'hi', recipients: [123] }));
-    expect(errors.some((e) => e.property === 'recipients')).toBe(true);
+    expect(errors.some(e => e.property === 'recipients')).toBe(true);
   });
 
   it('rejects more than 256 recipients', async () => {
     const recipients = Array.from({ length: 257 }, (_, i) => `${i}@c.us`);
     const errors = await validate(plainToInstance(SendTextStatusDto, { text: 'hi', recipients }));
-    expect(errors.some((e) => e.property === 'recipients')).toBe(true);
+    expect(errors.some(e => e.property === 'recipients')).toBe(true);
   });
 
   it('accepts exactly 256 recipients', async () => {
@@ -42,7 +42,7 @@ describe('SendTextStatusDto recipients validation', () => {
     const errors = await validate(
       plainToInstance(SendTextStatusDto, { text: 'hi', recipients: ['not-a-jid', '123@g.us', '@c.us', 'abc@lid'] }),
     );
-    expect(errors.some((e) => e.property === 'recipients')).toBe(true);
+    expect(errors.some(e => e.property === 'recipients')).toBe(true);
   });
 
   it('accepts @lid recipients', async () => {

--- a/src/modules/status/dto/send-text-status.dto.ts
+++ b/src/modules/status/dto/send-text-status.dto.ts
@@ -1,14 +1,4 @@
-import {
-  IsString,
-  IsOptional,
-  IsInt,
-  Min,
-  Max,
-  Matches,
-  IsArray,
-  ArrayMinSize,
-  ArrayMaxSize,
-} from 'class-validator';
+import { IsString, IsOptional, IsInt, Min, Max, Matches, IsArray, ArrayMinSize, ArrayMaxSize } from 'class-validator';
 
 export class SendTextStatusDto {
   @IsString()


### PR DESCRIPTION
## Summary

Implements `/api/sessions/{id}/status/send-text | send-image | send-video` (and `deleteStatus`) for the **Baileys engine**. whatsapp-web.js sessions return `501` — status posting is Baileys-only by upstream limitation (details below).

Closes #455.

## Why Baileys-only

whatsapp-web.js 1.34.7 *does* have a status-posting code path, but it's broken against current WhatsApp Web: the branch calls `window.require('WAWebStatusGatingUtils').canCheckStatusRankingPosterGating()`, which WhatsApp removed around 2026-04-30. Verified empirically by probing the cached WA-Web builds — only one already-expiring build still has the function, and no sustainable `WWEBJS_WEB_VERSION` pin restores it. So wwebjs will keep returning 501 until upstream wwebjs patches the status branch; this side will light up automatically if/when they do.

Baileys posts status via `sendMessage('status@broadcast', …, { statusJidList })` — tested end-to-end (plain text, styled text with background/font, and image), delivered to and viewable by recipients.

## What this PR adds

The contract refactor, Baileys implementation, and `recipients` security hardening already landed on `main`; this PR completes the feature:

- **wwebjs 501 tests** — all 4 status methods assert `EngineNotSupportedError` under the new contract.
- **Webhook no-dispatch guard** — regression test pinning that a status post never triggers `message.sent`/`message.received`, WebSocket emits, or DB inserts (two independent guards: the `messages.upsert type==='notify'` filter + `isStatusBroadcast`).
- **SDK updates (JS / Python / PHP)** — required `recipients` on the 3 request types; optional `mimetype` on media. The JS SDK also fixes a pre-existing wrong return type (`StatusRecord` → `StatusResult { statusId, timestamp, expiresAt }` for POST; `StatusRecord` retained for GET).
- **Docs + CHANGELOG** — API spec updated (recipients required, Baileys-only, sender-side "waiting" caveat); CHANGELOG `[Unreleased]` + thanks @CharlesLightjarvis.
- **Lint fix** — prettier formatting on the status work.

## Design

- `recipients: string[]` is **required** (empty → 400), validated `@ArrayMinSize(1) @ArrayMaxSize(256) @Matches(/^\d+@(c\.us|lid)$/)`.
- Unified `StatusPostOptions { recipients, backgroundColor?, font?, caption? }` across the engine contract.
- No `messageStore.put` for status; recipients denormalized `@c.us → @s.whatsapp.net` (`@lid` left untouched).

## Testing

- 1524 tests pass (116 suites); `tsc --noEmit` clean; `eslint`/`prettier` clean.
- Per-task reviews approved; final whole-branch review: **MERGE-READY**.

## Known limitations (documented)

- `deleteStatus` revoke shape is empirically unverified (the live spike covered posting only) — best-effort, with a `501` fallback ready if WhatsApp rejects it.
- GET status endpoints (`getStatuses`/`getContactStatus`) remain 501 on Baileys (reading is weak on both engines) — separate effort.
- `@lid` recipients are best-effort (sender-key distribution to privacy-ids unverified); `@c.us` (phone) is the reliable path.
- The posting account's own phone may show *"waiting for this status update"*; recipients view it normally.
