### PR TITLE
fix(baileys): keep Contact.jid phone fallback type-safe across engine versions

### DIFF
--- a/src/engine/adapters/baileys-session-store.ts
+++ b/src/engine/adapters/baileys-session-store.ts
@@ -7,8 +7,14 @@ import type { LidMappingStore } from '../identity/lid-mapping-store.service';
  * Baileys `Contact` does not include a `phoneNumber` field, but WhatsApp Business events may supply
  * the resolved phone JID alongside the lid-based id. We extend the input type locally so callers can
  * pass `phoneNumber` when available (e.g. from `contacts.upsert` payloads that carry lid+pn pairs).
+ *
+ * `jid` is declared locally as well: it carries the contact's phone `@s.whatsapp.net` on
+ * `@whiskeysockets/baileys` 6.7.x, but the field was dropped from `Contact` in 6.17.x. Declaring it
+ * here (optional) keeps the `merged.jid` phone fallback type-safe across both engine versions — the
+ * value is read at runtime on 6.7.x and is simply `undefined` (harmlessly skipped) on newer Baileys,
+ * instead of becoming an `error`-typed access that trips the type-aware `no-unsafe-*` lint rules.
  */
-type BaileysContactWithPhone = BaileysContact & { phoneNumber?: string };
+type BaileysContactWithPhone = BaileysContact & { phoneNumber?: string; jid?: string };
 
 interface LastMessage {
   key: WAMessageKey;


### PR DESCRIPTION
## What

`src/engine/adapters/baileys-session-store.ts` reads `merged.jid` as a phone-JID fallback when learning `lid -> phone` pairs from `contacts.upsert`:

```ts
// The phone is `jid` on a Baileys Contact (`@s.whatsapp.net`); `phoneNumber` only appears on the
// WhatsApp Business event shape we extend in locally.
const phone = merged.phoneNumber ?? merged.jid;
if (merged.lid && phone) {
  this.lidToPn.set(merged.lid, phone);
  this.persistLidMapping(merged.lid, phone);
}
```

`jid` is a field on `@whiskeysockets/baileys`'s `Contact` in **6.7.x**, but it was **removed in 6.17.x** (`Contact` is now `id`, `lid?`, `name?`, `notify?`, `verifiedName?`, `imgUrl?`, `status?`). Under a newer engine, `merged.jid` becomes an `error`-typed property access, which trips the type-aware ESLint rules:

```
src/engine/adapters/baileys-session-store.ts
  60:13  error    Unsafe assignment of an error typed value                                     @typescript-eslint/no-unsafe-assignment
  62:38  warning  Unsafe argument of type error typed assigned to a parameter of type `string`  @typescript-eslint/no-unsafe-argument
  63:44  warning  Unsafe argument of type error typed assigned to a parameter of type `string`  @typescript-eslint/no-unsafe-argument
```

Nothing is broken on the pinned `6.7.23` today — this is a **forward-compatibility / defensive-typing** change so the engine adapter survives the next Baileys bump.

## Fix

Declare `jid?: string` on the local `BaileysContactWithPhone` extension (which already adds `phoneNumber?`), so `merged.jid` is typed `string | undefined` regardless of whether the installed `Contact` declares it:

```ts
type BaileysContactWithPhone = BaileysContact & { phoneNumber?: string; jid?: string };
```

- **6.7.x** — `jid` is present at runtime and read exactly as before: no behavior change.
- **6.17+** — `jid` is absent, so the value is `undefined` and the fallback is harmlessly skipped; the access is type-safe instead of `error`-typed.

One-line type change plus a comment explaining why `jid` is declared locally.

## Verification

Same source file, only the Baileys version swapped in `node_modules`:

| Baileys | `eslint src/engine/adapters/baileys-session-store.ts` |
|---------|-------------------------------------------------------|
| `6.7.23` (pinned) | clean — before and after this change |
| `6.17.16` | **before:** 1 error + 2 warnings · **after:** clean |

Reproduce:
```bash
npm i --no-save @whiskeysockets/baileys@6.17.16
npx eslint src/engine/adapters/baileys-session-store.ts
npm i --no-save @whiskeysockets/baileys@6.7.23   # restore the pin
```

## Out of scope (heads-up)

`src/engine/adapters/baileys-group-mapper.spec.ts:5` (the `as GroupMetadata` cast in the test helper) also starts failing `@typescript-eslint/no-unnecessary-type-assertion` under 6.17.x, because `GroupMetadata`'s shape changed. It is **intentionally left untouched here**: the assertion is still required on the pinned 6.7.x (removing it regresses the current version), so it's best resolved if/when the engine is actually bumped. Flagging it so it's on the radar.
