### PR TITLE
fix(engine): skip Chat-only operations on WhatsApp Channel (newsletter) JIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Sending to — or operating on — a WhatsApp Channel (newsletter) no longer logs internal errors.** On the whatsapp-web.js engine a channel JID (`…@newsletter`) resolves to a `Channel`, which has none of the per-chat operations; the gateway now skips those for channels instead of throwing. The typing indicator that precedes a send, the typing/recording presence endpoint and its MCP tool, mark-unread, and delete-chat now cleanly no-op for a channel (presence does nothing; mark-unread and delete-chat report no change) rather than emitting an internal `TypeError`. Fetching chat labels for a channel previously failed with HTTP 500 — it now returns an empty list. Direct chats, groups, and broadcast lists are unaffected. (#554) Thanks @DanielOberlechner.
+
 ## [0.7.16] - 2026-06-30
 
 ### Added

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -290,6 +290,20 @@ describe('WhatsAppWebJsAdapter channel-JID guard (#554 — wwebjs Channel lacks 
       expect(getChatById).toHaveBeenCalledWith(USER);
       expect(sendStateTyping).toHaveBeenCalled();
     });
+
+    it('drives recording presence on a user JID', async () => {
+      const sendStateRecording = jest.fn().mockResolvedValue(undefined);
+      const getChatById = jest.fn().mockResolvedValue({ sendStateRecording });
+      await readyAdapter({ getChatById }).sendChatState(USER, 'recording');
+      expect(sendStateRecording).toHaveBeenCalled();
+    });
+
+    it('clears presence on a user JID for the paused state', async () => {
+      const clearState = jest.fn().mockResolvedValue(undefined);
+      const getChatById = jest.fn().mockResolvedValue({ clearState });
+      await readyAdapter({ getChatById }).sendChatState(USER, 'paused');
+      expect(clearState).toHaveBeenCalled();
+    });
   });
 
   describe('markUnread', () => {

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -265,6 +265,80 @@ describe('WhatsAppWebJsAdapter.forwardMessage (returns the real sent id, not a s
   });
 });
 
