### PR TITLE
fix(engine): recover text from Baileys inbound interactive messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Incoming WhatsApp Business interactive messages no longer arrive with an empty body on the Baileys engine.** Messages sent as interactive/button/template shapes — which businesses use for one-time codes and verification prompts — were saved with `type: "unknown"` and a blank body, dropping the text (e.g. an OTP) entirely. The engine now extracts the display text from `interactiveMessage`, `buttonsMessage`, `templateMessage`, and `interactiveResponseMessage` into the message body and classifies them as `text`, so the content is retrievable over the standard messages API and rendered in the dashboard. (#562)
+
 ## [0.7.17] - 2026-07-01
 
 ### Added

--- a/src/engine/adapters/baileys-message-mapper.spec.ts
+++ b/src/engine/adapters/baileys-message-mapper.spec.ts
@@ -1,6 +1,7 @@
 import {
   BaileysIncomingFields,
   buildIncomingMessageFromBaileys,
+  extractBaileysBody,
   mapBaileysMessageType,
   mapBaileysStatus,
 } from './baileys-message-mapper';
@@ -17,6 +18,12 @@ describe('mapBaileysMessageType (baileys content-type -> neutral MessageType)', 
     ['stickerMessage', false, 'sticker'],
     ['locationMessage', false, 'location'],
     ['contactMessage', false, 'contact'],
+    // WhatsApp Business interactive shapes carry their display text (e.g. OTP codes) and are flattened
+    // to `text` so consumers render them and read the body over the standard API (#562).
+    ['interactiveMessage', false, 'text'],
+    ['buttonsMessage', false, 'text'],
+    ['templateMessage', false, 'text'],
+    ['interactiveResponseMessage', false, 'text'],
     [undefined, false, 'unknown'],
     ['pollCreationMessage', false, 'unknown'],
     // Regression trap: calls arrive via the `call` socket event, never as a message content type,
@@ -43,6 +50,62 @@ describe('mapBaileysStatus (proto WAMessageStatus -> neutral DeliveryStatus)', (
   it('returns null for an unknown/absent status so the adapter skips the ack', () => {
     expect(mapBaileysStatus(undefined)).toBeNull();
     expect(mapBaileysStatus(99)).toBeNull();
+  });
+});
+
+describe('extractBaileysBody (inbound text/caption + interactive shapes)', () => {
+  it('returns plain conversation text', () => {
+    expect(extractBaileysBody({ conversation: 'hi' })).toBe('hi');
+  });
+
+  it('falls back to extendedTextMessage text', () => {
+    expect(extractBaileysBody({ extendedTextMessage: { text: 'hey' } })).toBe('hey');
+  });
+
+  it('falls back to a media caption', () => {
+    expect(extractBaileysBody({ imageMessage: { caption: 'pic' } })).toBe('pic');
+    expect(extractBaileysBody({ videoMessage: { caption: 'clip' } })).toBe('clip');
+    expect(extractBaileysBody({ documentMessage: { caption: 'doc' } })).toBe('doc');
+  });
+
+  // #562: business interactive messages (OTP/verification codes) were dropped as empty body.
+  it('extracts interactiveMessage body text', () => {
+    expect(extractBaileysBody({ interactiveMessage: { body: { text: 'Your code is 123456' } } })).toBe(
+      'Your code is 123456',
+    );
+  });
+
+  it('extracts buttonsMessage contentText', () => {
+    expect(extractBaileysBody({ buttonsMessage: { contentText: 'Verification: 987654' } })).toBe(
+      'Verification: 987654',
+    );
+  });
+
+  it('extracts templateMessage hydrated content text (both field aliases)', () => {
+    expect(extractBaileysBody({ templateMessage: { hydratedTemplate: { hydratedContentText: 'OTP 4242' } } })).toBe(
+      'OTP 4242',
+    );
+    expect(
+      extractBaileysBody({ templateMessage: { hydratedFourRowTemplate: { hydratedContentText: 'OTP 1111' } } }),
+    ).toBe('OTP 1111');
+  });
+
+  it('extracts interactiveResponseMessage body text', () => {
+    expect(extractBaileysBody({ interactiveResponseMessage: { body: { text: 'Selected: Yes' } } })).toBe(
+      'Selected: Yes',
+    );
+  });
+
+  it('prefers plain text over an interactive fallback when both are present', () => {
+    expect(extractBaileysBody({ conversation: 'plain', interactiveMessage: { body: { text: 'ignored' } } })).toBe(
+      'plain',
+    );
+  });
+
+  it('returns empty string when no extractable text is present', () => {
+    expect(extractBaileysBody({})).toBe('');
+    expect(extractBaileysBody({ interactiveMessage: {} })).toBe('');
+    expect(extractBaileysBody({ templateMessage: {} })).toBe('');
   });
 });
 

--- a/src/engine/adapters/baileys-message-mapper.ts
+++ b/src/engine/adapters/baileys-message-mapper.ts
@@ -32,9 +32,60 @@ export function mapBaileysMessageType(contentType: string | undefined, isPtt = f
     case 'contactMessage':
     case 'contactsArrayMessage':
       return 'contact';
+    case 'interactiveMessage':
+    case 'buttonsMessage':
+    case 'templateMessage':
+    case 'interactiveResponseMessage':
+      // WhatsApp Business interactive shapes (OTP/verification codes, button/template prompts). They
+      // carry display text that {@link extractBaileysBody} flattens into `body`, so they surface as
+      // `text` instead of being dropped as `unknown` with an empty body (#562).
+      return 'text';
     default:
       return 'unknown';
   }
+}
+
+/**
+ * The inbound message-content subset the body extractor reads. Declared structurally (not
+ * `proto.IMessage`) so body extraction is unit-testable with plain objects and stays decoupled from
+ * the Baileys proto shape — mirroring the rationale for {@link BaileysIncomingFields}.
+ */
+export interface BaileysBodyContent {
+  conversation?: string | null;
+  extendedTextMessage?: { text?: string | null } | null;
+  imageMessage?: { caption?: string | null } | null;
+  videoMessage?: { caption?: string | null } | null;
+  documentMessage?: { caption?: string | null } | null;
+  interactiveMessage?: { body?: { text?: string | null } | null } | null;
+  buttonsMessage?: { contentText?: string | null } | null;
+  templateMessage?: {
+    hydratedTemplate?: { hydratedContentText?: string | null } | null;
+    hydratedFourRowTemplate?: { hydratedContentText?: string | null } | null;
+  } | null;
+  interactiveResponseMessage?: { body?: { text?: string | null } | null } | null;
+}
+
+/**
+ * Extract the display text of an inbound Baileys message: plain text first, then a media caption,
+ * then the WhatsApp Business interactive shapes (interactive / buttons / template / interactive-
+ * response) whose text was previously dropped — the OTP/verification text businesses send via these
+ * shapes (#562). Returns `''` when the message carries no extractable text. Pass the NORMALIZED
+ * content (ephemeral/viewOnce/documentWithCaption wrappers already unwrapped), as the adapter does.
+ */
+export function extractBaileysBody(content: BaileysBodyContent): string {
+  return (
+    content.conversation ??
+    content.extendedTextMessage?.text ??
+    content.imageMessage?.caption ??
+    content.videoMessage?.caption ??
+    content.documentMessage?.caption ??
+    content.interactiveMessage?.body?.text ??
+    content.buttonsMessage?.contentText ??
+    content.templateMessage?.hydratedTemplate?.hydratedContentText ??
+    content.templateMessage?.hydratedFourRowTemplate?.hydratedContentText ??
+    content.interactiveResponseMessage?.body?.text ??
+    ''
+  );
 }
 
 /**

--- a/src/engine/adapters/baileys.adapter.ts
+++ b/src/engine/adapters/baileys.adapter.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as qrcode from 'qrcode';
 import type * as BaileysLib from '@whiskeysockets/baileys';
 import type { AnyMessageContent, MiscMessageGenerationOptions, WAMessage, WASocket } from '@whiskeysockets/baileys';
-import { buildIncomingMessageFromBaileys, mapBaileysStatus } from './baileys-message-mapper';
+import { buildIncomingMessageFromBaileys, extractBaileysBody, mapBaileysStatus } from './baileys-message-mapper';
 import { mapBaileysGroup, mapBaileysGroupInfo } from './baileys-group-mapper';
 import type { ILogger } from '@whiskeysockets/baileys/lib/Utils/logger.js';
 import {
@@ -1056,14 +1056,8 @@ export class BaileysAdapter implements IWhatsAppEngine {
     // an inner message, so the raw wrapper exposes none at top level. Identity no-op when unwrapped.
     const normalized = b.normalizeMessageContent(content) ?? content;
 
-    // Body: text first, then media caption as fallback.
-    const body =
-      normalized.conversation ??
-      normalized.extendedTextMessage?.text ??
-      normalized.imageMessage?.caption ??
-      normalized.videoMessage?.caption ??
-      normalized.documentMessage?.caption ??
-      '';
+    // Body: text first, then media caption, then WhatsApp Business interactive shapes (#562).
+    const body = extractBaileysBody(normalized);
 
     // --- location ---
     // ILocationMessage has name/address; ILiveLocationMessage does not — use the static variant only.


### PR DESCRIPTION
## Summary

On the Baileys engine, incoming WhatsApp Business **interactive** messages — the interactive/button/template shapes businesses use for one-time codes and verification prompts — were persisted with `type: "unknown"` and an **empty body**, losing the message text entirely.

The Baileys inbound body extraction only handled plain text (`conversation`, `extendedTextMessage`) and media captions. Any other shape fell through to an empty string, and the type mapper returned `unknown`, so the content was never stored or exposed over the API.

## Changes

- Extract display text from `interactiveMessage`, `buttonsMessage`, `templateMessage`, and `interactiveResponseMessage` into the message `body`, using the exact Baileys proto fields (`body.text`, `contentText`, `hydratedTemplate.hydratedContentText` and its `hydratedFourRowTemplate` alias).
- Classify these shapes as `text` instead of `unknown`, so they render in the dashboard and read back over `GET /sessions/:id/messages` like any other message.
- Factor body extraction out of the adapter into a pure `extractBaileysBody` helper in the message mapper, following the module's existing structural-typing pattern so the logic is unit-testable without constructing a full proto message.

Behavior for all previously-handled message types is unchanged — the existing fallback order (text → caption) is preserved, with the interactive shapes appended.

## Impact

Recovers the visible text of business interactive messages (e.g. OTP codes), which was silently dropped. Non-breaking, Baileys engine only.

## Tests

- 13 new unit tests covering the interactive type mappings and the body extractor (each interactive shape, caption fallbacks, plain-text precedence, and empty-content cases).
- Full backend suite green (1703 tests), build and lint clean.

Fixes #562.