### PR TITLE
fix(security): sanitize SSRF rejection messages on send and webhook registration

### DIFF
--- a/src/common/security/ssrf-guard.ts
+++ b/src/common/security/ssrf-guard.ts
@@ -12,6 +12,14 @@ export class SsrfBlockedError extends Error {
 }
 
 /**
+ * Generic, non-revealing message to return to an API caller when an outbound URL is SSRF-blocked. The
+ * raw SsrfBlockedError message names the resolved internal IP ("… resolves to a blocked internal address:
+ * 10.0.0.5"), which is a recon / DNS-rebind oracle, so it must never reach a client — log the detail
+ * server-side and return this instead. Shared by the single-send, bulk, and webhook-registration paths.
+ */
+export const SSRF_BLOCKED_CLIENT_MESSAGE = 'Destination address is not allowed';
+
+/**
  * Outbound webhook SSRF protection. Default ON; disable only with an explicit
  * WEBHOOK_SSRF_PROTECT=false (e.g. a closed network that delivers to internal sidecars — prefer
  * the SSRF_ALLOWED_HOSTS escape-hatch instead of disabling protection wholesale).

--- a/src/modules/message/bulk-message.service.ts
+++ b/src/modules/message/bulk-message.service.ts
@@ -14,7 +14,7 @@ import { MessageStatus } from './entities/message.entity';
 import { SessionService } from '../session/session.service';
 import { MessageService } from './message.service';
 import { assertBase64WithinMediaCap } from './media-cap.util';
-import { SsrfBlockedError } from '../../common/security/ssrf-guard';
+import { SsrfBlockedError, SSRF_BLOCKED_CLIENT_MESSAGE } from '../../common/security/ssrf-guard';
 import { renderTemplate } from '../../common/utils/template-render';
 import { IWhatsAppEngine, MessageResult } from '../../engine/interfaces/whatsapp-engine.interface';
 
@@ -52,7 +52,7 @@ export function resolveFinalBatchStatus(
  */
 export function sanitizeBatchError(error: unknown): { code: string; message: string } {
   if (error instanceof SsrfBlockedError) {
-    return { code: 'SEND_BLOCKED', message: 'Destination address is not allowed' };
+    return { code: 'SEND_BLOCKED', message: SSRF_BLOCKED_CLIENT_MESSAGE };
   }
   return { code: 'SEND_FAILED', message: error instanceof Error ? error.message : String(error) };
 }

--- a/src/modules/message/message.service.spec.ts
+++ b/src/modules/message/message.service.spec.ts
@@ -333,12 +333,15 @@ describe('MessageService', () => {
       );
     });
 