+describe('WhatsAppWebJsAdapter channel-JID guard (#554 — wwebjs Channel lacks Chat methods)', () => {
+  const NEWSLETTER = '120363401234567890@newsletter';
+  const USER = '628111@c.us';
+
+  const readyAdapter = (client: unknown): WhatsAppWebJsAdapter => {
+    const adapter = new WhatsAppWebJsAdapter({ sessionId: 's', sessionDataPath: './data/sessions', puppeteer: {} });
+    (adapter as unknown as { status: EngineStatus }).status = EngineStatus.READY;
+    (adapter as unknown as { client: unknown }).client = client;
+    return adapter;
+  };
+
+  describe('sendChatState', () => {
+    it('no-ops on a newsletter JID without resolving a Channel (the #554 TypeError path)', async () => {
+      const getChatById = jest.fn();
+      await expect(readyAdapter({ getChatById }).sendChatState(NEWSLETTER, 'typing')).resolves.toBeUndefined();
+      expect(getChatById).not.toHaveBeenCalled();
+    });
+
+    it('still drives typing presence on a user JID', async () => {
+      const sendStateTyping = jest.fn().mockResolvedValue(undefined);
+      const getChatById = jest.fn().mockResolvedValue({ sendStateTyping });
+      await readyAdapter({ getChatById }).sendChatState(USER, 'typing');
+      expect(getChatById).toHaveBeenCalledWith(USER);
+      expect(sendStateTyping).toHaveBeenCalled();
+    });
+  });
+
+  describe('markUnread', () => {
+    it('returns false and skips getChatById on a newsletter JID', async () => {
+      const getChatById = jest.fn();
+      await expect(readyAdapter({ getChatById }).markUnread(NEWSLETTER)).resolves.toBe(false);
+      expect(getChatById).not.toHaveBeenCalled();
+    });
+
+    it('marks a user chat unread (returns true)', async () => {
+      const markUnread = jest.fn().mockResolvedValue(undefined);
+      const getChatById = jest.fn().mockResolvedValue({ markUnread });
+      await expect(readyAdapter({ getChatById }).markUnread(USER)).resolves.toBe(true);
+      expect(markUnread).toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteChat', () => {
+    it('returns false and skips getChatById on a newsletter JID (does not route to deleteChannel)', async () => {
+      const getChatById = jest.fn();
+      await expect(readyAdapter({ getChatById }).deleteChat(NEWSLETTER)).resolves.toBe(false);
+      expect(getChatById).not.toHaveBeenCalled();
+    });
+
+    it('deletes a user chat (returns the underlying delete result)', async () => {
+      const del = jest.fn().mockResolvedValue(true);
+      const getChatById = jest.fn().mockResolvedValue({ delete: del });
+      await expect(readyAdapter({ getChatById }).deleteChat(USER)).resolves.toBe(true);
+      expect(del).toHaveBeenCalled();
+    });
+  });
+
+  describe('getChatLabels', () => {
+    it('returns [] on a newsletter JID instead of throwing (was an unguarded HTTP 500)', async () => {
+      const getChatById = jest.fn();
+      await expect(readyAdapter({ getChatById }).getChatLabels(NEWSLETTER)).resolves.toEqual([]);
+      expect(getChatById).not.toHaveBeenCalled();
+    });
+
+    it('maps labels through for a user JID', async () => {
+      const getLabels = jest.fn().mockResolvedValue([{ id: 1, name: 'VIP', hexColor: '#fff' }]);
+      const getChatById = jest.fn().mockResolvedValue({ getLabels });
+      await expect(readyAdapter({ getChatById }).getChatLabels(USER)).resolves.toEqual([
+        { id: '1', name: 'VIP', hexColor: '#fff' },
+      ]);
+    });
+  });
+});
+
 describe('WhatsAppWebJsAdapter.forceDestroy (recover a wedged session, #351)', () => {
   const newAdapter = (): WhatsAppWebJsAdapter =>
     new WhatsAppWebJsAdapter({ sessionId: 'sess-1', sessionDataPath: './data/sessions', puppeteer: {} });

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -34,6 +34,7 @@ import {
   ReactionEvent,
 } from '../interfaces/whatsapp-engine.interface';
 import { resolveWebVersionPin } from '../wa-web-version';
+import { isChannelJid } from '../identity/wa-id';
 import { createLogger } from '../../common/services/logger.service';
 import { EngineNotReadyError } from '../../common/errors/engine-not-ready.error';
 import { EngineNotSupportedError } from '../../common/errors/engine-not-supported.error';
@@ -1242,6 +1243,11 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
 
   async getChatLabels(chatId: string): Promise<Label[]> {
     this.ensureReady();
+    if (isChannelJid(chatId)) {
+      // A channel resolves to a wwebjs `Channel`, which has no getLabels() and carries no chat labels.
+      // Return empty instead of letting the unguarded call throw a TypeError (HTTP 500).
+      return [];
+    }
     const chat = await this.client!.getChatById(chatId);
     const labels = await (chat as unknown as GroupChat).getLabels();
     if (!labels) {
@@ -1570,6 +1576,11 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
 
   async markUnread(chatId: string): Promise<boolean> {
     this.ensureReady();
+    if (isChannelJid(chatId)) {
+      // A channel resolves to a wwebjs `Channel`, which has no markUnread() — there is no unread
+      // state to toggle on a channel. Report the no-op rather than throwing a TypeError.
+      return false;
+    }
     try {
       const chat = await this.client!.getChatById(chatId);
       // Chat.markUnread() resolves void, so synthesize the boolean from a clean call.
@@ -1583,6 +1594,11 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
 
   async deleteChat(chatId: string): Promise<boolean> {
     this.ensureReady();
+    if (isChannelJid(chatId)) {
+      // A channel resolves to a wwebjs `Channel`, which has no delete() (only the destructive
+      // deleteChannel()); a generic chat-delete must not silently unsubscribe a channel.
+      return false;
+    }
     try {
       const chat = await this.client!.getChatById(chatId);
       return await chat.delete();
@@ -1594,6 +1610,11 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
 
   async sendChatState(chatId: string, state: ChatState): Promise<void> {
     this.ensureReady();
+    if (isChannelJid(chatId)) {
+      // A channel resolves to a wwebjs `Channel`, which has no presence methods
+      // (sendStateTyping/sendStateRecording/clearState). Presence is best-effort, so no-op.
+      return;
+    }
     try {
       const chat = await this.client!.getChatById(chatId);
       if (state === 'typing') {

--- a/src/engine/identity/wa-id.spec.ts
+++ b/src/engine/identity/wa-id.spec.ts
@@ -1,4 +1,4 @@
-import { parseWaId, toNeutralJid, userPart } from './wa-id';
+import { isChannelJid, parseWaId, toNeutralJid, userPart } from './wa-id';
 
 describe('wa-id', () => {
   describe('userPart', () => {
@@ -25,6 +25,23 @@ describe('wa-id', () => {
       expect(parseWaId('123@broadcast')).toMatchObject({ kind: 'broadcast', userPart: '123' });
       expect(parseWaId('ABC@NEWSLETTER')).toMatchObject({ kind: 'newsletter', userPart: 'abc' });
       expect(parseWaId('AbCd@LID')).toMatchObject({ kind: 'lid', userPart: 'abcd' });
+    });
+  });
+
+  describe('isChannelJid', () => {
+    it('is true only for a @newsletter (channel) JID', () => {
+      expect(isChannelJid('120363401234567890@newsletter')).toBe(true);
+      expect(isChannelJid('ABC@NEWSLETTER')).toBe(true); // case-insensitive
+    });
+
+    it('is false for user, group, lid, broadcast and status JIDs (they resolve to a real Chat)', () => {
+      expect(isChannelJid('628111@c.us')).toBe(false);
+      expect(isChannelJid('628111@s.whatsapp.net')).toBe(false);
+      expect(isChannelJid('120-456@g.us')).toBe(false);
+      expect(isChannelJid('111@lid')).toBe(false);
+      expect(isChannelJid('123@broadcast')).toBe(false);
+      expect(isChannelJid('status@broadcast')).toBe(false);
+      expect(isChannelJid('not-a-jid')).toBe(false);
     });
   });
 

--- a/src/engine/identity/wa-id.ts
+++ b/src/engine/identity/wa-id.ts
@@ -99,3 +99,14 @@ export function toNeutralJid(jid: string, resolvePhone?: (jid: string) => string
       return jid;
   }
 }
+
+/**
+ * True for a channel/newsletter JID (`<id>@newsletter`). whatsapp-web.js resolves these to a `Channel`,
+ * which — unlike a `Chat` — has no per-chat presence (`sendStateTyping`/`sendStateRecording`/`clearState`),
+ * `markUnread`, `delete`, or `getLabels`. The wwebjs adapter uses this to skip those Chat-only operations
+ * instead of letting `getChatById` hand back a `Channel` that throws `TypeError`. Broadcast lists and
+ * `status@broadcast` resolve to a real `Chat` and are intentionally NOT matched here.
+ */
+export function isChannelJid(jid: string): boolean {
+  return parseWaId(jid).kind === 'newsletter';
+}


### PR DESCRIPTION
## Summary

Sending a text message to a WhatsApp **Channel** (a `…@newsletter` chat) on the whatsapp-web.js engine produced a recurring error in the logs:

```
Error setting chat state 'typing' for <id>@newsletter TypeError: chat.sendStateTyping is not a function
```

The message itself was still delivered — this was log noise rather than a delivery failure — but it appeared on every send to a channel, and the same underlying cause affected a few neighbouring operations. This change handles the whole class.

Thanks to @DanielOberlechner for the clear report (#554).

## Root cause

On the whatsapp-web.js engine, `client.getChatById(jid)` is polymorphic: a `…@newsletter` JID resolves to a `Channel`, a `…@g.us` JID to a `GroupChat`, and everything else to a regular `Chat`. A `Channel` implements only a subset of operations (`sendMessage`, `sendSeen`, `fetchMessages`, `mute`/`unmute`, channel-admin actions); it has none of the per-chat methods such as `sendStateTyping`, `markUnread`, `delete`, or `getLabels`. The adapter called those methods unconditionally, so any of them threw a `TypeError` for a channel JID.

## What changes

A small engine-neutral predicate, `isChannelJid()`, is added alongside the existing JID helpers, and the whatsapp-web.js adapter now short-circuits the channel case before resolving the chat:

| Operation | Before (channel JID) | After |
| --- | --- | --- |
| `getChatLabels` | **HTTP 500** (unhandled `TypeError`) | returns `[]` (a channel carries no chat labels) |
| typing / recording presence (incl. the pre-send "typing…" indicator) | `TypeError`, logged at error level | clean no-op |
| `markUnread` | `TypeError`, logged at error level | returns `false` (no change) |
| `deleteChat` | `TypeError`, logged at error level | returns `false` (no change) |

The presence guard covers all three paths that reach it: the anti-ban typing indicator that runs before a send, the explicit presence endpoint, and the corresponding agent tool.

`deleteChat` intentionally returns `false` rather than routing to the channel's `deleteChannel()` — deleting a chat thread and unsubscribing from / destroying a channel are different operations, and a generic "delete chat" call should not carry the latter side effect.

## Impact / compatibility

- Direct chats, groups, broadcast lists, and `status@broadcast` are unaffected — `isChannelJid()` matches `…@newsletter` only. (Broadcast and status JIDs resolve to a regular `Chat` and keep working exactly as before.)
- The only externally visible behaviour change is `getChatLabels` for a channel: previously an HTTP 500, now an empty list. This is a bug fix, so the change is patch-level.

## Tests

- `isChannelJid()` unit tests — true for newsletter only; false for user / group / lid / broadcast / status.
- Adapter tests for each guarded method — a channel JID no-ops without resolving a chat, and a normal user JID still drives the underlying call through.

Full backend suite green (1672 tests); build and lint clean.

Closes #554.
