### PR TITLE
fix(baileys): source disappearing-messages timer from inbound messages (#473)

### DIFF
--- a/src/engine/adapters/baileys-session-store.spec.ts
+++ b/src/engine/adapters/baileys-session-store.spec.ts
@@ -96,6 +96,82 @@ describe('BaileysSessionStore', () => {
       expect(store.getEphemeralExpiration('628444@s.whatsapp.net')).toBeUndefined();
       expect(store.getEphemeralExpiration('nope@s.whatsapp.net')).toBeUndefined();
     });
+
+    it('learns the timer from an inbound message ephemeralDuration without any chats.* upsert', () => {
+      // The real-world case: Chat.ephemeralExpiration is never populated, but every inbound message in
+      // a disappearing chat carries the live timer. A neutral @c.us send target must resolve it too.
+      store.recordMessage({
+        key: { remoteJid: '628111@s.whatsapp.net', fromMe: false, id: 'M1' },
+        message: { conversation: 'hi' },
+        messageTimestamp: 100,
+        ephemeralDuration: 7776000,
+      });
+      expect(store.getEphemeralExpiration('628111@s.whatsapp.net')).toBe(7776000);
+      expect(store.getEphemeralExpiration('628111@c.us')).toBe(7776000);
+    });
+
+    it('resolves a timer learned under @lid when the send targets the phone jid (#473 LID migration)', () => {
+      store.addLidMappings([{ lid: '41562515988583@lid', pn: '5491169954736@s.whatsapp.net' }]);
+      store.recordMessage({
+        key: { remoteJid: '41562515988583@lid', fromMe: false, id: 'M2' },
+        message: { conversation: 'hola' },
+        messageTimestamp: 100,
+        ephemeralDuration: 7776000,
+      });
+      // matchwa replies to the neutral phone jid OpenWA delivered on the webhook — the prior no-op case.
+      expect(store.getEphemeralExpiration('5491169954736@c.us')).toBe(7776000);
+      expect(store.getEphemeralExpiration('5491169954736@s.whatsapp.net')).toBe(7776000);
+      expect(store.getEphemeralExpiration('41562515988583@lid')).toBe(7776000);
+    });
+
+    it('ignores a non-positive ephemeralDuration and never clears a known timer', () => {
+      store.recordMessage({
+        key: { remoteJid: '628111@s.whatsapp.net', fromMe: false, id: 'M1' },
+        message: { conversation: 'hi' },
+        messageTimestamp: 100,
+        ephemeralDuration: 86400,
+      });
+      store.recordMessage({
+        key: { remoteJid: '628111@s.whatsapp.net', fromMe: false, id: 'M2' },
+        message: { conversation: 'later' },
+        messageTimestamp: 200,
+        ephemeralDuration: 0,
+      });
+      expect(store.getEphemeralExpiration('628111@s.whatsapp.net')).toBe(86400);
+    });
+
+    it('prefers the message-learned timer over a stale Chat.ephemeralExpiration', () => {
+      store.upsertChats([{ id: '628111@s.whatsapp.net', ephemeralExpiration: 604800 }]);
+      store.recordMessage({
+        key: { remoteJid: '628111@s.whatsapp.net', fromMe: false, id: 'M1' },
+        message: { conversation: 'hi' },
+        messageTimestamp: 100,
+        ephemeralDuration: 7776000,
+      });
+      expect(store.getEphemeralExpiration('628111@s.whatsapp.net')).toBe(7776000);
+    });
+
+    it('learns the timer from contextInfo.expiration when ephemeralDuration is absent (live 1:1)', () => {
+      // WebMessageInfo.ephemeralDuration is empty on a live 1:1 upsert; the per-message expiration on the
+      // content's contextInfo is the reliable source.
+      store.recordMessage({
+        key: { remoteJid: '628111@s.whatsapp.net', fromMe: false, id: 'M1' },
+        message: { extendedTextMessage: { text: 'hi', contextInfo: { expiration: 7776000 } } },
+        messageTimestamp: 100,
+      });
+      expect(store.getEphemeralExpiration('628111@s.whatsapp.net')).toBe(7776000);
+    });
+
+    it('unwraps an ephemeralMessage envelope to read contextInfo.expiration', () => {
+      store.recordMessage({
+        key: { remoteJid: '628111@s.whatsapp.net', fromMe: false, id: 'M2' },
+        message: {
+          ephemeralMessage: { message: { extendedTextMessage: { text: 'hi', contextInfo: { expiration: 86400 } } } },
+        },
+        messageTimestamp: 100,
+      });
+      expect(store.getEphemeralExpiration('628111@c.us')).toBe(86400);
+    });
   });
 
   it('resolves a phone jid to its user-part, a lid via lidPnMappings, and a contact phoneNumber', () => {

--- a/src/engine/adapters/baileys-session-store.ts
+++ b/src/engine/adapters/baileys-session-store.ts
@@ -26,6 +26,15 @@ export class BaileysSessionStore {
   private readonly chats = new Map<string, Chat>();
   private readonly lastMessages = new Map<string, LastMessage>();
   private readonly lidToPn = new Map<string, string>();
+  /**
+   * Per-chat disappearing-messages timer (seconds) learned from inbound messages (#473), the reliable
+   * source for it: `Chat.ephemeralExpiration` (from `chats.*`/history sync) is empirically absent for a
+   * long-standing timer after a reconnect (observed live: 0 of 159 cached chats carried it). Keyed by
+   * both the raw and neutral JID so an outbound send addressed in either dialect (phone `@c.us` /
+   * `@s.whatsapp.net` or `@lid`) resolves to the same entry. See {@link extractEphemeralDuration} for
+   * which message field is read.
+   */
+  private readonly ephemeralByChat = new Map<string, number>();
 
   /**
    * @param lidStore  optional persisted, cross-session lid->phone table that backs resolution beyond
@@ -100,6 +109,10 @@ export class BaileysSessionStore {
     if (!chatId || !msg.key) {
       return;
     }
+    // Learn the chat's disappearing-messages timer from the message itself (#473). This runs before the
+    // newest-message guard so every inbound refreshes it; the timer is cached under both the raw and
+    // neutral JID so an outbound send addressed in either dialect (phone or @lid) finds it.
+    this.recordEphemeralFromMessage(chatId, msg);
     const timestamp = this.toUnixSeconds(msg.messageTimestamp);
     const existing = this.lastMessages.get(chatId);
     if (existing && existing.timestamp >= timestamp) {
@@ -107,6 +120,60 @@ export class BaileysSessionStore {
     }
     const text = msg.message?.conversation ?? msg.message?.extendedTextMessage?.text ?? '';
     this.lastMessages.set(chatId, { key: msg.key, timestamp, text });
+  }
+
+  /**
+   * Cache a positive disappearing-messages timer learned from an inbound message under both the raw chat
+   * JID and its neutral form, so {@link getEphemeralExpiration} hits regardless of which dialect the caller
+   * sends to. A non-positive/absent value means "no live timer on this message" and is left untouched (a
+   * single non-ephemeral message must not clear a known timer; WhatsApp keeps stamping it while on).
+   */
+  private recordEphemeralFromMessage(chatId: string, msg: WAMessage): void {
+    const duration = this.extractEphemeralDuration(msg);
+    if (duration === undefined) {
+      return;
+    }
+    this.ephemeralByChat.set(chatId, duration);
+    this.ephemeralByChat.set(this.toNeutralJid(chatId), duration);
+  }
+
+  /**
+   * Best-effort read of a message's disappearing timer (seconds). `WebMessageInfo.ephemeralDuration` is
+   * populated on history-synced messages but is typically ABSENT on a live 1:1 `messages.upsert`, so fall
+   * back to the per-message `contextInfo.expiration` WhatsApp stamps on every message in a disappearing
+   * chat — read after unwrapping the ephemeral / view-once / document-with-caption envelope.
+   */
+  private extractEphemeralDuration(msg: WAMessage): number | undefined {
+    const fromInfo = msg.ephemeralDuration;
+    if (typeof fromInfo === 'number' && fromInfo > 0) {
+      return fromInfo;
+    }
+    const fromContext = this.contextExpiration(msg.message);
+    return typeof fromContext === 'number' && fromContext > 0 ? fromContext : undefined;
+  }
+
+  /** Walk a message's content (unwrapping known envelopes) and return the first positive `contextInfo.expiration`. */
+  private contextExpiration(content: WAMessage['message'], depth = 0): number | undefined {
+    if (!content || typeof content !== 'object' || depth > 4) {
+      return undefined;
+    }
+    const nodes = content as Record<
+      string,
+      { contextInfo?: { expiration?: number | null }; message?: WAMessage['message'] } | undefined
+    >;
+    for (const node of Object.values(nodes)) {
+      const exp = node?.contextInfo?.expiration;
+      if (typeof exp === 'number' && exp > 0) {
+        return exp;
+      }
+      if (node?.message) {
+        const nested = this.contextExpiration(node.message, depth + 1);
+        if (nested !== undefined) {
+          return nested;
+        }
+      }
+    }
+    return undefined;
   }
 
   listContacts(): Contact[] {
@@ -135,7 +202,18 @@ export class BaileysSessionStore {
    * disappear. Folds a neutral `@c.us` id to the engine dialect first, like the other chat lookups.
    */
   getEphemeralExpiration(chatId: string): number | undefined {
-    const chat = this.chats.get(chatId) ?? this.chats.get(this.toEngineJid(chatId));
+    // Prefer the timer learned from inbound messages (reliably present); try the raw, engine, and
+    // neutral keys so an @lid-keyed entry and a phone-dialect send target resolve to the same value.
+    const fromMessage =
+      this.ephemeralByChat.get(chatId) ??
+      this.ephemeralByChat.get(this.toEngineJid(chatId)) ??
+      this.ephemeralByChat.get(this.toNeutralJid(chatId));
+    if (typeof fromMessage === 'number' && fromMessage > 0) {
+      return fromMessage;
+    }
+    // Fallback to the chat object's own timer for sessions/engines that do surface it on `chats.*`.
+    const chat =
+      this.chats.get(chatId) ?? this.chats.get(this.toEngineJid(chatId)) ?? this.chats.get(this.toNeutralJid(chatId));
     const exp = chat?.ephemeralExpiration;
     return typeof exp === 'number' && exp > 0 ? exp : undefined;
   }


### PR DESCRIPTION
> **Draft.** This builds on #503 and is shared mainly as a **diagnosis + proposed direction**. One step (the exact field the live 1:1 timer lives in) I could not confirm end‑to‑end on my box — details below. Happy to adjust or hand it over.

## TL;DR

After deploying #503 (the disappearing‑messages fix for the Baileys engine) to production, the *"This message won't disappear — the sender may be using an older version of WhatsApp"* notice **still appears** on a real 1:1 chat with a 90‑day timer. I instrumented the running adapter and traced it: **#503 no‑ops in practice**, for two independent reasons.

## Root cause (instrumented on a live session, `v0.7.10 + #503`)

**1. `Chat.ephemeralExpiration` is never populated.** `getEphemeralExpiration` reads `chat?.ephemeralExpiration`, but a debug dump of the in‑memory `chats` map showed **0 of 159 chats** (across two sessions) carrying any `ephemeralExpiration`. Baileys 6.7.23 only emits `EPHEMERAL_SETTING` → `chats.update` on a *fresh* toggle; for a long‑standing timer the post‑reconnect `messaging-history.set` snapshot doesn't carry it, and the in‑memory store is wiped on every restart. So the value the fix depends on is simply not there.

**2. `getEphemeralExpiration` doesn't bridge `@lid` ↔ phone.** Under WhatsApp's LID migration the 1:1 chat is keyed in the store under the contact's `@lid` JID (live `contacts.update` showed the peer as `…@lid`, with `contacts.upsert` carrying a separate `@s.whatsapp.net` id). The lookup does `chats.get(chatId) ?? chats.get(toEngineJid(chatId))`, and `toEngineJid` only folds `@c.us`↔`@s.whatsapp.net` — a `@lid` id passes through unchanged. The outbound send targets the **phone** JID (the neutral `from` OpenWA delivered on the webhook), so both probes miss the `@lid`‑keyed chat → `undefined` → 2‑arg `sendMessage` → notice persists.

(The send wiring itself is correct — a plain‑text reply does route through `withEphemeral`. The gap is entirely on the read/population side.)

## What this PR changes

- **Source the timer from inbound messages**, which every message in a disappearing chat carries, rather than from `Chat.ephemeralExpiration`. Cached in a new `ephemeralByChat` map keyed by **both the raw and neutral JID**, so a send addressed in either dialect (phone or `@lid`) resolves to the same entry — this also closes the `@lid` gap.
- **`getEphemeralExpiration`** now tries the message‑learned timer across raw/engine/neutral keys first, then falls back to `Chat.ephemeralExpiration` for engines/sessions that do surface it (so existing behavior is preserved).
- **+6 unit tests** (inbound‑sourced timer, `@lid`→phone resolution, `contextInfo.expiration` incl. an `ephemeralMessage` envelope, non‑positive‑doesn't‑clear, precedence). Full suite green; lint/prettier clean.

## ⚠️ The one thing I couldn't verify live (why this is a draft)

My first attempt read `WebMessageInfo.ephemeralDuration` — but instrumentation showed it **empty on live 1:1 `messages.upsert`** (it appears to be a group/history‑sync field). So `extractEphemeralDuration` now also reads the per‑message **`contextInfo.expiration`** after unwrapping the ephemeral/view‑once/document envelope, which is my best guess for the live 1:1 source.

I could **not** confirm that extraction end‑to‑end, because on the test box `baileys_stored_messages` was empty — the session was orphaned (`No parent session row … skipping Baileys message store`, the #319 FK‑skip path), so I had no stored raw message to inspect, and I didn't want to keep guessing against production. **Could you sanity‑check where the 1:1 disappearing timer actually lands on an inbound `messages.upsert` in 6.7.23** (`contextInfo.expiration` vs `disappearingMode` vs the `ephemeralMessage` wrapper)? If it's elsewhere, it's a one‑line tweak to `extractEphemeralDuration`.

## Repro

Real LID‑migrated 1:1 chat, disappearing timer = 90 days. An OpenWA‑driven session auto‑replies via the send‑text endpoint; the reply still shows the recipient‑side "older version" notice. Won't reproduce on a contact that resolves purely as `@c.us` (no `@lid`), which is likely why it passed review.

## Test plan

- [x] `baileys-session-store.spec.ts` — 36/36 (6 new)
- [x] `baileys.adapter.spec.ts` — 99/99
- [x] eslint/prettier clean on touched files
- [ ] **Live confirmation of the `contextInfo.expiration` source** (needs a session whose message store isn't orphaned) — the open question above

Thanks for #503 and the quick turnaround on the original report 🙏
