### PR TITLE
feat: send true WhatsApp voice notes (PTT) via send-audio, bulk, and MCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Send true WhatsApp voice notes (PTT).** The `send-audio` endpoint, bulk send, and the `MessageSendAudio` agent tool now accept an optional `ptt` boolean; when set, the message is delivered as a real voice note — the microphone bubble with a waveform — instead of a plain audio file, on both the Baileys and whatsapp-web.js engines. Voice notes require `audio/ogg; codecs=opus` audio, so the server defaults the mimetype to that when `ptt` is set without one (supply OGG/Opus bytes for reliable playback), and stores the message as `type: "voice"`. Fulfills FR-MSG-004. (OpenWA-n8n #13)
+
 ### Fixed
 
 - **Sending to — or operating on — a WhatsApp Channel (newsletter) no longer logs internal errors.** On the whatsapp-web.js engine a channel JID (`…@newsletter`) resolves to a `Channel`, which has none of the per-chat operations; the gateway now skips those for channels instead of throwing. The typing indicator that precedes a send, the typing/recording presence endpoint and its MCP tool, mark-unread, and delete-chat now cleanly no-op for a channel (presence does nothing; mark-unread and delete-chat report no change) rather than emitting an internal `TypeError`. Fetching chat labels for a channel previously failed with HTTP 500 — it now returns an empty list. Direct chats, groups, and broadcast lists are unaffected. (#554) Thanks @DanielOberlechner.

--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -996,7 +996,7 @@ Send a video (by URL or base64) with an optional caption. Uses the same `SendMed
 
 #### POST /api/sessions/:sessionId/messages/send-audio
 
-Send an audio/voice message (by URL or base64). Uses `SendMediaMessageDto`. A `caption` is accepted by the DTO but not persisted for audio.
+Send an audio message (by URL or base64). Uses `SendAudioMessageDto`. A `caption` is accepted by the DTO but not persisted for audio. Set `ptt: true` to send a real WhatsApp **voice note** (microphone bubble + waveform) instead of a plain audio file. `ptt` is a JSON boolean, exclusive to this endpoint, and — because voice notes require `audio/ogg; codecs=opus` — the server defaults the mimetype to that when you set `ptt` without one; for reliable playback (especially on the Baileys engine, which does not transcode) supply OGG/Opus bytes. A `ptt` voice note is stored as message `type: "voice"`.
 
 **Auth:** API key (OPERATOR)
 
@@ -1006,10 +1006,10 @@ Send an audio/voice message (by URL or base64). Uses `SendMediaMessageDto`. A `c
 | --- | --- | --- |
 | sessionId | string | Session ID |
 
-**Request body** — `SendMediaMessageDto` (fields `chatId`, `url`, `base64`, `mimetype`, `filename`, `caption` — see `send-image`)
+**Request body** — `SendAudioMessageDto` (all `SendMediaMessageDto` fields — `chatId`, `url`, `base64`, `mimetype`, `filename`, `caption` — plus optional `ptt` boolean)
 
 ```json
-{ "chatId": "628123456789@c.us", "url": "https://example.com/voice.ogg", "mimetype": "audio/ogg" }
+{ "chatId": "628123456789@c.us", "url": "https://example.com/voice.ogg", "mimetype": "audio/ogg", "ptt": true }
 ```
 
 **Response** `201`

--- a/docs/07-api-collection.md
+++ b/docs/07-api-collection.md
@@ -278,13 +278,13 @@ curl -X POST "$BASE/api/sessions/my-session/messages/send-video" \
 
 #### POST /api/sessions/:sessionId/messages/send-audio
 
-Send an audio/voice message by URL or base64.
+Send an audio message by URL or base64. Add `"ptt": true` to send a real WhatsApp voice note (mic bubble + waveform); the server defaults the mimetype to `audio/ogg; codecs=opus` when `ptt` is set without one.
 
 ```bash
 curl -X POST "$BASE/api/sessions/my-session/messages/send-audio" \
   -H "X-API-Key: $API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{ "chatId": "628123456789@c.us", "url": "https://example.com/voice.ogg", "mimetype": "audio/ogg" }'
+  -d '{ "chatId": "628123456789@c.us", "url": "https://example.com/voice.ogg", "mimetype": "audio/ogg", "ptt": true }'
 ```
 
 #### POST /api/sessions/:sessionId/messages/send-document

--- a/sdk/javascript/README.md
+++ b/sdk/javascript/README.md
@@ -33,6 +33,10 @@ console.log(result.messageId);
 
 CommonJS consumers use `require('@rmyndharis/openwa')` identically.
 
+## Messaging
+
+> Voice notes: pass `ptt: true` to `sendAudio` to send a real WhatsApp voice note (PTT). Supply `audio/ogg; codecs=opus` audio for reliable playback; the server defaults the mimetype to that when `ptt` is set without one.
+
 ## Errors
 
 Non-2xx responses throw a typed `OpenWAApiError` subclass

--- a/sdk/javascript/src/types.ts
+++ b/sdk/javascript/src/types.ts
@@ -108,6 +108,8 @@ export interface SendMediaRequest {
   filename?: string;
   /** Max 1024 chars. */
   caption?: string;
+  /** Audio only: send as a WhatsApp voice note (PTT). Server defaults mimetype to audio/ogg; codecs=opus. */
+  ptt?: boolean;
 }
 
 export interface SendLocationRequest {

--- a/sdk/php/README.md
+++ b/sdk/php/README.md
@@ -44,6 +44,10 @@ $client = new Client([
 ]);
 ```
 
+## Messaging
+
+> Voice notes: pass `'ptt' => true` to `sendAudio` to send a real WhatsApp voice note (PTT). Supply `audio/ogg; codecs=opus` audio for reliable playback; the server defaults the mimetype to that when `ptt` is set without one.
+
 ## Errors
 
 A non-2xx response throws a typed `OpenWA\Exceptions\OpenWAApiException` subclass —

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -45,6 +45,10 @@ import httpx
 client = OpenWAClient(base_url="…", api_key="…", transport=httpx.MockTransport(handler))
 ```
 
+## Messaging
+
+> Voice notes: pass `ptt=True` inside the body dict to `send_audio` to send a real WhatsApp voice note (PTT). Supply `audio/ogg; codecs=opus` audio for reliable playback; the server defaults the mimetype to that when `ptt` is set without one.
+
 ## Errors
 
 A non-2xx response raises a typed `OpenWAApiError` subclass — `OpenWAAuthError` (401),

--- a/sdk/python/openwa/types.py
+++ b/sdk/python/openwa/types.py
@@ -107,6 +107,7 @@ class SendMediaRequest(TypedDict, total=False):
     mimetype: str
     filename: str
     caption: str
+    ptt: bool  # audio only: send as a WhatsApp voice note (PTT)
 
 
 class SendLocationRequest(TypedDict, total=False):

--- a/src/core/agent-tools/tools/message.tools.ts
+++ b/src/core/agent-tools/tools/message.tools.ts
@@ -157,6 +157,7 @@ export function messageTools(message: MessageService): ToolDescriptor[] {
         mimetype: z.string().optional().describe('MIME type (required when using base64)'),
         filename: z.string().max(255).optional(),
         caption: z.string().max(1024).optional(),
+        ptt: z.boolean().optional().describe('Send as a WhatsApp voice note (PTT)'),
       }),
       handler: (input: {
         sessionId: string;
@@ -166,6 +167,7 @@ export function messageTools(message: MessageService): ToolDescriptor[] {
         mimetype?: string;
         filename?: string;
         caption?: string;
+        ptt?: boolean;
       }) =>
         message.sendAudio(input.sessionId, {
           chatId: input.chatId,
@@ -174,6 +176,7 @@ export function messageTools(message: MessageService): ToolDescriptor[] {
           mimetype: input.mimetype,
           filename: input.filename,
           caption: input.caption,
+          ptt: input.ptt,
         }),
     },
     {

--- a/src/engine/adapters/baileys.adapter.spec.ts
+++ b/src/engine/adapters/baileys.adapter.spec.ts
@@ -1409,6 +1409,20 @@ describe('BaileysAdapter media sends', () => {
     });
   });
 
+  it('sendAudioMessage with ptt sends a voice note (ptt:true)', async () => {
+    const adapter = await ready();
+    await adapter.sendAudioMessage('628111@s.whatsapp.net', {
+      mimetype: 'audio/ogg; codecs=opus',
+      data: Buffer.from([1]),
+      ptt: true,
+    });
+    expect(fakeSock.sendMessage).toHaveBeenCalledWith('628111@s.whatsapp.net', {
+      audio: Buffer.from([1]),
+      mimetype: 'audio/ogg; codecs=opus',
+      ptt: true,
+    });
+  });
+
   it('sendStickerMessage sends the sticker buffer', async () => {
     const adapter = await ready();
     await adapter.sendStickerMessage('628111@s.whatsapp.net', { mimetype: 'image/webp', data: Buffer.from([7]) });

--- a/src/engine/adapters/baileys.adapter.ts
+++ b/src/engine/adapters/baileys.adapter.ts
@@ -534,7 +534,7 @@ export class BaileysAdapter implements IWhatsAppEngine {
   async sendAudioMessage(chatId: string, media: MediaInput): Promise<MessageResult> {
     this.ensureReady();
     const { data, mimetype } = await this.resolveMediaBuffer(media);
-    return this.sendContent(chatId, { audio: data, mimetype, ptt: false });
+    return this.sendContent(chatId, { audio: data, mimetype, ptt: media.ptt ?? false });
   }
 
   async sendDocumentMessage(chatId: string, media: MediaInput): Promise<MessageResult> {

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -1188,8 +1188,11 @@ describe('outbound voice note (PTT)', () => {
       mimetype: 'audio/mpeg',
       data: Buffer.from([1]).toString('base64'),
     });
-    const opts = sendMessage.mock.calls[0][2] as { sendAudioAsVoice?: boolean };
-    expect(opts.sendAudioAsVoice).toBeUndefined();
+    expect(sendMessage).toHaveBeenCalledWith(
+      '628@c.us',
+      expect.anything(),
+      expect.not.objectContaining({ sendAudioAsVoice: true }),
+    );
   });
 });
 

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -1159,6 +1159,40 @@ describe('outbound mentions (#530)', () => {
   });
 });
 
