### PR TITLE
fix(session): release the stored failure reason when a session is deleted

### DIFF
--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -630,6 +630,20 @@ describe('SessionService', () => {
       expect(result.lastError).toBe('chromium missing');
     });
 
+    it('clears the stored failure reason when the session is deleted (no in-memory leak)', async () => {
+      const callbacks = await startAndCapture();
+      callbacks.onError?.('chromium missing');
+
+      const sessionErrors = (service as unknown as { sessionErrors: Map<string, string> }).sessionErrors;
+      expect(sessionErrors.has('sess-uuid-1')).toBe(true); // precondition: the FAILED reason is recorded
+
+      (repository.findOne as jest.Mock).mockResolvedValue(createMockSession({ status: SessionStatus.FAILED }));
+      await service.delete('sess-uuid-1');
+
+      // Without cleanup, the entry would linger forever keyed by a deleted UUID (unbounded growth).
+      expect(sessionErrors.has('sess-uuid-1')).toBe(false);
+    });
+
     it('does not surface lastError once the session has recovered', async () => {
       const callbacks = await startAndCapture();
       callbacks.onError?.('transient failure');

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -377,6 +377,9 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
       // Always clear the teardown mark so a later recreate/start with this id isn't suppressed.
       this.stoppingSessions.delete(id);
       this.lastDispatchedStatus.delete(id);
+      // Drop the FAILED-reason entry too: it's keyed by a now-deleted UUID that can never be read
+      // again, so leaving it would grow the map without bound across create/fail/delete churn.
+      this.sessionErrors.delete(id);
     }
   }
 


### PR DESCRIPTION
## Summary
`SessionService` keeps a per-session map of the most recent terminal failure reason (surfaced as `lastError` while a session is `FAILED`). It is cleared when a session re-initializes and when it becomes ready — but **not** when the session is deleted.

## Why it matters
Deleting a `FAILED` session leaves its entry behind, keyed by a UUID that can never be read again. On a long-running gateway with create/fail/delete churn the map grows without bound (a slow in-memory leak).

## Change
`delete()` now drops the entry in its `finally` block, alongside the other per-session bookkeeping it already clears there.

## Tests
Adds a regression test: a FAILED session's reason is recorded, then asserted gone from the map after `delete()`. Full backend suite green (1532 tests).