### PR TITLE
fix(engine): forward the original deleted message id as `revokedId` on message.revoked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Deleting a message "for everyone" now reliably flags it as revoked, and `message.revoked` carries the original message id.** On the whatsapp-web.js engine the revoke event's `id` is the _revocation notification_ — a distinct message whose id never matched the stored row — so the stored message was silently never marked revoked, and webhook/WebSocket consumers had no id to reconcile against. The `message.revoked` payload now includes an optional `revokedId` (the original deleted message's id) that both engines populate; OpenWA flags the stored message on `revokedId` (falling back to `id`), and consumers should match the same way. Purely additive and backward-compatible — on Baileys `id` and `revokedId` coincide. (#567) Thanks @JibayMcs.
+
 ## [0.7.17] - 2026-07-01
 
 ### Added

--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -4519,7 +4519,7 @@ These are the events OpenWA actually emits. A webhook is registered with an `eve
 | `message.sent` | An outbound message is created/sent from this session | Same message object shape as `message.received` |
 | `message.ack` | A delivery/read receipt updates an outbound message | `{ id, messageId, status, ack }` — `status` is the canonical state (`pending`/`sent`/`delivered`/`read`/`failed`); `ack` is the deprecated legacy integer derived from it |
 | `message.failed` | A receipt resolves to `failed` (dispatched in addition to `message.ack`) | `{ id, messageId, status: "failed", ack: -1 }` |
-| `message.revoked` | A message is deleted/recalled | The engine's revoked-message object (e.g. `{ id, … }`) |
+| `message.revoked` | A message is deleted/recalled | `{ id, revokedId?, chatId, from, to, type: "revoked", body: "", timestamp }` — **reconcile on `revokedId`** (the original deleted message's id), falling back to `id`. On whatsapp-web.js `id` is the *revocation notification* (a distinct message that won't match a stored id) and `revokedId` may be absent when the original isn't cached locally; on Baileys the two coincide |
 | `message.reaction` | A reaction is added, changed, or removed | `{ messageId, chatId, reaction, senderId, reactions }` — `reactions` is the post-apply `{ senderId: emoji }` snapshot; `reaction` is empty when removed |
 | `session.qr` | A new pairing QR is generated | `{ sessionId, qr }` (raw QR string) |
 | `session.authenticated` | The session pairs and becomes ready | `{ sessionId, phone, pushName }` |

--- a/src/engine/adapters/baileys.adapter.spec.ts
+++ b/src/engine/adapters/baileys.adapter.spec.ts
@@ -1238,11 +1238,14 @@ describe('BaileysAdapter inbound fan-out', () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     const revoked = onMessageRevoked.mock.calls[0][0] as {
       id: string;
+      revokedId?: string;
       chatId: string;
       type: string;
       body: string;
     };
     expect(revoked.id).toBe('ORIGINAL_ID');
+    // The REVOKE protocolMessage key IS the original, so revokedId mirrors id here.
+    expect(revoked.revokedId).toBe('ORIGINAL_ID');
     expect(revoked.chatId).toBe('628111@c.us'); // canonicalized to the neutral dialect
     expect(revoked.type).toBe('revoked');
     expect(revoked.body).toBe('');

--- a/src/engine/adapters/baileys.adapter.ts
+++ b/src/engine/adapters/baileys.adapter.ts
@@ -947,6 +947,10 @@ export class BaileysAdapter implements IWhatsAppEngine {
           const to = msg.key.fromMe === true ? remoteJid : this.normalizedSelfJid();
           const revoked: RevokedMessage = {
             id: pm.key?.id ?? '',
+            // The REVOKE protocolMessage's key points at the ORIGINAL deleted message,
+            // so `id` already IS the original here. Mirror it into `revokedId` so that
+            // field is the reliable cross-engine handle (wwebjs sets it separately).
+            revokedId: pm.key?.id ?? undefined,
             chatId: this.sessionStore.toNeutralJid(remoteJid),
             from: this.sessionStore.toNeutralJid(from),
             to: this.sessionStore.toNeutralJid(to),

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -1122,6 +1122,67 @@ describe('WhatsAppWebJsAdapter inbound media (MEDIA_DOWNLOAD_ENABLED=false)', ()
   });
 });
 
+describe('WhatsAppWebJsAdapter message_revoke_everyone (forwards the original deleted id as revokedId)', () => {
+  const wireRevokeHandler = (): { onMessageRevoked: jest.Mock; client: EventEmitter } => {
+    const adapter = new WhatsAppWebJsAdapter({
+      sessionId: 'sess-revoke-test',
+      sessionDataPath: './data/sessions',
+      puppeteer: {},
+    });
+    const client = Object.assign(new EventEmitter(), {
+      info: { wid: { _serialized: 'me@c.us', user: '628123' }, pushname: 'Tester' },
+      getState: jest.fn().mockResolvedValue(WAState.CONNECTED),
+      pupPage: { evaluate: jest.fn().mockResolvedValue(true) },
+    });
+    (adapter as unknown as { client: unknown }).client = client;
+    const onMessageRevoked = jest.fn();
+    (adapter as unknown as { callbacks: unknown }).callbacks = { onMessageRevoked };
+    (adapter as unknown as { setupEventHandlers: () => void }).setupEventHandlers();
+    return { onMessageRevoked, client };
+  };
+
+  it('emits revokedId from `before` (the original) distinct from `id` (the revocation notification)', () => {
+    const { onMessageRevoked, client } = wireRevokeHandler();
+
+    client.emit(
+      'message_revoke_everyone',
+      { id: { _serialized: 'REVOKE_NOTIF' }, from: 'peer@c.us', to: 'me@c.us', timestamp: 1700000070 },
+      { id: { _serialized: 'ORIGINAL_MSG' } },
+    );
+
+    expect(onMessageRevoked).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const revoked = onMessageRevoked.mock.calls[0][0] as {
+      id: string;
+      revokedId?: string;
+      chatId: string;
+      type: string;
+      body: string;
+    };
+    expect(revoked.id).toBe('REVOKE_NOTIF');
+    expect(revoked.revokedId).toBe('ORIGINAL_MSG');
+    expect(revoked.chatId).toBe('peer@c.us'); // incoming: chatId is the peer, not self
+    expect(revoked.type).toBe('revoked');
+    expect(revoked.body).toBe('');
+  });
+
+  it('leaves revokedId undefined when whatsapp-web.js has no `before` (original not in local store)', () => {
+    const { onMessageRevoked, client } = wireRevokeHandler();
+
+    client.emit(
+      'message_revoke_everyone',
+      { id: { _serialized: 'REVOKE_NOTIF_2' }, from: 'peer@c.us', to: 'me@c.us', timestamp: 1700000071 },
+      undefined,
+    );
+
+    expect(onMessageRevoked).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const revoked = onMessageRevoked.mock.calls[0][0] as { id: string; revokedId?: string };
+    expect(revoked.id).toBe('REVOKE_NOTIF_2');
+    expect(revoked.revokedId).toBeUndefined();
+  });
+});
+
 describe('outbound mentions (#530)', () => {
   const ready = (client: unknown): WhatsAppWebJsAdapter => {
     const adapter = new WhatsAppWebJsAdapter({ sessionId: 's', sessionDataPath: './data/sessions', puppeteer: {} });

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -493,13 +493,19 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
       this.callbacks.onMessageAck?.(msg.id._serialized, wwebjsAckToDeliveryStatus(ack));
     });
 
-    this.client.on('message_revoke_everyone', after => {
+    this.client.on('message_revoke_everyone', (after, before) => {
       try {
         const selfWid = this.client?.info?.wid?._serialized;
         // Emit structured data only; the engine layer never produces a localized
         // display string. The dashboard renders the localized "message deleted" text.
+        //
+        // `after` is the revocation notification (its own id); `before` is the
+        // ORIGINAL deleted message (when whatsapp-web.js has it in the local store).
+        // We forward `before.id` as `revokedId` so consumers can reconcile the
+        // deleted message in their own storage.
         const payload: RevokedMessage = {
           id: after.id._serialized,
+          revokedId: before?.id?._serialized,
           chatId: after.from === selfWid ? after.to : after.from,
           from: after.from,
           to: after.to,

--- a/src/engine/interfaces/whatsapp-engine.interface.ts
+++ b/src/engine/interfaces/whatsapp-engine.interface.ts
@@ -347,10 +347,17 @@ export type DeliveryStatus = 'pending' | 'sent' | 'delivered' | 'read' | 'failed
 export interface RevokedMessage {
   id: string;
   /**
-   * Serialized id of the ORIGINAL message that was deleted (when available in the
-   * local store). `id` above is the id of the revocation notification, which is a
-   * different message; consumers that want to reconcile the deleted message in
-   * their own storage should match on `revokedId`.
+   * Serialized id of the ORIGINAL message that was deleted (when available).
+   *
+   * This is the reliable cross-engine field for reconciling the deleted message in
+   * your own storage — both adapters populate it with the original message id:
+   *  - whatsapp-web.js: `id` is the revocation NOTIFICATION (a distinct message), so
+   *    `id !== revokedId`. `revokedId` may be undefined when the original is not in
+   *    the local store.
+   *  - Baileys: the revoke arrives as a protocolMessage whose key already points at
+   *    the original, so `id === revokedId`.
+   *
+   * Consumers should match on `revokedId` (falling back to `id`) rather than `id`.
    */
   revokedId?: string;
   chatId: string;

--- a/src/engine/interfaces/whatsapp-engine.interface.ts
+++ b/src/engine/interfaces/whatsapp-engine.interface.ts
@@ -346,6 +346,13 @@ export type DeliveryStatus = 'pending' | 'sent' | 'delivered' | 'read' | 'failed
  */
 export interface RevokedMessage {
   id: string;
+  /**
+   * Serialized id of the ORIGINAL message that was deleted (when available in the
+   * local store). `id` above is the id of the revocation notification, which is a
+   * different message; consumers that want to reconcile the deleted message in
+   * their own storage should match on `revokedId`.
+   */
+  revokedId?: string;
   chatId: string;
   from: string;
   to: string;

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -1410,6 +1410,17 @@ describe('SessionService', () => {
         { sessionId: 'sess-uuid-1', waMessageId: 'ORIGINAL_MSG' },
         { body: '', type: 'revoked' },
       );
+
+      // The DB flag is an internal side effect; the delivered payload is the public contract
+      // this fix exists for. Webhook and WS consumers must receive `revokedId` (the original),
+      // not just the revocation-notification `id`, so they can reconcile the deleted message.
+      expect(dispatchedEvents('message.revoked')[0][2]).toEqual(
+        expect.objectContaining({ id: 'REVOKE_NOTIF', revokedId: 'ORIGINAL_MSG' }),
+      );
+      expect(eventsGateway.emitMessageRevoked as jest.Mock).toHaveBeenCalledWith(
+        'sess-uuid-1',
+        expect.objectContaining({ id: 'REVOKE_NOTIF', revokedId: 'ORIGINAL_MSG' }),
+      );
     });
 
     it('falls back to `id` for the DB flag when revokedId is absent (Baileys shape)', async () => {

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -1390,6 +1390,48 @@ describe('SessionService', () => {
       expect(eventsGateway.emitMessageRevoked as jest.Mock).toHaveBeenCalledWith('sess-uuid-1', expect.anything());
     });
 
+    it('flags the DB row by revokedId (the original), not the revocation notification id', async () => {
+      const callbacks = await startAndCaptureCallbacks();
+
+      // wwebjs shape: `id` is the revocation notification, `revokedId` the original message.
+      callbacks.onMessageRevoked!({
+        id: 'REVOKE_NOTIF',
+        revokedId: 'ORIGINAL_MSG',
+        chatId: 'peer@c.us',
+        from: 'peer@c.us',
+        to: 'me@c.us',
+        type: 'revoked',
+        body: '',
+        timestamp: 1706868000,
+      });
+      await flush();
+
+      expect(messageRepository.update as jest.Mock).toHaveBeenCalledWith(
+        { sessionId: 'sess-uuid-1', waMessageId: 'ORIGINAL_MSG' },
+        { body: '', type: 'revoked' },
+      );
+    });
+
+    it('falls back to `id` for the DB flag when revokedId is absent (Baileys shape)', async () => {
+      const callbacks = await startAndCaptureCallbacks();
+
+      callbacks.onMessageRevoked!({
+        id: 'ORIGINAL_MSG',
+        chatId: 'peer@c.us',
+        from: 'peer@c.us',
+        to: 'me@c.us',
+        type: 'revoked',
+        body: '',
+        timestamp: 1706868000,
+      });
+      await flush();
+
+      expect(messageRepository.update as jest.Mock).toHaveBeenCalledWith(
+        { sessionId: 'sess-uuid-1', waMessageId: 'ORIGINAL_MSG' },
+        { body: '', type: 'revoked' },
+      );
+    });
+
     // ── session lifecycle events ──────────────────────────────────────
 
     it('dispatches session.qr with the QR payload when the engine emits a QR code', async () => {

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -891,10 +891,15 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
         // Flag the stored message as revoked (best-effort; the message may not be in the
         // DB). The dashboard renders the localized "message deleted" text, so no display
         // string is persisted here.
+        //
+        // Match on `revokedId` (the ORIGINAL deleted message's id) when present: on wwebjs
+        // `message.id` is the revocation notification, which never matches a stored row.
+        // `revokedId` falls back to `id` (Baileys, where the two are the same).
+        const revokedWaMessageId = message.revokedId ?? message.id;
         void this.messageRepository
-          .update({ sessionId: id, waMessageId: message.id }, { body: '', type: 'revoked' })
+          .update({ sessionId: id, waMessageId: revokedWaMessageId }, { body: '', type: 'revoked' })
           .catch(err => {
-            this.logger.error(`Failed to update revoked message: ${message.id}`, String(err));
+            this.logger.error(`Failed to update revoked message: ${revokedWaMessageId}`, String(err));
           });
 
         // Notify consumers regardless of whether the row existed: webhook (message.revoked


### PR DESCRIPTION
## Problem

**Use case.** I use OpenWA to back a two-way synced WhatsApp inbox: messages are
persisted on my side (keyed by their WhatsApp id) and rendered in a conversation UI.
When a user deletes a message *for everyone* from their phone, I need that deletion to
propagate to the stored conversation — i.e. flag the corresponding row as revoked and
update the UI. The `message.revoked` webhook is exactly the signal for that... except it
doesn't carry the id of the message that was deleted, so there's nothing to match against.

Digging in, the root cause is on the **whatsapp-web.js** engine. whatsapp-web.js emits
`message_revoke_everyone(after, before)` where:

- `after` is the **revocation notification** — a *new, distinct* message whose id has
  nothing to do with the deleted one;
- `before` is the **original deleted message** (present whenever it's in the local store).

The current handler only reads `after` and emits `id: after.id._serialized`. That id
never matches any stored row, so:

1. **OpenWA's own reconciliation is a silent no-op.** In `SessionService`, the revoke
   handler runs `messageRepository.update({ waMessageId: message.id }, { type: 'revoked' })`.
   Because `message.id` is the notification id, it matches zero rows — the stored message
   is never flagged as revoked on wwebjs.
2. **Webhook consumers can't reconcile either.** Anyone building an inbox on top of
   `message.revoked` (like the case above) receives an id they can't map back to the
   message they stored, so the deletion can't be reflected.

Baileys is not affected the same way (its revoke arrives as a `protocolMessage` whose key
already points at the original), but the payload shape was inconsistent between the two
engines, so there was no reliable cross-engine field to match on.

## Fix

Add an optional `revokedId` to `RevokedMessage`: the serialized id of the **original**
deleted message. Both adapters populate it, so consumers have one reliable field.

- **whatsapp-web.js adapter** — capture the second callback arg and set
  `revokedId: before?.id?._serialized` (undefined when the original isn't in the local
  store). `id` still carries the revocation notification, unchanged.
- **Baileys adapter** — mirror the original into `revokedId` (`id === revokedId` there),
  so the field is always present and consistent across engines.
- **SessionService** — reconcile the stored message on `revokedId ?? id`, so the
  original is matched on wwebjs while Baileys behaviour is preserved.

Guidance for consumers (documented on the interface): **match on `revokedId`, falling
back to `id`.**

## Backwards compatibility

- `revokedId` is optional and purely additive; `id`, `chatId`, `from`, `to`, `type`,
  `body`, `timestamp` are unchanged.
- Existing consumers keep working; those that want reliable reconciliation switch to
  `revokedId ?? id`.

## Tests

- **whatsapp-web.js adapter**: `revokedId` is taken from `before` and is distinct from
  `id`; `revokedId` is `undefined` when whatsapp-web.js provides no `before`.
- **Baileys adapter**: `revokedId` mirrors the original id (`id === revokedId`).
- **SessionService**: the repository update targets `revokedId` when present and falls
  back to `id`.

## Notes

Branch is cut from the `v0.7.17` tag; the affected handler and interface are byte-identical
on `main`, so it applies cleanly.
It works like a charm on my docker instance :partying_face: 

Thanks for your work on this amazing tool !