### PR TITLE
fix(engine): resolve LID for individual whatsapp-web.js sends (#573)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Sending to a contact WhatsApp has migrated to LID addressing no longer fails with HTTP 500 on the whatsapp-web.js engine.** WhatsApp has begun addressing some individual chats by privacy id (`@lid`) instead of the phone-number WID (`@c.us`); for those contacts whatsapp-web.js rejected the send with `No LID for user`, which surfaced as a 500 (and as a passed-through 500 in integrations such as n8n). Pinning the WhatsApp Web version did not help because this is an addressing change, not version drift. The engine now resolves an individual recipient to its current WhatsApp id before sending — across text, media (image/video/audio/document), location, contact, and sticker messages, plus the typing indicator — and falls back to the original id if resolution is unavailable, so a send is never blocked on it. Group and channel sends are unaffected; the Baileys engine already handled this. (#573) Thanks @lexcorp.
+
 ## [0.7.18] - 2026-07-02
 
 ### Added

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -1257,6 +1257,65 @@ describe('outbound voice note (PTT)', () => {
   });
 });
 
+describe('LID resolution for individual sends (#573 — WhatsApp @c.us → @lid migration)', () => {
+  const ready = (client: unknown): WhatsAppWebJsAdapter => {
+    const adapter = new WhatsAppWebJsAdapter({ sessionId: 's', sessionDataPath: './data/sessions', puppeteer: {} });
+    (adapter as unknown as { status: EngineStatus }).status = EngineStatus.READY;
+    (adapter as unknown as { client: unknown }).client = client;
+    return adapter;
+  };
+  const sentMessage = { id: { _serialized: 'OUT1' }, timestamp: 1700000001 };
+
+  it('sendTextMessage resolves a migrated @c.us recipient to its @lid before sending', async () => {
+    const getNumberId = jest.fn().mockResolvedValue({ _serialized: '159442138038327@lid' });
+    const sendMessage = jest.fn().mockResolvedValue(sentMessage);
+    await ready({ getNumberId, sendMessage }).sendTextMessage('529934031058@c.us', 'hi');
+    expect(getNumberId).toHaveBeenCalledWith('529934031058@c.us');
+    expect(sendMessage).toHaveBeenCalledWith('159442138038327@lid', 'hi');
+  });
+
+  it('leaves a @g.us group id untouched (no LID lookup)', async () => {
+    const getNumberId = jest.fn();
+    const sendMessage = jest.fn().mockResolvedValue(sentMessage);
+    await ready({ getNumberId, sendMessage }).sendTextMessage('120@g.us', 'hi');
+    expect(getNumberId).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledWith('120@g.us', 'hi');
+  });
+
+  it('falls back to the original id when getNumberId returns null (unregistered/unmigrated)', async () => {
+    const getNumberId = jest.fn().mockResolvedValue(null);
+    const sendMessage = jest.fn().mockResolvedValue(sentMessage);
+    await ready({ getNumberId, sendMessage }).sendTextMessage('628@c.us', 'hi');
+    expect(sendMessage).toHaveBeenCalledWith('628@c.us', 'hi');
+  });
+
+  it('never blocks the send when resolution throws (best-effort)', async () => {
+    const getNumberId = jest.fn().mockRejectedValue(new Error('network'));
+    const sendMessage = jest.fn().mockResolvedValue(sentMessage);
+    await ready({ getNumberId, sendMessage }).sendTextMessage('628@c.us', 'hi');
+    expect(sendMessage).toHaveBeenCalledWith('628@c.us', 'hi');
+  });
+
+  it('resolves the recipient on media sends too (sendImageMessage)', async () => {
+    const getNumberId = jest.fn().mockResolvedValue({ _serialized: '159442138038327@lid' });
+    const sendMessage = jest.fn().mockResolvedValue(sentMessage);
+    await ready({ getNumberId, sendMessage }).sendImageMessage('529934031058@c.us', {
+      mimetype: 'image/png',
+      data: Buffer.from([1]).toString('base64'),
+    });
+    expect(sendMessage).toHaveBeenCalledWith('159442138038327@lid', expect.anything(), expect.anything());
+  });
+
+  it('resolves the recipient on the typing path (sendChatState) so it no longer errors', async () => {
+    const getNumberId = jest.fn().mockResolvedValue({ _serialized: '159442138038327@lid' });
+    const sendStateTyping = jest.fn().mockResolvedValue(undefined);
+    const getChatById = jest.fn().mockResolvedValue({ sendStateTyping });
+    await ready({ getNumberId, getChatById }).sendChatState('529934031058@c.us', 'typing');
+    expect(getChatById).toHaveBeenCalledWith('159442138038327@lid');
+    expect(sendStateTyping).toHaveBeenCalled();
+  });
+});
+
 describe('extractWwebjsCall (call_log → { video, missed }, salvaged from #494)', () => {
   const m = (over: Record<string, unknown>) => over as unknown as Parameters<typeof extractWwebjsCall>[0];
 

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -803,13 +803,32 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     return this.pushName;
   }
 
+  /**
+   * Resolve an individual (`@c.us`) recipient to its LID (`@lid`) when WhatsApp has migrated that
+   * contact to privacy-id addressing. On a migrated chat whatsapp-web.js throws `No LID for user`
+   * for the phone WID, but the id `getNumberId` returns (which may be a `@lid`) is accepted (#573).
+   * Groups/channels and already-`@lid` targets are returned unchanged, and any resolution failure
+   * falls back to the original id so a send is never blocked on it.
+   */
+  private async resolveSendId(chatId: string): Promise<string> {
+    if (!chatId.endsWith('@c.us')) {
+      return chatId;
+    }
+    try {
+      return (await this.getNumberId(chatId)) ?? chatId;
+    } catch {
+      return chatId;
+    }
+  }
+
   async sendTextMessage(chatId: string, text: string, mentions?: string[]): Promise<MessageResult> {
     this.ensureReady();
+    const to = await this.resolveSendId(chatId);
     // wwebjs accepts neutral `<phone>@c.us` WIDs directly as mentionedJidList, so no de-normalization
     // is needed. Omit the options object entirely when none are given to keep today's send behavior.
     const msg = mentions?.length
-      ? await this.client!.sendMessage(chatId, text, { mentions })
-      : await this.client!.sendMessage(chatId, text);
+      ? await this.client!.sendMessage(to, text, { mentions })
+      : await this.client!.sendMessage(to, text);
     return {
       id: msg.id._serialized,
       timestamp: msg.timestamp,
@@ -838,6 +857,7 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     extraOptions?: { sendAudioAsVoice?: boolean },
   ): Promise<MessageResult> {
     this.ensureReady();
+    const to = await this.resolveSendId(chatId);
 
     let messageMedia: MessageMedia;
 
@@ -854,7 +874,7 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
       messageMedia = new MessageMedia(media.mimetype, media.data.toString('base64'), media.filename);
     }
 
-    const msg = await this.client!.sendMessage(chatId, messageMedia, {
+    const msg = await this.client!.sendMessage(to, messageMedia, {
       caption: media.caption,
       ...(media.mentions?.length ? { mentions: media.mentions } : {}),
       // sendAudioAsVoice only for audio; {...undefined} contributes no keys.
@@ -964,7 +984,8 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
       name: location.description || '',
       address: location.address || '',
     });
-    const msg = await this.client!.sendMessage(chatId, loc);
+    const to = await this.resolveSendId(chatId);
+    const msg = await this.client!.sendMessage(to, loc);
     return {
       id: msg.id._serialized,
       timestamp: msg.timestamp,
@@ -977,7 +998,8 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     // can't inject extra vCard fields — the previous inline build interpolated raw values.
     const vcard = buildVCard(contact);
 
-    const msg = await this.client!.sendMessage(chatId, vcard, {
+    const to = await this.resolveSendId(chatId);
+    const msg = await this.client!.sendMessage(to, vcard, {
       parseVCards: true,
     });
     return {
@@ -1000,7 +1022,8 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
       messageMedia = new MessageMedia(media.mimetype, media.data.toString('base64'), media.filename);
     }
 
-    const msg = await this.client!.sendMessage(chatId, messageMedia, {
+    const to = await this.resolveSendId(chatId);
+    const msg = await this.client!.sendMessage(to, messageMedia, {
       sendMediaAsSticker: true,
     });
     return {
@@ -1658,7 +1681,8 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
       return;
     }
     try {
-      const chat = await this.client!.getChatById(chatId);
+      const to = await this.resolveSendId(chatId);
+      const chat = await this.client!.getChatById(to);
       if (state === 'typing') {
         await chat.sendStateTyping();
       } else if (state === 'recording') {


### PR DESCRIPTION
## Summary

WhatsApp has started addressing some individual chats by privacy id (`@lid`) instead of the phone-number WID (`@c.us`). For those contacts, whatsapp-web.js rejects a send with `No LID for user`, which OpenWA surfaced as an HTTP 500 (and which downstream integrations such as n8n passed through as a 500). Pinning the WhatsApp Web version does not help, because this is an addressing change rather than version drift.

This change resolves an individual recipient to its current WhatsApp id before sending.

## What changed

- Added a private `resolveSendId()` helper to the whatsapp-web.js adapter. For an individual `@c.us` recipient it looks up the current id via `getNumberId()` (which returns the `@lid` when the contact has been migrated) and sends to that. Group (`@g.us`), channel/newsletter, and already-`@lid` targets are returned unchanged, and any resolution failure falls back to the original id so a send is never blocked on it.
- Routed all direct-send methods through it: text, media (image / video / audio / document), location, contact, and sticker.
- Applied the same resolution on the typing-indicator path, which hit the identical error and previously logged `No LID for user` on every send to a migrated contact. That path was already best-effort (caught and swallowed), so it only produced log noise — resolving it removes the noise.

## Impact

- Sends to LID-migrated contacts now succeed instead of returning 500.
- No behavior change for group and channel sends, or for contacts that have not been migrated (`getNumberId` returns the same `@c.us`).
- The Baileys engine already canonicalizes lid/phone addressing from inbound keys and is unaffected.

## Testing

- New adapter unit tests: a migrated `@c.us` recipient is resolved to its `@lid` before sending (text and media); a `@g.us` group id is left untouched (no lookup); resolution returning `null` or throwing falls back to the original id; the typing path resolves the same way.
- Full backend gate green: build, lint, and 1815 unit tests.

Closes #573
