### PR TITLE
perf(dashboard): stop caching full media base64 in the chat thread view

### DIFF
--- a/dashboard/src/hooks/useChatMessages.ts
+++ b/dashboard/src/hooks/useChatMessages.ts
@@ -16,10 +16,12 @@ export function messagesQueryKey(sessionId: string, chatId: string): MessagesQue
 }
 
 /**
- * Fetch messages for one (sessionId, chatId) and keep them cached forever
- * (staleTime: Infinity). Realtime updates flow through useChatMessagesActions,
- * not through refetches. Cache eviction happens 30 min after the chat stops
- * being observed (gcTime).
+ * Fetch messages for one (sessionId, chatId) and keep them cached (staleTime: Infinity); realtime
+ * updates flow through useChatMessagesActions, not refetches. Engine history is fetched WITHOUT media
+ * to keep the cache small — a single 50 MiB message would otherwise sit in heap as base64 (held twice
+ * as a `data:` URI). Recent media still renders from the DB copy (which wins in mergeChatMessages);
+ * older history media shows the omitted placeholder. Cache eviction happens 5 min after the chat stops
+ * being observed (gcTime), so browsing several media-rich chats doesn't accumulate large slices.
  */
 export function useChatMessages(sessionId: string, chatId: string | null): UseQueryResult<ChatMessageView[], Error> {
   return useQuery<ChatMessageView[], Error>({
@@ -27,7 +29,7 @@ export function useChatMessages(sessionId: string, chatId: string | null): UseQu
     queryFn: async () => {
       const [dbRes, historyRes] = await Promise.allSettled([
         sessionApi.getChatMessages(sessionId, chatId!, 100),
-        sessionApi.getChatHistory(sessionId, chatId!, 100, true),
+        sessionApi.getChatHistory(sessionId, chatId!, 100, false),
       ]);
       if (dbRes.status === 'rejected' && historyRes.status === 'rejected') throw dbRes.reason;
       const dbMessages = dbRes.status === 'fulfilled' ? dbRes.value.messages : [];
@@ -36,7 +38,7 @@ export function useChatMessages(sessionId: string, chatId: string | null): UseQu
     },
     enabled: Boolean(sessionId && chatId),
     staleTime: Infinity,
-    gcTime: 30 * 60 * 1000,
+    gcTime: 5 * 60 * 1000,
   });
 }
 

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -163,7 +163,7 @@ export interface ChatMessage {
   timestamp?: number;
   createdAt: string;
   metadata?: {
-    media?: { mimetype: string; filename?: string; data?: string };
+    media?: { mimetype: string; filename?: string; data?: string; omitted?: boolean; sizeBytes?: number };
     quotedMessage?: { id: string; body: string };
     reactions?: Record<string, string>;
   };

--- a/dashboard/src/utils/chatMessages.test.ts
+++ b/dashboard/src/utils/chatMessages.test.ts
@@ -48,6 +48,23 @@ test('mapEngineHistoryMessage: derives createdAt from the unix timestamp', () =>
   assert.equal(Date.parse(m.createdAt), 1782053533 * 1000);
 });
 
+test('mapEngineHistoryMessage: a media-type message with no loaded media gets an omitted marker', () => {
+  // History is fetched without media (footprint), so an old media message arrives with no payload —
+  // surface it as the omitted placeholder (📎 Media) instead of an empty bubble.
+  const m = mapEngineHistoryMessage(hist({ type: 'image', media: undefined }));
+  assert.equal(m.metadata?.media?.omitted, true);
+});
+
+test('mapEngineHistoryMessage: a media message that DID carry media keeps it (no marker override)', () => {
+  const m = mapEngineHistoryMessage(hist({ type: 'image', media: { mimetype: 'image/png', data: 'BASE64' } }));
+  assert.equal(m.metadata?.media?.data, 'BASE64');
+  assert.equal(m.metadata?.media?.omitted, undefined);
+});
+
+test('mapEngineHistoryMessage: a text message gets no media metadata', () => {
+  assert.equal(mapEngineHistoryMessage(hist({ type: 'text' })).metadata, undefined);
+});
+
 test('mergeChatMessages: an engine-only message (no DB row) is included — the backfill case', () => {
   const merged = mergeChatMessages([], [mapEngineHistoryMessage(hist())]);
   assert.equal(merged.length, 1);

--- a/dashboard/src/utils/chatMessages.ts
+++ b/dashboard/src/utils/chatMessages.ts
@@ -2,6 +2,11 @@ import type { ChatMessage, EngineHistoryMessage, MessageType } from '../services
 
 export type { EngineHistoryMessage };
 
+// Message types whose history rows carry media. History is fetched WITHOUT media (footprint), so such
+// a row arrives with no payload — surface it as the omitted placeholder (📎 Media) instead of an empty
+// bubble. The DB copy of a recent message still wins in mergeChatMessages, so its real media is kept.
+const HISTORY_MEDIA_TYPES = new Set(['image', 'video', 'audio', 'voice', 'sticker', 'document']);
+
 // Normalize an engine history message into the DB ChatMessage shape the thread renders. Historical
 // messages have no live delivery state, so default to `read` (they are old/already-seen); real status
 // for current-session messages still comes from the DB copy and live websocket acks.
@@ -18,7 +23,11 @@ export function mapEngineHistoryMessage(h: EngineHistoryMessage): ChatMessage {
     status: 'read',
     timestamp: h.timestamp,
     createdAt: new Date((h.timestamp ?? 0) * 1000).toISOString(),
-    metadata: h.media ? { media: h.media } : undefined,
+    metadata: h.media
+      ? { media: h.media }
+      : HISTORY_MEDIA_TYPES.has(h.type)
+        ? { media: { mimetype: '', omitted: true } }
+        : undefined,
   };
 }
 


### PR DESCRIPTION
## Problem

Opening a chat caches its thread in React Query (`useChatMessages`) by fetching the DB slice **plus** engine history with `includeMedia=true`, then holding it at `staleTime: Infinity` with a 30-minute `gcTime` and no byte cap. A single 50 MiB message sits in heap as base64 — held twice once it becomes a `data:` URI — so browsing several media-rich chats can OOM the tab.

## Fix

- **History is fetched without media** (`getChatHistory(..., includeMedia=false)`), removing the dominant source of cached base64.
- **`gcTime` lowered to 5 minutes**, so an unobserved chat's slice is released sooner instead of accumulating across chats.

Recent media still renders: the DB copy of a message wins in `mergeChatMessages`, so persisted media keeps its payload. Only *older, history-only* media changes — it now shows the existing **omitted placeholder** (`📎 Media`), synthesized for media-type history rows that arrive without a payload (the same marker the inbound path already uses).

This is client-only and does **not** touch the inbound media-download path (`MEDIA_DOWNLOAD_ENABLED`) — it just reuses that path's omitted-marker contract on the dashboard.

## Tests

- `mapEngineHistoryMessage` synthesizes an omitted marker for a media-type history row with no media.
- A history row that did carry media keeps it (no marker override); a text row gets no media metadata.

Dashboard build + lint + unit tests green (75 tests).