### PR TITLE
feat(plugins): send WhatsApp voice notes via ctx.conversations.send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Plugins can send WhatsApp voice notes through `ctx.conversations.send`.** A new `voice` envelope type sends the media at `mediaUrl` as a PTT voice note (audio bubble with waveform) rather than a plain audio file — the host maps it to an audio send with `ptt` set, which defaults the codec to `audio/ogg; codecs=opus` and classifies the message as `voice`, matching inbound classification. It rides the same `conversation:send` permission and activated-session scope as the other media types. (#607)
+
 ## [0.8.2] - 2026-07-03
 
 ### Added

--- a/src/core/plugins/conversation-send-facade.spec.ts
+++ b/src/core/plugins/conversation-send-facade.spec.ts
@@ -90,6 +90,27 @@ describe('conversation.send facade', () => {
     expect(res).toEqual({ id: 'm2' });
   });
 
+  it('routes a voice envelope to sendMedia with type voice (loader maps it to a PTT audio send)', async () => {
+    const sendMedia = jest.fn().mockResolvedValue({ id: 'v1' });
+    const facade = buildConversationSendFacade({
+      manifest: manifest(['conversation:send']) as never,
+      assertPermission: () => undefined,
+      assertSessionActive: jest.fn(),
+      resolveChatId: () => Promise.resolve('chat@c.us'),
+      runGuarded: (_events: string[], run: () => Promise<unknown>) => run(),
+      sendText: jest.fn(),
+      reply: jest.fn(),
+      sendMedia,
+    } as never);
+    await facade.send({ type: 'voice', mediaUrl: 'https://cdn.example/n.ogg', sessionId: 's', chatId: 'chat@c.us' });
+    expect(sendMedia).toHaveBeenCalledWith('s', {
+      chatId: 'chat@c.us',
+      url: 'https://cdn.example/n.ogg',
+      type: 'voice',
+      caption: undefined,
+    });
+  });
+
   it('rejects replyTo on a media envelope — media-reply is unsupported by the engine', async () => {
     const sendMedia = jest.fn();
     const facade = buildConversationSendFacade({

--- a/src/core/plugins/conversation-send-facade.ts
+++ b/src/core/plugins/conversation-send-facade.ts
@@ -28,10 +28,13 @@ export interface ConversationSendDeps {
   ) => Promise<unknown>;
 }
 
-/** Envelope types carried as media by URL. `location` is a non-text type but has no mediaUrl, so it is excluded. */
-export type ConversationMediaType = 'image' | 'file' | 'audio' | 'video';
+/**
+ * Envelope types carried as media by URL. `voice` is a PTT audio note (the loader maps it to an audio
+ * send with `ptt`). `location` is a non-text type but has no mediaUrl, so it is excluded.
+ */
+export type ConversationMediaType = 'image' | 'file' | 'audio' | 'video' | 'voice';
 
-const MEDIA_TYPES: readonly ConversationMediaType[] = ['image', 'file', 'audio', 'video'];
+const MEDIA_TYPES: readonly ConversationMediaType[] = ['image', 'file', 'audio', 'video', 'voice'];
 
 const isMediaType = (type: ConversationSendEnvelope['type']): type is ConversationMediaType =>
   (MEDIA_TYPES as readonly string[]).includes(type);

--- a/src/core/plugins/plugin-loader.service.spec.ts
+++ b/src/core/plugins/plugin-loader.service.spec.ts
@@ -88,13 +88,27 @@ describe('dispatchConversationMedia', () => {
     ['video', 'sendVideo'],
     ['audio', 'sendAudio'],
     ['file', 'sendDocument'],
-  ] as const)('routes %s to %s with a url+caption DTO', async (type, method) => {
+  ] as const)('routes %s to %s with a url+caption DTO (no ptt)', async (type, method) => {
     const s = svc();
     await dispatchConversationMedia(s, 's', opts(type));
     expect(s[method]).toHaveBeenCalledWith('s', { chatId: 'c@c.us', url: 'https://cdn.example/m', caption: 'cap' });
     // No sibling method is invoked for the wrong type.
     for (const other of ['sendImage', 'sendVideo', 'sendAudio', 'sendDocument'] as const) {
       if (other !== method) expect(s[other]).not.toHaveBeenCalled();
+    }
+  });
+
+  it("routes 'voice' to sendAudio with ptt:true so it renders as a WhatsApp voice note", async () => {
+    const s = svc();
+    await dispatchConversationMedia(s, 's', { chatId: 'c@c.us', url: 'https://cdn.example/n.ogg', type: 'voice' });
+    expect(s.sendAudio).toHaveBeenCalledWith('s', {
+      chatId: 'c@c.us',
+      url: 'https://cdn.example/n.ogg',
+      caption: undefined,
+      ptt: true,
+    });
+    for (const other of ['sendImage', 'sendVideo', 'sendDocument'] as const) {
+      expect(s[other]).not.toHaveBeenCalled();
     }
   });
 });

--- a/src/core/plugins/plugin-loader.service.ts
+++ b/src/core/plugins/plugin-loader.service.ts
@@ -116,6 +116,10 @@ export function dispatchConversationMedia(
       return svc.sendVideo(sessionId, dto);
     case 'audio':
       return svc.sendAudio(sessionId, dto);
+    case 'voice':
+      // A voice envelope is a PTT note: sendAudio with ptt classifies it as 'voice' and defaults the
+      // codec to audio/ogg;opus, so it renders as a WhatsApp voice bubble rather than an audio file.
+      return svc.sendAudio(sessionId, { ...dto, ptt: true });
     case 'file':
       return svc.sendDocument(sessionId, dto);
   }

--- a/src/core/plugins/plugin.interfaces.ts
+++ b/src/core/plugins/plugin.interfaces.ts
@@ -215,7 +215,7 @@ export interface ConversationSendEnvelope {
   sessionId?: string;
   instanceId?: string;
   chatId?: string;
-  type: 'text' | 'image' | 'file' | 'audio' | 'video' | 'location';
+  type: 'text' | 'image' | 'file' | 'audio' | 'video' | 'voice' | 'location';
   text?: string;
   mediaUrl?: string;
   replyTo?: string;


### PR DESCRIPTION
## Summary

Extends `ctx.conversations.send` (added in v0.8.2) with a `voice` envelope type, so a plugin can relay a WhatsApp voice note (PTT) rather than a plain audio file. This is the host-side prerequisite for adapters that bridge voice messages — for example, relaying a voice note recorded in an external inbox back to the WhatsApp contact.

## Changes

- Add `voice` to `ConversationSendEnvelope.type`.
- Route a `voice` envelope through the loader's media dispatcher to `MessageService.sendAudio` with `ptt: true`. That path already classifies the message as `voice`, sets `media.ptt`, and defaults the mimetype to `audio/ogg; codecs=opus` when omitted — so the recipient sees a voice bubble with a waveform, and the persisted record, outbound webhook echo, stats, and dashboard all agree with the inbound `voice` classification.
- `audio` continues to send a plain audio file (no `ptt`).

## Behavior

| Envelope | Result |
| --- | --- |
| `voice` + `mediaUrl` | WhatsApp voice note (PTT), `audio/ogg; codecs=opus` by default |
| `audio` + `mediaUrl` | plain audio file (unchanged) |
| everything else | unchanged |

`voice` behaves like the other media types otherwise: it requires a `mediaUrl` (falls through to the text path without one), rejects `replyTo` (the engine media path cannot quote), and stays under the `conversation:send` permission and the plugin's activated-session scope.

## Tests

- Facade: a `voice` envelope routes to `sendMedia` with `type: 'voice'`.
- Dispatch: `voice` routes to `sendAudio` with `ptt: true`; `audio` routes to `sendAudio` without it.
- Full backend suite green (151 suites / 1903 tests); lint and build clean.

Additive and backward-compatible. Targeted for the next patch release (0.8.3).
