### PR TITLE
feat(baileys): honor chat disappearing-messages timer on outbound sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Disappearing-messages support (Baileys engine).** Outbound messages now honor a chat's disappearing-messages timer: the Baileys adapter reads the chat's cached `ephemeralExpiration` and sets it on each send (text, media, and replies), so recipients no longer see _"This message won't disappear — the sender may be using an older version of WhatsApp."_ The timer is applied only when a positive value is known for the chat; when it's unknown, disabled, or not yet synced, the per-message expiration is omitted, exactly as before. Reactions, deletes/revokes, and status posts are unaffected. Thanks @ulises2k for the report. (#473)
+
 ## [0.7.10] - 2026-06-28
 
 ### Added

--- a/src/engine/adapters/baileys-session-store.spec.ts
+++ b/src/engine/adapters/baileys-session-store.spec.ts
@@ -76,6 +76,28 @@ describe('BaileysSessionStore', () => {
     expect(store.lastMessage('unknown@s.whatsapp.net')).toBeNull();
   });
 
+  describe('getEphemeralExpiration (#473)', () => {
+    it('returns the cached disappearing-messages timer for a chat', () => {
+      store.upsertChats([{ id: '628111@s.whatsapp.net', ephemeralExpiration: 604800 }]);
+      expect(store.getEphemeralExpiration('628111@s.whatsapp.net')).toBe(604800);
+    });
+
+    it('accepts a neutral @c.us id and folds it to the engine dialect for lookup', () => {
+      store.upsertChats([{ id: '628111@s.whatsapp.net', ephemeralExpiration: 86400 }]);
+      expect(store.getEphemeralExpiration('628111@c.us')).toBe(86400);
+    });
+
+    it('returns undefined when the chat is unknown, disabled (0), or null (no forced disappear)', () => {
+      store.upsertChats([{ id: '628222@s.whatsapp.net', ephemeralExpiration: 0 }]);
+      store.upsertChats([{ id: '628333@s.whatsapp.net', ephemeralExpiration: null }]);
+      store.upsertChats([{ id: '628444@s.whatsapp.net' }]); // field absent
+      expect(store.getEphemeralExpiration('628222@s.whatsapp.net')).toBeUndefined();
+      expect(store.getEphemeralExpiration('628333@s.whatsapp.net')).toBeUndefined();
+      expect(store.getEphemeralExpiration('628444@s.whatsapp.net')).toBeUndefined();
+      expect(store.getEphemeralExpiration('nope@s.whatsapp.net')).toBeUndefined();
+    });
+  });
+
   it('resolves a phone jid to its user-part, a lid via lidPnMappings, and a contact phoneNumber', () => {
     expect(store.resolvePhone('628111@s.whatsapp.net')).toBe('628111');
     store.addLidMappings([{ lid: '111@lid', pn: '628999@s.whatsapp.net' }]);

--- a/src/engine/adapters/baileys-session-store.ts
+++ b/src/engine/adapters/baileys-session-store.ts
@@ -127,6 +127,19 @@ export class BaileysSessionStore {
     return m ? { key: m.key, timestamp: m.timestamp } : null;
   }
 
+  /**
+   * The chat's disappearing-messages timer in seconds (#473), or `undefined` when no timer is known.
+   * Only a positive value is returned: `0` / `null` / absent all mean "no known timer", so the caller
+   * omits the per-message `ephemeralExpiration` and reproduces today's send behavior (Baileys' own send
+   * guard is truthy). This keeps a stale-empty or boot-window cache from ever forcing a message to
+   * disappear. Folds a neutral `@c.us` id to the engine dialect first, like the other chat lookups.
+   */
+  getEphemeralExpiration(chatId: string): number | undefined {
+    const chat = this.chats.get(chatId) ?? this.chats.get(this.toEngineJid(chatId));
+    const exp = chat?.ephemeralExpiration;
+    return typeof exp === 'number' && exp > 0 ? exp : undefined;
+  }
+
   resolvePhone(id: string): string | null {
     const parsed = parseWaId(id);
     // A user id (@c.us / @s.whatsapp.net) already carries the phone as its user-part. The @c.us case

--- a/src/engine/adapters/baileys.adapter.spec.ts
+++ b/src/engine/adapters/baileys.adapter.spec.ts
@@ -561,6 +561,18 @@ describe('BaileysAdapter messaging', () => {
     expect(res).toEqual({ id: 'OUT1', timestamp: 1700000001 });
   });
 
+  it('sendTextMessage honors the chat disappearing timer when one is cached (#473)', async () => {
+    fakeSock.sendMessage.mockResolvedValue({ key: { id: 'OUT1' }, messageTimestamp: 1700000001 });
+    const adapter = await readyAdapter();
+    fakeSock.fire('chats.upsert', [{ id: '628111@s.whatsapp.net', ephemeralExpiration: 604800 }]);
+    await adapter.sendTextMessage('628111@s.whatsapp.net', 'hello');
+    expect(fakeSock.sendMessage).toHaveBeenCalledWith(
+      '628111@s.whatsapp.net',
+      { text: 'hello' },
+      { ephemeralExpiration: 604800 },
+    );
+  });
+
   it('getNumberId resolves via onWhatsApp and returns a NEUTRAL jid (never @s.whatsapp.net)', async () => {
     fakeSock.onWhatsApp.mockResolvedValue([{ jid: '628111@s.whatsapp.net', exists: true }]);
     const adapter = await readyAdapter();
@@ -1306,6 +1318,41 @@ describe('BaileysAdapter store-backed ops', () => {
     fakeStore.getMessage.mockResolvedValue(stored);
     const adapter = await ready();
     await adapter.deleteMessage('628111@s.whatsapp.net', 'TARGET', true);
+    expect(fakeSock.sendMessage).toHaveBeenCalledWith('628111@s.whatsapp.net', { delete: stored.key });
+  });
+
+  it('media sends honor the chat disappearing timer via the funnel (#473)', async () => {
+    const adapter = await ready();
+    fakeSock.fire('chats.upsert', [{ id: '628111@s.whatsapp.net', ephemeralExpiration: 86400 }]);
+    await adapter.sendImageMessage('628111@s.whatsapp.net', { mimetype: 'image/png', data: Buffer.from([1]) });
+    expect(fakeSock.sendMessage).toHaveBeenCalledWith(
+      '628111@s.whatsapp.net',
+      expect.objectContaining({ image: Buffer.from([1]) }),
+      { ephemeralExpiration: 86400 },
+    );
+  });
+
+  it('replyToMessage merges the disappearing timer with the quoted option (#473)', async () => {
+    fakeStore.getMessage.mockResolvedValue(stored);
+    const adapter = await ready();
+    fakeSock.fire('chats.upsert', [{ id: '628111@s.whatsapp.net', ephemeralExpiration: 604800 }]);
+    await adapter.replyToMessage('628111@s.whatsapp.net', 'TARGET', 'my reply');
+    expect(fakeSock.sendMessage).toHaveBeenCalledWith(
+      '628111@s.whatsapp.net',
+      { text: 'my reply' },
+      { quoted: stored, ephemeralExpiration: 604800 },
+    );
+  });
+
+  it('react and delete never carry an ephemeral timer (Baileys does not exclude reactions) (#473)', async () => {
+    fakeStore.getMessage.mockResolvedValue(stored);
+    const adapter = await ready();
+    fakeSock.fire('chats.upsert', [{ id: '628111@s.whatsapp.net', ephemeralExpiration: 604800 }]);
+    await adapter.reactToMessage('628111@s.whatsapp.net', 'TARGET', '👍');
+    await adapter.deleteMessage('628111@s.whatsapp.net', 'TARGET', true);
+    expect(fakeSock.sendMessage).toHaveBeenCalledWith('628111@s.whatsapp.net', {
+      react: { text: '👍', key: stored.key },
+    });
     expect(fakeSock.sendMessage).toHaveBeenCalledWith('628111@s.whatsapp.net', { delete: stored.key });
   });
 

--- a/src/engine/adapters/baileys.adapter.ts
+++ b/src/engine/adapters/baileys.adapter.ts
@@ -467,7 +467,10 @@ export class BaileysAdapter implements IWhatsAppEngine {
 
   async sendTextMessage(chatId: string, text: string): Promise<MessageResult> {
     this.ensureReady();
-    const sent = await this.sock!.sendMessage(chatId, { text });
+    const options = this.withEphemeral(chatId);
+    const sent = options
+      ? await this.sock!.sendMessage(chatId, { text }, options)
+      : await this.sock!.sendMessage(chatId, { text });
     if (sent) {
       void this.config.messageStore?.put(this.config.sessionId, sent).catch(err =>
         this.logger.warn('Failed to persist sent message to store', {
@@ -1311,14 +1314,34 @@ export class BaileysAdapter implements IWhatsAppEngine {
     ].join('\n');
   }
 
+  /**
+   * Fold the chat's known disappearing-messages timer into Baileys' send options so outbound messages
+   * honor the chat's ephemeral setting (#473). Returns `options` unchanged when no positive timer is
+   * cached: omitting `ephemeralExpiration` reproduces today's behavior (Baileys' send guard is truthy),
+   * so an unknown / boot-window / stale-empty cache never forces a message to disappear. Returning
+   * `undefined` keeps the send a 2-arg call, identical to before. React/delete/status do not route
+   * through here, so they are excluded by construction (reactions are NOT excluded by Baileys' guard).
+   */
+  private withEphemeral(
+    chatId: string,
+    options?: MiscMessageGenerationOptions,
+  ): MiscMessageGenerationOptions | undefined {
+    const ephemeralExpiration = this.sessionStore.getEphemeralExpiration(chatId);
+    if (ephemeralExpiration === undefined) {
+      return options;
+    }
+    return { ...options, ephemeralExpiration };
+  }
+
   /** Send a Baileys content object and shape the result like the other sends. */
   private async sendContent(
     chatId: string,
     content: AnyMessageContent,
     options?: MiscMessageGenerationOptions,
   ): Promise<MessageResult> {
-    const sent = options
-      ? await this.sock!.sendMessage(chatId, content, options)
+    const merged = this.withEphemeral(chatId, options);
+    const sent = merged
+      ? await this.sock!.sendMessage(chatId, content, merged)
       : await this.sock!.sendMessage(chatId, content);
     if (sent) {
       void this.config.messageStore?.put(this.config.sessionId, sent).catch(err =>


### PR DESCRIPTION
## Summary

Outbound messages on the Baileys engine now honor a chat's disappearing-messages timer. Previously, sending into a chat with disappearing messages enabled left the per-message expiration unset, so recipients saw _"This message won't disappear — the sender may be using an older version of WhatsApp."_ (#473). The adapter now reads the chat's known timer and applies it on send.

## Why this works without an interface change

Baileys already streams each chat's `ephemeralExpiration` into the in-memory session store via the normal event flow (`messaging-history.set`, `chats.upsert`, and `chats.update` — the last of which also fires when a chat's disappearing setting is toggled mid-session). The data needed to set the timer is therefore already cached per session; this change only adds a **read path**, not new state, configuration, or any change to the engine interface or DTOs.

## Changes

- **`BaileysSessionStore.getEphemeralExpiration(chatId)`** — returns the chat's cached timer (seconds) only when a positive value is known; `0`, `null`, and absent all return `undefined`. A neutral `@c.us` id is folded to the engine dialect first, matching the existing chat lookups.
- **`BaileysAdapter.withEphemeral()`** — a small helper that folds the known timer into Baileys' send options. It is wired into the two outbound entry points: `sendTextMessage` and the `sendContent` funnel that backs media, replies, and forwards.

## Safety: unknown means omit

When no positive timer is known for a chat — unknown chat, disabling set, or the brief window before the session's history has synced — the per-message `ephemeralExpiration` is **omitted entirely** and the send is byte-for-byte identical to today's behavior. This relies on Baileys' own truthy guard on `ephemeralExpiration`, so an empty or not-yet-synced cache can never force a message to disappear unexpectedly. Reactions, deletes/revokes, and status posts do not route through the send funnel and are excluded by construction (notably, Baileys does **not** exclude reactions from its own expiration injection, so keeping them off the funnel is the safe path).

## Tests

- Store: positive timer returned; neutral-id fold; `0` / `null` / absent / unknown all return `undefined`.
- Adapter: text, media, and replies carry the timer when one is cached (replies merge it with the `quoted` option); reactions and deletes never carry it; and existing send assertions continue to pass unchanged, confirming the omit-when-unknown path.

Full backend gate green: lint, build, and 1531 unit tests.

Closes #473