+describe('outbound voice note (PTT)', () => {
+  const ready = (client: unknown): WhatsAppWebJsAdapter => {
+    const adapter = new WhatsAppWebJsAdapter({ sessionId: 's', sessionDataPath: './data/sessions', puppeteer: {} });
+    (adapter as unknown as { status: EngineStatus }).status = EngineStatus.READY;
+    (adapter as unknown as { client: unknown }).client = client;
+    return adapter;
+  };
+  const sentMessage = { id: { _serialized: 'OUT1' }, timestamp: 1700000001 };
+
+  it('sendAudioMessage with ptt passes sendAudioAsVoice:true', async () => {
+    const sendMessage = jest.fn().mockResolvedValue(sentMessage);
+    await ready({ sendMessage }).sendAudioMessage('628@c.us', {
+      mimetype: 'audio/ogg; codecs=opus',
+      data: Buffer.from([1]).toString('base64'),
+      ptt: true,
+    });
+    expect(sendMessage).toHaveBeenCalledWith(
+      '628@c.us',
+      expect.anything(),
+      expect.objectContaining({ sendAudioAsVoice: true }),
+    );
+  });
+
+  it('sendAudioMessage without ptt passes no sendAudioAsVoice option', async () => {
+    const sendMessage = jest.fn().mockResolvedValue(sentMessage);
+    await ready({ sendMessage }).sendAudioMessage('628@c.us', {
+      mimetype: 'audio/mpeg',
+      data: Buffer.from([1]).toString('base64'),
+    });
+    const opts = sendMessage.mock.calls[0][2] as { sendAudioAsVoice?: boolean };
+    expect(opts.sendAudioAsVoice).toBeUndefined();
+  });
+});
+
 describe('extractWwebjsCall (call_log → { video, missed }, salvaged from #494)', () => {
   const m = (over: Record<string, unknown>) => over as unknown as Parameters<typeof extractWwebjsCall>[0];
 

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -819,14 +819,18 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
   }
 
   async sendAudioMessage(chatId: string, media: MediaInput): Promise<MessageResult> {
-    return this.sendMediaMessage(chatId, media);
+    return this.sendMediaMessage(chatId, media, media.ptt ? { sendAudioAsVoice: true } : undefined);
   }
 
   async sendDocumentMessage(chatId: string, media: MediaInput): Promise<MessageResult> {
     return this.sendMediaMessage(chatId, media);
   }
 
-  private async sendMediaMessage(chatId: string, media: MediaInput): Promise<MessageResult> {
+  private async sendMediaMessage(
+    chatId: string,
+    media: MediaInput,
+    extraOptions?: { sendAudioAsVoice?: boolean },
+  ): Promise<MessageResult> {
     this.ensureReady();
 
     let messageMedia: MessageMedia;
@@ -847,6 +851,8 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     const msg = await this.client!.sendMessage(chatId, messageMedia, {
       caption: media.caption,
       ...(media.mentions?.length ? { mentions: media.mentions } : {}),
+      // sendAudioAsVoice only for audio; {...undefined} contributes no keys.
+      ...extraOptions,
     });
 
     return {

--- a/src/engine/interfaces/whatsapp-engine.interface.ts
+++ b/src/engine/interfaces/whatsapp-engine.interface.ts
@@ -35,6 +35,8 @@ export interface MediaInput {
   caption?: string;
   /** Neutral WIDs (`<phone>@c.us`) to @mention in the caption. The adapter de-normalizes per engine. */
   mentions?: string[];
+  /** When true, send as a WhatsApp voice note (PTT). audio-only; ignored by other media types. */
+  ptt?: boolean;
 }
 
 /**

--- a/src/modules/message/bulk-message.service.spec.ts
+++ b/src/modules/message/bulk-message.service.spec.ts
@@ -176,6 +176,30 @@ describe('BulkMessageService.processBatch', () => {
     );
   });
 
+  it('sends a bulk audio item with ptt as a voice note and persists type "voice"', async () => {
+    engine.sendAudioMessage = jest.fn().mockResolvedValue({ id: 'wa2', timestamp: 222 });
+    const batch = {
+      id: 'b1',
+      batchId: 'bx',
+      sessionId: 's1',
+      status: BatchStatus.PENDING,
+      currentIndex: 0,
+      messages: [{ chatId: 'c0@c.us', type: 'audio', content: { audio: { url: 'https://x/v', ptt: true } } }],
+      options: { delayBetweenMessages: 0, randomizeDelay: false, stopOnError: false },
+      progress: { total: 1, sent: 0, failed: 0, pending: 1, cancelled: 0 },
+      results: [],
+    } as unknown as MessageBatch;
+    repo.findOne.mockResolvedValue(batch);
+
+    await runProcessBatch();
+
+    expect(engine.sendAudioMessage).toHaveBeenCalledWith(
+      'c0@c.us',
+      expect.objectContaining({ ptt: true, mimetype: 'audio/ogg; codecs=opus' }),
+    );
+    expect(messageService.saveOutgoingMessage).toHaveBeenCalledWith('s1', expect.objectContaining({ type: 'voice' }));
+  });
+
   it('strips base64 media payloads from the stored batch once it completes (footprint)', async () => {
     const batch = makeBatch(1);
     batch.messages = [

--- a/src/modules/message/bulk-message.service.ts
+++ b/src/modules/message/bulk-message.service.ts
@@ -24,7 +24,7 @@ interface BulkMessageContent {
   caption?: string;
   image?: { url?: string; base64?: string; mimetype?: string; filename?: string };
   video?: { url?: string; base64?: string; mimetype?: string; filename?: string };
-  audio?: { url?: string; base64?: string; mimetype?: string; filename?: string };
+  audio?: { url?: string; base64?: string; mimetype?: string; filename?: string; ptt?: boolean };
   document?: { url?: string; base64?: string; mimetype?: string; filename?: string };
 }
 
@@ -384,12 +384,14 @@ export class BulkMessageService implements OnApplicationBootstrap {
     result: MessageResult,
   ): Promise<void> {
     const media = content.image ?? content.video ?? content.audio ?? content.document;
+    // A bulk audio item flagged ptt is a voice note; store it in the 'voice' bucket like inbound PTT.
+    const persistType = type === 'audio' && content.audio?.ptt ? 'voice' : type;
     try {
       await this.messageService.saveOutgoingMessage(sessionId, {
         waMessageId: result.id,
         chatId,
         body: content.text ?? content.caption ?? '',
-        type,
+        type: persistType,
         timestamp: result.timestamp,
         status: MessageStatus.SENT,
         metadata: media
@@ -430,8 +432,9 @@ export class BulkMessageService implements OnApplicationBootstrap {
         });
       case 'audio':
         return engine.sendAudioMessage(chatId, {
-          mimetype: content.audio?.mimetype || 'audio/mpeg',
+          mimetype: content.audio?.mimetype || (content.audio?.ptt ? 'audio/ogg; codecs=opus' : 'audio/mpeg'),
           data: content.audio?.url || content.audio?.base64 || '',
+          ptt: content.audio?.ptt,
         });
       case 'document':
         return engine.sendDocumentMessage(chatId, {

--- a/src/modules/message/dto/bulk-message.dto.ts
+++ b/src/modules/message/dto/bulk-message.dto.ts
@@ -35,6 +35,11 @@ class BulkMediaDto {
   @IsOptional()
   @IsString()
   filename?: string;
+
+  @ApiPropertyOptional({ description: 'Audio only: send as a WhatsApp voice note (PTT)' })
+  @IsOptional()
+  @IsBoolean()
+  ptt?: boolean;
 }
 
 class BulkMessageContentDto {

--- a/src/modules/message/dto/send-message.dto.ts
+++ b/src/modules/message/dto/send-message.dto.ts
@@ -1,5 +1,15 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsString, IsNotEmpty, IsOptional, MaxLength, IsUrl, ValidateIf, IsArray, ArrayMaxSize } from 'class-validator';
+import {
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  MaxLength,
+  IsUrl,
+  ValidateIf,
+  IsArray,
+  ArrayMaxSize,
+  IsBoolean,
+} from 'class-validator';
 
 const MENTIONS_DESCRIPTION =
   'WIDs to @mention (e.g. ["62811@c.us"]). The text/caption must also contain the @<number> token.';
@@ -92,6 +102,18 @@ export class SendMediaMessageDto {
   @IsString({ each: true })
   @MaxLength(64, { each: true })
   mentions?: string[];
+}
+
+export class SendAudioMessageDto extends SendMediaMessageDto {
+  @ApiPropertyOptional({
+    description:
+      'Send as a WhatsApp voice note (PTT — mic bubble + waveform). Provide audio/ogg; codecs=opus ' +
+      'bytes for reliable playback; when the mimetype is omitted it defaults to that for voice notes. ' +
+      'Expects a JSON boolean. Default false = plain audio file. Only valid on send-audio.',
+  })
+  @IsOptional()
+  @IsBoolean()
+  ptt?: boolean;
 }
 
 export class MessageResponseDto {

--- a/src/modules/message/message.controller.ts
+++ b/src/modules/message/message.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Post, Get, Param, Body, Query, HttpCode, HttpStatus } from 
 import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiQuery } from '@nestjs/swagger';
 import { MessageService } from './message.service';
 import { BulkMessageService } from './bulk-message.service';
-import { SendTextMessageDto, SendMediaMessageDto, MessageResponseDto } from './dto';
+import { SendTextMessageDto, SendMediaMessageDto, SendAudioMessageDto, MessageResponseDto } from './dto';
 import { SendTemplateMessageDto } from './dto/send-template.dto';
 import { SendBulkMessageDto, BulkMessageResponseDto } from './dto/bulk-message.dto';
 import {
@@ -148,7 +148,7 @@ export class MessageController {
   })
   async sendAudio(
     @Param('sessionId') sessionId: string,
-    @Body() dto: SendMediaMessageDto,
+    @Body() dto: SendAudioMessageDto,
   ): Promise<MessageResponseDto> {
     return this.messageService.sendAudio(sessionId, dto);
   }

--- a/src/modules/message/message.service.spec.ts
+++ b/src/modules/message/message.service.spec.ts
@@ -531,6 +531,41 @@ describe('MessageService', () => {
       });
       expect(mockEngine.sendAudioMessage).toHaveBeenCalled();
     });
+
+    it('sends a voice note (ptt) and defaults the mimetype to ogg/opus when omitted', async () => {
+      await service.sendAudio('sess-1', {
+        chatId: 'test@c.us',
+        url: 'https://example.com/voice',
+        ptt: true,
+      });
+      expect(mockEngine.sendAudioMessage).toHaveBeenCalledWith(
+        'test@c.us',
+        expect.objectContaining({ ptt: true, mimetype: 'audio/ogg; codecs=opus' }),
+      );
+    });
+
+    it('respects a caller-supplied mimetype for a voice note', async () => {
+      await service.sendAudio('sess-1', {
+        chatId: 'test@c.us',
+        url: 'https://example.com/voice.ogg',
+        mimetype: 'audio/ogg',
+        ptt: true,
+      });
+      expect(mockEngine.sendAudioMessage).toHaveBeenCalledWith(
+        'test@c.us',
+        expect.objectContaining({ ptt: true, mimetype: 'audio/ogg' }),
+      );
+    });
+
+    it('persists a voice note as type "voice"', async () => {
+      await service.sendAudio('sess-1', { chatId: 'test@c.us', url: 'https://example.com/voice', ptt: true });
+      expect(repository.create).toHaveBeenCalledWith(expect.objectContaining({ type: 'voice' }));
+    });
+
+    it('persists a plain audio send (no ptt) as type "audio"', async () => {
+      await service.sendAudio('sess-1', { chatId: 'test@c.us', url: 'https://example.com/audio.ogg' });
+      expect(repository.create).toHaveBeenCalledWith(expect.objectContaining({ type: 'audio' }));
+    });
   });
 
   describe('sendDocument', () => {

--- a/src/modules/message/message.service.ts
+++ b/src/modules/message/message.service.ts
@@ -2,7 +2,7 @@ import { Injectable, BadRequestException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { SessionService } from '../session/session.service';
-import { SendTextMessageDto, SendMediaMessageDto, MessageResponseDto } from './dto';
+import { SendTextMessageDto, SendMediaMessageDto, SendAudioMessageDto, MessageResponseDto } from './dto';
 import { SendTemplateMessageDto } from './dto/send-template.dto';
 import { assertBase64WithinMediaCap } from './media-cap.util';
 import { MediaInput, IWhatsAppEngine, MessageResult } from '../../engine/interfaces/whatsapp-engine.interface';
@@ -158,16 +158,22 @@ export class MessageService {
     return this.persistSentState(message, result);
   }
 
-  async sendAudio(sessionId: string, dto: SendMediaMessageDto): Promise<MessageResponseDto> {
+  async sendAudio(sessionId: string, dto: SendAudioMessageDto): Promise<MessageResponseDto> {
     const engine = this.getEngine(sessionId);
-    const media = this.buildMediaInput(dto);
+    // Voice notes need a real audio codec; default to ogg/opus when the caller omits a mimetype so the
+    // wire message and the persisted record agree. Resolved BEFORE buildMediaInput so its base64
+    // mimetype guard sees the effective type. buildMediaInput itself stays generic (shared by all media).
+    const audioDto = dto.ptt && !dto.mimetype ? { ...dto, mimetype: 'audio/ogg; codecs=opus' } : dto;
+    const media = this.buildMediaInput(audioDto);
+    media.ptt = dto.ptt;
 
-    // Save message as pending BEFORE sending
+    // Save message as pending BEFORE sending. A PTT send is a 'voice' note (matches inbound
+    // classification, the outbound webhook echo, stats, and the dashboard), not a plain 'audio' file.
     const message = await this.saveOutgoingMessage(sessionId, {
       chatId: dto.chatId,
-      type: 'audio',
+      type: dto.ptt ? 'voice' : 'audio',
       metadata: {
-        media: { mimetype: dto.mimetype, filename: dto.filename, data: dto.base64 || dto.url },
+        media: { mimetype: audioDto.mimetype, filename: dto.filename, data: dto.base64 || dto.url },
       },
     });
 


### PR DESCRIPTION
## Summary

`POST /messages/send-audio` previously only ever sent a **plain audio file** — never a true WhatsApp voice note (the microphone bubble with a waveform). Both underlying engines are capable of it (Baileys via `ptt`, whatsapp-web.js via `sendAudioAsVoice`), but the flag was never wired through the gateway. This PR adds an opt-in `ptt` boolean so callers can send a real voice note, across every audio send path, on both engines. It fulfils the long-standing **FR-MSG-004** requirement ("send audio/voice notes").

Origin: a request to send voice messages through the API (OpenWA-n8n #13).

## What changed

- **`send-audio` endpoint** — new optional `ptt` boolean on a dedicated `SendAudioMessageDto` (extends the shared media DTO, so the flag is validated only where it is meaningful; the other media endpoints are untouched).
- **Both engine adapters** — Baileys now sends `ptt: media.ptt ?? false`; whatsapp-web.js passes `sendAudioAsVoice: true` only when `ptt` is set (image/video/document sends are byte-identical).
- **Effective mimetype** — a WhatsApp voice note needs `audio/ogg; codecs=opus`. When `ptt` is set and the caller omits a mimetype, the server defaults to that; a caller-supplied mimetype is always respected. The default is resolved before media validation so base64 voice notes without an explicit mimetype are accepted rather than rejected.
- **Message type** — an outbound voice note is now persisted as `type: "voice"` (not `"audio"`), matching how inbound voice notes are already classified and how the outbound `message.sent` webhook/WS event already reports them, so stored history, stats, the dashboard, and webhooks stay consistent for the same send.
- **Bulk send** and the **`MessageSendAudio` MCP agent tool** gained the same `ptt` flag.
- **SDKs & docs** — `ptt` added to the JavaScript and Python request types (PHP passes an untyped body), documented in the REST API spec, the API collection, and the three SDK READMEs. CHANGELOG updated under `[Unreleased]`.

## Behaviour & compatibility

- Fully backward compatible: `ptt` is optional and defaults to off. Without it, `send-audio` behaves exactly as before (a plain audio file, persisted as `type: "audio"`).
- No transcoding is performed. whatsapp-web.js re-encodes to a voice note itself; Baileys only sets the protocol flag, so for reliable playback provide `audio/ogg; codecs=opus` audio — this is documented.
- Sending `ptt` to a non-audio media endpoint returns `400` (the field is exclusive to `send-audio`).
- Non-breaking feature → patch bump per the project's SemVer-0.x policy; staged under `[Unreleased]`.

## Testing

- New unit tests: Baileys `ptt:true` voice note; whatsapp-web.js `sendAudioAsVoice` present-with-`ptt` / absent-without; service-level ogg/opus default, caller-mimetype respected, and `type: "voice"` vs `"audio"` persistence; bulk audio voice note.
- The pre-existing Baileys "sets ptt:false" test is unchanged and still passes (no-`ptt` path is identical).
- Full backend suite green (1690 tests), lint and build clean, dashboard build and lint clean.

## Example

```json
POST /api/sessions/:sessionId/messages/send-audio
{ "chatId": "628123456789@c.us", "url": "https://example.com/voice.ogg", "mimetype": "audio/ogg", "ptt": true }
```
