### PR TITLE
fix(baileys): extract location and history content from ephemeral-wrapped messages

### DIFF
--- a/src/engine/adapters/baileys.adapter.spec.ts
+++ b/src/engine/adapters/baileys.adapter.spec.ts
@@ -666,6 +666,64 @@ describe('BaileysAdapter inbound fan-out', () => {
     expect(msg).toMatchObject({ id: 'IN1', body: 'hi there', type: 'text', fromMe: false });
   });
 
+  it('extracts coordinates from an ephemeral (disappearing) location message', async () => {
+    const onMessage = jest.fn();
+    const adapter = newAdapter();
+    await adapter.initialize({ onMessage });
+    const inner = {
+      locationMessage: { degreesLatitude: 24.1, degreesLongitude: 55.2, name: 'Office', address: '1 Main St' },
+    };
+    baileys.getContentType.mockReturnValue('locationMessage');
+    baileys.normalizeMessageContent.mockReturnValue(inner); // unwrap the ephemeral wrapper
+    fakeSock.fire('messages.upsert', {
+      type: 'notify',
+      messages: [
+        {
+          key: { remoteJid: '628111@s.whatsapp.net', fromMe: false, id: 'LOC1' },
+          message: { ephemeralMessage: { message: inner } }, // wrapped location
+          messageTimestamp: 1700000002,
+        },
+      ],
+    });
+    await new Promise(r => setImmediate(r));
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const msg = onMessage.mock.calls[0][0] as { location?: Record<string, unknown> };
+    expect(msg.location).toMatchObject({
+      latitude: 24.1,
+      longitude: 55.2,
+      description: 'Office',
+      address: '1 Main St',
+    });
+  });
+
+  it('maps an ephemeral-wrapped history message to its real type and body (not unknown/empty)', async () => {
+    const onHistoryMessages = jest.fn();
+    const adapter = newAdapter();
+    await adapter.initialize({ onHistoryMessages });
+    const inner = { conversation: 'disappearing hello' };
+    baileys.normalizeMessageContent.mockReturnValue(inner); // unwrap the ephemeral wrapper
+    baileys.getContentType.mockReturnValue('conversation');
+    fakeSock.fire('messaging-history.set', {
+      contacts: [],
+      chats: [],
+      messages: [
+        {
+          key: { remoteJid: '628111@s.whatsapp.net', fromMe: false, id: 'H1' },
+          message: { ephemeralMessage: { message: inner } },
+          messageTimestamp: 1700000000,
+          pushName: 'Alice',
+        },
+      ],
+    });
+    await new Promise(r => setImmediate(r));
+    await new Promise(r => setImmediate(r));
+    expect(onHistoryMessages).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const mapped = onHistoryMessages.mock.calls[0][0] as Array<{ id: string; type: string; body: string }>;
+    expect(mapped[0]).toMatchObject({ id: 'H1', type: 'text', body: 'disappearing hello' });
+  });
+
   it('surfaces inbound @mentions as neutral mentionedIds (contextInfo.mentionedJid)', async () => {
     const onMessage = jest.fn();
     const adapter = newAdapter();

--- a/src/engine/adapters/baileys.adapter.ts
+++ b/src/engine/adapters/baileys.adapter.ts
@@ -265,7 +265,7 @@ export class BaileysAdapter implements IWhatsAppEngine {
       const h = history as unknown as { lidPnMappings?: { lid: string; pn: string }[]; syncType?: unknown };
       const lidPnMappings = h.lidPnMappings;
       this.sessionStore.addLidMappings(lidPnMappings ?? []);
-      this.captureHistoryMessages(history.messages ?? []);
+      void this.captureHistoryMessages(history.messages ?? []);
       this.logger.debug('History sync received', {
         action: 'baileys_history_set',
         sessionId: this.config.sessionId,
@@ -1074,9 +1074,11 @@ export class BaileysAdapter implements IWhatsAppEngine {
     // ILocationMessage has name/address; ILiveLocationMessage does not — use the static variant only.
     let location: IncomingMessage['location'];
     if (contentType === 'locationMessage' || contentType === 'liveLocationMessage') {
-      const lm = content.locationMessage ?? content.liveLocationMessage;
+      // Read off the NORMALIZED content: an ephemeral/disappearing-chat location nests under the wrapper,
+      // so the raw `content.locationMessage` is undefined and the coordinates would be silently dropped.
+      const lm = normalized.locationMessage ?? normalized.liveLocationMessage;
       if (lm) {
-        const staticLm = content.locationMessage; // only ILocationMessage has name/address
+        const staticLm = normalized.locationMessage; // only ILocationMessage has name/address
         location = {
           latitude: lm.degreesLatitude ?? 0,
           longitude: lm.degreesLongitude ?? 0,
@@ -1239,10 +1241,11 @@ export class BaileysAdapter implements IWhatsAppEngine {
    * `onHistoryMessages` callback, harvesting `pushName` into contacts on the way (history `contacts`
    * carry no names) and seeding each chat's last-message preview.
    */
-  private captureHistoryMessages(messages: WAMessage[]): void {
+  private async captureHistoryMessages(messages: WAMessage[]): Promise<void> {
     if (!messages.length) {
       return;
     }
+    const b = await this.loadLib();
     const nameUpdates: { id: string; notify: string }[] = [];
     const mapped: IncomingMessage[] = [];
     for (const msg of messages) {
@@ -1255,7 +1258,7 @@ export class BaileysAdapter implements IWhatsAppEngine {
       // Seed the chat's last-message preview + sort time (newest wins); else history-only chats
       // would read "No messages yet".
       this.sessionStore.recordMessage(msg);
-      const incoming = this.mapHistoryMessage(msg);
+      const incoming = this.mapHistoryMessage(b, msg);
       if (incoming) {
         mapped.push(incoming);
       }
@@ -1303,26 +1306,26 @@ export class BaileysAdapter implements IWhatsAppEngine {
    * messages would be ruinous; the type is kept, the payload dropped). Returns null for protocol /
    * reaction / key / empty messages, which carry nothing for the chat view.
    */
-  private mapHistoryMessage(msg: WAMessage): IncomingMessage | null {
-    const content = msg.message;
-    if (!content || !msg.key?.remoteJid || !msg.key.id) {
+  private mapHistoryMessage(b: typeof BaileysLib, msg: WAMessage): IncomingMessage | null {
+    const raw = msg.message;
+    if (!raw || !msg.key?.remoteJid || !msg.key.id) {
       return null;
     }
-    const contentType = Object.keys(content)[0];
+    // Unwrap ephemeral/viewOnce/documentWithCaption/edited wrappers so the real type and body surface —
+    // else a disappearing-chat message maps to type 'unknown' with an empty body. Identity no-op when
+    // already unwrapped. Derive ONE contentType from the normalized content for both the skip-filter and
+    // the type mapping, and reuse extractBaileysBody (the same body extraction the live path uses).
+    const content = b.normalizeMessageContent(raw) ?? raw;
+    const contentType = b.getContentType(content);
     if (
+      !contentType ||
       contentType === 'protocolMessage' ||
       contentType === 'reactionMessage' ||
       contentType === 'senderKeyDistributionMessage'
     ) {
       return null;
     }
-    const body =
-      content.conversation ??
-      content.extendedTextMessage?.text ??
-      content.imageMessage?.caption ??
-      content.videoMessage?.caption ??
-      content.documentMessage?.caption ??
-      '';
+    const body = extractBaileysBody(content);
     return buildIncomingMessageFromBaileys(
       {
         id: msg.key.id,


### PR DESCRIPTION
## Summary

Two Baileys inbound-extraction gaps for ephemeral (disappearing-chat) and other wrapped messages.

## Changes

- **Ephemeral location coordinates were dropped.** Live location extraction read `content.locationMessage` off the raw message, but a disappearing-chat location nests under the wrapper, so the raw field was undefined and the coordinates were lost. It now reads off the normalized (unwrapped) content, matching how the media path already works.
- **History-sync missed wrapped messages.** `mapHistoryMessage` took the raw top-level key as the type and read the body off raw fields, so an ephemeral/viewOnce-wrapped history message mapped to type `unknown` with an empty body. It now normalizes the content first (unwrapping ephemeral/viewOnce/documentWithCaption/edited), derives one content type for both the skip-filter and the type mapping, and reuses `extractBaileysBody` — the same extraction the live path uses. `captureHistoryMessages` loads the lib once and passes it down.

## Verification

`npm run build` ✓ · `npm test` ✓ (1865/1865, +2) · lint ✓. New tests: an ephemeral location message surfaces its coordinates; an ephemeral-wrapped history message maps to its real type/body.