### PR TITLE
i18n: complete templates page + kill-session dialog translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The message-templates page and the kill-stuck-session dialog are now fully localized.** Both sections previously fell back to English in French, Spanish, Arabic, Hebrew, Telugu, and Chinese (Simplified and Traditional); all of those strings are now translated, with interpolation placeholders preserved. (#PRR)
 - **The i18n parity check now catches more than missing keys.** It additionally hard-fails on a translated string whose `{{placeholder}}` tokens differ from the reference (the bug class above), and warns when a long value is byte-identical to English (likely untranslated) — giving a CI signal for locale drift. (#547)
 - **Sandboxed plugins have a ceiling on concurrent host capability calls.** A single worker-thread plugin can now have at most 32 capability calls (message sends, network fetches, storage writes) running host-side at once; a burst beyond that is rejected (the plugin sees a thrown error) rather than amplified into unbounded host work. (#544)
 - **Plugin lifecycle operations on the same plugin are serialized.** Enable, disable, update, uninstall, and install for a given plugin id now run one at a time, so two operations firing together can no longer race on the plugin's directory or runtime state. (#544)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **The message-templates page and the kill-stuck-session dialog are now fully localized.** Both sections previously fell back to English in French, Spanish, Arabic, Hebrew, Telugu, and Chinese (Simplified and Traditional); all of those strings are now translated, with interpolation placeholders preserved. (#PRR)
+- **The message-templates page and the kill-stuck-session dialog are now fully localized.** Both sections previously fell back to English in French, Spanish, Arabic, Hebrew, Telugu, and Chinese (Simplified and Traditional); all of those strings are now translated, with interpolation placeholders preserved. (#550)
 - **The i18n parity check now catches more than missing keys.** It additionally hard-fails on a translated string whose `{{placeholder}}` tokens differ from the reference (the bug class above), and warns when a long value is byte-identical to English (likely untranslated) — giving a CI signal for locale drift. (#547)
 - **Sandboxed plugins have a ceiling on concurrent host capability calls.** A single worker-thread plugin can now have at most 32 capability calls (message sends, network fetches, storage writes) running host-side at once; a burst beyond that is rejected (the plugin sees a thrown error) rather than amplified into unbounded host work. (#544)
 - **Plugin lifecycle operations on the same plugin are serialized.** Enable, disable, update, uninstall, and install for a given plugin id now run one at a time, so two operations firing together can no longer race on the plugin's directory or runtime state. (#544)

--- a/dashboard/src/i18n/locales/ar.json
+++ b/dashboard/src/i18n/locales/ar.json
@@ -264,7 +264,7 @@
       "stop": "إيقاف",
       "reconnect": "إعادة الاتصال",
       "delete": "حذف",
-      "killStuck": "Kill Stuck"
+      "killStuck": "إنهاء العالقة"
     },
     "toasts": {
       "readyTitle": "الجلسة جاهزة",
@@ -281,14 +281,14 @@
       "error": "خطأ"
     },
     "forceKill": {
-      "title": "Kill Stuck Session",
-      "message": "Are you sure you want to force-kill session \"{{name}}\"?",
-      "warning": "This will forcefully terminate the WhatsApp browser process. The session may need to be re-scanned on restart.",
-      "confirm": "Kill Session",
-      "successTitle": "Session Killed",
-      "success": "Session has been force-killed. You can restart it now.",
-      "failedTitle": "Force-Kill Failed",
-      "failed": "Failed to force-kill the session."
+      "title": "إنهاء جلسة عالقة",
+      "message": "هل أنت متأكد أنك تريد إنهاء الجلسة \"{{name}}\" قسريًا؟",
+      "warning": "سيؤدي هذا إلى إنهاء عملية متصفح WhatsApp قسريًا. قد تحتاج الجلسة إلى إعادة المسح عند إعادة التشغيل.",
+      "confirm": "إنهاء الجلسة",
+      "successTitle": "تم إنهاء الجلسة",
+      "success": "تم إنهاء الجلسة قسريًا. يمكنك إعادة تشغيلها الآن.",
+      "failedTitle": "فشل الإنهاء القسري",
+      "failed": "فشل إنهاء الجلسة قسريًا."
     }
   },
   "webhooks": {
@@ -375,48 +375,48 @@
     }
   },
   "templates": {
-    "title": "Templates",
-    "subtitle": "Create reusable message templates for each WhatsApp session",
-    "createTitle": "Create Template",
-    "editTitle": "Edit Template",
-    "newTemplate": "New Template",
-    "createTemplate": "Create Template",
-    "saveChanges": "Save Changes",
-    "viewOnly": "View Only",
-    "noSessions": "No sessions",
-    "sessionHint": "Saved under {{name}}",
-    "namePlaceholder": "e.g., order-confirmation",
-    "header": "Header",
-    "headerPlaceholder": "Optional intro line",
-    "body": "Body",
-    "bodyPlaceholder": "Hi {{customer}}, your order {{orderId}} is ready.",
-    "footer": "Footer",
-    "footerPlaceholder": "Optional closing line",
-    "previewTitle": "Preview",
-    "previewValuePlaceholder": "Sample value",
-    "previewEmpty": "Start writing a template to preview it here.",
-    "noPlaceholders": "Use {{name}} placeholders to test substitutions.",
-    "savedTitle": "Saved Templates",
-    "count": "{{count}} total",
-    "deleteTitle": "Delete Template",
-    "deleteConfirm": "Delete template \"{{name}}\"? This action cannot be undone.",
+    "title": "القوالب",
+    "subtitle": "أنشئ قوالب رسائل قابلة لإعادة الاستخدام لكل جلسة WhatsApp",
+    "createTitle": "إنشاء قالب",
+    "editTitle": "تعديل القالب",
+    "newTemplate": "قالب جديد",
+    "createTemplate": "إنشاء قالب",
+    "saveChanges": "حفظ التغييرات",
+    "viewOnly": "عرض فقط",
+    "noSessions": "لا توجد جلسات",
+    "sessionHint": "محفوظ ضمن {{name}}",
+    "namePlaceholder": "مثال: order-confirmation",
+    "header": "الترويسة",
+    "headerPlaceholder": "سطر افتتاحي اختياري",
+    "body": "المتن",
+    "bodyPlaceholder": "مرحبًا {{customer}}، طلبك {{orderId}} جاهز.",
+    "footer": "التذييل",
+    "footerPlaceholder": "سطر ختامي اختياري",
+    "previewTitle": "معاينة",
+    "previewValuePlaceholder": "قيمة تجريبية",
+    "previewEmpty": "ابدأ بكتابة قالب لمعاينته هنا.",
+    "noPlaceholders": "استخدم العناصر النائبة {{name}} لاختبار الاستبدالات.",
+    "savedTitle": "القوالب المحفوظة",
+    "count": "{{count}} إجمالًا",
+    "deleteTitle": "حذف القالب",
+    "deleteConfirm": "هل تريد حذف القالب \"{{name}}\"؟ لا يمكن التراجع عن هذا الإجراء.",
     "actions": {
-      "copyName": "Copy template name"
+      "copyName": "نسخ اسم القالب"
     },
     "empty": {
-      "title": "No templates saved",
-      "description": "Create a reusable template to speed up common replies and notifications.",
-      "noSessionsTitle": "No sessions available",
-      "noSessionsDesc": "Create a WhatsApp session before adding templates."
+      "title": "لا توجد قوالب محفوظة",
+      "description": "أنشئ قالبًا قابلًا لإعادة الاستخدام لتسريع الردود والإشعارات الشائعة.",
+      "noSessionsTitle": "لا توجد جلسات متاحة",
+      "noSessionsDesc": "أنشئ جلسة WhatsApp قبل إضافة القوالب."
     },
     "toasts": {
-      "created": "Template created successfully",
-      "createFailed": "Failed to create template: {{message}}",
-      "updated": "Template updated successfully",
-      "updateFailed": "Failed to update template: {{message}}",
-      "deleted": "Template deleted successfully",
-      "deleteFailed": "Failed to delete template: {{message}}",
-      "copied": "Template name copied"
+      "created": "تم إنشاء القالب بنجاح",
+      "createFailed": "فشل إنشاء القالب: {{message}}",
+      "updated": "تم تحديث القالب بنجاح",
+      "updateFailed": "فشل تحديث القالب: {{message}}",
+      "deleted": "تم حذف القالب بنجاح",
+      "deleteFailed": "فشل حذف القالب: {{message}}",
+      "copied": "تم نسخ اسم القالب"
     }
   },
   "apiKeys": {

--- a/dashboard/src/i18n/locales/es.json
+++ b/dashboard/src/i18n/locales/es.json
@@ -264,7 +264,7 @@
       "stop": "Detener",
       "reconnect": "Reconectar",
       "delete": "Eliminar",
-      "killStuck": "Kill Stuck"
+      "killStuck": "Cerrar bloqueada"
     },
     "toasts": {
       "readyTitle": "Sesión lista",
@@ -281,14 +281,14 @@
       "error": "Error"
     },
     "forceKill": {
-      "title": "Kill Stuck Session",
-      "message": "Are you sure you want to force-kill session \"{{name}}\"?",
-      "warning": "This will forcefully terminate the WhatsApp browser process. The session may need to be re-scanned on restart.",
-      "confirm": "Kill Session",
-      "successTitle": "Session Killed",
-      "success": "Session has been force-killed. You can restart it now.",
-      "failedTitle": "Force-Kill Failed",
-      "failed": "Failed to force-kill the session."
+      "title": "Cerrar sesión bloqueada",
+      "message": "¿Seguro que quieres forzar el cierre de la sesión \"{{name}}\"?",
+      "warning": "Esto cerrará de forma forzada el proceso del navegador de WhatsApp. Es posible que la sesión deba volver a escanearse al reiniciar.",
+      "confirm": "Cerrar sesión",
+      "successTitle": "Sesión cerrada",
+      "success": "La sesión se cerró de forma forzada. Ya puedes reiniciarla.",
+      "failedTitle": "Error al forzar el cierre",
+      "failed": "No se pudo forzar el cierre de la sesión."
     }
   },
   "webhooks": {

--- a/dashboard/src/i18n/locales/fr.json
+++ b/dashboard/src/i18n/locales/fr.json
@@ -264,7 +264,7 @@
       "stop": "Arrêter",
       "reconnect": "Reconnecter",
       "delete": "Supprimer",
-      "killStuck": "Kill Stuck"
+      "killStuck": "Arrêter (bloquée)"
     },
     "toasts": {
       "readyTitle": "Session prête",
@@ -281,14 +281,14 @@
       "error": "Erreur"
     },
     "forceKill": {
-      "title": "Kill Stuck Session",
-      "message": "Are you sure you want to force-kill session \"{{name}}\"?",
-      "warning": "This will forcefully terminate the WhatsApp browser process. The session may need to be re-scanned on restart.",
-      "confirm": "Kill Session",
-      "successTitle": "Session Killed",
-      "success": "Session has been force-killed. You can restart it now.",
-      "failedTitle": "Force-Kill Failed",
-      "failed": "Failed to force-kill the session."
+      "title": "Arrêter la session bloquée",
+      "message": "Voulez-vous vraiment forcer l'arrêt de la session « {{name}} » ?",
+      "warning": "Cela mettra fin de force au processus du navigateur WhatsApp. La session devra peut-être être rescannée au redémarrage.",
+      "confirm": "Arrêter la session",
+      "successTitle": "Session arrêtée",
+      "success": "L'arrêt forcé de la session a réussi. Vous pouvez la redémarrer maintenant.",
+      "failedTitle": "Échec de l'arrêt forcé",
+      "failed": "Échec de l'arrêt forcé de la session."
     }
   },
   "webhooks": {
@@ -372,47 +372,47 @@
   },
   "templates": {
     "title": "Templates",
-    "subtitle": "Create reusable message templates for each WhatsApp session",
-    "createTitle": "Create Template",
-    "editTitle": "Edit Template",
-    "newTemplate": "New Template",
-    "createTemplate": "Create Template",
-    "saveChanges": "Save Changes",
-    "viewOnly": "View Only",
-    "noSessions": "No sessions",
-    "sessionHint": "Saved under {{name}}",
-    "namePlaceholder": "e.g., order-confirmation",
-    "header": "Header",
-    "headerPlaceholder": "Optional intro line",
-    "body": "Body",
-    "bodyPlaceholder": "Hi {{customer}}, your order {{orderId}} is ready.",
-    "footer": "Footer",
-    "footerPlaceholder": "Optional closing line",
-    "previewTitle": "Preview",
-    "previewValuePlaceholder": "Sample value",
-    "previewEmpty": "Start writing a template to preview it here.",
-    "noPlaceholders": "Use {{name}} placeholders to test substitutions.",
-    "savedTitle": "Saved Templates",
-    "count": "{{count}} total",
-    "deleteTitle": "Delete Template",
-    "deleteConfirm": "Delete template \"{{name}}\"? This action cannot be undone.",
+    "subtitle": "Créez des templates de message réutilisables pour chaque session WhatsApp",
+    "createTitle": "Créer un template",
+    "editTitle": "Modifier le template",
+    "newTemplate": "Nouveau template",
+    "createTemplate": "Créer le template",
+    "saveChanges": "Enregistrer les modifications",
+    "viewOnly": "Lecture seule",
+    "noSessions": "Aucune session",
+    "sessionHint": "Enregistré dans {{name}}",
+    "namePlaceholder": "ex. : confirmation-commande",
+    "header": "En-tête",
+    "headerPlaceholder": "Ligne d'introduction (facultatif)",
+    "body": "Corps",
+    "bodyPlaceholder": "Bonjour {{customer}}, votre commande {{orderId}} est prête.",
+    "footer": "Pied de page",
+    "footerPlaceholder": "Ligne de conclusion (facultatif)",
+    "previewTitle": "Aperçu",
+    "previewValuePlaceholder": "Exemple de valeur",
+    "previewEmpty": "Commencez à rédiger un template pour l'afficher ici.",
+    "noPlaceholders": "Utilisez des variables {{name}} pour tester les substitutions.",
+    "savedTitle": "Templates enregistrés",
+    "count": "{{count}} au total",
+    "deleteTitle": "Supprimer le template",
+    "deleteConfirm": "Supprimer le template « {{name}} » ? Cette action est irréversible.",
     "actions": {
-      "copyName": "Copy template name"
+      "copyName": "Copier le nom du template"
     },
     "empty": {
-      "title": "No templates saved",
-      "description": "Create a reusable template to speed up common replies and notifications.",
-      "noSessionsTitle": "No sessions available",
-      "noSessionsDesc": "Create a WhatsApp session before adding templates."
+      "title": "Aucun template enregistré",
+      "description": "Créez un template réutilisable pour accélérer vos réponses et notifications courantes.",
+      "noSessionsTitle": "Aucune session disponible",
+      "noSessionsDesc": "Créez une session WhatsApp avant d'ajouter des templates."
     },
     "toasts": {
-      "created": "Template created successfully",
-      "createFailed": "Failed to create template: {{message}}",
-      "updated": "Template updated successfully",
-      "updateFailed": "Failed to update template: {{message}}",
-      "deleted": "Template deleted successfully",
-      "deleteFailed": "Failed to delete template: {{message}}",
-      "copied": "Template name copied"
+      "created": "Template créé avec succès",
+      "createFailed": "Échec de la création du template : {{message}}",
+      "updated": "Template mis à jour avec succès",
+      "updateFailed": "Échec de la mise à jour du template : {{message}}",
+      "deleted": "Template supprimé avec succès",
+      "deleteFailed": "Échec de la suppression du template : {{message}}",
+      "copied": "Nom du template copié"
     }
   },
   "apiKeys": {

--- a/dashboard/src/i18n/locales/he.json
+++ b/dashboard/src/i18n/locales/he.json
@@ -264,7 +264,7 @@
       "stop": "עצירה",
       "reconnect": "התחברות מחדש",
       "delete": "מחיקה",
-      "killStuck": "Kill Stuck"
+      "killStuck": "סגור תקוע"
     },
     "toasts": {
       "readyTitle": "ה-Session מוכן",
@@ -281,14 +281,14 @@
       "error": "שגיאה"
     },
     "forceKill": {
-      "title": "Kill Stuck Session",
-      "message": "Are you sure you want to force-kill session \"{{name}}\"?",
-      "warning": "This will forcefully terminate the WhatsApp browser process. The session may need to be re-scanned on restart.",
-      "confirm": "Kill Session",
-      "successTitle": "Session Killed",
-      "success": "Session has been force-killed. You can restart it now.",
-      "failedTitle": "Force-Kill Failed",
-      "failed": "Failed to force-kill the session."
+      "title": "סגירת סשן תקוע",
+      "message": "האם אתם בטוחים שברצונכם לסגור בכוח את הסשן \"{{name}}\"?",
+      "warning": "פעולה זו תסיים בכוח את תהליך הדפדפן של WhatsApp. ייתכן שיהיה צורך לסרוק מחדש את הסשן לאחר ההפעלה מחדש.",
+      "confirm": "סגור סשן",
+      "successTitle": "הסשן נסגר",
+      "success": "הסשן נסגר בכוח. ניתן להפעיל אותו מחדש כעת.",
+      "failedTitle": "הסגירה בכוח נכשלה",
+      "failed": "סגירת הסשן בכוח נכשלה."
     }
   },
   "webhooks": {
@@ -372,48 +372,48 @@
     }
   },
   "templates": {
-    "title": "Templates",
-    "subtitle": "Create reusable message templates for each WhatsApp session",
-    "createTitle": "Create Template",
-    "editTitle": "Edit Template",
-    "newTemplate": "New Template",
-    "createTemplate": "Create Template",
-    "saveChanges": "Save Changes",
-    "viewOnly": "View Only",
-    "noSessions": "No sessions",
-    "sessionHint": "Saved under {{name}}",
-    "namePlaceholder": "e.g., order-confirmation",
-    "header": "Header",
-    "headerPlaceholder": "Optional intro line",
-    "body": "Body",
-    "bodyPlaceholder": "Hi {{customer}}, your order {{orderId}} is ready.",
-    "footer": "Footer",
-    "footerPlaceholder": "Optional closing line",
-    "previewTitle": "Preview",
-    "previewValuePlaceholder": "Sample value",
-    "previewEmpty": "Start writing a template to preview it here.",
-    "noPlaceholders": "Use {{name}} placeholders to test substitutions.",
-    "savedTitle": "Saved Templates",
-    "count": "{{count}} total",
-    "deleteTitle": "Delete Template",
-    "deleteConfirm": "Delete template \"{{name}}\"? This action cannot be undone.",
+    "title": "תבניות",
+    "subtitle": "צרו תבניות הודעה לשימוש חוזר עבור כל סשן WhatsApp",
+    "createTitle": "יצירת תבנית",
+    "editTitle": "עריכת תבנית",
+    "newTemplate": "תבנית חדשה",
+    "createTemplate": "צור תבנית",
+    "saveChanges": "שמירת שינויים",
+    "viewOnly": "צפייה בלבד",
+    "noSessions": "אין סשנים",
+    "sessionHint": "נשמר תחת {{name}}",
+    "namePlaceholder": "לדוגמה, order-confirmation",
+    "header": "כותרת",
+    "headerPlaceholder": "שורת פתיחה (אופציונלי)",
+    "body": "גוף ההודעה",
+    "bodyPlaceholder": "שלום {{customer}}, ההזמנה שלך {{orderId}} מוכנה.",
+    "footer": "כותרת תחתונה",
+    "footerPlaceholder": "שורת סיום (אופציונלי)",
+    "previewTitle": "תצוגה מקדימה",
+    "previewValuePlaceholder": "ערך לדוגמה",
+    "previewEmpty": "התחילו לכתוב תבנית כדי לראות אותה כאן בתצוגה מקדימה.",
+    "noPlaceholders": "השתמשו במצייני מיקום {{name}} כדי לבדוק החלפות.",
+    "savedTitle": "תבניות שמורות",
+    "count": "{{count}} בסך הכול",
+    "deleteTitle": "מחיקת תבנית",
+    "deleteConfirm": "למחוק את התבנית \"{{name}}\"? לא ניתן לבטל פעולה זו.",
     "actions": {
-      "copyName": "Copy template name"
+      "copyName": "העתקת שם התבנית"
     },
     "empty": {
-      "title": "No templates saved",
-      "description": "Create a reusable template to speed up common replies and notifications.",
-      "noSessionsTitle": "No sessions available",
-      "noSessionsDesc": "Create a WhatsApp session before adding templates."
+      "title": "אין תבניות שמורות",
+      "description": "צרו תבנית לשימוש חוזר כדי לזרז תשובות והתראות נפוצות.",
+      "noSessionsTitle": "אין סשנים זמינים",
+      "noSessionsDesc": "צרו סשן WhatsApp לפני הוספת תבניות."
     },
     "toasts": {
-      "created": "Template created successfully",
-      "createFailed": "Failed to create template: {{message}}",
-      "updated": "Template updated successfully",
-      "updateFailed": "Failed to update template: {{message}}",
-      "deleted": "Template deleted successfully",
-      "deleteFailed": "Failed to delete template: {{message}}",
-      "copied": "Template name copied"
+      "created": "התבנית נוצרה בהצלחה",
+      "createFailed": "יצירת התבנית נכשלה: {{message}}",
+      "updated": "התבנית עודכנה בהצלחה",
+      "updateFailed": "עדכון התבנית נכשל: {{message}}",
+      "deleted": "התבנית נמחקה בהצלחה",
+      "deleteFailed": "מחיקת התבנית נכשלה: {{message}}",
+      "copied": "שם התבנית הועתק"
     }
   },
   "apiKeys": {

--- a/dashboard/src/i18n/locales/te.json
+++ b/dashboard/src/i18n/locales/te.json
@@ -264,7 +264,7 @@
       "stop": "ఆపివేయి",
       "reconnect": "మళ్లీ కనెక్ట్ చేయి",
       "delete": "తొలగించు",
-      "killStuck": "Kill Stuck"
+      "killStuck": "నిలిచిపోయినదాన్ని ఆపండి"
     },
     "toasts": {
       "readyTitle": "సెషన్ సిద్ధంగా ఉంది",
@@ -281,14 +281,14 @@
       "error": "లోపం"
     },
     "forceKill": {
-      "title": "Kill Stuck Session",
-      "message": "Are you sure you want to force-kill session \"{{name}}\"?",
-      "warning": "This will forcefully terminate the WhatsApp browser process. The session may need to be re-scanned on restart.",
-      "confirm": "Kill Session",
-      "successTitle": "Session Killed",
-      "success": "Session has been force-killed. You can restart it now.",
-      "failedTitle": "Force-Kill Failed",
-      "failed": "Failed to force-kill the session."
+      "title": "నిలిచిపోయిన సెషన్‌ను ఆపండి",
+      "message": "\"{{name}}\" సెషన్‌ను బలవంతంగా ఆపాలని మీరు ఖచ్చితంగా అనుకుంటున్నారా?",
+      "warning": "ఇది WhatsApp బ్రౌజర్ ప్రాసెస్‌ను బలవంతంగా ముగిస్తుంది. పునఃప్రారంభంలో సెషన్‌ను మళ్లీ స్కాన్ చేయాల్సి రావచ్చు.",
+      "confirm": "సెషన్‌ను ఆపండి",
+      "successTitle": "సెషన్ ఆపబడింది",
+      "success": "సెషన్ బలవంతంగా ఆపబడింది. మీరు ఇప్పుడు దాన్ని పునఃప్రారంభించవచ్చు.",
+      "failedTitle": "బలవంతంగా ఆపడం విఫలమైంది",
+      "failed": "సెషన్‌ను బలవంతంగా ఆపడం విఫలమైంది."
     }
   },
   "webhooks": {
@@ -371,48 +371,48 @@
     }
   },
   "templates": {
-    "title": "Templates",
-    "subtitle": "Create reusable message templates for each WhatsApp session",
-    "createTitle": "Create Template",
-    "editTitle": "Edit Template",
-    "newTemplate": "New Template",
-    "createTemplate": "Create Template",
-    "saveChanges": "Save Changes",
-    "viewOnly": "View Only",
-    "noSessions": "No sessions",
-    "sessionHint": "Saved under {{name}}",
-    "namePlaceholder": "e.g., order-confirmation",
-    "header": "Header",
-    "headerPlaceholder": "Optional intro line",
-    "body": "Body",
-    "bodyPlaceholder": "Hi {{customer}}, your order {{orderId}} is ready.",
-    "footer": "Footer",
-    "footerPlaceholder": "Optional closing line",
-    "previewTitle": "Preview",
-    "previewValuePlaceholder": "Sample value",
-    "previewEmpty": "Start writing a template to preview it here.",
-    "noPlaceholders": "Use {{name}} placeholders to test substitutions.",
-    "savedTitle": "Saved Templates",
-    "count": "{{count}} total",
-    "deleteTitle": "Delete Template",
-    "deleteConfirm": "Delete template \"{{name}}\"? This action cannot be undone.",
+    "title": "టెంప్లేట్‌లు",
+    "subtitle": "ప్రతి WhatsApp సెషన్‌కు పునర్వినియోగ మెసేజ్ టెంప్లేట్‌లను సృష్టించండి",
+    "createTitle": "టెంప్లేట్ సృష్టించండి",
+    "editTitle": "టెంప్లేట్‌ను సవరించండి",
+    "newTemplate": "కొత్త టెంప్లేట్",
+    "createTemplate": "టెంప్లేట్ సృష్టించండి",
+    "saveChanges": "మార్పులను సేవ్ చేయండి",
+    "viewOnly": "వీక్షణ మాత్రమే",
+    "noSessions": "సెషన్‌లు లేవు",
+    "sessionHint": "{{name}} కింద సేవ్ చేయబడింది",
+    "namePlaceholder": "ఉదా., order-confirmation",
+    "header": "హెడర్",
+    "headerPlaceholder": "ఐచ్ఛిక పరిచయ లైన్",
+    "body": "బాడీ",
+    "bodyPlaceholder": "హాయ్ {{customer}}, మీ ఆర్డర్ {{orderId}} సిద్ధంగా ఉంది.",
+    "footer": "ఫుటర్",
+    "footerPlaceholder": "ఐచ్ఛిక ముగింపు లైన్",
+    "previewTitle": "ప్రివ్యూ",
+    "previewValuePlaceholder": "నమూనా విలువ",
+    "previewEmpty": "ఇక్కడ ప్రివ్యూ చూడటానికి టెంప్లేట్ రాయడం ప్రారంభించండి.",
+    "noPlaceholders": "సబ్‌స్టిట్యూషన్‌లను పరీక్షించడానికి {{name}} ప్లేస్‌హోల్డర్‌లను ఉపయోగించండి.",
+    "savedTitle": "సేవ్ చేసిన టెంప్లేట్‌లు",
+    "count": "మొత్తం {{count}}",
+    "deleteTitle": "టెంప్లేట్‌ను తొలగించండి",
+    "deleteConfirm": "\"{{name}}\" టెంప్లేట్‌ను తొలగించాలా? ఈ చర్యను రద్దు చేయలేరు.",
     "actions": {
-      "copyName": "Copy template name"
+      "copyName": "టెంప్లేట్ పేరును కాపీ చేయండి"
     },
     "empty": {
-      "title": "No templates saved",
-      "description": "Create a reusable template to speed up common replies and notifications.",
-      "noSessionsTitle": "No sessions available",
-      "noSessionsDesc": "Create a WhatsApp session before adding templates."
+      "title": "టెంప్లేట్‌లు ఏవీ సేవ్ కాలేదు",
+      "description": "సాధారణ ప్రత్యుత్తరాలు మరియు నోటిఫికేషన్‌లను వేగవంతం చేయడానికి పునర్వినియోగ టెంప్లేట్‌ను సృష్టించండి.",
+      "noSessionsTitle": "సెషన్‌లు అందుబాటులో లేవు",
+      "noSessionsDesc": "టెంప్లేట్‌లను జోడించే ముందు WhatsApp సెషన్‌ను సృష్టించండి."
     },
     "toasts": {
-      "created": "Template created successfully",
-      "createFailed": "Failed to create template: {{message}}",
-      "updated": "Template updated successfully",
-      "updateFailed": "Failed to update template: {{message}}",
-      "deleted": "Template deleted successfully",
-      "deleteFailed": "Failed to delete template: {{message}}",
-      "copied": "Template name copied"
+      "created": "టెంప్లేట్ విజయవంతంగా సృష్టించబడింది",
+      "createFailed": "టెంప్లేట్ సృష్టించడం విఫలమైంది: {{message}}",
+      "updated": "టెంప్లేట్ విజయవంతంగా నవీకరించబడింది",
+      "updateFailed": "టెంప్లేట్ నవీకరించడం విఫలమైంది: {{message}}",
+      "deleted": "టెంప్లేట్ విజయవంతంగా తొలగించబడింది",
+      "deleteFailed": "టెంప్లేట్ తొలగించడం విఫలమైంది: {{message}}",
+      "copied": "టెంప్లేట్ పేరు కాపీ చేయబడింది"
     }
   },
   "apiKeys": {

--- a/dashboard/src/i18n/locales/zh-CN.json
+++ b/dashboard/src/i18n/locales/zh-CN.json
@@ -264,7 +264,7 @@
       "stop": "停止",
       "reconnect": "重新连接",
       "delete": "删除",
-      "killStuck": "Kill Stuck"
+      "killStuck": "终止卡死会话"
     },
     "toasts": {
       "readyTitle": "会话就绪",
@@ -281,14 +281,14 @@
       "error": "错误"
     },
     "forceKill": {
-      "title": "Kill Stuck Session",
-      "message": "Are you sure you want to force-kill session \"{{name}}\"?",
-      "warning": "This will forcefully terminate the WhatsApp browser process. The session may need to be re-scanned on restart.",
-      "confirm": "Kill Session",
-      "successTitle": "Session Killed",
-      "success": "Session has been force-killed. You can restart it now.",
-      "failedTitle": "Force-Kill Failed",
-      "failed": "Failed to force-kill the session."
+      "title": "终止卡死的会话",
+      "message": "确定要强制终止会话“{{name}}”吗？",
+      "warning": "此操作将强制结束 WhatsApp 浏览器进程。重启后该会话可能需要重新扫码。",
+      "confirm": "终止会话",
+      "successTitle": "会话已终止",
+      "success": "会话已被强制终止。您现在可以重新启动它。",
+      "failedTitle": "强制终止失败",
+      "failed": "强制终止会话失败。"
     }
   },
   "webhooks": {
@@ -371,48 +371,48 @@
     }
   },
   "templates": {
-    "title": "Templates",
-    "subtitle": "Create reusable message templates for each WhatsApp session",
-    "createTitle": "Create Template",
-    "editTitle": "Edit Template",
-    "newTemplate": "New Template",
-    "createTemplate": "Create Template",
-    "saveChanges": "Save Changes",
-    "viewOnly": "View Only",
-    "noSessions": "No sessions",
-    "sessionHint": "Saved under {{name}}",
-    "namePlaceholder": "e.g., order-confirmation",
-    "header": "Header",
-    "headerPlaceholder": "Optional intro line",
-    "body": "Body",
-    "bodyPlaceholder": "Hi {{customer}}, your order {{orderId}} is ready.",
-    "footer": "Footer",
-    "footerPlaceholder": "Optional closing line",
-    "previewTitle": "Preview",
-    "previewValuePlaceholder": "Sample value",
-    "previewEmpty": "Start writing a template to preview it here.",
-    "noPlaceholders": "Use {{name}} placeholders to test substitutions.",
-    "savedTitle": "Saved Templates",
-    "count": "{{count}} total",
-    "deleteTitle": "Delete Template",
-    "deleteConfirm": "Delete template \"{{name}}\"? This action cannot be undone.",
+    "title": "模板",
+    "subtitle": "为每个 WhatsApp 会话创建可复用的消息模板",
+    "createTitle": "创建模板",
+    "editTitle": "编辑模板",
+    "newTemplate": "新建模板",
+    "createTemplate": "创建模板",
+    "saveChanges": "保存更改",
+    "viewOnly": "仅查看",
+    "noSessions": "暂无会话",
+    "sessionHint": "保存在 {{name}} 下",
+    "namePlaceholder": "例如：order-confirmation",
+    "header": "页眉",
+    "headerPlaceholder": "可选的开头语",
+    "body": "正文",
+    "bodyPlaceholder": "您好 {{customer}}，您的订单 {{orderId}} 已就绪。",
+    "footer": "页脚",
+    "footerPlaceholder": "可选的结尾语",
+    "previewTitle": "预览",
+    "previewValuePlaceholder": "示例值",
+    "previewEmpty": "开始编写模板后即可在此预览。",
+    "noPlaceholders": "使用 {{name}} 占位符可测试替换效果。",
+    "savedTitle": "已保存的模板",
+    "count": "共 {{count}} 个",
+    "deleteTitle": "删除模板",
+    "deleteConfirm": "确定删除模板“{{name}}”吗？此操作无法撤销。",
     "actions": {
-      "copyName": "Copy template name"
+      "copyName": "复制模板名称"
     },
     "empty": {
-      "title": "No templates saved",
-      "description": "Create a reusable template to speed up common replies and notifications.",
-      "noSessionsTitle": "No sessions available",
-      "noSessionsDesc": "Create a WhatsApp session before adding templates."
+      "title": "暂无已保存的模板",
+      "description": "创建可复用的模板，加快处理常见回复和通知。",
+      "noSessionsTitle": "暂无可用会话",
+      "noSessionsDesc": "添加模板前请先创建 WhatsApp 会话。"
     },
     "toasts": {
-      "created": "Template created successfully",
-      "createFailed": "Failed to create template: {{message}}",
-      "updated": "Template updated successfully",
-      "updateFailed": "Failed to update template: {{message}}",
-      "deleted": "Template deleted successfully",
-      "deleteFailed": "Failed to delete template: {{message}}",
-      "copied": "Template name copied"
+      "created": "模板创建成功",
+      "createFailed": "创建模板失败：{{message}}",
+      "updated": "模板更新成功",
+      "updateFailed": "更新模板失败：{{message}}",
+      "deleted": "模板删除成功",
+      "deleteFailed": "删除模板失败：{{message}}",
+      "copied": "已复制模板名称"
     }
   },
   "apiKeys": {

--- a/dashboard/src/i18n/locales/zh-HK.json
+++ b/dashboard/src/i18n/locales/zh-HK.json
@@ -264,7 +264,7 @@
       "stop": "停止",
       "reconnect": "重新連線",
       "delete": "刪除",
-      "killStuck": "Kill Stuck"
+      "killStuck": "強制終止"
     },
     "toasts": {
       "readyTitle": "工作階段就緒",
@@ -281,14 +281,14 @@
       "error": "錯誤"
     },
     "forceKill": {
-      "title": "Kill Stuck Session",
-      "message": "Are you sure you want to force-kill session \"{{name}}\"?",
-      "warning": "This will forcefully terminate the WhatsApp browser process. The session may need to be re-scanned on restart.",
-      "confirm": "Kill Session",
-      "successTitle": "Session Killed",
-      "success": "Session has been force-killed. You can restart it now.",
-      "failedTitle": "Force-Kill Failed",
-      "failed": "Failed to force-kill the session."
+      "title": "強制終止卡住的工作階段",
+      "message": "確定要強制終止工作階段「{{name}}」嗎？",
+      "warning": "這會強制結束 WhatsApp 瀏覽器程序。工作階段重新啟動後可能需要重新掃描。",
+      "confirm": "終止工作階段",
+      "successTitle": "工作階段已終止",
+      "success": "工作階段已強制終止。你現在可以重新啟動它。",
+      "failedTitle": "強制終止失敗",
+      "failed": "無法強制終止工作階段。"
     }
   },
   "webhooks": {
@@ -371,48 +371,48 @@
     }
   },
   "templates": {
-    "title": "Templates",
-    "subtitle": "Create reusable message templates for each WhatsApp session",
-    "createTitle": "Create Template",
-    "editTitle": "Edit Template",
-    "newTemplate": "New Template",
-    "createTemplate": "Create Template",
-    "saveChanges": "Save Changes",
-    "viewOnly": "View Only",
-    "noSessions": "No sessions",
-    "sessionHint": "Saved under {{name}}",
-    "namePlaceholder": "e.g., order-confirmation",
-    "header": "Header",
-    "headerPlaceholder": "Optional intro line",
-    "body": "Body",
-    "bodyPlaceholder": "Hi {{customer}}, your order {{orderId}} is ready.",
-    "footer": "Footer",
-    "footerPlaceholder": "Optional closing line",
-    "previewTitle": "Preview",
-    "previewValuePlaceholder": "Sample value",
-    "previewEmpty": "Start writing a template to preview it here.",
-    "noPlaceholders": "Use {{name}} placeholders to test substitutions.",
-    "savedTitle": "Saved Templates",
-    "count": "{{count}} total",
-    "deleteTitle": "Delete Template",
-    "deleteConfirm": "Delete template \"{{name}}\"? This action cannot be undone.",
+    "title": "範本",
+    "subtitle": "為每個 WhatsApp 工作階段建立可重用的訊息範本",
+    "createTitle": "建立範本",
+    "editTitle": "編輯範本",
+    "newTemplate": "新範本",
+    "createTemplate": "建立範本",
+    "saveChanges": "儲存變更",
+    "viewOnly": "僅供檢視",
+    "noSessions": "沒有工作階段",
+    "sessionHint": "儲存於 {{name}}",
+    "namePlaceholder": "例如：order-confirmation",
+    "header": "標題",
+    "headerPlaceholder": "可選的開首句",
+    "body": "內文",
+    "bodyPlaceholder": "你好 {{customer}}，你的訂單 {{orderId}} 已經準備好。",
+    "footer": "頁尾",
+    "footerPlaceholder": "可選的結尾句",
+    "previewTitle": "預覽",
+    "previewValuePlaceholder": "範例值",
+    "previewEmpty": "開始撰寫範本，即可在此預覽。",
+    "noPlaceholders": "使用 {{name}} 佔位符測試替換效果。",
+    "savedTitle": "已儲存的範本",
+    "count": "共 {{count}} 個",
+    "deleteTitle": "刪除範本",
+    "deleteConfirm": "確定刪除範本「{{name}}」？此操作無法復原。",
     "actions": {
-      "copyName": "Copy template name"
+      "copyName": "複製範本名稱"
     },
     "empty": {
-      "title": "No templates saved",
-      "description": "Create a reusable template to speed up common replies and notifications.",
-      "noSessionsTitle": "No sessions available",
-      "noSessionsDesc": "Create a WhatsApp session before adding templates."
+      "title": "未儲存任何範本",
+      "description": "建立可重用的範本，加快常用回覆和通知的速度。",
+      "noSessionsTitle": "沒有可用的工作階段",
+      "noSessionsDesc": "請先建立 WhatsApp 工作階段，才能新增範本。"
     },
     "toasts": {
-      "created": "Template created successfully",
-      "createFailed": "Failed to create template: {{message}}",
-      "updated": "Template updated successfully",
-      "updateFailed": "Failed to update template: {{message}}",
-      "deleted": "Template deleted successfully",
-      "deleteFailed": "Failed to delete template: {{message}}",
-      "copied": "Template name copied"
+      "created": "範本建立成功",
+      "createFailed": "建立範本失敗：{{message}}",
+      "updated": "範本更新成功",
+      "updateFailed": "更新範本失敗：{{message}}",
+      "deleted": "範本刪除成功",
+      "deleteFailed": "刪除範本失敗：{{message}}",
+      "copied": "已複製範本名稱"
     }
   },
   "apiKeys": {


### PR DESCRIPTION
## Summary

Two dashboard sections were still rendering English in several locales. This completes them.

- **`templates.*`** (37 strings — the message-templates page) was untranslated in **French, Arabic, Hebrew, Telugu, Simplified Chinese, and Traditional Chinese (HK)**.
- **`sessions.forceKill.*`** + the **`sessions.actions.killStuck`** action (9 strings — the kill-stuck-session dialog) was untranslated in **Spanish** and the six locales above.

`it` and `pt-BR` were already complete and are untouched.

## How it was done

Each locale was translated by a native-fluent pass, then merged programmatically so that:
- every `{{placeholder}}` token (`{{name}}`, `{{count}}`, `{{customer}}`, `{{orderId}}`, `{{message}}`) is byte-identical to the English reference — verified per key before writing, and re-verified by the repo's `i18n:check` placeholder gate;
- brand names (`WhatsApp`) stay untranslated;
- files keep the canonical `JSON.stringify(obj, null, 2)` formatting (2-space, trailing newline), so the diff is values-only.

## Result

The `i18n:check` untranslated warnings for these two sections drop to zero across all locales (the lone remaining per-locale warning, `login.version`, predates this change and is present even in the otherwise-complete `it`/`pt-BR`).

## Testing
Dashboard build, lint, unit tests (82), and `i18n:check` parity all green.