### PR TITLE
perf(webhook): run the delivery Worker with concurrency > 1

### DIFF
--- a/src/modules/queue/processors/webhook.processor.ts
+++ b/src/modules/queue/processors/webhook.processor.ts
@@ -5,7 +5,7 @@ import { ConfigService } from '@nestjs/config';
 import { Repository } from 'typeorm';
 import { createLogger } from '../../../common/services/logger.service';
 import { QUEUE_NAMES } from '../queue-names';
-import { workerConnectionOptions } from '../redis-connection';
+import { workerConnectionOptions, webhookWorkerConcurrency } from '../redis-connection';
 import { WebhookJobData } from '../../webhook/webhook.service';
 import { Webhook } from '../../webhook/entities/webhook.entity';
 import { HookManager } from '../../../core/hooks';
@@ -19,8 +19,10 @@ export interface WebhookJobResult {
 }
 
 // Override the Worker's connection so it does NOT inherit the producer's `enableOfflineQueue: false`
-// from the shared BullModule connection — the Worker must tolerate a brief Redis reconnect.
-@Processor(QUEUE_NAMES.WEBHOOK, { connection: workerConnectionOptions() })
+// from the shared BullModule connection — the Worker must tolerate a brief Redis reconnect. Set an
+// explicit concurrency: BullMQ defaults a Worker to 1, which serializes every session's webhook
+// deliveries behind one slow/timing-out receiver.
+@Processor(QUEUE_NAMES.WEBHOOK, { connection: workerConnectionOptions(), concurrency: webhookWorkerConcurrency() })
 export class WebhookProcessor extends WorkerHost {
   private readonly logger = createLogger('WebhookProcessor');
 

--- a/src/modules/queue/redis-connection.spec.ts
+++ b/src/modules/queue/redis-connection.spec.ts
@@ -1,4 +1,4 @@
-import { workerConnectionOptions } from './redis-connection';
+import { workerConnectionOptions, webhookWorkerConcurrency } from './redis-connection';
 
 describe('workerConnectionOptions (webhook Worker connection)', () => {
   const ORIGINAL_ENV = process.env;
@@ -38,5 +38,30 @@ describe('workerConnectionOptions (webhook Worker connection)', () => {
       password: 'secret',
       connectTimeout: 1234,
     });
+  });
+});
+
+describe('webhookWorkerConcurrency', () => {
+  const ORIGINAL_ENV = process.env;
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('defaults to 10 so deliveries do not serialize behind one slow receiver', () => {
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.WEBHOOK_WORKER_CONCURRENCY;
+    expect(webhookWorkerConcurrency()).toBe(10);
+  });
+
+  it('honors a positive override', () => {
+    process.env = { ...ORIGINAL_ENV, WEBHOOK_WORKER_CONCURRENCY: '25' };
+    expect(webhookWorkerConcurrency()).toBe(25);
+  });
+
+  it('falls back to the default for a non-positive/garbage override', () => {
+    process.env = { ...ORIGINAL_ENV, WEBHOOK_WORKER_CONCURRENCY: '0' };
+    expect(webhookWorkerConcurrency()).toBe(10);
+    process.env = { ...ORIGINAL_ENV, WEBHOOK_WORKER_CONCURRENCY: 'abc' };
+    expect(webhookWorkerConcurrency()).toBe(10);
   });
 });

--- a/src/modules/queue/redis-connection.ts
+++ b/src/modules/queue/redis-connection.ts
@@ -28,3 +28,18 @@ export function workerConnectionOptions(): WorkerConnectionOptions {
     connectTimeout: parseInt(process.env.REDIS_CONNECT_TIMEOUT_MS || '5000', 10),
   };
 }
+
+/** Default number of webhook deliveries the Worker processes in parallel. */
+const DEFAULT_WEBHOOK_WORKER_CONCURRENCY = 10;
+
+/**
+ * Webhook Worker concurrency. BullMQ defaults a Worker to 1, which serializes ALL webhook deliveries
+ * process-wide: one slow or timing-out receiver head-of-line-blocks every other session's webhooks
+ * until it finishes (up to WEBHOOK_TIMEOUT + retries). Running several in parallel decouples healthy
+ * receivers from a stuck one. Override via WEBHOOK_WORKER_CONCURRENCY; a non-positive/garbage value
+ * falls back to the default. (Read at module import like workerConnectionOptions above.)
+ */
+export function webhookWorkerConcurrency(): number {
+  const parsed = parseInt(process.env.WEBHOOK_WORKER_CONCURRENCY || '', 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : DEFAULT_WEBHOOK_WORKER_CONCURRENCY;
+}


### PR DESCRIPTION
## Summary
The webhook BullMQ Worker carried no `concurrency` option, so it ran at the library default of **1**. Delivery was therefore strictly serial across the whole process: one job, await the HTTP POST (up to `WEBHOOK_TIMEOUT` + retries/backoff), then the next.

## Why it matters
A single slow or unresponsive receiver head-of-line-blocks **every other session's** webhooks — throughput is capped at `1/responseTime` regardless of Redis or CPU headroom. With a dead endpoint at retryCount 5 and exponential backoff, a burst of events serializes into minutes of latency for unrelated, healthy webhooks.

## Change
Sets an explicit Worker concurrency (default **10**, override via `WEBHOOK_WORKER_CONCURRENCY`) on the `@Processor`. A stuck receiver now occupies one slot instead of the whole pipeline. Each job is independent and deduped by idempotency key, so no ordering guarantee changes and the per-success DB update is idempotent.

## Tests
Unit tests for the concurrency resolver (default / override / garbage-fallback) alongside the existing Worker-connection guard. Full backend suite green (1534 tests).