### PR TITLE
feat(plugins): send media through ctx.conversations.send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Plugins can send media through `ctx.conversations.send`.** The conversation-send capability now accepts `image`, `video`, `audio`, and `file` envelopes that carry a `mediaUrl`, sending them by URL through the same media pipeline as the REST media endpoints (the caption comes from `text`). It stays under the existing `conversation:send` permission and the plugin's activated-session scope — the text/reply behavior is unchanged. A `replyTo` on a media envelope is rejected, since the engine media path cannot quote a message.
 - **Official Java SDK (`com.rmyndharis:openwa`).** A hand-written, synchronous Java 17 client covering the full REST surface — all 12 resources (sessions, messages, contacts, groups, webhooks, chats, labels, channels, catalog, status, templates, health) plus API-key validation — with typed request builders, immutable response records, a typed error hierarchy, and an injectable HTTP transport for testing. One runtime dependency (Gson); published to Maven Central as `com.rmyndharis:openwa:0.1.1`. Lives in `sdk/java` and is drift-tested against the backend DTOs like the JavaScript, Python, and PHP SDKs. (#602)
 
 ## [0.8.1] - 2026-07-02

--- a/src/core/plugins/conversation-send-facade.spec.ts
+++ b/src/core/plugins/conversation-send-facade.spec.ts
@@ -59,4 +59,71 @@ describe('conversation.send facade', () => {
     expect(runGuarded).toHaveBeenCalled();
     expect(res).toEqual({ id: 'm1' });
   });
+
+  it('routes a media envelope to sendMedia with the caption from text, not sendText', async () => {
+    const sendMedia = jest.fn().mockResolvedValue({ id: 'm2' });
+    const sendText = jest.fn();
+    const facade = buildConversationSendFacade({
+      manifest: manifest(['conversation:send']) as never,
+      assertPermission: () => undefined,
+      assertSessionActive: jest.fn(),
+      resolveChatId: () => Promise.resolve('chat@c.us'),
+      runGuarded: (_events: string[], run: () => Promise<unknown>) => run(),
+      sendText,
+      reply: jest.fn(),
+      sendMedia,
+    } as never);
+    const res = await facade.send({
+      type: 'image',
+      mediaUrl: 'https://cdn.example/x.jpg',
+      text: 'a caption',
+      sessionId: 's',
+      chatId: 'chat@c.us',
+    });
+    expect(sendMedia).toHaveBeenCalledWith('s', {
+      chatId: 'chat@c.us',
+      url: 'https://cdn.example/x.jpg',
+      type: 'image',
+      caption: 'a caption',
+    });
+    expect(sendText).not.toHaveBeenCalled();
+    expect(res).toEqual({ id: 'm2' });
+  });
+
+  it('rejects replyTo on a media envelope — media-reply is unsupported by the engine', async () => {
+    const sendMedia = jest.fn();
+    const facade = buildConversationSendFacade({
+      manifest: manifest(['conversation:send']) as never,
+      assertPermission: () => undefined,
+      assertSessionActive: jest.fn(),
+      resolveChatId: () => Promise.resolve('chat@c.us'),
+      runGuarded: (_events: string[], run: () => Promise<unknown>) => run(),
+      sendText: jest.fn(),
+      reply: jest.fn(),
+      sendMedia,
+    } as never);
+    await expect(
+      facade.send({ type: 'image', mediaUrl: 'https://cdn.example/x.jpg', replyTo: 'Q1', sessionId: 's', chatId: 'c' }),
+    ).rejects.toThrow(PluginCapabilityError);
+    expect(sendMedia).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a text send when a media type carries no mediaUrl (URL-in-text fallback)', async () => {
+    const sendMedia = jest.fn();
+    const sendText = jest.fn().mockResolvedValue({ id: 't1' });
+    const facade = buildConversationSendFacade({
+      manifest: manifest(['conversation:send']) as never,
+      assertPermission: () => undefined,
+      assertSessionActive: jest.fn(),
+      resolveChatId: () => Promise.resolve('chat@c.us'),
+      runGuarded: (_events: string[], run: () => Promise<unknown>) => run(),
+      sendText,
+      reply: jest.fn(),
+      sendMedia,
+    } as never);
+    const res = await facade.send({ type: 'video', text: 'https://cdn.example/v.mp4', sessionId: 's', chatId: 'c' });
+    expect(sendMedia).not.toHaveBeenCalled();
+    expect(sendText).toHaveBeenCalledWith('s', { chatId: 'c', text: 'https://cdn.example/v.mp4' });
+    expect(res).toEqual({ id: 't1' });
+  });
 });

