### PR TITLE
fix(webhook): keep delivery identifiers and per-webhook data consistent under before-hooks

### DIFF
--- a/src/modules/webhook/webhook.service.spec.ts
+++ b/src/modules/webhook/webhook.service.spec.ts
@@ -332,6 +332,64 @@ describe('WebhookService', () => {
       expect(body.data).toEqual({ from: '628123456789@c.us' });
     });
 
+    it('keeps the server-canonical idempotency/delivery ids on the signed body, overriding a tampering plugin', async () => {
+      const webhook = createMockWebhook({ events: ['message.received'] });
+      (repository.find as jest.Mock).mockResolvedValue([webhook]);
+      (repository.update as jest.Mock).mockResolvedValue({ affected: 1 });
+
+      // A webhook:before plugin returns a payload with forged identifiers (other hook events pass through).
+      (hookManager.execute as jest.Mock).mockImplementation((event: string, ctx: { payload?: WebhookPayload }) =>
+        event === 'webhook:before' && ctx.payload
+          ? Promise.resolve({
+              continue: true,
+              data: { payload: { ...ctx.payload, idempotencyKey: 'PLUGIN-FORGED', deliveryId: 'PLUGIN-FORGED' } },
+            })
+          : Promise.resolve({ continue: true, data: {} }),
+      );
+
+      await service.dispatch('sess-1', 'message.received', { from: '628123456789@c.us' });
+
+      const call = mockFetch.mock.calls[0] as [unknown, { headers: Record<string, string>; body: string }];
+      const headers = call[1].headers;
+      const body = JSON.parse(call[1].body) as WebhookPayload;
+      // Receivers dedupe on the header, so the signed body field must equal the header — and both must
+      // be the server's value, not the plugin's forgery.
+      expect(body.idempotencyKey).toBe(headers['X-OpenWA-Idempotency-Key']);
+      expect(body.deliveryId).toBe(headers['X-OpenWA-Delivery-Id']);
+      expect(body.idempotencyKey).not.toBe('PLUGIN-FORGED');
+      expect(body.deliveryId).not.toBe('PLUGIN-FORGED');
+    });
+
+    it("isolates each webhook's data so an in-place before-hook mutation cannot bleed across webhooks", async () => {
+      const a = createMockWebhook({ id: 'wh-a', events: ['message.received'] });
+      const b = createMockWebhook({ id: 'wh-b', events: ['message.received'] });
+      (repository.find as jest.Mock).mockResolvedValue([a, b]);
+      (repository.update as jest.Mock).mockResolvedValue({ affected: 1 });
+
+      // The hook mutates payload.data in place every time it runs (returns no payload key → finalPayload
+      // is the mutated input). With a shared data object the second webhook would see the first's tag.
+      (hookManager.execute as jest.Mock).mockImplementation((event: string, ctx: { payload?: WebhookPayload }) => {
+        if (event === 'webhook:before' && ctx.payload) {
+          const d = ctx.payload.data as { tag?: number };
+          d.tag = (d.tag ?? 0) + 1;
+          return Promise.resolve({ continue: true, data: { payload: ctx.payload } });
+        }
+        return Promise.resolve({ continue: true, data: {} });
+      });
+
+      await service.dispatch('sess-1', 'message.received', { from: 'x@c.us' });
+
+      const bodyA = JSON.parse((mockFetch.mock.calls[0] as [unknown, { body: string }])[1].body) as {
+        data: { tag: number };
+      };
+      const bodyB = JSON.parse((mockFetch.mock.calls[1] as [unknown, { body: string }])[1].body) as {
+        data: { tag: number };
+      };
+      // Each webhook starts from its own clone of the original data, so both see exactly one increment.
+      expect(bodyA.data.tag).toBe(1);
+      expect(bodyB.data.tag).toBe(1);
+    });
+
     it('test() probes the receiver using the configured WEBHOOK_TIMEOUT', async () => {
       const webhook = createMockWebhook({ events: ['message.received'] });
       (repository.findOne as jest.Mock).mockResolvedValue(webhook);
@@ -660,16 +718,11 @@ describe('WebhookService', () => {
       // Verify signature format
       expect(capturedHeaders['X-OpenWA-Signature']).toMatch(/^sha256=[a-f0-9]{64}$/);
 
-      // Verify signature correctness
-      const body = JSON.stringify({
-        event: 'message.received',
-        data: {},
-        timestamp: '',
-        sessionId: 'sess-1',
-        idempotencyKey: 'k',
-        deliveryId: 'd',
-      });
-      const expected = `sha256=${crypto.createHmac('sha256', 'test-secret-123').update(body).digest('hex')}`;
+      // Verify signature correctness against the ACTUAL delivered body. The body now carries the
+      // server-canonical idempotency/delivery ids (re-asserted over the plugin's 'k'/'d'), so the
+      // signature is checked against what the receiver actually gets — the real verification contract.
+      const sentBody = (mockFetch.mock.calls[0] as [unknown, { body: string }])[1].body;
+      const expected = `sha256=${crypto.createHmac('sha256', 'test-secret-123').update(sentBody).digest('hex')}`;
       expect(capturedHeaders['X-OpenWA-Signature']).toBe(expected);
 
       mockFetch.mockReset();

--- a/src/modules/webhook/webhook.service.ts
+++ b/src/modules/webhook/webhook.service.ts
@@ -238,7 +238,10 @@ export class WebhookService {
         sessionId,
         idempotencyKey,
         deliveryId,
-        data,
+        // Give each webhook its own copy of the event data: a webhook:before hook that mutates
+        // payload.data in place would otherwise bleed that change into every later webhook for this
+        // event (they all shared one object reference).
+        data: structuredClone(data),
       };
 
       // Execute hook before webhook dispatch - plugins can modify payload
@@ -259,6 +262,12 @@ export class WebhookService {
       // Use the plugin-modified payload, falling back to the original if a before-hook returned a
       // result without a `payload` key — otherwise we'd POST an `undefined` body.
       const finalPayload = (hookResult as { payload?: WebhookPayload }).payload ?? payload;
+
+      // The idempotency + delivery ids are server-generated and are the documented dedup key
+      // (receivers dedupe on the X-OpenWA-Idempotency-Key header). Re-assert them onto the post-hook
+      // payload so a webhook:before plugin can't desync the signed body field from the header.
+      finalPayload.idempotencyKey = idempotencyKey;
+      finalPayload.deliveryId = deliveryId;
 
       // Build headers — custom headers FIRST so the system headers below always win.
       const headers: Record<string, string> = {


### PR DESCRIPTION
## Summary
Two coupled defects in the webhook dispatch loop, both reachable when an operator installs a `webhook:before` hook that returns a modified payload.

### Header/body identifier desync
The `X-OpenWA-Idempotency-Key` and `X-OpenWA-Delivery-Id` headers were built from the server-generated values, but the **signed request body** used the post-hook payload. A plugin that returned different `idempotencyKey`/`deliveryId` made the header disagree with the body — breaking any receiver that dedupes on the body field, and contradicting the documented "dedupe on the header" contract. The server-generated ids are now re-asserted onto the final payload, so the header and the signed body always agree (server-canonical).

### Shared `data` reference bleed
Every webhook for a given event shared a single `data` object reference, so a hook that mutated `payload.data` in place bled that change into the other webhooks of the same event. Each webhook now receives its own `structuredClone` of the event data.

## Tests
- A tampering before-hook can no longer override the body's idempotency/delivery ids (header == body, != plugin value).
- An in-place `payload.data` mutation in one webhook's hook does not affect another webhook's delivered data.
- The existing HMAC test now verifies the signature against the actually-delivered body (the real receiver contract).

Full backend suite green (1533 tests).