### PR TITLE
feat(message): outbound @mentions on text and media sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Outbound @mentions on text and media sends.** `send-text` and the media send routes now accept an optional `mentions` array of WIDs (`<phone>@c.us`) to tag participants — most useful in groups. The contract is engine-neutral: pass neutral `@c.us` WIDs and the active engine (whatsapp-web.js or Baileys) de-normalizes them. For a tag to render and notify, the `text`/`caption` must also contain the matching `@<number>` token. This brings outbound parity with the `mentions` field already surfaced on inbound webhooks. (#530) Thanks @adampalli.
+
 ## [0.7.13] - 2026-06-29
 
 ### Fixed

--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -125,6 +125,7 @@ All media send routes (`send-image`, `send-video`, `send-audio`, `send-document`
 | `mimetype` | string | conditional | required when `base64` is used | MIME type, e.g. `image/jpeg`, `video/mp4`, `application/pdf` |
 | `filename` | string | no | max 255 chars | Optional file name (also used as the persisted body fallback for documents) |
 | `caption` | string | no | max 1024 chars | Optional caption (not persisted for audio) |
+| `mentions` | string[] | no | array of WIDs | WIDs to @mention in the caption (e.g. `["62811@c.us"]`). See **Mentions** below |
 
 Provide **exactly one** of `url` or `base64`. Omitting both, or supplying `base64` without `mimetype`, returns `400`.
 
@@ -152,6 +153,15 @@ There is a **single shared media byte cap**, not a per-type table. A base64 (or 
 ### Text Limit
 
 `send-text` enforces a maximum body length of **4096 characters** (`text` is `@MaxLength(4096)`). Media captions are limited to **1024 characters**.
+
+### Mentions
+
+`send-text` and the media send routes accept an optional `mentions` array of WIDs (`<phone>@c.us`) to tag participants — most useful in groups. Two things are required for WhatsApp to render a tag and notify the participant:
+
+1. The `mentions` array lists the WID(s), e.g. `["62811@c.us"]`.
+2. The `text`/`caption` contains the matching `@<number>` token, e.g. `Hello @62811`.
+
+The contract is engine-neutral: pass neutral `@c.us` WIDs and the active engine (whatsapp-web.js or Baileys) de-normalizes them internally. Whether a mention surfaces a notification is ultimately client-side — outside a shared group some clients may not render it.
 
 ## 6.4 REST API Reference
 
@@ -864,9 +874,14 @@ Send a plain text message.
 | --- | --- | --- | --- | --- |
 | chatId | string | Yes | non-empty | `phone@c.us` or `groupId@g.us` |
 | text | string | Yes | non-empty, max 4096 | Message text |
+| mentions | string[] | No | array of WIDs | WIDs to @mention (e.g. `["62811@c.us"]`). See **Mentions** below |
 
 ```json
 { "chatId": "628123456789@c.us", "text": "Hello from OpenWA!" }
+```
+
+```json
+{ "chatId": "120363000000000000@g.us", "text": "Hello @62811", "mentions": ["62811@c.us"] }
 ```
 
 **Response** `201`

--- a/src/engine/adapters/baileys.adapter.spec.ts
+++ b/src/engine/adapters/baileys.adapter.spec.ts
@@ -573,6 +573,23 @@ describe('BaileysAdapter messaging', () => {
     );
   });
 
+  it('sendTextMessage de-normalizes mentions to engine jids (#530)', async () => {
+    fakeSock.sendMessage.mockResolvedValue({ key: { id: 'OUT1' }, messageTimestamp: 1700000001 });
+    const adapter = await readyAdapter();
+    await adapter.sendTextMessage('120@g.us', 'hi @62811', ['62811@c.us']);
+    expect(fakeSock.sendMessage).toHaveBeenCalledWith('120@g.us', {
+      text: 'hi @62811',
+      mentions: ['62811@s.whatsapp.net'],
+    });
+  });
+
+  it('sendTextMessage omits the mentions key when none are given (no behavior change)', async () => {
+    fakeSock.sendMessage.mockResolvedValue({ key: { id: 'OUT1' }, messageTimestamp: 1700000001 });
+    const adapter = await readyAdapter();
+    await adapter.sendTextMessage('120@g.us', 'plain', []);
+    expect(fakeSock.sendMessage).toHaveBeenCalledWith('120@g.us', { text: 'plain' });
+  });
+
   it('getNumberId resolves via onWhatsApp and returns a NEUTRAL jid (never @s.whatsapp.net)', async () => {
     fakeSock.onWhatsApp.mockResolvedValue([{ jid: '628111@s.whatsapp.net', exists: true }]);
     const adapter = await readyAdapter();
@@ -1237,6 +1254,20 @@ describe('BaileysAdapter media sends', () => {
       mimetype: 'image/png',
     });
     expect(res).toEqual({ id: 'M1', timestamp: 1700000005 });
+  });
+
+  it('sendImageMessage de-normalizes media.mentions into the content (#530)', async () => {
+    const adapter = await ready();
+    await adapter.sendImageMessage('120@g.us', {
+      mimetype: 'image/png',
+      data: Buffer.from([1]),
+      caption: 'look @62811',
+      mentions: ['62811@c.us'],
+    });
+    expect(fakeSock.sendMessage).toHaveBeenCalledWith(
+      '120@g.us',
+      expect.objectContaining({ mentions: ['62811@s.whatsapp.net'] }),
+    );
   });
 
   it('resolves a base64 data string to a Buffer (no URL fetch)', async () => {

--- a/src/engine/adapters/baileys.adapter.ts
+++ b/src/engine/adapters/baileys.adapter.ts
@@ -468,12 +468,13 @@ export class BaileysAdapter implements IWhatsAppEngine {
 
   // ----- Messaging -----
 
-  async sendTextMessage(chatId: string, text: string): Promise<MessageResult> {
+  async sendTextMessage(chatId: string, text: string, mentions?: string[]): Promise<MessageResult> {
     this.ensureReady();
     const options = this.withEphemeral(chatId);
+    const content = { text, ...this.withMentions(mentions) };
     const sent = options
-      ? await this.sock!.sendMessage(chatId, { text }, options)
-      : await this.sock!.sendMessage(chatId, { text });
+      ? await this.sock!.sendMessage(chatId, content, options)
+      : await this.sock!.sendMessage(chatId, content);
     if (sent) {
       void this.config.messageStore?.put(this.config.sessionId, sent).catch(err =>
         this.logger.warn('Failed to persist sent message to store', {
@@ -510,13 +511,23 @@ export class BaileysAdapter implements IWhatsAppEngine {
   async sendImageMessage(chatId: string, media: MediaInput): Promise<MessageResult> {
     this.ensureReady();
     const { data, mimetype } = await this.resolveMediaBuffer(media);
-    return this.sendContent(chatId, { image: data, caption: media.caption, mimetype });
+    return this.sendContent(chatId, {
+      image: data,
+      caption: media.caption,
+      mimetype,
+      ...this.withMentions(media.mentions),
+    });
   }
 
   async sendVideoMessage(chatId: string, media: MediaInput): Promise<MessageResult> {
     this.ensureReady();
     const { data, mimetype } = await this.resolveMediaBuffer(media);
-    return this.sendContent(chatId, { video: data, caption: media.caption, mimetype });
+    return this.sendContent(chatId, {
+      video: data,
+      caption: media.caption,
+      mimetype,
+      ...this.withMentions(media.mentions),
+    });
   }
 
   async sendAudioMessage(chatId: string, media: MediaInput): Promise<MessageResult> {
@@ -533,6 +544,7 @@ export class BaileysAdapter implements IWhatsAppEngine {
       mimetype,
       fileName: media.filename ?? 'file',
       caption: media.caption,
+      ...this.withMentions(media.mentions),
     });
   }
 
@@ -646,6 +658,16 @@ export class BaileysAdapter implements IWhatsAppEngine {
    */
   private toEngineParticipants(participants: string[]): string[] {
     return participants.map(p => this.sessionStore.toEngineJid(p));
+  }
+
+  /**
+   * Build the `{ mentions }` slice of a Baileys message content, de-normalizing neutral `@c.us` WIDs to
+   * the engine dialect. Returns an empty object when none are given so the content is byte-identical to
+   * the pre-#530 send (no stray `mentions` key). The text must still contain the `@<number>` token for
+   * WhatsApp to render the tag — that is the caller's responsibility.
+   */
+  private withMentions(mentions?: string[]): { mentions?: string[] } {
+    return mentions?.length ? { mentions: this.toEngineParticipants(mentions) } : {};
   }
 
   async leaveGroup(groupId: string): Promise<void> {

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -873,3 +873,40 @@ describe('WhatsAppWebJsAdapter inbound media (MEDIA_DOWNLOAD_ENABLED=false)', ()
     expect(msg.media?.sizeBytes).toBe(5000);
   });
 });
+
+describe('outbound mentions (#530)', () => {
+  const ready = (client: unknown): WhatsAppWebJsAdapter => {
+    const adapter = new WhatsAppWebJsAdapter({ sessionId: 's', sessionDataPath: './data/sessions', puppeteer: {} });
+    (adapter as unknown as { status: EngineStatus }).status = EngineStatus.READY;
+    (adapter as unknown as { client: unknown }).client = client;
+    return adapter;
+  };
+  const sentMessage = { id: { _serialized: 'OUT1' }, timestamp: 1700000001 };
+
+  it('sendTextMessage forwards mentions as a wwebjs option (WIDs pass through)', async () => {
+    const sendMessage = jest.fn().mockResolvedValue(sentMessage);
+    await ready({ sendMessage }).sendTextMessage('120@g.us', 'hi @62811', ['62811@c.us']);
+    expect(sendMessage).toHaveBeenCalledWith('120@g.us', 'hi @62811', { mentions: ['62811@c.us'] });
+  });
+
+  it('sendTextMessage sends no options object when there are no mentions (no behavior change)', async () => {
+    const sendMessage = jest.fn().mockResolvedValue(sentMessage);
+    await ready({ sendMessage }).sendTextMessage('120@g.us', 'plain');
+    expect(sendMessage).toHaveBeenCalledWith('120@g.us', 'plain');
+  });
+
+  it('sendImageMessage forwards media.mentions alongside the caption', async () => {
+    const sendMessage = jest.fn().mockResolvedValue(sentMessage);
+    await ready({ sendMessage }).sendImageMessage('120@g.us', {
+      mimetype: 'image/png',
+      data: Buffer.from([1]).toString('base64'),
+      caption: 'look @62811',
+      mentions: ['62811@c.us'],
+    });
+    expect(sendMessage).toHaveBeenCalledWith(
+      '120@g.us',
+      expect.anything(),
+      expect.objectContaining({ caption: 'look @62811', mentions: ['62811@c.us'] }),
+    );
+  });
+});

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -752,9 +752,13 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     return this.pushName;
   }
 
-  async sendTextMessage(chatId: string, text: string): Promise<MessageResult> {
+  async sendTextMessage(chatId: string, text: string, mentions?: string[]): Promise<MessageResult> {
     this.ensureReady();
-    const msg = await this.client!.sendMessage(chatId, text);
+    // wwebjs accepts neutral `<phone>@c.us` WIDs directly as mentionedJidList, so no de-normalization
+    // is needed. Omit the options object entirely when none are given to keep today's send behavior.
+    const msg = mentions?.length
+      ? await this.client!.sendMessage(chatId, text, { mentions })
+      : await this.client!.sendMessage(chatId, text);
     return {
       id: msg.id._serialized,
       timestamp: msg.timestamp,
@@ -797,6 +801,7 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
 
     const msg = await this.client!.sendMessage(chatId, messageMedia, {
       caption: media.caption,
+      ...(media.mentions?.length ? { mentions: media.mentions } : {}),
     });
 
     return {

--- a/src/engine/interfaces/whatsapp-engine.interface.ts
+++ b/src/engine/interfaces/whatsapp-engine.interface.ts
@@ -33,6 +33,8 @@ export interface MediaInput {
   data: Buffer | string; // Buffer or base64 or URL
   filename?: string;
   caption?: string;
+  /** Neutral WIDs (`<phone>@c.us`) to @mention in the caption. The adapter de-normalizes per engine. */
+  mentions?: string[];
 }
 
 /**
@@ -407,7 +409,7 @@ export interface IWhatsAppEngine {
   getPushName(): string | null;
 
   // Messaging - Basic
-  sendTextMessage(chatId: string, text: string): Promise<MessageResult>;
+  sendTextMessage(chatId: string, text: string, mentions?: string[]): Promise<MessageResult>;
   sendImageMessage(chatId: string, media: MediaInput): Promise<MessageResult>;
   sendVideoMessage(chatId: string, media: MediaInput): Promise<MessageResult>;
   sendAudioMessage(chatId: string, media: MediaInput): Promise<MessageResult>;

--- a/src/modules/message/dto/send-message.dto.spec.ts
+++ b/src/modules/message/dto/send-message.dto.spec.ts
@@ -1,0 +1,44 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { SendTextMessageDto, SendMediaMessageDto } from './send-message.dto';
+
+// Mirror the global ValidationPipe (main.ts): whitelist + forbidNonWhitelisted strip/reject unknown props.
+const validateDto = (cls: new () => object, obj: unknown) =>
+  validate(plainToInstance(cls, obj), { whitelist: true, forbidNonWhitelisted: true });
+
+describe('SendTextMessageDto mentions', () => {
+  it('accepts an optional array of mention WIDs', async () => {
+    const errors = await validateDto(SendTextMessageDto, {
+      chatId: 'g@g.us',
+      text: 'hi @62811',
+      mentions: ['62811@c.us'],
+    });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('is omittable (mentions stays optional)', async () => {
+    const errors = await validateDto(SendTextMessageDto, { chatId: 'g@g.us', text: 'hi' });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects a non-string element in mentions', async () => {
+    const errors = await validateDto(SendTextMessageDto, {
+      chatId: 'g@g.us',
+      text: 'hi',
+      mentions: [123],
+    });
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe('SendMediaMessageDto mentions', () => {
+  it('accepts an optional array of mention WIDs', async () => {
+    const errors = await validateDto(SendMediaMessageDto, {
+      chatId: 'g@g.us',
+      url: 'https://example.com/a.jpg',
+      caption: 'look @62811',
+      mentions: ['62811@c.us'],
+    });
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/src/modules/message/dto/send-message.dto.ts
+++ b/src/modules/message/dto/send-message.dto.ts
@@ -1,5 +1,8 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsString, IsNotEmpty, IsOptional, MaxLength, IsUrl, ValidateIf } from 'class-validator';
+import { IsString, IsNotEmpty, IsOptional, MaxLength, IsUrl, ValidateIf, IsArray } from 'class-validator';
+
+const MENTIONS_DESCRIPTION =
+  'WIDs to @mention (e.g. ["62811@c.us"]). The text/caption must also contain the @<number> token.';
 
 export class SendTextMessageDto {
   @ApiProperty({
@@ -19,6 +22,12 @@ export class SendTextMessageDto {
   @IsNotEmpty()
   @MaxLength(4096)
   text: string;
+
+  @ApiPropertyOptional({ description: MENTIONS_DESCRIPTION, example: ['628123456789@c.us'], type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  mentions?: string[];
 }
 
 export class SendMediaMessageDto {
@@ -73,6 +82,12 @@ export class SendMediaMessageDto {
   @IsString()
   @MaxLength(1024)
   caption?: string;
+
+  @ApiPropertyOptional({ description: MENTIONS_DESCRIPTION, example: ['628123456789@c.us'], type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  mentions?: string[];
 }
 
 export class MessageResponseDto {

--- a/src/modules/message/message.service.spec.ts
+++ b/src/modules/message/message.service.spec.ts
@@ -127,6 +127,16 @@ describe('MessageService', () => {
       expect(mockEngine.sendTextMessage).toHaveBeenCalledWith('628123456789@c.us', 'Hello');
     });
 
+    it('threads mentions through to the engine (#530)', async () => {
+      const input = { chatId: '120@g.us', text: 'hi @62811', mentions: ['62811@c.us'] };
+      (hookManager.execute as jest.Mock).mockResolvedValueOnce({
+        continue: true,
+        data: { sessionId: 'sess-1', input, type: 'text' },
+      });
+      await service.sendText('sess-1', input);
+      expect(mockEngine.sendTextMessage).toHaveBeenCalledWith('120@g.us', 'hi @62811', ['62811@c.us']);
+    });
+
     it('should save outgoing message as pending before sending, then update to sent', async () => {
       await service.sendText('sess-1', {
         chatId: '628123456789@c.us',
@@ -292,6 +302,20 @@ describe('MessageService', () => {
       expect(mockEngine.sendImageMessage).toHaveBeenCalledWith(
         '628123456789@c.us',
         expect.objectContaining({ data: 'iVBORw0KGgoAAAAN...', mimetype: 'image/png' }),
+      );
+    });
+
+    it('threads media mentions into the MediaInput (#530)', async () => {
+      await service.sendImage('sess-1', {
+        chatId: '120@g.us',
+        base64: 'AAAA',
+        mimetype: 'image/png',
+        caption: 'look @62811',
+        mentions: ['62811@c.us'],
+      });
+      expect(mockEngine.sendImageMessage).toHaveBeenCalledWith(
+        '120@g.us',
+        expect.objectContaining({ mentions: ['62811@c.us'] }),
       );
     });
 

--- a/src/modules/message/message.service.ts
+++ b/src/modules/message/message.service.ts
@@ -64,7 +64,10 @@ export class MessageService {
     await this.simulateTypingIfEnabled(engine, finalDto.chatId, finalDto.text);
 
     try {
-      const result = await engine.sendTextMessage(finalDto.chatId, finalDto.text);
+      // Keep the 2-arg call shape for plain sends; only pass mentions when the caller supplied any.
+      const result = finalDto.mentions?.length
+        ? await engine.sendTextMessage(finalDto.chatId, finalDto.text, finalDto.mentions)
+        : await engine.sendTextMessage(finalDto.chatId, finalDto.text);
 
       // Update with actual WhatsApp message ID and status
       message.waMessageId = result.id;
@@ -662,6 +665,7 @@ export class MessageService {
       data: dto.url || dto.base64!,
       filename: dto.filename,
       caption: dto.caption,
+      mentions: dto.mentions,
     };
   }
 }


### PR DESCRIPTION
## Summary

Adds an optional `mentions` field to the outbound `send-text` and media send routes, so messages can tag group participants with a real WhatsApp @mention that triggers a notification. This brings outbound parity with the `mentions` field already surfaced on inbound webhooks.

Closes #530.

```json
{
  "chatId": "120363000000000000@g.us",
  "text": "Hello @62811",
  "mentions": ["62811@c.us"]
}
```

## Changes

- **DTOs** — `SendTextMessageDto` and `SendMediaMessageDto` accept an optional `mentions?: string[]` (array of WIDs). Previously any unknown field was rejected by the global validation pipe, which is why passing `mentions` returned `400`.
- **Engine contract** — `IWhatsAppEngine.sendTextMessage` gains an optional trailing `mentions` parameter; `MediaInput` gains an optional `mentions` field that already threads through all four media send methods.
- **Adapters** — engine-neutral on both sides:
  - **whatsapp-web.js** accepts neutral `<phone>@c.us` WIDs directly as `mentionedJidList`, so they pass through unchanged.
  - **Baileys** de-normalizes them to the engine dialect (`@s.whatsapp.net`) via the existing `toEngineJid` helper.
  - Both omit `mentions` entirely when none are given, so a plain send is byte-identical to before.
- **Docs** — API specification documents the field, the two requirements for a tag to render (WID in `mentions` **and** `@<number>` in the text/caption), and the client-side caveat.

## Behavior notes

For WhatsApp to render a tag and notify the participant, the message text/caption must contain the matching `@<number>` token in addition to the `mentions` array — this is the caller's responsibility. Whether the mention surfaces a notification is ultimately client-side; outside a shared group some clients may not render it.

## Testing

TDD throughout — DTO validation, both adapters (text + media, including the no-mentions no-op path), and service threading. Full suite green: **1614 tests**, build and lint clean.
