### PR TITLE
fix(message): scope bulk-batch id uniqueness to the session

### DIFF
--- a/src/modules/message/bulk-message.service.spec.ts
+++ b/src/modules/message/bulk-message.service.spec.ts
@@ -198,12 +198,13 @@ describe('BulkMessageService.processBatch', () => {
 
 describe('BulkMessageService.createBatch base64 media cap', () => {
   let service: BulkMessageService;
-  let repo: { findOne: jest.Mock; save: jest.Mock };
+  let repo: { findOne: jest.Mock; save: jest.Mock; create: jest.Mock };
 
   beforeEach(async () => {
     repo = {
       findOne: jest.fn().mockResolvedValue(undefined),
       save: jest.fn().mockImplementation(b => Promise.resolve(b)),
+      create: jest.fn().mockImplementation((b: MessageBatch) => b),
     };
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -234,5 +235,25 @@ describe('BulkMessageService.createBatch base64 media cap', () => {
     } finally {
       delete process.env.MEDIA_DOWNLOAD_MAX_BYTES;
     }
+  });
+
+  it('scopes the batchId uniqueness check to the session (no cross-session collision/oracle)', async () => {
+    // Simulate a DB where batchId 'dup' exists only under session 's1'.
+    repo.findOne.mockImplementation((opts: { where: { batchId?: string; sessionId?: string } }) => {
+      const w = opts.where;
+      const existsForS1 = w.batchId === 'dup' && (w.sessionId === undefined || w.sessionId === 's1');
+      return Promise.resolve(existsForS1 ? { id: 'b1', batchId: 'dup', sessionId: 's1' } : undefined);
+    });
+
+    // A different session reusing the same batchId must succeed — the check is (batchId, sessionId)-scoped,
+    // so it neither collides with another tenant's namespace nor leaks that the id is in use elsewhere.
+    await expect(
+      service.createBatch('s2', {
+        messages: [{ chatId: 'c0@c.us', type: 'text', content: { text: { body: 'hi' } } }],
+        batchId: 'dup',
+      } as unknown as SendBulkMessageDto),
+    ).resolves.toBeDefined();
+
+    expect(repo.findOne).toHaveBeenCalledWith({ where: { batchId: 'dup', sessionId: 's2' } });
   });
 });

--- a/src/modules/message/bulk-message.service.ts
+++ b/src/modules/message/bulk-message.service.ts
@@ -107,8 +107,10 @@ export class BulkMessageService implements OnApplicationBootstrap {
 
     const batchId = dto.batchId || `batch_${randomUUID().split('-')[0]}`;
 
-    // Check if batchId already exists
-    const existing = await this.batchRepository.findOne({ where: { batchId } });
+    // Check if this batchId already exists FOR THIS SESSION. Scoping by sessionId (matching how
+    // getBatchStatus/cancelBatch already query) makes (sessionId, batchId) the namespace: one session
+    // can't deny another a batchId, and the 400-vs-202 difference can't probe another session's ids.
+    const existing = await this.batchRepository.findOne({ where: { batchId, sessionId } });
     if (existing) {
       throw new BadRequestException(`Batch ID '${batchId}' already exists`);
     }


### PR DESCRIPTION
## Summary
`createBatch` checked whether a caller-supplied `batchId` already existed using a query scoped only by `batchId` — across **all** sessions — while the read (`getBatchStatus`) and `cancelBatch` paths already scope by `(batchId, sessionId)`.

## Why it matters
The global check meant:
- **Cross-tenant namespace collision:** one session could deny another the use of a chosen `batchId`.
- **Existence oracle:** the `400 'already exists'` vs `202` response difference let a caller probe whether a `batchId` was in use by any other session.

## Change
Scope the uniqueness probe to `(batchId, sessionId)`, matching how reads/cancels already query, so the batch-id namespace is per session. (The internal processor looks batches up by primary `id`, so it's unaffected.)

## Tests
Adds a regression test: a second session reusing another session's `batchId` now succeeds, and the uniqueness probe is asserted session-scoped. Full backend suite green (1532 tests).