### PR TITLE
fix(engine): sanitize contact-card vCards in both engine adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Failed API-key authentication attempts are now recorded in the audit log.** Rejected or denied keys (invalid, disabled/expired, IP- or session-scope-denied, or insufficient role) previously left no audit entry; the gateway now logs an `api_key_auth_failed` event with the client IP, method, path, and reason, giving administrators a forensic trail for credential probing. Audit logging stays best-effort and never affects the request outcome. (#535)
 - **The SSRF guard blocks the deprecated IPv6 site-local range (`fec0::/10`).** Webhook and server-side media URLs are now rejected when they resolve into `fec0::/10`, closing a gap alongside the already-blocked unique-local and link-local ranges. (#536)
 - **Session-scoped MCP tools require a session id before authorization.** A session-scoped tool invoked without a session id is now rejected, so a session-restricted API key can't be used to drive such a tool against a session outside its scope. (#536)
+- **Contact-card vCards are sanitized on both engines.** Sending a contact whose name or number contained CR/LF could inject extra vCard fields on the whatsapp-web.js engine; both adapters now build the vCard through one shared sanitizing helper (CR/LF stripped, digits-only `waid`). (#537)
 
 ## [0.7.12] - 2026-06-29
 

--- a/src/engine/adapters/baileys.adapter.ts
+++ b/src/engine/adapters/baileys.adapter.ts
@@ -41,6 +41,7 @@ import { MessageNotFoundError } from '../../common/errors/message-not-found.erro
 import { createLogger } from '../../common/services/logger.service';
 import { BaileysAdapterConfig, BaileysLogger } from '../types/baileys.types';
 import { BaileysSessionStore } from './baileys-session-store';
+import { buildVCard } from './vcard';
 import {
   capInboundMedia,
   coerceDeclaredSize,
@@ -556,7 +557,7 @@ export class BaileysAdapter implements IWhatsAppEngine {
   async sendContactMessage(chatId: string, contact: ContactCard): Promise<MessageResult> {
     this.ensureReady();
     return this.sendContent(chatId, {
-      contacts: { displayName: contact.name, contacts: [{ vcard: this.buildVCard(contact) }] },
+      contacts: { displayName: contact.name, contacts: [{ vcard: buildVCard(contact) }] },
     });
   }
 
@@ -1326,20 +1327,6 @@ export class BaileysAdapter implements IWhatsAppEngine {
   }
 
   /** Build a minimal WhatsApp-compatible vCard from a neutral contact card. */
-  private buildVCard(contact: ContactCard): string {
-    const clean = (s: string): string => s.replace(/[\r\n]+/g, ' ');
-    const name = clean(contact.name);
-    const number = clean(contact.number);
-    const waid = number.replace(/\D/g, '');
-    return [
-      'BEGIN:VCARD',
-      'VERSION:3.0',
-      `FN:${name}`,
-      `TEL;type=CELL;type=VOICE;waid=${waid}:${number}`,
-      'END:VCARD',
-    ].join('\n');
-  }
-
   /**
    * Fold the chat's known disappearing-messages timer into Baileys' send options so outbound messages
    * honor the chat's ephemeral setting (#473). Returns `options` unchanged when no positive timer is

--- a/src/engine/adapters/vcard.spec.ts
+++ b/src/engine/adapters/vcard.spec.ts
@@ -1,0 +1,30 @@
+import { buildVCard } from './vcard';
+
+describe('buildVCard', () => {
+  it('strips CR/LF from name and number so extra vCard lines cannot be injected', () => {
+    const vcard = buildVCard({ name: 'Alice\r\nEMAIL:attacker@evil.com', number: '+1 234\r\nNOTE:x' });
+    const lines = vcard.split('\n');
+    // No injected lines — exactly the five canonical vCard lines. The crafted text is folded into the
+    // FN/TEL values as inline text rather than becoming a standalone EMAIL/NOTE property line.
+    expect(lines).toHaveLength(5);
+    expect(lines.some(l => l.startsWith('EMAIL:') || l.startsWith('NOTE:'))).toBe(false);
+    expect(lines[0]).toBe('BEGIN:VCARD');
+    expect(lines[4]).toBe('END:VCARD');
+  });
+
+  it('reduces the waid to digits only', () => {
+    const vcard = buildVCard({ name: 'Bob', number: '+1 (234) 567-8900' });
+    expect(vcard).toContain('waid=12345678900:');
+  });
+
+  it('produces a VERSION:3.0 vCard with FN and TEL', () => {
+    const vcard = buildVCard({ name: 'Carol', number: '628123' });
+    expect(vcard.split('\n')).toEqual([
+      'BEGIN:VCARD',
+      'VERSION:3.0',
+      'FN:Carol',
+      'TEL;type=CELL;type=VOICE;waid=628123:628123',
+      'END:VCARD',
+    ]);
+  });
+});

--- a/src/engine/adapters/vcard.ts
+++ b/src/engine/adapters/vcard.ts
@@ -1,0 +1,22 @@
+import { ContactCard } from '../interfaces/whatsapp-engine.interface';
+
+/**
+ * Build a VERSION:3.0 vCard for a contact-card send, shared by both engine adapters.
+ *
+ * CR/LF are stripped from the name and number so a crafted value (e.g. `name = "Alice\r\nEMAIL:..."`)
+ * cannot inject extra vCard lines/fields, and the `waid` is reduced to digits. The number is used once
+ * in the TEL value as-is (after the CR/LF strip) rather than being unconditionally `+`-prefixed.
+ */
+export function buildVCard(contact: ContactCard): string {
+  const clean = (s: string): string => s.replace(/[\r\n]+/g, ' ');
+  const name = clean(contact.name);
+  const number = clean(contact.number);
+  const waid = number.replace(/\D/g, '');
+  return [
+    'BEGIN:VCARD',
+    'VERSION:3.0',
+    `FN:${name}`,
+    `TEL;type=CELL;type=VOICE;waid=${waid}:${number}`,
+    'END:VCARD',
+  ].join('\n');
+}

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -48,6 +48,7 @@ import {
   GroupCreateResult,
 } from '../types/whatsapp-web-js.types';
 import { buildIncomingMessageBase, mapContactFields } from './message-mapper';
+import { buildVCard } from './vcard';
 import {
   capInboundMedia,
   coerceDeclaredSize,
@@ -910,14 +911,9 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
 
   async sendContactMessage(chatId: string, contact: ContactCard): Promise<MessageResult> {
     this.ensureReady();
-    // Create vCard format
-    const vcard = [
-      'BEGIN:VCARD',
-      'VERSION:3.0',
-      `FN:${contact.name}`,
-      `TEL;type=CELL;type=VOICE;waid=${contact.number}:+${contact.number}`,
-      'END:VCARD',
-    ].join('\n');
+    // Shared builder sanitizes name/number (strips CR/LF, digits-only waid) so a crafted contact
+    // can't inject extra vCard fields — the previous inline build interpolated raw values.
+    const vcard = buildVCard(contact);
 
     const msg = await this.client!.sendMessage(chatId, vcard, {
       parseVCards: true,


### PR DESCRIPTION
## Summary

The whatsapp-web.js adapter built a contact-card vCard by interpolating the raw `contact.name` and `contact.number` directly into the vCard text. A value containing CR/LF could therefore inject additional vCard lines/fields (for example, an `EMAIL`/`URL` property the caller never intended), and a number containing non-digits produced a malformed `waid`. The Baileys adapter already guarded against this in a private helper.

## Change

The sanitizing vCard builder — strip CR/LF from the name and number, reduce the `waid` to digits, and use the number once in the `TEL` value — is extracted into a single shared module (`buildVCard`) and used by both adapters. The Baileys adapter's private duplicate is removed, so the two engines now produce contact vCards through one audited code path.

## Tests

A dedicated test for the shared builder covers CR/LF stripping (no injected lines), the digits-only `waid`, and the canonical vCard shape.

Full backend suite green (1602 tests), lint and build clean.