### PR TITLE
feat(security): make CSP upgrade-insecure-requests configurable (#611)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -276,3 +276,5 @@ API_MASTER_KEY=
 # =============================================================================
 ENABLE_SWAGGER=true                 # Enable API documentation at /api/docs (set false to disable on exposed deployments)
 BODY_SIZE_LIMIT=25mb                # Max request body size (base64 media sends ride in the JSON body)
+# CSP_UPGRADE_INSECURE_REQUESTS=false # Set false for an HTTP-only deployment on a trusted private network
+                                    # (default: on in production). Stops the browser upgrading the dashboard to https.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`CSP_UPGRADE_INSECURE_REQUESTS` env var** to control the CSP `upgrade-insecure-requests` directive. It defaults to the existing behaviour (on in production, off elsewhere); set it to `false` for an HTTP-only deployment on a trusted private network, where the browser would otherwise upgrade the dashboard to `https` and make it unreachable. Set it to `true` to force it on. (#611)
+
 ## [0.8.3] - 2026-07-03
 
 ### Added

--- a/src/config/bootstrap-security.spec.ts
+++ b/src/config/bootstrap-security.spec.ts
@@ -1,6 +1,7 @@
 import {
   resolveCorsPolicy,
   isSwaggerEnabled,
+  isUpgradeInsecureRequestsEnabled,
   resolveBodyLimit,
   assertNoDefaultSecretsInProduction,
   isApiKeyPepperMissingInProduction,
@@ -41,6 +42,24 @@ describe('resolveCorsPolicy', () => {
 
   it('still allows wildcard in development', () => {
     expect(resolveCorsPolicy('*', 'development').allowAnyOrigin).toBe(true);
+  });
+});
+
+describe('isUpgradeInsecureRequestsEnabled', () => {
+  it('keeps the legacy default: on in production, off elsewhere (unset)', () => {
+    expect(isUpgradeInsecureRequestsEnabled(undefined, 'production')).toBe(true);
+    expect(isUpgradeInsecureRequestsEnabled(undefined, 'development')).toBe(false);
+    expect(isUpgradeInsecureRequestsEnabled(undefined)).toBe(false);
+  });
+  it('lets an explicit value override NODE_ENV', () => {
+    // HTTP-only private-network prod opts OUT so the dashboard stays reachable (#611)
+    expect(isUpgradeInsecureRequestsEnabled('false', 'production')).toBe(false);
+    // and it can be forced on outside production
+    expect(isUpgradeInsecureRequestsEnabled('true', 'development')).toBe(true);
+  });
+  it('treats any non-"true"/"false" value as unset (falls back to NODE_ENV)', () => {
+    expect(isUpgradeInsecureRequestsEnabled('', 'production')).toBe(true);
+    expect(isUpgradeInsecureRequestsEnabled('1', 'development')).toBe(false);
   });
 });
 

--- a/src/config/bootstrap-security.ts
+++ b/src/config/bootstrap-security.ts
@@ -44,6 +44,19 @@ export function isSwaggerEnabled(enableSwaggerEnv?: string, nodeEnv?: string): b
   return nodeEnv !== 'production';
 }
 
+/**
+ * Whether to emit the CSP `upgrade-insecure-requests` directive (browsers auto-upgrade HTTP→HTTPS).
+ * An explicit CSP_UPGRADE_INSECURE_REQUESTS wins ('true'/'false'). When unset it keeps the legacy
+ * behaviour — ON in production only (the secure default for Internet-facing TLS deployments), OFF
+ * elsewhere. Set CSP_UPGRADE_INSECURE_REQUESTS=false for an HTTP-only deployment on a trusted private
+ * network, where the upgrade would otherwise force the dashboard to https and make it unreachable. (#611)
+ */
+export function isUpgradeInsecureRequestsEnabled(cspEnv?: string, nodeEnv?: string): boolean {
+  if (cspEnv === 'true') return true;
+  if (cspEnv === 'false') return false;
+  return nodeEnv === 'production';
+}
+
 /** Request body-size cap (DoS hardening). Default is media-aware (base64 sends ride in the JSON body). */
 export function resolveBodyLimit(bodySizeEnv?: string): string {
   const trimmed = bodySizeEnv?.trim();

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import { createSwaggerConfig } from './config/swagger.config';
 import {
   resolveCorsPolicy,
   isSwaggerEnabled,
+  isUpgradeInsecureRequestsEnabled,
   resolveBodyLimit,
   assertNoDefaultSecretsInProduction,
   isApiKeyPepperMissingInProduction,
@@ -121,7 +122,14 @@ async function bootstrap() {
           connectSrc: ["'self'"],
           fontSrc: ["'self'", 'https://fonts.gstatic.com'],
           objectSrc: ["'none'"],
-          upgradeInsecureRequests: process.env.NODE_ENV === 'production' ? [] : null,
+          // Auto-upgrade HTTP→HTTPS in production, unless CSP_UPGRADE_INSECURE_REQUESTS opts out for an
+          // HTTP-only private-network deployment (otherwise the browser forces the dashboard to https). (#611)
+          upgradeInsecureRequests: isUpgradeInsecureRequestsEnabled(
+            process.env.CSP_UPGRADE_INSECURE_REQUESTS,
+            process.env.NODE_ENV,
+          )
+            ? []
+            : null,
         },
       },
       hsts: {


### PR DESCRIPTION
Closes #611.

## Summary

The CSP `upgrade-insecure-requests` directive was hardcoded on whenever `NODE_ENV=production`, so browsers auto-upgrade every dashboard request from HTTP to HTTPS. That is correct for Internet-facing TLS deployments, but a production instance intentionally served over HTTP on a trusted private network (TLS terminated elsewhere, or not required) becomes unreachable from the browser — the request to `http://server:2785` is silently rewritten to `https://server:2785`.

## Change

A new `CSP_UPGRADE_INSECURE_REQUESTS` environment variable controls the directive, resolved by a pure `isUpgradeInsecureRequestsEnabled` helper next to the other `bootstrap-security` env gates:

| Value | Result |
| --- | --- |
| unset | legacy default — on in production, off elsewhere |
| `false` | off (HTTP-only private-network deployments) |
| `true` | on, regardless of `NODE_ENV` |

Backward compatible: the default is unchanged, so existing deployments are unaffected. The REST API was never affected; this only concerns the browser dashboard.

## Tests

Unit tests for the resolver cover the legacy default per `NODE_ENV`, the explicit override in both directions, and non-`true`/`false` values falling back to the default. Full backend suite green (1906 tests); lint and build clean. `.env.example` documents the flag.