--- a/src/core/plugins/conversation-send-facade.ts
+++ b/src/core/plugins/conversation-send-facade.ts
@@ -20,7 +20,21 @@ export interface ConversationSendDeps {
   runGuarded: <T>(events: string[], run: () => Promise<T>) => Promise<T>;
   sendText: (sessionId: string, opts: { chatId: string; text: string }) => Promise<unknown>;
   reply: (sessionId: string, opts: { chatId: string; quotedMessageId: string; text: string }) => Promise<unknown>;
+  // Media send by URL. The loader binds this to the per-type MessageService media methods
+  // (sendImage/sendVideo/sendAudio/sendDocument) — the facade stays DTO-agnostic.
+  sendMedia: (
+    sessionId: string,
+    opts: { chatId: string; url: string; type: ConversationMediaType; caption?: string },
+  ) => Promise<unknown>;
 }
+
+/** Envelope types carried as media by URL. `location` is a non-text type but has no mediaUrl, so it is excluded. */
+export type ConversationMediaType = 'image' | 'file' | 'audio' | 'video';
+
+const MEDIA_TYPES: readonly ConversationMediaType[] = ['image', 'file', 'audio', 'video'];
+
+const isMediaType = (type: ConversationSendEnvelope['type']): type is ConversationMediaType =>
+  (MEDIA_TYPES as readonly string[]).includes(type);
 
 const MESSAGE_HOOK_EVENTS = ['message:sending'];
 
