### PR TITLE
fix(message): drop media base64 from failed sends and completed bulk batches

### DIFF
--- a/src/modules/message/bulk-message.service.spec.ts
+++ b/src/modules/message/bulk-message.service.spec.ts
@@ -150,6 +150,27 @@ describe('BulkMessageService.processBatch', () => {
     );
   });
 
+  it('strips base64 media payloads from the stored batch once it completes (footprint)', async () => {
+    const batch = makeBatch(1);
+    batch.messages = [
+      {
+        chatId: 'c0@c.us',
+        type: 'image',
+        content: { image: { base64: 'QkFTRTY0SU1BR0U=', mimetype: 'image/png', filename: 'p.png' } },
+      },
+    ];
+    repo.findOne.mockResolvedValue(batch);
+
+    await runProcessBatch();
+
+    // A completed batch is terminal (never resumed), so the persisted message_batches.messages must not
+    // retain the (often multi-MB) base64 — only the descriptive fields are kept.
+    const savedBatch = (repo.save.mock.calls as [MessageBatch][]).at(-1)![0];
+    const img = (savedBatch.messages[0].content as { image?: { base64?: unknown; mimetype?: string } }).image;
+    expect(img?.base64).toBeUndefined();
+    expect(img?.mimetype).toBe('image/png');
+  });
+
   it('stops sending when the batch is cancelled in the DB by another instance/restart', async () => {
     // First load is the running batch; the cadence re-read reports a CANCELLED status.
     repo.findOne.mockResolvedValueOnce(makeBatch(3)).mockResolvedValue({ status: BatchStatus.CANCELLED });

--- a/src/modules/message/bulk-message.service.ts
+++ b/src/modules/message/bulk-message.service.ts
@@ -309,10 +309,30 @@ export class BulkMessageService implements OnApplicationBootstrap {
     }
     batch.completedAt = new Date();
     batch.results = results;
+    // The batch is terminal now (never resumed), so drop the base64 media payloads before persisting —
+    // otherwise the message_batches row retains multi-MB media forever. Intermediate (cadence) saves
+    // above keep the payload so a batch interrupted mid-run can still resume from currentIndex.
+    this.stripBatchMediaPayloads(batch.messages);
     await this.batchRepository.save(batch);
 
     this.processingBatches.delete(batch.id);
     this.logger.log(`Batch ${batch.batchId} completed: ${batch.progress.sent} sent, ${batch.progress.failed} failed`);
+  }
+
+  /**
+   * Drop base64 payloads from a finished batch's stored message list. A completed/cancelled batch is
+   * terminal (never resumed), so the (often multi-MB) base64 in `message_batches.messages` is dead
+   * weight; the descriptive fields (mimetype/filename/caption/url) are kept.
+   */
+  private stripBatchMediaPayloads(messages: MessageBatch['messages']): void {
+    for (const m of messages) {
+      for (const key of ['image', 'video', 'audio', 'document']) {
+        const media = m.content[key] as { base64?: unknown } | undefined;
+        if (media && typeof media === 'object' && 'base64' in media) {
+          delete media.base64;
+        }
+      }
+    }
   }
 
   private applyVariables(content: BulkMessageContent, variables?: Record<string, string>): BulkMessageContent {

--- a/src/modules/message/message.service.spec.ts
+++ b/src/modules/message/message.service.spec.ts
@@ -318,6 +318,29 @@ describe('MessageService', () => {
         delete process.env.MEDIA_DOWNLOAD_MAX_BYTES;
       }
     });
+
+    it('strips the base64 payload from a FAILED media row but keeps mimetype/filename', async () => {
+      mockEngine.sendImageMessage.mockRejectedValueOnce(new Error('engine down'));
+
+      await expect(
+        service.sendImage('sess-1', {
+          chatId: '628123456789@c.us',
+          base64: 'QUJDREVGISBhIGJpZyBwYXlsb2Fk',
+          mimetype: 'image/png',
+          filename: 'pic.png',
+        }),
+      ).rejects.toThrow();
+
+      // The persisted FAILED row must not retain the (often multi-MB) base64 — it's never displayed
+      // or retried — but should keep the descriptive mimetype/filename.
+      const calls = (repository.save as jest.Mock).mock.calls as [Message][];
+      const saved = calls.at(-1)![0];
+      expect(saved.status).toBe(MessageStatus.FAILED);
+      const media = (saved.metadata as { media?: { data?: unknown; mimetype?: string; filename?: string } }).media;
+      expect(media?.data).toBeUndefined();
+      expect(media?.mimetype).toBe('image/png');
+      expect(media?.filename).toBe('pic.png');
+    });
   });
 
   // ── getMessages pagination guard ──────────────────────────────────