-    it('maps a blocked-media-URL SSRF error to HTTP 400', async () => {
-      mockEngine.sendImageMessage.mockRejectedValueOnce(new SsrfBlockedError('Blocked internal address: 127.0.0.1'));
+    it('maps a blocked-media-URL SSRF error to HTTP 400 with a generic message (no internal IP leak)', async () => {
+      mockEngine.sendImageMessage.mockRejectedValueOnce(
+        new SsrfBlockedError('Host x resolves to a blocked internal address: 169.254.169.254'),
+      );
 
+      // Generic client message — the resolved internal IP must NOT reach the caller (recon oracle).
       await expect(
         service.sendImage('sess-1', { chatId: '628123456789@c.us', url: 'http://127.0.0.1/x.png' }),
-      ).rejects.toBeInstanceOf(BadRequestException);
+      ).rejects.toMatchObject({ response: { message: 'Destination address is not allowed' } });
     });
 
     it('rejects a base64 image over the media cap before sending or persisting', async () => {

--- a/src/modules/message/message.service.ts
+++ b/src/modules/message/message.service.ts
@@ -11,7 +11,7 @@ import { HookManager } from '../../core/hooks';
 import { TemplateService } from '../template/template.service';
 import { renderTemplate } from '../../common/utils/template-render';
 import { createLogger } from '../../common/services/logger.service';
-import { SsrfBlockedError } from '../../common/security/ssrf-guard';
+import { SsrfBlockedError, SSRF_BLOCKED_CLIENT_MESSAGE } from '../../common/security/ssrf-guard';
 import { userPart } from '../../engine/identity/wa-id';
 import { LidMappingStoreService } from '../../engine/identity/lid-mapping-store.service';
 
@@ -574,11 +574,13 @@ export class MessageService {
   /**
    * Map a blocked outbound media fetch (SSRF guard) to an HTTP 400 so a
    * caller-supplied internal/unsafe URL returns a client error instead of a 500.
-   * All other errors pass through unchanged.
+   * The raw guard message names the resolved internal IP (a recon/DNS-rebind oracle), so return a
+   * generic message to the client and keep the detail in the server log only. Others pass through.
    */
   private toClientFacingError(error: unknown): unknown {
     if (error instanceof SsrfBlockedError) {
-      return new BadRequestException(error.message);
+      this.logger.warn(`Outbound media fetch blocked by SSRF guard: ${error.message}`);
+      return new BadRequestException(SSRF_BLOCKED_CLIENT_MESSAGE);
     }
     return error;
   }

--- a/src/modules/webhook/webhook.service.spec.ts
+++ b/src/modules/webhook/webhook.service.spec.ts
@@ -153,13 +153,13 @@ describe('WebhookService', () => {
 
     // ── validate URL at registration, default-on ──────────
 
-    it('rejects an internal webhook URL at registration with 400 (protection on by default)', async () => {
+    it('rejects an internal webhook URL at registration with 400 and a generic message (no IP leak)', async () => {
       const origProtect = process.env.WEBHOOK_SSRF_PROTECT;
       delete process.env.WEBHOOK_SSRF_PROTECT; // default → on
       try {
-        await expect(service.create('sess-1', { url: 'http://127.0.0.1/hook' })).rejects.toBeInstanceOf(
-          BadRequestException,
-        );
+        await expect(service.create('sess-1', { url: 'http://127.0.0.1/hook' })).rejects.toMatchObject({
+          response: { message: 'Destination address is not allowed' },
+        });
         expect(repository.create).not.toHaveBeenCalled();
       } finally {
         if (origProtect === undefined) delete process.env.WEBHOOK_SSRF_PROTECT;

--- a/src/modules/webhook/webhook.service.ts
+++ b/src/modules/webhook/webhook.service.ts
@@ -21,6 +21,7 @@ import {
   withSafeFetch,
   isSsrfProtectionEnabled,
   SsrfBlockedError,
+  SSRF_BLOCKED_CLIENT_MESSAGE,
 } from '../../common/security/ssrf-guard';
 import { HookManager } from '../../core/hooks';
 
@@ -76,7 +77,9 @@ export class WebhookService {
       await assertSafeFetchUrl(url);
     } catch (error) {
       if (error instanceof SsrfBlockedError) {
-        throw new BadRequestException(error.message);
+        // The raw message names the resolved internal IP (a recon oracle): log it server-side, return generic.
+        this.logger.warn(`Webhook URL rejected by SSRF guard: ${error.message}`);
+        throw new BadRequestException(SSRF_BLOCKED_CLIENT_MESSAGE);
       }
       throw error;
     }


### PR DESCRIPTION
## Summary

The SSRF guard's error message names the resolved internal IP address (e.g. *"Host x resolves to a blocked internal address: 169.254.169.254"*). The bulk-send path already sanitized this, but the single-send media path and webhook registration returned it verbatim as an HTTP 400 — a recon / DNS-rebind oracle for internal addresses.

## Changes

- Added a shared generic client message `SSRF_BLOCKED_CLIENT_MESSAGE` ("Destination address is not allowed").
- Single-send media (`MessageService.toClientFacingError`) and webhook registration (`WebhookService.validateWebhookUrl`, covering both `create` and `update`) now return the generic message and log the verbatim detail server-side for debugging.
- The bulk path reuses the same shared constant.

## Verification

`npm run build` ✓ · `npm test` ✓ (1863/1863) · lint ✓. Tests assert the client-facing 400 carries the generic message (not the internal IP) on both the send and webhook-registration paths.