@@ -32,8 +46,18 @@ export function buildConversationSendFacade(deps: ConversationSendDeps) {
       if (!sessionId) throw new PluginCapabilityError('conversation.send: sessionId is required');
       deps.assertSessionActive(sessionId);
       const chatId = env.chatId ?? (await deps.resolveChatId(env));
-      // Only text/reply are wired in P0; media types are additive in a later minor.
       return deps.runGuarded(MESSAGE_HOOK_EVENTS, async () => {
+        // A media type carrying a mediaUrl is sent as native media. A media type WITHOUT a mediaUrl has
+        // nothing to send as media, so it falls through to the text/reply path — a plugin that puts the
+        // URL in `text` as a fallback still delivers a (text) message rather than erroring.
+        if (isMediaType(env.type) && env.mediaUrl) {
+          // The engine media path takes only (chatId, media) — it cannot quote a message, so a media
+          // reply is not expressible. Reject rather than silently drop the quote.
+          if (env.replyTo) {
+            throw new PluginCapabilityError('conversation.send: replyTo is not supported for media messages');
+          }
+          return deps.sendMedia(sessionId, { chatId, url: env.mediaUrl, type: env.type, caption: env.text });
+        }
         if (env.replyTo) {
           return deps.reply(sessionId, { chatId, quotedMessageId: env.replyTo, text: env.text ?? '' });
         }

--- a/src/core/plugins/plugin-loader.service.spec.ts
+++ b/src/core/plugins/plugin-loader.service.spec.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { resolvePluginMainPath, buildSandboxWorkerEnv } from './plugin-loader.service';
+import { resolvePluginMainPath, buildSandboxWorkerEnv, dispatchConversationMedia } from './plugin-loader.service';
 
 /** Regression lock: a plugin's manifest.main must not escape its plugin directory. */
 describe('resolvePluginMainPath', () => {
@@ -65,6 +65,37 @@ describe('buildSandboxWorkerEnv', () => {
 
   it('defaults NODE_ENV to production when the host has none', () => {
     expect(buildSandboxWorkerEnv({}).NODE_ENV).toBe('production');
+  });
+});
+
+/** conversation.send media types must route to the matching MessageService method (not a copy-paste sibling). */
+describe('dispatchConversationMedia', () => {
+  const svc = () => ({
+    sendImage: jest.fn().mockResolvedValue({ messageId: 'i' }),
+    sendVideo: jest.fn().mockResolvedValue({ messageId: 'v' }),
+    sendAudio: jest.fn().mockResolvedValue({ messageId: 'a' }),
+    sendDocument: jest.fn().mockResolvedValue({ messageId: 'd' }),
+  });
+  const opts = (type: 'image' | 'video' | 'audio' | 'file') => ({
+    chatId: 'c@c.us',
+    url: 'https://cdn.example/m',
+    caption: 'cap',
+    type,
+  });
+
+  it.each([
+    ['image', 'sendImage'],
+    ['video', 'sendVideo'],
+    ['audio', 'sendAudio'],
+    ['file', 'sendDocument'],
+  ] as const)('routes %s to %s with a url+caption DTO', async (type, method) => {
+    const s = svc();
+    await dispatchConversationMedia(s, 's', opts(type));
+    expect(s[method]).toHaveBeenCalledWith('s', { chatId: 'c@c.us', url: 'https://cdn.example/m', caption: 'cap' });
+    // No sibling method is invoked for the wrong type.
+    for (const other of ['sendImage', 'sendVideo', 'sendAudio', 'sendDocument'] as const) {
+      if (other !== method) expect(s[other]).not.toHaveBeenCalled();
+    }
   });
 });
 

--- a/src/core/plugins/plugin-loader.service.ts
+++ b/src/core/plugins/plugin-loader.service.ts
@@ -31,7 +31,7 @@ import { PluginWorkerHost } from './sandbox/plugin-worker-host';
 import { WorkerThreadChannel } from './sandbox/worker-thread-channel';
 import { dispatchCapabilityVerb } from './sandbox/capability-router';
 import { PluginLogLevel } from './sandbox/protocol';
-import { buildConversationSendFacade } from './conversation-send-facade';
+import { buildConversationSendFacade, ConversationMediaType } from './conversation-send-facade';
 import { shouldDispatchToPlugin } from './handover-gate';
 import { makeOnWebhookSubscribe } from './webhook-subscribe.util';
 import { INGRESS_DISPATCH_TIMEOUT_MS } from '../../modules/integration/integration.constants';
@@ -95,6 +95,30 @@ export function buildSandboxWorkerEnv(source: NodeJS.ProcessEnv = process.env): 
   }
   env.NODE_ENV = source.NODE_ENV ?? 'production';
   return env;
+}
+
+/**
+ * Translate a normalized conversation media send into the concrete MessageService media method for the
+ * envelope's type. Kept pure (no `this`) so the loader binds it directly and it can be unit-tested in
+ * isolation. The switch is exhaustive over ConversationMediaType — adding a type without a case is a
+ * compile error here rather than a silent runtime fall-through.
+ */
+export function dispatchConversationMedia(
+  svc: Pick<MessageService, 'sendImage' | 'sendVideo' | 'sendAudio' | 'sendDocument'>,
+  sessionId: string,
+  opts: { chatId: string; url: string; type: ConversationMediaType; caption?: string },
+): Promise<unknown> {
+  const dto = { chatId: opts.chatId, url: opts.url, caption: opts.caption };
+  switch (opts.type) {
+    case 'image':
+      return svc.sendImage(sessionId, dto);
+    case 'video':
+      return svc.sendVideo(sessionId, dto);
+    case 'audio':
+      return svc.sendAudio(sessionId, dto);
+    case 'file':
+      return svc.sendDocument(sessionId, dto);
+  }
 }
 
 @Injectable()
@@ -1043,6 +1067,7 @@ export class PluginLoaderService implements OnModuleInit, OnModuleDestroy {
             : run(),
         sendText: (sessionId, opts) => this.getMessageService().sendText(sessionId, opts),
         reply: (sessionId, opts) => this.getMessageService().reply(sessionId, opts),
+        sendMedia: (sessionId, opts) => dispatchConversationMedia(this.getMessageService(), sessionId, opts),
       } satisfies Parameters<typeof buildConversationSendFacade>[0]) satisfies PluginConversationsCapability,
       handover: {
         set: async (key, state) => {


### PR DESCRIPTION
## Summary

The Integration SDK v1 outbound facade (`ctx.conversations.send`) wired only text and reply. It never read `env.type` or `env.mediaUrl`, so a plugin that built an `image`/`video`/`audio`/`file` envelope had an empty text message delivered to the chat — no media, no error, no log. The vendored `ConversationSendEnvelope` type already advertises the full media surface, so this closes the gap between the declared surface and the runtime.

## Changes

- Add a `sendMedia` dependency to `ConversationSendDeps`, bound by the loader to the per-type `MessageService` media methods (`sendImage`/`sendVideo`/`sendAudio`/`sendDocument`) — the same path the `POST /messages/send-{image,video,audio,document}` endpoints use to send media by URL through the engine adapters. The dispatch is a pure, exported `dispatchConversationMedia` helper with an exhaustive `switch`, so adding a media type without a case is a compile error rather than a silent fall-through.
- Branch in `send()`: a media type carrying a `mediaUrl` is delivered as native media, with `text` used as the caption. Text and reply envelopes are unchanged. The send stays under the `conversation:send` permission and inside the `message:sending` re-entrancy guard.

## Behavior

| Envelope | Result |
| --- | --- |
| `text` (± `replyTo`) | unchanged (`sendText` / `reply`) |
| media + `mediaUrl` | native media, caption from `text` |
| media + `mediaUrl` + `replyTo` | rejected — the engine media path cannot quote a message |
| media without `mediaUrl` | falls through to the text path (URL-in-text fallback still delivers) |

`replyTo` on a media envelope is rejected rather than forwarded: `sendImageMessage(chatId, media)` and its siblings take no quoted-message argument, and `SendMediaMessageDto` has no quoted field, so a quote id would be silently dropped. Quoting media would require extending `MediaInput` and both engine adapters, and is out of scope here.

## Tests

- Facade: a media envelope routes to `sendMedia` with the caption taken from `text` (not `sendText`); `replyTo` on media is rejected; a media type without a `mediaUrl` falls back to a text send.
- Dispatch: each media type routes to its matching `MessageService` method and no sibling.
- Full backend suite green (151 suites / 1901 tests); lint and build clean.

Additive and backward-compatible — text and reply behavior is unchanged. Targeted for the next patch release (0.8.2).
