### PR TITLE
feat(plugins): expose engine.getChatHistory to plugins (#609)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Plugins can read recent chat history** via a new `ctx.engine.getChatHistory(sessionId, chatId, limit?, includeMedia?)` capability, gated by the `engine:read` permission and the plugin's active-session scope like the other engine reads. The limit is clamped host-side (max 100), and both message directions are returned. This is the host-side prerequisite for an adapter to backfill prior conversation context. (#609)
+
 ## [0.8.4] - 2026-07-03
 
 ### Added

--- a/src/core/plugins/plugin-capability.spec.ts
+++ b/src/core/plugins/plugin-capability.spec.ts
@@ -219,6 +219,31 @@ describe('PluginLoaderService capability facade — ctx.engine', () => {
     await ctx.engine.getGroupInfo('sess-1', 'g@g.us');
     expect(engine.getGroupInfo).toHaveBeenCalledWith('g@g.us');
   });
+
+  it('engine.getChatHistory delegates to the engine and clamps the limit to 100', async () => {
+    const engine = { getChatHistory: jest.fn().mockResolvedValue([]) };
+    build(engine);
+    const ctx = contextFor(makePlugin(['*'], ['engine:read']));
+    await ctx.engine.getChatHistory('sess-1', 'c@c.us', 500, true);
+    expect(engine.getChatHistory).toHaveBeenCalledWith('c@c.us', 100, true); // 500 clamped to 100
+  });
+
+  it('engine.getChatHistory defaults the limit and clamps a non-positive value to 1', async () => {
+    const engine = { getChatHistory: jest.fn().mockResolvedValue([]) };
+    build(engine);
+    const ctx = contextFor(makePlugin(['*'], ['engine:read']));
+    await ctx.engine.getChatHistory('sess-1', 'c@c.us'); // no limit → default 50, includeMedia → false
+    await ctx.engine.getChatHistory('sess-1', 'c@c.us', 0);
+    expect(engine.getChatHistory).toHaveBeenNthCalledWith(1, 'c@c.us', 50, false);
+    expect(engine.getChatHistory).toHaveBeenNthCalledWith(2, 'c@c.us', 1, false);
+  });
+
+  it('denies engine.getChatHistory without the engine:read permission', async () => {
+    const { sessionService } = build({ getChatHistory: jest.fn() });
+    const ctx = contextFor(makePlugin(['*'], ['messages:send']));
+    await expect(ctx.engine.getChatHistory('sess-1', 'c@c.us')).rejects.toBeInstanceOf(PluginCapabilityError);
+    expect(sessionService.getEngine).not.toHaveBeenCalled();
+  });
 });
 
 describe('PluginLoaderService capability facade — ctx.net', () => {

--- a/src/core/plugins/plugin-loader.service.ts
+++ b/src/core/plugins/plugin-loader.service.ts
@@ -1012,6 +1012,14 @@ export class PluginLoaderService implements OnModuleInit, OnModuleDestroy {
         checkNumberExists: async (sessionId, phone) =>
           this.resolveEngineRead(plugin, sessionId).checkNumberExists(phone),
         getChats: async sessionId => this.resolveEngineRead(plugin, sessionId).getChats(),
+        getChatHistory: async (sessionId, chatId, limit, includeMedia) =>
+          this.resolveEngineRead(plugin, sessionId).getChatHistory(
+            chatId,
+            // Clamp to the REST non-deep ceiling (MessageService.MAX_CHAT_HISTORY_LIMIT = 100) so an
+            // untrusted plugin can't request an unbounded history fetch.
+            Math.min(Math.max(Math.trunc(limit ?? 50), 1), 100),
+            includeMedia ?? false,
+          ),
       } satisfies PluginEngineReadCapability,
       net: {
         fetch: async (url, init) => {

--- a/src/core/plugins/plugin.interfaces.ts
+++ b/src/core/plugins/plugin.interfaces.ts
@@ -279,6 +279,13 @@ export interface PluginEngineReadCapability {
   getContactById(sessionId: string, contactId: string): ReturnType<IWhatsAppEngine['getContactById']>;
   checkNumberExists(sessionId: string, phone: string): ReturnType<IWhatsAppEngine['checkNumberExists']>;
   getChats(sessionId: string): ReturnType<IWhatsAppEngine['getChats']>;
+  /** Recent messages for a chat (both directions), for history backfill. `limit` is clamped host-side. */
+  getChatHistory(
+    sessionId: string,
+    chatId: string,
+    limit?: number,
+    includeMedia?: boolean,
+  ): ReturnType<IWhatsAppEngine['getChatHistory']>;
 }
 
 /** Outbound HTTP for a plugin — always through the host SSRF guard, scoped to `manifest.net.allow`. */


### PR DESCRIPTION
Part of #609 (initial history sync). Host-side prerequisite for the chatwoot-adapter history backfill.

## Summary

Adds `getChatHistory(sessionId, chatId, limit?, includeMedia?)` to `PluginEngineReadCapability`, so a plugin can read recent messages for a chat (both directions) — the read a backfill needs. It sits alongside the existing engine reads (`getChats`, `getContacts`, …).

## Gating & bounds

- Bound in the loader through the same `resolveEngineRead` gate as the other engine reads: requires the `engine:read` permission **and** an active session for the plugin.
- The `limit` is clamped inline to **100** (the REST non-deep ceiling) so an untrusted plugin cannot request an unbounded history fetch. Defaults to 50; a non-positive value clamps to 1.
- Trust delta is modest — the plugin already receives live messages and contacts for its activated sessions; this exposes recent past ones under the same gate.

## Tests

Delegation with the limit clamped (500 → 100), the default/clamp-to-1 cases, and a permission denial (no `engine:read` → `PluginCapabilityError`, engine never resolved). Full backend suite green (1909 tests); lint and build clean.

Additive and backward-compatible. Targeted for the next patch (0.8.5), which the `chatwoot-adapter` backfill will pin.