### PR TITLE
fix(session): clean up a session's messages and bulk batches on delete

### DIFF
--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -6,6 +6,7 @@ import { ConfigService } from '@nestjs/config';
 import { SessionService, ACK_RECONCILE_DELAY_MS } from './session.service';
 import { Session, SessionStatus } from './entities/session.entity';
 import { Message, MessageStatus } from '../message/entities/message.entity';
+import { MessageBatch } from '../message/entities/message-batch.entity';
 import { EngineFactory } from '../../engine/engine.factory';
 import { EventsGateway } from '../events/events.gateway';
 import { WebhookService } from '../webhook/webhook.service';
@@ -68,6 +69,7 @@ describe('SessionService', () => {
         const manager = {
           save: jest.fn().mockImplementation((entity: unknown) => Promise.resolve(entity)),
           remove: jest.fn().mockResolvedValue(undefined),
+          delete: jest.fn().mockResolvedValue({ affected: 0 }),
         };
         return cb(manager);
       }),
@@ -442,6 +444,24 @@ describe('SessionService', () => {
       await service.delete('sess-uuid-1');
 
       expect(mockEngine.destroy).toHaveBeenCalled();
+    });
+
+    it('removes the session messages and bulk batches in the same transaction (no orphaned rows)', async () => {
+      const session = createMockSession();
+      (repository.findOne as jest.Mock).mockResolvedValue(session);
+
+      const managerDelete = jest.fn().mockResolvedValue({ affected: 0 });
+      const managerRemove = jest.fn().mockResolvedValue(undefined);
+      (dataSource.transaction as jest.Mock).mockImplementationOnce(async (cb: (m: unknown) => Promise<unknown>) =>
+        cb({ save: jest.fn(), remove: managerRemove, delete: managerDelete }),
+      );
+
+      await service.delete('sess-uuid-1');
+
+      // These tables carry sessionId but have no FK cascade, so delete() must clean them explicitly.
+      expect(managerDelete).toHaveBeenCalledWith(Message, { sessionId: 'sess-uuid-1' });
+      expect(managerDelete).toHaveBeenCalledWith(MessageBatch, { sessionId: 'sess-uuid-1' });
+      expect(managerRemove).toHaveBeenCalledWith(session);
     });
   });
 

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -14,6 +14,7 @@ import { Repository, In, Not, IsNull, DataSource, FindManyOptions } from 'typeor
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 import { Session, SessionStatus } from './entities/session.entity';
 import { Message, MessageDirection, MessageStatus } from '../message/entities/message.entity';
+import { MessageBatch } from '../message/entities/message-batch.entity';
 import { CreateSessionDto } from './dto';
 import { EngineFactory } from '../../engine/engine.factory';
 import { paginate, ListOptions, resolveListWindow } from '../../common/utils/paginate';
@@ -366,7 +367,12 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
       );
 
       // DB removal is NOT best-effort: a genuine failure must surface (500) rather than be swallowed.
+      // messages and message_batches carry a sessionId but have no FK cascade to sessions (unlike
+      // webhooks/templates/baileys_stored_messages), so remove them explicitly in the same transaction
+      // — otherwise deleting a session leaves its full history orphaned forever.
       await this.dataSource.transaction(async manager => {
+        await manager.delete(Message, { sessionId: id });
+        await manager.delete(MessageBatch, { sessionId: id });
         await manager.remove(session);
       });
       this.logger.log(`Session deleted: ${session.name}`, {


### PR DESCRIPTION
## Summary
Deleting a session previously removed only the `sessions` row. The `messages` and `message_batches` tables carry a `sessionId` but, unlike `webhooks`/`templates`/`baileys_stored_messages`, have no foreign-key cascade — so their rows were left behind permanently.

## Why it matters
On any deployment that creates and deletes sessions over time this:
- grows the two highest-volume tables without bound (dead rows are never reclaimed),
- skews global message statistics on the dashboard, and
- retains message bodies/metadata for sessions an operator believed were deleted.

## Change
`SessionService.delete()` now removes the session's `messages` and `message_batches` rows inside the **same transaction** as the session removal. This is dialect-agnostic (TypeORM repository API), atomic (a failure rolls back together), and needs **no schema migration** — avoiding the operational risk of adding a cascade FK to two large existing tables (SQLite table rebuild + Postgres lock + orphan pre-scan).

## Tests
Adds a regression test asserting `delete()` removes both tables' rows for the session within the transaction. Full backend suite green (1532 tests).