### PR TITLE
style: fix lint errors in spec files

### DIFF
--- a/src/modules/integration/plugin-instance.service.spec.ts
+++ b/src/modules/integration/plugin-instance.service.spec.ts
@@ -101,12 +101,7 @@ describe('PluginInstanceService', () => {
     await service.create('chatwoot', 'acct1', { config: { apiToken: 'real-token', accountId: 1 } });
 
     // Dashboard round-trips the masked config back with an edited non-secret field.
-    const updated = await service.update(
-      'chatwoot',
-      'acct1',
-      { config: { apiToken: '***', accountId: 2 } },
-      schema,
-    );
+    const updated = await service.update('chatwoot', 'acct1', { config: { apiToken: '***', accountId: 2 } }, schema);
 
     expect(updated?.config).toEqual({ apiToken: 'real-token', accountId: 2 });
   });

--- a/src/modules/webhook/webhook.service.spec.ts
+++ b/src/modules/webhook/webhook.service.spec.ts
@@ -14,7 +14,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { getQueueToken } from '@nestjs/bullmq';
 import { In, Repository } from 'typeorm';
-import { NotFoundException, BadRequestException } from '@nestjs/common';
+import { NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import * as crypto from 'crypto';
 import { fetch as undiciFetch } from 'undici';


### PR DESCRIPTION
Restores a clean `npm run lint`: collapse a multi-line call to satisfy prettier and drop a now-unused `BadRequestException` import left over from an earlier assertion change. No behavior change; `npm run lint` ✓ `npm run build` ✓ `npm test` ✓ (1865/1865).