### PR TITLE
fix(plugins): bridge engine.getChatHistory to sandboxed plugins + enrich wwjs history (#609)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.6] - 2026-07-03
+
+### Fixed
+
+- **The `engine.getChatHistory` plugin capability (added in 0.8.5) now reaches sandboxed plugins.** It was wired only into the host-side context, not the plugin-worker bridge, so a sandboxed plugin's `ctx.engine.getChatHistory` was `undefined` and the call failed silently. It is now bridged through the worker capability + router like the other engine reads. Historical messages from the whatsapp-web.js engine also carry location coordinates and quoted-message references now, matching the live message path (previously a backfilled location rendered empty and replies lost their thread link). (#609)
+
 ## [0.8.5] - 2026-07-03
 
 ### Added

--- a/src/core/plugins/sandbox/capability-router.spec.ts
+++ b/src/core/plugins/sandbox/capability-router.spec.ts
@@ -12,6 +12,7 @@ function makeContext() {
       getContactById: jest.fn().mockResolvedValue(null),
       checkNumberExists: jest.fn().mockResolvedValue(true),
       getChats: jest.fn().mockResolvedValue([]),
+      getChatHistory: jest.fn().mockResolvedValue([]),
     },
     storage: {
       get: jest.fn().mockResolvedValue('v'),
@@ -54,6 +55,12 @@ describe('dispatchCapabilityVerb', () => {
     const ctx = makeContext();
     await dispatchCapabilityVerb(ctx, 'engine.getGroupInfo', ['s', 'g']);
     expect(ctx.engine.getGroupInfo).toHaveBeenCalledWith('s', 'g');
+  });
+
+  it('routes engine.getChatHistory with chatId, limit and includeMedia', async () => {
+    const ctx = makeContext();
+    await dispatchCapabilityVerb(ctx, 'engine.getChatHistory', ['s', 'c@c.us', 20, true]);
+    expect(ctx.engine.getChatHistory).toHaveBeenCalledWith('s', 'c@c.us', 20, true);
   });
 
   it('routes storage.get and returns its value', async () => {

--- a/src/core/plugins/sandbox/capability-router.ts
+++ b/src/core/plugins/sandbox/capability-router.ts
@@ -49,6 +49,8 @@ export async function dispatchCapabilityVerb(
       return context.engine.checkNumberExists(s(0), s(1));
     case 'engine.getChats':
       return context.engine.getChats(s(0));
+    case 'engine.getChatHistory':
+      return context.engine.getChatHistory(s(0), s(1), args[2] as number | undefined, args[3] as boolean | undefined);
     case 'storage.get':
       return context.storage.get(s(0));
     case 'storage.set':

--- a/src/core/plugins/sandbox/worker-capability.spec.ts
+++ b/src/core/plugins/sandbox/worker-capability.spec.ts
@@ -55,6 +55,9 @@ describe('buildSandboxContext', () => {
     await ctx.engine.getGroupInfo('s', 'g');
     expect(call).toHaveBeenCalledWith('engine.getGroupInfo', ['s', 'g']);
 
+    await ctx.engine.getChatHistory('s', 'c@c.us', 20, true);
+    expect(call).toHaveBeenCalledWith('engine.getChatHistory', ['s', 'c@c.us', 20, true]);
+
     await ctx.storage.set('k', { a: 1 });
     expect(call).toHaveBeenCalledWith('storage.set', ['k', { a: 1 }]);
   });

--- a/src/core/plugins/sandbox/worker-capability.ts
+++ b/src/core/plugins/sandbox/worker-capability.ts
@@ -41,6 +41,7 @@ export interface SandboxCapabilityContext {
     getContactById(sessionId: string, contactId: string): Promise<unknown>;
     checkNumberExists(sessionId: string, phone: string): Promise<unknown>;
     getChats(sessionId: string): Promise<unknown>;
+    getChatHistory(sessionId: string, chatId: string, limit?: number, includeMedia?: boolean): Promise<unknown>;
   };
   storage: {
     get(key: string): Promise<unknown>;
@@ -81,6 +82,8 @@ export function buildSandboxContext(client: WorkerCapabilityClient): SandboxCapa
       getContactById: (sessionId, contactId) => client.call('engine.getContactById', [sessionId, contactId]),
       checkNumberExists: (sessionId, phone) => client.call('engine.checkNumberExists', [sessionId, phone]),
       getChats: sessionId => client.call('engine.getChats', [sessionId]),
+      getChatHistory: (sessionId, chatId, limit, includeMedia) =>
+        client.call('engine.getChatHistory', [sessionId, chatId, limit, includeMedia]),
     },
     storage: {
       get: key => client.call('storage.get', [key]),

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -206,6 +206,55 @@ describe('WhatsAppWebJsAdapter readiness guard (#100)', () => {
   });
 });
 
+describe('WhatsAppWebJsAdapter.getChatHistory enrichment (parity with the live path)', () => {
+  const readyAdapter = (client: unknown): WhatsAppWebJsAdapter => {
+    const adapter = new WhatsAppWebJsAdapter({ sessionId: 's', sessionDataPath: './data/sessions', puppeteer: {} });
+    (adapter as unknown as { status: EngineStatus }).status = EngineStatus.READY;
+    (adapter as unknown as { client: unknown }).client = client;
+    return adapter;
+  };
+
+  it('populates location coordinates and resolves the quoted message for historical messages', async () => {
+    const locMsg = {
+      id: { _serialized: 'M1' },
+      from: '621@c.us',
+      to: 'me',
+      body: '',
+      type: 'location',
+      timestamp: 100,
+      fromMe: false,
+      hasMedia: false,
+      hasQuotedMsg: false,
+      location: { latitude: -6.2, longitude: 106.8, description: 'Office', address: 'Jkt', url: '' },
+    };
+    const replyMsg = {
+      id: { _serialized: 'M2' },
+      from: '621@c.us',
+      to: 'me',
+      body: '..',
+      type: 'chat',
+      timestamp: 200,
+      fromMe: false,
+      hasMedia: false,
+      hasQuotedMsg: true,
+      getQuotedMessage: jest.fn().mockResolvedValue({ id: { _serialized: 'Q1' }, body: 'earlier' }),
+    };
+    const chat = { fetchMessages: jest.fn().mockResolvedValue([locMsg, replyMsg]) };
+    const client = { getChatById: jest.fn().mockResolvedValue(chat) };
+
+    const out = await readyAdapter(client).getChatHistory('621@c.us', 50, false);
+
+    expect(out[0].location).toEqual({
+      latitude: -6.2,
+      longitude: 106.8,
+      description: 'Office',
+      address: 'Jkt',
+      url: undefined,
+    });
+    expect(out[1].quotedMessage).toEqual({ id: 'Q1', body: 'earlier' });
+  });
+});
+
 describe('WhatsAppWebJsAdapter.forwardMessage (returns the real sent id, not a synthetic fwd_ id)', () => {
   const readyAdapter = (client: unknown): WhatsAppWebJsAdapter => {
     const adapter = new WhatsAppWebJsAdapter({ sessionId: 's', sessionDataPath: './data/sessions', puppeteer: {} });

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -1519,6 +1519,25 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
       out.isStatusBroadcast = chatId === 'status@broadcast';
       const call = extractWwebjsCall(msg);
       if (call) out.call = call;
+      // Mirror the live handler's location + quoted-message enrichment so history renders identically —
+      // buildIncomingMessageBase sets type='location' but no coordinates, and never resolves quotes.
+      if (msg.type === MessageTypes.LOCATION && msg.location) {
+        out.location = {
+          latitude: Number(msg.location.latitude),
+          longitude: Number(msg.location.longitude),
+          description: msg.location.description || undefined,
+          address: msg.location.address || undefined,
+          url: msg.location.url || undefined,
+        };
+      }
+      if (msg.hasQuotedMsg) {
+        try {
+          const quoted = await msg.getQuotedMessage();
+          out.quotedMessage = { id: quoted.id._serialized, body: quoted.body };
+        } catch (error) {
+          this.logger.warn(`Failed to resolve quoted message for ${msg.id._serialized}: ${String(error)}`);
+        }
+      }
       if (includeMedia && msg.hasMedia) {
         try {
           // Same pre-gate + limiter as live media: a large historical blob shouldn't bloat the response/heap.


### PR DESCRIPTION
Follow-up to #613 (which added `engine.getChatHistory` in 0.8.5). A deep review found the capability was wired only host-side, so it was unreachable by **sandboxed** plugins — the exact consumers it was written for.

## Fixes

1. **Sandbox bridge.** `engine.getChatHistory` was absent from both halves of the plugin-worker bridge: `worker-capability.ts` (the sandbox-side proxy interface + builder) and `capability-router.ts` (the host dispatch). A sandboxed plugin's `ctx.engine.getChatHistory` was therefore `undefined`, and a hand-crafted verb hit the router default ("Unknown capability verb"). It is now wired in both, mirroring the other five engine reads.
2. **whatsapp-web.js history enrichment.** `getChatHistory` built messages via `buildIncomingMessageBase` only, which does not set location coordinates or resolve quoted messages. So a backfilled location rendered as an empty bubble and historical replies lost their in-reply-to link. `getChatHistory` now mirrors the live handler's `location` + `quotedMessage` enrichment.

## Tests

- Router routes `engine.getChatHistory` with `(sessionId, chatId, limit, includeMedia)`; the worker proxy forwards the same verb + args.
- `getChatHistory` populates location coordinates and resolves the quoted message for historical messages.
- Full backend suite green (1911 tests); lint and build clean.

Patch (0.8.6). Baileys `getChatHistory` remains `unsupported` (unchanged); a consumer must degrade gracefully.