### PR TITLE
feat(integration): extend a plugin's net.allow from its configured hosts

### DIFF
--- a/src/core/plugins/plugin-loader.service.ts
+++ b/src/core/plugins/plugin-loader.service.ts
@@ -973,17 +973,21 @@ export class PluginLoaderService implements OnModuleInit, OnModuleDestroy {
       } satisfies PluginEngineReadCapability,
       net: {
         fetch: async (url, init) => {
-          // Two gates: the declared permission, then the effective host allowlist (manifest net.allow
-          // plus the hosts of any net.allowConfigHosts config keys, resolved for the firing session). The
-          // SSRF guard inside performPluginFetch still blocks internal IPs even when the host is allowed.
+          // Two gates: the declared permission, then the effective host allowlist = manifest net.allow
+          // UNION the hosts of net.allowConfigHosts keys across the base config AND every per-session
+          // override. The host gate has no firing-session context for a sandboxed plugin's cap round-trip,
+          // so admit every operator-configured tenant host (all public + still SSRF-guarded at connect)
+          // rather than resolving a single, possibly wrong (base-only), one. The SSRF guard inside
+          // performPluginFetch still blocks internal IPs even when the host is allowlisted.
           this.assertPermission(plugin.manifest, PluginCapabilityPermission.NET_FETCH);
-          const cfg = resolvePluginConfig(
-            plugin.config,
-            plugin.sessionConfig,
-            this.hookSession.getStore()?.sessionId,
-            plugin.manifest.sessionScoped !== false,
-          );
-          const allow = effectiveNetAllow(plugin.manifest.net?.allow, plugin.manifest.net?.allowConfigHosts, cfg);
+          const netConfigs = [plugin.config ?? {}, ...Object.values(plugin.sessionConfig ?? {})];
+          const allow = [
+            ...new Set(
+              netConfigs.flatMap(cfg =>
+                effectiveNetAllow(plugin.manifest.net?.allow, plugin.manifest.net?.allowConfigHosts, cfg),
+              ),
+            ),
+          ];
           if (!isNetHostAllowed(allow, url)) {
             throw new PluginCapabilityError(
               `Plugin ${plugin.manifest.id} may not fetch ${url} — add its host to net.allow or net.allowConfigHosts`,

--- a/src/core/plugins/plugin-loader.service.ts
+++ b/src/core/plugins/plugin-loader.service.ts
@@ -24,7 +24,7 @@ import {
   PluginLogger,
   validateIngressManifest,
 } from './plugin.interfaces';
-import { isNetHostAllowed, performPluginFetch } from './plugin-net';
+import { effectiveNetAllow, isNetHostAllowed, performPluginFetch } from './plugin-net';
 import { PluginStorageService } from './plugin-storage.service';
 import { isPluginActiveForSession, resolvePluginConfig } from './plugin-activation';
 import { PluginWorkerHost } from './sandbox/plugin-worker-host';
@@ -973,12 +973,20 @@ export class PluginLoaderService implements OnModuleInit, OnModuleDestroy {
       } satisfies PluginEngineReadCapability,
       net: {
         fetch: async (url, init) => {
-          // Two gates: the declared permission, then the manifest host allowlist. The SSRF guard
-          // inside performPluginFetch still blocks internal IPs even when the host is allowlisted.
+          // Two gates: the declared permission, then the effective host allowlist (manifest net.allow
+          // plus the hosts of any net.allowConfigHosts config keys, resolved for the firing session). The
+          // SSRF guard inside performPluginFetch still blocks internal IPs even when the host is allowed.
           this.assertPermission(plugin.manifest, PluginCapabilityPermission.NET_FETCH);
-          if (!isNetHostAllowed(plugin.manifest.net?.allow, url)) {
+          const cfg = resolvePluginConfig(
+            plugin.config,
+            plugin.sessionConfig,
+            this.hookSession.getStore()?.sessionId,
+            plugin.manifest.sessionScoped !== false,
+          );
+          const allow = effectiveNetAllow(plugin.manifest.net?.allow, plugin.manifest.net?.allowConfigHosts, cfg);
+          if (!isNetHostAllowed(allow, url)) {
             throw new PluginCapabilityError(
-              `Plugin ${plugin.manifest.id} may not fetch ${url} — add its host to the manifest net.allow list`,
+              `Plugin ${plugin.manifest.id} may not fetch ${url} — add its host to net.allow or net.allowConfigHosts`,
             );
           }
           return performPluginFetch(url, init);

--- a/src/core/plugins/plugin-net.spec.ts
+++ b/src/core/plugins/plugin-net.spec.ts
@@ -111,4 +111,10 @@ describe('effectiveNetAllow', () => {
     expect(effectiveNetAllow([], ['baseUrl'], { baseUrl: 'http://x' })).toEqual([]); // https-only
     expect(effectiveNetAllow([], ['baseUrl'], { baseUrl: 'https://u:p@x' })).toEqual([]); // no credentials
   });
+  it("never admits the '*' wildcard sentinel from a config value, and preserves an explicit port", () => {
+    expect(effectiveNetAllow([], ['baseUrl'], { baseUrl: 'https://*' })).toEqual([]); // bare '*' would open all hosts
+    expect(effectiveNetAllow([], ['baseUrl'], { baseUrl: 'https://%2A' })).toEqual([]); // encoded '*' too
+    expect(effectiveNetAllow([], ['baseUrl'], { baseUrl: 'https://*:443/x' })).toEqual([]);
+    expect(effectiveNetAllow([], ['baseUrl'], { baseUrl: 'https://host.com:8443' })).toEqual(['host.com:8443']);
+  });
 });

--- a/src/core/plugins/plugin-net.spec.ts
+++ b/src/core/plugins/plugin-net.spec.ts
@@ -1,4 +1,4 @@
-import { isNetHostAllowed, performPluginFetch } from './plugin-net';
+import { effectiveNetAllow, isNetHostAllowed, performPluginFetch } from './plugin-net';
 import type { withSafeFetch } from '../../common/security/ssrf-guard';
 
 /** A stand-in for withSafeFetch that hands `use` a canned Response and records the init it was given. */
@@ -94,5 +94,21 @@ describe('performPluginFetch', () => {
     const fetcher = fakeSafeFetch(cannedResponse('x', { 'content-length': big }), sink);
 
     await expect(performPluginFetch('https://api.example.com/t', {}, { fetch: fetcher })).rejects.toThrow(/cap/i);
+  });
+});
+
+describe('effectiveNetAllow', () => {
+  it('adds the host of each named config URL to the static allowlist', () => {
+    expect(effectiveNetAllow(['api.static.com'], ['baseUrl'], { baseUrl: 'https://chat.acme.com' })).toEqual([
+      'api.static.com',
+      'chat.acme.com',
+    ]);
+  });
+  it('ignores missing / non-string / non-https / credentialed config values', () => {
+    expect(effectiveNetAllow([], ['baseUrl'], {})).toEqual([]);
+    expect(effectiveNetAllow([], ['baseUrl'], { baseUrl: 42 })).toEqual([]);
+    expect(effectiveNetAllow([], ['baseUrl'], { baseUrl: 'not a url' })).toEqual([]);
+    expect(effectiveNetAllow([], ['baseUrl'], { baseUrl: 'http://x' })).toEqual([]); // https-only
+    expect(effectiveNetAllow([], ['baseUrl'], { baseUrl: 'https://u:p@x' })).toEqual([]); // no credentials
   });
 });

--- a/src/core/plugins/plugin-net.ts
+++ b/src/core/plugins/plugin-net.ts
@@ -28,6 +28,32 @@ export interface PluginNetResponse {
 }
 
 /**
+ * The effective outbound-host allowlist for a plugin: its static manifest `net.allow` plus the host of
+ * every `net.allowConfigHosts` config key that resolves to an https URL. Lets a marketplace adapter reach
+ * an operator-configured host (e.g. a Chatwoot base URL) without `net.allow:['*']`. Credentialed or
+ * non-https values are ignored; the SSRF guard still blocks private IPs at connect regardless.
+ */
+export function effectiveNetAllow(
+  allow: string[] | undefined,
+  allowConfigHosts: string[] | undefined,
+  config: Record<string, unknown>,
+): string[] {
+  const out = [...(allow ?? [])];
+  for (const key of allowConfigHosts ?? []) {
+    const raw = config[key];
+    if (typeof raw !== 'string') continue;
+    try {
+      const u = new URL(raw);
+      if (u.protocol !== 'https:' || u.username || u.password) continue;
+      out.push(u.hostname);
+    } catch {
+      // Not a URL — skip.
+    }
+  }
+  return out;
+}
+
+/**
  * Is `url` allowed by a plugin's manifest `net.allow` list? Deny-by-default. `'*'` allows any host
  * (the SSRF guard still blocks internal IPs at connect time); an entry may be `host:port` (exact) or
  * a bare `host` (any port). Only http(s) is ever allowed.

--- a/src/core/plugins/plugin-net.ts
+++ b/src/core/plugins/plugin-net.ts
@@ -45,7 +45,8 @@ export function effectiveNetAllow(
     try {
       const u = new URL(raw);
       if (u.protocol !== 'https:' || u.username || u.password) continue;
-      out.push(u.hostname);
+      if (u.hostname.includes('*')) continue; // never let a config value inject the '*' wildcard sentinel
+      out.push(u.host); // host:port when a port is set, else bare host
     } catch {
       // Not a URL — skip.
     }

--- a/src/core/plugins/plugin.interfaces.ts
+++ b/src/core/plugins/plugin.interfaces.ts
@@ -90,8 +90,9 @@ export interface PluginManifest {
 
   // Outbound-HTTP host allowlist for `ctx.net.fetch` (requires the `net:fetch` permission). Each
   // entry is `host:port` (exact) or a bare `host` (any port); `'*'` allows any public host. Absent /
-  // empty = deny all. The SSRF guard still blocks internal IPs regardless of this list.
-  net?: { allow?: string[] };
+  // empty = deny all. `allowConfigHosts` additionally admits the host of each named config key (e.g. an
+  // operator-set base URL), resolved at fetch time. The SSRF guard still blocks internal IPs regardless.
+  net?: { allow?: string[]; allowConfigHosts?: string[] };
 
   // Localized dashboard text (name/description/config field titles) per locale code. English is the
   // base manifest + fallback. Dashboard-only; does not affect runtime behavior.


### PR DESCRIPTION
> Stacked on `feat/ctx-mappings-handover` — review/merge that first.

Lets a marketplace plugin reach an operator-configured host (for example a provider base URL) without granting a wildcard outbound allowlist.

## Changes

- A manifest may declare `net.allowConfigHosts` — a list of config keys whose URL host is added to the plugin's outbound allowlist. The effective allowlist is the manifest `net.allow` unioned with the hosts of those config keys across the base config and every per-session override, so a per-instance host is admitted regardless of which session is active.
- Only https hosts are admitted; credentialed URLs and the `*` wildcard host form are rejected, and an explicit port is preserved.

## Impact

The SSRF guard is unchanged — private and link-local addresses are still blocked at connect time even for an allowlisted host, so this only widens the allowlist to operator-chosen public hosts. Additive: a plugin without `allowConfigHosts` behaves exactly as before.

Verified with `tsc` over the build config and the `src/core/plugins` test suite.
