### PR TITLE
fix: SQLite/PostgreSQL parity for stats timestamps, uuid defaults, and id column types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Bulk batch ids are unique per session, not globally.** A batch id claimed by one session no longer prevents another session from using the same id — the uniqueness constraint is now scoped to `(session, batchId)`, matching the per-session lookup, so an explicit cross-session reuse no longer fails with a `500`. Reusing an id within the same session is still rejected with a clear `400`. Existing databases are migrated in place. (#531)
 - **A message arriving while a session is being deleted is no longer persisted as an orphan.** The inbound-message handler re-checks that the session is still live after its asynchronous processing, so a message that races a session deletion can't leave behind a `messages` row (which has no cascade) for a session that no longer exists. (#531)
+- **Per-session stats return a consistent `lastActive` timestamp on SQLite and PostgreSQL.** `GET /stats/sessions/:id` previously emitted a different `topChats[].lastActive` format depending on the database (an ISO date-time on PostgreSQL versus the stored text on SQLite); it is now formatted to a stable `YYYY-MM-DD HH:MM:SS` on both. (#533)
+- **The uuid id default now works on PostgreSQL 12 and older.** Id generation relies on a `gen_random_uuid()` column default, which is a core built-in only from PostgreSQL 13; on older servers it lives in the `pgcrypto` extension. The migration now enables `pgcrypto` first, so a fresh deploy against PostgreSQL ≤ 12 no longer fails on startup or first insert. (#533)
 
 ### Security
 

--- a/src/database/add-uuid-defaults-migration.spec.ts
+++ b/src/database/add-uuid-defaults-migration.spec.ts
@@ -25,20 +25,28 @@ describe('AddUuidDefaultsForPostgres migration', () => {
     expect(qr.hasTable).not.toHaveBeenCalled();
   });
 
-  it('on Postgres up() sets a uuid DEFAULT on every existing table', async () => {
+  it('on Postgres up() creates pgcrypto, then sets a uuid DEFAULT on every existing table', async () => {
     const qr = makeQueryRunner('postgres', new Set(ALL_TABLES));
     await migration.up(qr as unknown as QueryRunner);
 
-    expect(qr.query).toHaveBeenCalledTimes(ALL_TABLES.length);
+    // 1 CREATE EXTENSION + one ALTER per table.
+    expect(qr.query).toHaveBeenCalledTimes(ALL_TABLES.length + 1);
+    const calls = qr.query.mock.calls.map(call => String((call as unknown[])[0]));
+    // pgcrypto must be ensured before any gen_random_uuid() default that depends on it (PG <= 12).
+    const extIdx = calls.findIndex(q => /CREATE EXTENSION IF NOT EXISTS pgcrypto/i.test(q));
+    const firstAlterIdx = calls.findIndex(q => /gen_random_uuid\(\)/i.test(q));
+    expect(extIdx).toBe(0);
+    expect(extIdx).toBeLessThan(firstAlterIdx);
     expect(qr.query).toHaveBeenCalledWith(
       'ALTER TABLE "sessions" ALTER COLUMN "id" SET DEFAULT gen_random_uuid()::varchar',
     );
   });
 
-  it('skips tables that do not exist', async () => {
+  it('skips tables that do not exist (still creates pgcrypto)', async () => {
     const qr = makeQueryRunner('postgres', new Set(['sessions', 'messages']));
     await migration.up(qr as unknown as QueryRunner);
-    expect(qr.query).toHaveBeenCalledTimes(2);
+    // 1 CREATE EXTENSION + 2 ALTERs (only the two existing tables).
+    expect(qr.query).toHaveBeenCalledTimes(3);
   });
 
   it('on Postgres down() drops the DEFAULT on every existing table', async () => {

--- a/src/database/migrations/1779235200000-AddUuidDefaultsForPostgres.ts
+++ b/src/database/migrations/1779235200000-AddUuidDefaultsForPostgres.ts
@@ -14,7 +14,10 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  *   This migration is a no-op on SQLite (TypeORM generates the UUID in the
  *   driver layer there, so no DB default is needed).
  *
- *   `gen_random_uuid()` is built into PostgreSQL 13+ — no extension required.
+ *   `gen_random_uuid()` is a core built-in only from PostgreSQL 13; on PG <= 12
+ *   it lives in the pgcrypto extension. We `CREATE EXTENSION IF NOT EXISTS
+ *   pgcrypto` first so the default (and every insert that relies on it) works on
+ *   older servers too. On PG 13+ the extension is harmless/redundant.
  */
 export class AddUuidDefaultsForPostgres1779235200000 implements MigrationInterface {
   name = 'AddUuidDefaultsForPostgres1779235200000';
@@ -24,6 +27,9 @@ export class AddUuidDefaultsForPostgres1779235200000 implements MigrationInterfa
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     if (queryRunner.connection.options.type !== 'postgres') return;
+
+    // gen_random_uuid() is core only on PG 13+; ensure pgcrypto is present so PG <= 12 resolves it too.
+    await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS pgcrypto`);
 
     for (const table of this.tables) {
       const exists = await queryRunner.hasTable(table);

--- a/src/modules/stats/stats.service.spec.ts
+++ b/src/modules/stats/stats.service.spec.ts
@@ -1,5 +1,5 @@
 import { DataSource } from 'typeorm';
-import { StatsService, timeSeriesTimestampSql, hourBucketSql } from './stats.service';
+import { StatsService, timeSeriesTimestampSql, hourBucketSql, maxCreatedAtSql } from './stats.service';
 import { Session, SessionStatus } from '../session/entities/session.entity';
 import { Message, MessageDirection, MessageStatus } from '../message/entities/message.entity';
 
@@ -18,6 +18,14 @@ describe('stats SQL dialect helpers', () => {
     expect(timeSeriesTimestampSql('postgres', 'hour')).toBe(`to_char(m."createdAt", 'YYYY-MM-DD HH24:00:00')`);
     expect(timeSeriesTimestampSql('postgres', 'day')).toBe(`to_char(m."createdAt", 'YYYY-MM-DD')`);
     expect(hourBucketSql('postgres')).toBe(`CAST(EXTRACT(HOUR FROM m."createdAt") AS INTEGER)`);
+  });
+
+  it('formats MAX(createdAt) to an identical text timestamp on both engines (lastActive parity)', () => {
+    // Postgres returns a timestamp the driver hydrates to a JS Date (serialized to a different ISO
+    // string than SQLite's stored text); pinning both to the same to_char/strftime format keeps the
+    // lastActive field stable regardless of the backing database.
+    expect(maxCreatedAtSql('sqlite')).toBe(`strftime('%Y-%m-%d %H:%M:%S', MAX(m.createdAt))`);
+    expect(maxCreatedAtSql('postgres')).toBe(`to_char(MAX(m."createdAt"), 'YYYY-MM-DD HH24:MI:SS')`);
   });
 });
 

--- a/src/modules/stats/stats.service.ts
+++ b/src/modules/stats/stats.service.ts
@@ -28,6 +28,19 @@ export function hourBucketSql(dbType: string): string {
     : `CAST(strftime('%H', m.createdAt) AS INTEGER)`;
 }
 
+/**
+ * SQL for the most-recent-activity timestamp (MAX of createdAt) as an identical text format on both
+ * engines. SQLite's MAX over a `datetime` column returns the stored text; Postgres returns a timestamp
+ * the driver hydrates to a JS Date (serialized to a different ISO string). to_char/strftime pin both
+ * to `YYYY-MM-DD HH:MM:SS`, matching the format the time-series buckets already use, so the lastActive
+ * field is stable regardless of the backing database.
+ */
+export function maxCreatedAtSql(dbType: string): string {
+  return dbType === 'postgres'
+    ? `to_char(MAX(m."createdAt"), 'YYYY-MM-DD HH24:MI:SS')`
+    : `strftime('%Y-%m-%d %H:%M:%S', MAX(m.createdAt))`;
+}
+
 export interface OverviewStats {
   sessions: {
     active: number;
@@ -251,7 +264,7 @@ export class StatsService {
       .createQueryBuilder('m')
       .select('m.chatId', 'chatId')
       .addSelect('COUNT(*)', 'count')
-      .addSelect('MAX(m.createdAt)', 'lastActive')
+      .addSelect(maxCreatedAtSql(this.dataDbType), 'lastActive')
       .where('m.sessionId = :sessionId', { sessionId })
       .groupBy('m.chatId')
       .orderBy('count', 'DESC')

--- a/src/modules/template/entities/template.entity.ts
+++ b/src/modules/template/entities/template.entity.ts
@@ -18,7 +18,9 @@ export class Template {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @Column({ type: 'uuid' })
+  // varchar (not uuid) to match the authoritative migration DDL and sessions.id; the data connection
+  // runs synchronize:false, so a 'uuid' decorator here would only mislead schema diffs / a stray sync.
+  @Column({ type: 'varchar' })
   sessionId: string;
 
   @ManyToOne(() => Session, { onDelete: 'CASCADE' })

--- a/src/modules/webhook/entities/webhook.entity.ts
+++ b/src/modules/webhook/entities/webhook.entity.ts
@@ -17,7 +17,9 @@ export class Webhook {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @Column({ type: 'uuid' })
+  // varchar (not uuid) to match the authoritative migration DDL and sessions.id; the data connection
+  // runs synchronize:false, so a 'uuid' decorator here would only mislead schema diffs / a stray sync.
+  @Column({ type: 'varchar' })
   sessionId: string;
 
   @ManyToOne(() => Session, { onDelete: 'CASCADE' })


### PR DESCRIPTION
A few places behaved differently on SQLite (used in development and the test suite) versus PostgreSQL (used in production). Because the suite runs on SQLite, these differences are not caught by tests, so each fix below reasons about both engines directly and is covered accordingly.

## Consistent `lastActive` timestamp in per-session stats

`GET /stats/sessions/:id` returns `topChats[].lastActive` from `MAX(createdAt)` via a raw query. On PostgreSQL the driver hydrates the aggregate to a `Date` (serialized as an ISO `…T…Z` string); on SQLite it comes back as the stored text (`YYYY-MM-DD HH:MM:SS`). The same endpoint therefore emitted a different timestamp format per database.

It is now formatted dialect-aware (`to_char` / `strftime`) to a stable `YYYY-MM-DD HH:MM:SS` on both engines — the same approach the time-series buckets already use. Added a unit test for the new SQL helper; the existing end-to-end SQLite stats test continues to pass.

## `pgcrypto` for the uuid id default on PostgreSQL < 13

Id generation on Postgres is delegated to a `gen_random_uuid()::varchar` column default. `gen_random_uuid()` is a core built-in only from PostgreSQL 13; on PostgreSQL ≤ 12 it is provided by the `pgcrypto` extension, so on an older server the migration — and every subsequent insert that relies on the default — failed with `function gen_random_uuid() does not exist`.

The migration now runs `CREATE EXTENSION IF NOT EXISTS pgcrypto` before installing the defaults (harmless and redundant on 13+), and the migration's own comment is corrected. SQLite is unaffected, since it generates the uuid in the driver. The existing migration spec is updated to assert the extension is created before any dependent default.

## `sessionId` column type aligned to the schema

`Webhook.sessionId` and `Template.sessionId` were decorated `type: 'uuid'`, but the authoritative migrations create those columns as `varchar` (matching `sessions.id`), and the data connection runs with `synchronize: false`. On PostgreSQL `uuid` and `varchar` are distinct types, so the mismatch would only mislead a schema diff or a stray `DATABASE_SYNCHRONIZE=true`. The decorators are aligned to `varchar`; no runtime behavior changes.

## Verification

Full backend suite green (1584 tests), lint and build clean.