### PR TITLE
fix(config): reject 0 for rate-limit limits and the webhook timeout

### DIFF
--- a/src/config/env.validation.spec.ts
+++ b/src/config/env.validation.spec.ts
@@ -56,6 +56,19 @@ describe('validateEnv', () => {
     expect(() => validateEnv({})).not.toThrow();
   });
 
+  it('rejects 0 for a rate-limit limit or the webhook timeout (self-DoS), but allows 0 where it is meaningful', () => {
+    expect(() => validateEnv({ RATE_LIMIT_SHORT_LIMIT: '0' })).toThrow(/RATE_LIMIT_SHORT_LIMIT/);
+    expect(() => validateEnv({ RATE_LIMIT_MEDIUM_LIMIT: '0' })).toThrow(/RATE_LIMIT_MEDIUM_LIMIT/);
+    expect(() => validateEnv({ RATE_LIMIT_LONG_LIMIT: '0' })).toThrow(/RATE_LIMIT_LONG_LIMIT/);
+    expect(() => validateEnv({ WEBHOOK_TIMEOUT: '0' })).toThrow(/WEBHOOK_TIMEOUT/);
+    // 0 stays valid where it has a real meaning: unlimited sessions, no webhook retries, a TTL.
+    expect(() =>
+      validateEnv({ MAX_CONCURRENT_SESSIONS: '0', WEBHOOK_MAX_RETRIES: '0', RATE_LIMIT_SHORT_TTL: '0' }),
+    ).not.toThrow();
+    // a positive value still passes
+    expect(() => validateEnv({ RATE_LIMIT_SHORT_LIMIT: '10', WEBHOOK_TIMEOUT: '10000' })).not.toThrow();
+  });
+
   it('rejects a sqlite data DB path that collides with the internal main database file', () => {
     // The 'main' (auth/audit) and 'data' connections must be separate SQLite files; sharing one
     // file means two migration ledgers + synchronize policies on the same tables.

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -80,19 +80,30 @@ export function validateEnv(config: EnvConfig): EnvConfig {
   };
   for (const key of [
     'RATE_LIMIT_SHORT_TTL',
-    'RATE_LIMIT_SHORT_LIMIT',
     'RATE_LIMIT_MEDIUM_TTL',
-    'RATE_LIMIT_MEDIUM_LIMIT',
     'RATE_LIMIT_LONG_TTL',
-    'RATE_LIMIT_LONG_LIMIT',
-    'WEBHOOK_TIMEOUT',
     'WEBHOOK_MAX_RETRIES',
     'WEBHOOK_RETRY_DELAY',
     'DATABASE_POOL_SIZE',
     'REDIS_CONNECT_TIMEOUT_MS',
-    'MAX_CONCURRENT_SESSIONS',
+    'MAX_CONCURRENT_SESSIONS', // 0 = unlimited
   ]) {
     checkNonNegativeInt(key);
+  }
+
+  // Some knobs are nonsensical at 0 and contradict the "non-negative" intent: a rate-limit LIMIT of 0
+  // disables that tier's throttling (a self-DoS), and a webhook timeout of 0 aborts every delivery
+  // immediately. Require a positive integer for these.
+  const checkPositiveInt = (key: string): void => {
+    const raw = str(key);
+    if (raw === undefined) return;
+    const n = Number(raw);
+    if (!Number.isInteger(n) || n < 1) {
+      errors.push(`${key} must be a positive integer (got "${raw}")`);
+    }
+  };
+  for (const key of ['RATE_LIMIT_SHORT_LIMIT', 'RATE_LIMIT_MEDIUM_LIMIT', 'RATE_LIMIT_LONG_LIMIT', 'WEBHOOK_TIMEOUT']) {
+    checkPositiveInt(key);
   }
 
   if (errors.length > 0) {


### PR DESCRIPTION
## Summary
Boot-time env validation checked several numeric knobs as **non-negative**, so a value of `0` passed. But `0` is a self-DoS for two of them, not a valid setting:
- a rate-limit **LIMIT** of `0` disables that tier's throttling, and
- a **webhook timeout** of `0` aborts every delivery immediately.

The existing "must be a non-negative integer" message even contradicts that intent.

## Change
Require a **positive** integer (≥ 1) for `RATE_LIMIT_{SHORT,MEDIUM,LONG}_LIMIT` and `WEBHOOK_TIMEOUT`. The knobs where `0` is genuinely meaningful are left non-negative: `MAX_CONCURRENT_SESSIONS` (0 = unlimited), `WEBHOOK_MAX_RETRIES` (0 = no retries), and the rate-limit TTLs.

## Tests
Adds a regression test asserting `0` is rejected for each limit and the webhook timeout, while still accepting `0` for the legitimately-zero keys. Full backend suite green (1532 tests).