### PR TITLE
fix(security): block the RFC6052 IPv4-translatable IPv6 form in the SSRF guard

### DIFF
--- a/src/common/security/ssrf-guard.spec.ts
+++ b/src/common/security/ssrf-guard.spec.ts
@@ -53,6 +53,9 @@ describe('isBlockedAddress', () => {
     ['2002:c0a8::', '6to4 of RFC1918 net 192.168.0.0 (compressed)'],
     ['::127.0.0.1', 'IPv4-compatible loopback (deprecated, dotted)'],
     ['::a9fe:a9fe', 'IPv4-compatible cloud metadata (deprecated, hex)'],
+    ['::ffff:0:7f00:1', 'IPv4-translatable loopback 127.0.0.1 (RFC6052, hex)'],
+    ['::ffff:0:127.0.0.1', 'IPv4-translatable loopback (RFC6052, dotted tail)'],
+    ['::ffff:0:a9fe:a9fe', 'IPv4-translatable cloud metadata 169.254.169.254 (RFC6052)'],
   ])('blocks %s (%s)', ip => {
     expect(isBlockedAddress(ip)).toBe(true);
   });
@@ -65,6 +68,7 @@ describe('isBlockedAddress', () => {
     ['::ffff:0808:0808', 'IPv4-mapped public 8.8.8.8 (hex)'],
     ['2002:0808:0808::', '6to4 of public 8.8.8.8 stays allowed'],
     ['64:ff9b::0808:0808', 'NAT64 of public 8.8.8.8 stays allowed'],
+    ['::ffff:0:0808:0808', 'IPv4-translatable public 8.8.8.8 stays allowed'],
   ])('allows %s (%s)', ip => {
     expect(isBlockedAddress(ip)).toBe(false);
   });

--- a/src/common/security/ssrf-guard.ts
+++ b/src/common/security/ssrf-guard.ts
@@ -150,6 +150,19 @@ export function isBlockedAddress(ip: string): boolean {
       if (hextets.slice(0, 6).every(h => h === 0) && (hextets[6] | hextets[7]) !== 0) {
         return isBlockedAddress(hextetsToV4(hextets[6], hextets[7])); // IPv4-compatible ::/96
       }
+      // RFC6052 IPv4-translatable (::ffff:0:a.b.c.d → 0:0:0:0:ffff:0:X:X): embeds an IPv4 in the
+      // low 32 bits just like the mapped/NAT64 forms, so a NAT64/SIIT translator could otherwise
+      // reach an internal IPv4 through it. Classify by the embedded address (public stays allowed).
+      if (
+        hextets[0] === 0 &&
+        hextets[1] === 0 &&
+        hextets[2] === 0 &&
+        hextets[3] === 0 &&
+        hextets[4] === 0xffff &&
+        hextets[5] === 0
+      ) {
+        return isBlockedAddress(hextetsToV4(hextets[6], hextets[7]));
+      }
     }
     return false;
   }


### PR DESCRIPTION
## Summary
The SSRF guard's `isBlockedAddress` decodes the common IPv4-in-IPv6 embeddings — IPv4-mapped (`::ffff:a.b.c.d` / `::ffff:hhhh:hhhh`), 6to4 (`2002::/16`), NAT64 (`64:ff9b::/96`), and deprecated IPv4-compatible (`::/96`) — and blocks them when the embedded IPv4 is internal. It did **not** decode the RFC6052 **IPv4-translatable** form `::ffff:0:a.b.c.d` (`0:0:0:0:ffff:0:X:X`).

## Why it matters
`::ffff:0:7f00:1` has a 3-part tail the `::ffff:` fast-path skips, and once expanded the embedded address sits at `hextets[6..7]` with `hextets[4]=ffff`, so none of the existing prefix checks match — it fell through to *allowed*. Behind a NAT64/SIIT translator that maps it back to the embedded IPv4, this bypasses the loopback / cloud-metadata / RFC1918 blocklist.

## Change
Decode the translatable form by its embedded IPv4, exactly like the mapped/NAT64/compat embeddings. A translatable form of a genuinely **public** IPv4 still returns `false`, so legitimate IPv6 delivery is unaffected.

## Tests
Adds blocked cases (`::ffff:0:7f00:1`, dotted `::ffff:0:127.0.0.1`, metadata `::ffff:0:a9fe:a9fe`) and an allowed case (`::ffff:0:0808:0808` = 8.8.8.8). Full backend suite + coverage green (1535 tests).