--- a/src/modules/message/message.service.ts
+++ b/src/modules/message/message.service.ts
@@ -145,8 +145,7 @@ export class MessageService {
         timestamp: result.timestamp,
       };
     } catch (error) {
-      message.status = MessageStatus.FAILED;
-      await this.messageRepository.save(message);
+      await this.saveFailedMessage(message);
       throw this.toClientFacingError(error);
     }
   }
@@ -179,8 +178,7 @@ export class MessageService {
         timestamp: result.timestamp,
       };
     } catch (error) {
-      message.status = MessageStatus.FAILED;
-      await this.messageRepository.save(message);
+      await this.saveFailedMessage(message);
       throw this.toClientFacingError(error);
     }
   }
@@ -212,8 +210,7 @@ export class MessageService {
         timestamp: result.timestamp,
       };
     } catch (error) {
-      message.status = MessageStatus.FAILED;
-      await this.messageRepository.save(message);
+      await this.saveFailedMessage(message);
       throw this.toClientFacingError(error);
     }
   }
@@ -246,8 +243,7 @@ export class MessageService {
         timestamp: result.timestamp,
       };
     } catch (error) {
-      message.status = MessageStatus.FAILED;
-      await this.messageRepository.save(message);
+      await this.saveFailedMessage(message);
       throw this.toClientFacingError(error);
     }
   }
@@ -341,8 +337,7 @@ export class MessageService {
         timestamp: result.timestamp,
       };
     } catch (error) {
-      message.status = MessageStatus.FAILED;
-      await this.messageRepository.save(message);
+      await this.saveFailedMessage(message);
       throw this.toClientFacingError(error);
     }
   }
@@ -377,8 +372,7 @@ export class MessageService {
         timestamp: result.timestamp,
       };
     } catch (error) {
-      message.status = MessageStatus.FAILED;
-      await this.messageRepository.save(message);
+      await this.saveFailedMessage(message);
       throw this.toClientFacingError(error);
     }
   }
@@ -410,8 +404,7 @@ export class MessageService {
         timestamp: result.timestamp,
       };
     } catch (error) {
-      message.status = MessageStatus.FAILED;
-      await this.messageRepository.save(message);
+      await this.saveFailedMessage(message);
       throw this.toClientFacingError(error);
     }
   }
@@ -457,8 +450,7 @@ export class MessageService {
         timestamp: result.timestamp,
       };
     } catch (error) {
-      message.status = MessageStatus.FAILED;
-      await this.messageRepository.save(message);
+      await this.saveFailedMessage(message);
       throw this.toClientFacingError(error);
     }
   }
@@ -493,8 +485,7 @@ export class MessageService {
         timestamp: result.timestamp,
       };
     } catch (error) {
-      message.status = MessageStatus.FAILED;
-      await this.messageRepository.save(message);
+      await this.saveFailedMessage(message);
       throw this.toClientFacingError(error);
     }
   }
@@ -543,6 +534,20 @@ export class MessageService {
       metadata: data.metadata,
     });
     return this.messageRepository.save(message);
+  }
+
+  /**
+   * Persist a send as FAILED, dropping any outbound media payload first. A failed row's media base64
+   * (often multi-MB) is never displayed or retried, so keeping it only bloats the messages table; the
+   * mimetype/filename are kept so the row still describes what was attempted.
+   */
+  private async saveFailedMessage(message: Message): Promise<void> {
+    const media = (message.metadata as { media?: { data?: unknown } } | undefined)?.media;
+    if (media) {
+      delete media.data;
+    }
+    message.status = MessageStatus.FAILED;
+    await this.messageRepository.save(message);
   }
 
   // ========== Phase 3: Reactions ==========


### PR DESCRIPTION
## Problem

Two persistence paths retained full media base64 long past any usefulness:

1. **Failed media sends.** Each media send (`image`/`video`/`audio`/`document`/`sticker`) persists its base64 to the pending row's `metadata.media.data` before sending. On failure the row is saved `FAILED` without clearing it, so failed sends accumulate full (often multi-MB) payloads in the `messages` table — never displayed, never retried.
2. **Completed bulk batches.** A bulk batch stores its entire `messages` array — base64 and all — in `message_batches.messages`, and it is never trimmed after the batch finishes.

## Fix

- A shared `saveFailedMessage(message)` helper drops `metadata.media.data` (keeping `mimetype`/`filename`) before persisting a send as `FAILED`. All send methods route their failure path through it; for non-media sends the strip is a no-op.
- Bulk processing drops the base64 payloads from `batch.messages` immediately before the **terminal** save. A completed/cancelled batch is never resumed, so the payload is dead weight; the intermediate cadence saves keep it so a batch interrupted mid-run can still resume from `currentIndex`.

Successful single sends are unchanged (their media is still available for the dashboard chat view).

## Tests

- A failed `sendImage` persists the `FAILED` row with `metadata.media.data` stripped but `mimetype`/`filename` retained.
- A completed batch's stored messages no longer carry `content.*.base64`, while the descriptive fields remain.

Full backend suite green (1575 tests).