### PR TITLE
fix(dashboard): harden pairing UI for RTL locales and the wwebjs link handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Link a WhatsApp session by pairing code from the dashboard.** The session connect modal now offers a "Link with Phone Number" tab next to the QR code: enter a phone number in international format and the dashboard requests an 8-character pairing code — via the existing `POST /sessions/:id/pairing-code` endpoint — to type into WhatsApp on the phone, a QR-free way to link a device. The phone field is constrained to digits with a numeric keypad, the code/instructions are fully localized across all 10 dashboard locales, and the pairing panel is keyboard- and screen-reader-accessible. (#551) Thanks @akash247777.
 
+### Fixed
+
+- **Pairing code renders in the correct order in right-to-left locales.** In Arabic/Hebrew the 8-character code's two halves could be transposed by the bidi algorithm (a code like `1234ABCD` shown as `ABCD - 1234`), causing the user to type the wrong code; the code display is now isolated to left-to-right. The pairing connect modal also no longer disappears mid-link on the whatsapp-web.js engine (it stayed mounted only through `authenticating`), and a rapid double-Enter can no longer fire overlapping pairing-code requests. (#552)
+
 ## [0.7.15] - 2026-06-30
 
 ### Added

--- a/dashboard/src/pages/Sessions.css
+++ b/dashboard/src/pages/Sessions.css
@@ -779,13 +779,13 @@
   padding: 0.75rem;
   border-radius: 8px;
   font-size: 0.875rem;
-  text-align: left;
+  text-align: start;
   color: var(--error);
   background: rgb(239 68 68 / 0.12);
 }
 
 .sessions-page .pairing-form {
-  text-align: left;
+  text-align: start;
 }
 
 .sessions-page .pairing-label {
@@ -809,6 +809,9 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  /* Force LTR so the two code halves never get reordered by the bidi algorithm in RTL locales. */
+  direction: ltr;
+  unicode-bidi: isolate;
   gap: 0.75rem;
   font-size: 2rem;
   font-weight: 700;

--- a/dashboard/src/pages/Sessions.tsx
+++ b/dashboard/src/pages/Sessions.tsx
@@ -128,9 +128,12 @@ export function Sessions() {
         }
       } catch {
         // Keep qrData alive so the polling interval keeps retrying until the QR
-        // is ready. Only stop polling if the session itself has failed.
+        // is ready. Only stop polling if the session itself has failed. 'authenticating' is included so
+        // the modal (and the pairing-code panel mounted in it) survives the brief post-link handshake
+        // instead of being torn down mid-pairing — it closes on the real 'ready'/'failed' transition.
         const updated = await sessionApi.get(sessionId).catch(() => null);
-        const stillInitializing = updated && ['initializing', 'connecting', 'qr_ready'].includes(updated.status);
+        const stillInitializing =
+          updated && ['initializing', 'connecting', 'qr_ready', 'authenticating'].includes(updated.status);
         if (!stillInitializing) {
           setQrData(null);
           currentSessionName.current = '';
@@ -162,6 +165,9 @@ export function Sessions() {
   }, []);
 
   const handleGeneratePairingCode = async () => {
+    // Guard against a second concurrent request: the button is disabled while in flight, but the
+    // input's Enter handler is not, so a rapid double-Enter would otherwise fire overlapping POSTs.
+    if (requestingPairing) return;
     if (!qrData || !phoneNumber.trim()) return;
     if (!/^[0-9]{6,15}$/.test(phoneNumber.trim())) {
       setPairingError(t('sessions.pairing.invalidPhone'));


### PR DESCRIPTION
Follow-up hardening for the pairing-code UI added in #551, fixing four issues found in a post-merge review (none of which were release-blocking, but all ship in the same unreleased version).

### RTL correctness (Arabic / Hebrew)
- **Pairing code was transposed.** The code display is a flex row of three text nodes (`first4` · `" - "` · `last4`). Under `dir="rtl"`, when the first half is all digits the Unicode bidi algorithm reorders the two runs, so a real code like `1234ABCD` rendered as `ABCD - 1234`. An RTL user would read and type the wrong code and pairing would fail. Fixed by forcing the display to `direction: ltr; unicode-bidi: isolate`, matching how the app already isolates other technical strings. Verified in Chromium: `1234 - ABCD` now renders in order under `dir=rtl` (it did not before).
- **Block alignment.** The error banner and form label/hint were hardcoded `text-align: left`; switched to `text-align: start` so they align to the writing-direction start in RTL.

### whatsapp-web.js link handshake
- **Modal no longer disappears mid-link.** The pairing panel is mounted inside the QR modal, which shares the QR poller. The poller's "still initializing" allow-list omitted `authenticating`, so when the wwebjs engine entered that state during linking, the poll tore the whole modal down — the code and instructions vanished for several seconds before the success toast. `authenticating` is now in the allow-list; the modal stays until the real `ready`/`failed` transition. (Baileys never enters this state, so it was already fine.)

### Robustness
- **No double-submit.** `handleGeneratePairingCode` now returns early if a request is already in flight. The button was disabled while requesting, but the input's Enter handler was not, so a rapid double-Enter could fire overlapping pairing requests.

Verification: `npm run build`, dashboard unit tests (82/82), `i18n:check`, eslint, and prettier all pass; the RTL fix was confirmed against the original symptom in a real browser.
