### PR TITLE
fix(database): migration CLI resolves a single DataSource

### DIFF
--- a/src/database/data-source.spec.ts
+++ b/src/database/data-source.spec.ts
@@ -1,5 +1,5 @@
 import { globSync } from 'glob';
-import dataDataSource, { postgresDataSource } from './data-source';
+import dataDataSource, { postgresDataSourceOptions } from './data-source';
 
 // The data CLI DataSource manages the DATA connection's migrations (session/webhook/message/
 // template/engine). It must NOT pull in the auth/audit entities — those belong to the always-SQLite
@@ -37,7 +37,7 @@ describe('data CLI DataSource', () => {
 // minutes on a large table. It must carry pool/connection timeouts for resilience but MUST NOT carry a
 // server-side statement_timeout, or a long migration would be aborted mid-flight.
 describe('Postgres migration connection pool timeouts', () => {
-  const extra = postgresDataSource.options.extra as Record<string, number | undefined>;
+  const extra = postgresDataSourceOptions.extra as Record<string, number | undefined>;
 
   it('sets idle and connection pool timeouts', () => {
     expect(extra.idleTimeoutMillis).toBe(30000);

--- a/src/database/data-source.ts
+++ b/src/database/data-source.ts
@@ -1,4 +1,4 @@
-import { DataSource } from 'typeorm';
+import { DataSource, DataSourceOptions } from 'typeorm';
 import * as path from 'path';
 import { loadCliEnv } from './load-cli-env';
 
@@ -10,46 +10,44 @@ const dbType = process.env.DATABASE_TYPE || 'sqlite';
 
 const sourceGlob = (...segments: string[]): string => path.join(__dirname, ...segments).replace(/\\/g, '/');
 
+// Scoped to the DATA-owned modules only (session/webhook/message/template/engine/integration), mirroring
+// the runtime data connection (app.module.ts). A broad '**' glob would also sweep in the main-owned
+// auth/audit entities and pollute `migration:generate` against the data DB with their DDL.
+const dataEntities = [
+  sourceGlob('..', 'modules', 'session', '**', '*.entity{.ts,.js}'),
+  sourceGlob('..', 'modules', 'webhook', '**', '*.entity{.ts,.js}'),
+  sourceGlob('..', 'modules', 'message', '**', '*.entity{.ts,.js}'),
+  sourceGlob('..', 'modules', 'template', '**', '*.entity{.ts,.js}'),
+  sourceGlob('..', 'engine', '**', '*.entity{.ts,.js}'),
+  sourceGlob('..', 'modules', 'integration', '**', '*.entity{.ts,.js}'),
+];
+const dataMigrations = [sourceGlob('migrations', '*{.ts,.js}')];
+
 // SQLite configuration
-const sqliteDataSource = new DataSource({
+const sqliteDataSourceOptions: DataSourceOptions = {
   type: 'sqlite',
   database: process.env.DATABASE_NAME || './data/openwa.sqlite',
-  // Scoped to the DATA-owned modules only (session/webhook/message/template/engine), mirroring the
-  // runtime data connection (app.module.ts). A broad '**' glob would also sweep in the main-owned
-  // auth/audit entities and pollute `migration:generate` against the data DB with their DDL.
-  entities: [
-    sourceGlob('..', 'modules', 'session', '**', '*.entity{.ts,.js}'),
-    sourceGlob('..', 'modules', 'webhook', '**', '*.entity{.ts,.js}'),
-    sourceGlob('..', 'modules', 'message', '**', '*.entity{.ts,.js}'),
-    sourceGlob('..', 'modules', 'template', '**', '*.entity{.ts,.js}'),
-    sourceGlob('..', 'engine', '**', '*.entity{.ts,.js}'),
-    sourceGlob('..', 'modules', 'integration', '**', '*.entity{.ts,.js}'),
-  ],
-  migrations: [sourceGlob('migrations', '*{.ts,.js}')],
+  entities: dataEntities,
+  migrations: dataMigrations,
   synchronize: false,
   logging: process.env.DATABASE_LOGGING === 'true',
-});
+};
 
-// PostgreSQL configuration
-export const postgresDataSource = new DataSource({
+// PostgreSQL configuration.
+//
+// Exported as plain DataSourceOptions, NOT a DataSource instance: the TypeORM CLI's loadDataSource()
+// rejects a data-source file that exports more than one DataSource instance ("must contain only one
+// export of DataSource"). Keeping the postgres config as an options object leaves exactly one instance
+// export (the default below) so every `migration:*` command resolves it.
+export const postgresDataSourceOptions: DataSourceOptions = {
   type: 'postgres',
   host: process.env.DATABASE_HOST || 'localhost',
   port: parseInt(process.env.DATABASE_PORT || '5432', 10),
   username: process.env.DATABASE_USERNAME,
   password: process.env.DATABASE_PASSWORD,
   database: process.env.DATABASE_NAME || 'openwa',
-  // Scoped to the DATA-owned modules only (session/webhook/message/template/engine), mirroring the
-  // runtime data connection (app.module.ts). A broad '**' glob would also sweep in the main-owned
-  // auth/audit entities and pollute `migration:generate` against the data DB with their DDL.
-  entities: [
-    sourceGlob('..', 'modules', 'session', '**', '*.entity{.ts,.js}'),
-    sourceGlob('..', 'modules', 'webhook', '**', '*.entity{.ts,.js}'),
-    sourceGlob('..', 'modules', 'message', '**', '*.entity{.ts,.js}'),
-    sourceGlob('..', 'modules', 'template', '**', '*.entity{.ts,.js}'),
-    sourceGlob('..', 'engine', '**', '*.entity{.ts,.js}'),
-    sourceGlob('..', 'modules', 'integration', '**', '*.entity{.ts,.js}'),
-  ],
-  migrations: [sourceGlob('migrations', '*{.ts,.js}')],
+  entities: dataEntities,
+  migrations: dataMigrations,
   synchronize: false, // Never auto-sync in production
   logging: process.env.DATABASE_LOGGING === 'true',
   ssl:
@@ -65,7 +63,7 @@ export const postgresDataSource = new DataSource({
     idleTimeoutMillis: parseInt(process.env.DATABASE_IDLE_TIMEOUT_MS || '30000', 10),
     connectionTimeoutMillis: parseInt(process.env.DATABASE_CONNECTION_TIMEOUT_MS || '10000', 10),
   },
-});
+};
 
-// Export the appropriate data source based on DATABASE_TYPE
-export default dbType === 'postgres' ? postgresDataSource : sqliteDataSource;
+// Exactly ONE DataSource instance is exported (the default), selected by DATABASE_TYPE.
+export default new DataSource(dbType === 'postgres' ? postgresDataSourceOptions : sqliteDataSourceOptions);


### PR DESCRIPTION
## Summary

The data-source file for the `data` connection exported two `DataSource` instances (the PostgreSQL one and the default). TypeORM's CLI `loadDataSource()` rejects any data-source module that exports more than one `DataSource` instance with *"Given data source file must contain only one export of DataSource instance"*, which broke every `migration:*` command (`migration:show`, `generate`, `run`, `revert`).

## Change

- Export the PostgreSQL configuration as a plain `DataSourceOptions` object (`postgresDataSourceOptions`) instead of a constructed `DataSource`.
- Construct the single default `DataSource` instance from the selected options (SQLite or PostgreSQL) — the only instance the file exports now.
- Factor the shared entity/migration globs so both configs stay in sync.

## Verification

- `npm run migration:show` now resolves and lists migrations (previously threw).
- `npm run build` ✓ · `npm test` ✓ (1845/1845) · lint ✓