### PR TITLE
fix(settings): require ADMIN to read application settings

### DIFF
--- a/src/modules/settings/settings.controller.spec.ts
+++ b/src/modules/settings/settings.controller.spec.ts
@@ -31,4 +31,10 @@ describe('SettingsController', () => {
     const role = new Reflector().get<ApiKeyRole | undefined>(REQUIRED_ROLE_KEY, proto.update);
     expect(role).toBe(ApiKeyRole.ADMIN);
   });
+
+  it('GET /settings requires the ADMIN role (env-derived config is not for low-privilege keys)', () => {
+    const proto = SettingsController.prototype as unknown as Record<string, object>;
+    const role = new Reflector().get<ApiKeyRole | undefined>(REQUIRED_ROLE_KEY, proto.get);
+    expect(role).toBe(ApiKeyRole.ADMIN);
+  });
 });

--- a/src/modules/settings/settings.controller.ts
+++ b/src/modules/settings/settings.controller.ts
@@ -53,9 +53,13 @@ export class SettingsController {
   }
 
   @Get()
+  @RequireRole(ApiKeyRole.ADMIN)
   @ApiOperation({ summary: 'Get application settings' })
   @ApiResponse({ status: 200, description: 'Current settings' })
   get(): Settings {
+    // Settings expose environment-derived configuration (debug flag, reconnect policy, rate-limit
+    // thresholds, base URL). Gate the read at ADMIN, matching the PUT below and the rest of the
+    // admin-config surface — a VIEWER or session-scoped key has no business reading server config.
     return this.settings;
   }
 


### PR DESCRIPTION
## Summary
`GET /settings` carried no role gate, so any valid key — including a `VIEWER` or a session-scoped key — could read it, while `PUT /settings` already required `ADMIN`.

## Why it matters
The exposed fields are environment-derived **server configuration** (debug flag, reconnect policy, rate-limit thresholds, base URL) — useful reconnaissance for a low-privilege key, and an inconsistent gate that only gets riskier as the surface grows.

## Change
Adds `@RequireRole(ApiKeyRole.ADMIN)` to the read handler, matching the `PUT` and the rest of the admin-config surface. The endpoint is not consumed by the dashboard, so no UI breaks.

## Tests
Adds a metadata assertion that the read handler requires `ADMIN` (mirroring the existing PUT test). Full backend suite green (1532 tests).