### PR TITLE
fix(dashboard): guard the infrastructure route and revoke attachment preview URLs

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -111,7 +111,7 @@ function AppContent() {
             {role === 'admin' && <Route path="api-keys" element={<ApiKeys />} />}
             <Route path="logs" element={<Logs />} />
             <Route path="message-tester" element={<MessageTester />} />
-            <Route path="infrastructure" element={<Infrastructure />} />
+            {role === 'admin' && <Route path="infrastructure" element={<Infrastructure />} />}
             {role === 'admin' && <Route path="plugins" element={<Plugins />} />}
             <Route path="*" element={<Navigate to="/" replace />} />
           </Route>

--- a/dashboard/src/pages/Chats.tsx
+++ b/dashboard/src/pages/Chats.tsx
@@ -180,6 +180,15 @@ export function Chats() {
     }
   }, [selectedSessionId, loadChats]);
 
+  // Revoke the object URL created for an image-attachment preview once it is replaced, cleared, or
+  // the page unmounts. The cleanup runs with the previous value on every change, so this single
+  // effect covers all paths (new file, remove, session switch) — otherwise each preview leaks a
+  // blob held for the lifetime of the document.
+  useEffect(() => {
+    if (!previewUrl) return;
+    return () => URL.revokeObjectURL(previewUrl);
+  }, [previewUrl]);
+
   const markChatRead = useCallback(
     (chatId: string) => {
       void sessionApi.markChatRead(selectedSessionId, chatId).catch(err => {


### PR DESCRIPTION
## Summary
Two small dashboard hygiene fixes.

### Infrastructure route guard
The `api-keys` and `plugins` routes are mounted only when `role === 'admin'`, but `infrastructure` was mounted unconditionally. The sidebar already hides it for non-admins and every infra endpoint enforces admin server-side, so this is **not an access hole** — but a viewer/operator who deep-links to `/infrastructure` rendered a broken, error-toast-spewing admin page, and the unguarded route invited a future copy-paste regression. It now falls through to the catch-all redirect like its siblings.

### Attachment preview object-URL leak
The image-attachment preview created a blob URL with `URL.createObjectURL` but never called `revokeObjectURL`, so every preview leaked a blob held for the page lifetime. A single effect now revokes the URL whenever it is replaced, cleared, or the component unmounts — covering all paths (new file, remove, session switch).

## Verification
Dashboard `build` + `lint` + i18n parity all green. (No component-test harness exists in the dashboard; these are declarative/effect changes verified by the type-checked build.)