### PR TITLE
feat/custom-select-dropdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Dashboard `<select>` elements replaced with a custom dropdown component.** The "All Status" filter (Sessions), "All Severities" filter (Logs), and language picker (Login) now use a reusable `CustomSelect` component that matches the dashboard design system with proper dark/light theming, keyboard navigation (arrows, Home/End, type-ahead, Escape), and responsive behavior. Focus returns to the trigger on close, matching native `<select>` semantics. Thanks @haseeblodhi1899.
 - The **"Install a plugin" modal is wider on desktop** (480px → 680px) to give the plugin catalog list more room, while still collapsing to a full-width bottom sheet on small screens.
 
 ### Fixed

--- a/dashboard/src/components/CustomSelect.css
+++ b/dashboard/src/components/CustomSelect.css
@@ -1,0 +1,128 @@
+.custom-select {
+  position: relative;
+  display: flex;
+  min-width: 0;
+}
+
+.custom-select-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.75rem 0;
+  border: none;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 0.9375rem;
+  font-family: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.custom-select-trigger:hover {
+  color: var(--text-primary);
+}
+
+.custom-select-trigger:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+.custom-select-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: left;
+}
+
+.custom-select-chevron {
+  flex-shrink: 0;
+  color: var(--text-muted);
+  transition: transform 0.2s ease;
+}
+
+.custom-select-chevron.open {
+  transform: rotate(180deg);
+}
+
+.custom-select-dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  min-width: 160px;
+  max-height: min(250px, 40vh);
+  overflow-y: auto;
+  background: var(--bg-white);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-lg);
+  z-index: 200;
+  padding: 0.3rem;
+  animation: customSelectFadeIn 0.15s ease;
+}
+
+@keyframes customSelectFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.custom-select-option {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-height: 34px;
+  padding: 0.45rem 0.6rem;
+  color: var(--text-secondary);
+  background: transparent;
+  border: 0;
+  border-radius: calc(var(--radius) - 2px);
+  font-size: 0.875rem;
+  font-weight: 500;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.custom-select-option:hover,
+.custom-select-option.focused {
+  background: var(--bg-light);
+  color: var(--text-primary);
+}
+
+.custom-select-option.selected {
+  background: var(--primary-soft);
+  color: var(--primary);
+  font-weight: 600;
+}
+
+/* RTL support */
+[dir='rtl'] .custom-select-label {
+  text-align: right;
+}
+
+[dir='rtl'] .custom-select-option {
+  text-align: right;
+}
+
+/* Mobile responsive */
+@media (max-width: 768px) {
+  .custom-select-trigger {
+    padding: 0.625rem 0;
+    font-size: 0.875rem;
+  }
+
+  .custom-select-dropdown {
+    max-height: min(220px, 40vh);
+  }
+}

--- a/dashboard/src/components/CustomSelect.tsx
+++ b/dashboard/src/components/CustomSelect.tsx
@@ -19,6 +19,9 @@ export function CustomSelect({ value, onChange, options, ariaLabel }: CustomSele
   const [focusedIndex, setFocusedIndex] = useState(-1);
   const containerRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const typeAheadBuffer = useRef('');
+  const typeAheadTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   const selectedOption = options.find(opt => opt.value === value);
   const selectedLabel = selectedOption?.label ?? '';
@@ -26,6 +29,7 @@ export function CustomSelect({ value, onChange, options, ariaLabel }: CustomSele
   const close = useCallback(() => {
     setIsOpen(false);
     setFocusedIndex(-1);
+    triggerRef.current?.focus();
   }, []);
 
   const toggle = useCallback(() => {
@@ -69,6 +73,14 @@ export function CustomSelect({ value, onChange, options, ariaLabel }: CustomSele
           e.preventDefault();
           setFocusedIndex(prev => (prev > 0 ? prev - 1 : options.length - 1));
           break;
+        case 'Home':
+          e.preventDefault();
+          setFocusedIndex(0);
+          break;
+        case 'End':
+          e.preventDefault();
+          setFocusedIndex(options.length - 1);
+          break;
         case 'Enter':
         case ' ':
           e.preventDefault();
@@ -78,6 +90,17 @@ export function CustomSelect({ value, onChange, options, ariaLabel }: CustomSele
           break;
         case 'Tab':
           close();
+          break;
+        default:
+          if (e.key.length === 1) {
+            typeAheadBuffer.current += e.key.toLowerCase();
+            clearTimeout(typeAheadTimer.current);
+            typeAheadTimer.current = setTimeout(() => { typeAheadBuffer.current = ''; }, 500);
+            const match = options.findIndex(opt =>
+              opt.label.toLowerCase().startsWith(typeAheadBuffer.current),
+            );
+            if (match >= 0) setFocusedIndex(match);
+          }
           break;
       }
     },
@@ -104,16 +127,20 @@ export function CustomSelect({ value, onChange, options, ariaLabel }: CustomSele
     }
   }, [isOpen, focusedIndex]);
 
+  useEffect(() => {
+    return () => clearTimeout(typeAheadTimer.current);
+  }, []);
+
   return (
     <div className="custom-select" ref={containerRef} onKeyDown={handleKeyDown}>
       <button
+        ref={triggerRef}
         type="button"
         className="custom-select-trigger"
         onClick={toggle}
         aria-haspopup="listbox"
         aria-expanded={isOpen}
         aria-label={ariaLabel}
-        aria-activedescendant={focusedIndex >= 0 ? `option-${options[focusedIndex]?.value}` : undefined}
       >
         <span className="custom-select-label">{selectedLabel}</span>
         <ChevronDown size={16} className={`custom-select-chevron ${isOpen ? 'open' : ''}`} />

--- a/dashboard/src/components/CustomSelect.tsx
+++ b/dashboard/src/components/CustomSelect.tsx
@@ -1,0 +1,142 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { ChevronDown } from 'lucide-react';
+import './CustomSelect.css';
+
+export interface CustomSelectOption {
+  value: string;
+  label: string;
+}
+
+interface CustomSelectProps {
+  value: string;
+  onChange: (value: string) => void;
+  options: CustomSelectOption[];
+  ariaLabel?: string;
+}
+
+export function CustomSelect({ value, onChange, options, ariaLabel }: CustomSelectProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [focusedIndex, setFocusedIndex] = useState(-1);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const selectedOption = options.find(opt => opt.value === value);
+  const selectedLabel = selectedOption?.label ?? '';
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    setFocusedIndex(-1);
+  }, []);
+
+  const toggle = useCallback(() => {
+    setIsOpen(prev => {
+      if (!prev) {
+        const idx = options.findIndex(opt => opt.value === value);
+        setFocusedIndex(idx >= 0 ? idx : 0);
+      }
+      return !prev;
+    });
+  }, [options, value]);
+
+  const selectOption = useCallback(
+    (optValue: string) => {
+      onChange(optValue);
+      close();
+    },
+    [onChange, close],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!isOpen) {
+        if (e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowDown') {
+          e.preventDefault();
+          toggle();
+        }
+        return;
+      }
+
+      switch (e.key) {
+        case 'Escape':
+          e.preventDefault();
+          close();
+          break;
+        case 'ArrowDown':
+          e.preventDefault();
+          setFocusedIndex(prev => (prev < options.length - 1 ? prev + 1 : 0));
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          setFocusedIndex(prev => (prev > 0 ? prev - 1 : options.length - 1));
+          break;
+        case 'Enter':
+        case ' ':
+          e.preventDefault();
+          if (focusedIndex >= 0 && focusedIndex < options.length) {
+            selectOption(options[focusedIndex].value);
+          }
+          break;
+        case 'Tab':
+          close();
+          break;
+      }
+    },
+    [isOpen, options, focusedIndex, toggle, close, selectOption],
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleOutsideClick = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        close();
+      }
+    };
+
+    document.addEventListener('mousedown', handleOutsideClick);
+    return () => document.removeEventListener('mousedown', handleOutsideClick);
+  }, [isOpen, close]);
+
+  useEffect(() => {
+    if (isOpen && focusedIndex >= 0 && listRef.current) {
+      const items = listRef.current.querySelectorAll<HTMLButtonElement>('.custom-select-option');
+      items[focusedIndex]?.focus();
+    }
+  }, [isOpen, focusedIndex]);
+
+  return (
+    <div className="custom-select" ref={containerRef} onKeyDown={handleKeyDown}>
+      <button
+        type="button"
+        className="custom-select-trigger"
+        onClick={toggle}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        aria-label={ariaLabel}
+        aria-activedescendant={focusedIndex >= 0 ? `option-${options[focusedIndex]?.value}` : undefined}
+      >
+        <span className="custom-select-label">{selectedLabel}</span>
+        <ChevronDown size={16} className={`custom-select-chevron ${isOpen ? 'open' : ''}`} />
+      </button>
+      {isOpen && (
+        <div className="custom-select-dropdown" ref={listRef} role="listbox" aria-label={ariaLabel}>
+          {options.map((option, index) => (
+            <button
+              key={option.value}
+              id={`option-${option.value}`}
+              type="button"
+              className={`custom-select-option ${option.value === value ? 'selected' : ''} ${index === focusedIndex ? 'focused' : ''}`}
+              role="option"
+              aria-selected={option.value === value}
+              onClick={() => selectOption(option.value)}
+              onMouseEnter={() => setFocusedIndex(index)}
+              tabIndex={-1}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/pages/Login.css
+++ b/dashboard/src/pages/Login.css
@@ -62,15 +62,9 @@
   flex-shrink: 0;
 }
 
-.login-container .login-language select{
+.login-container .login-language .custom-select{
   flex: 1;
   min-width: 0;
-  border: 0;
-  outline: 0;
-  color: var(--text-primary);
-  background: transparent;
-  font: inherit;
-  cursor: pointer;
 }
 
 .login-container .login-language:focus-within{

--- a/dashboard/src/pages/Login.tsx
+++ b/dashboard/src/pages/Login.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Eye, EyeOff, Languages } from 'lucide-react';
 import { GithubIcon } from '../components/GithubIcon';
+import { CustomSelect } from '../components/CustomSelect';
 import { languageOptions, resolveSupportedLanguage, type SupportedLanguage } from '../i18n';
 import { API_BASE_URL } from '../services/api';
 import './Login.css';
@@ -68,17 +69,12 @@ export function Login({ onLogin }: LoginProps) {
 
         <div className="login-language">
           <Languages size={18} />
-          <select
+          <CustomSelect
             value={currentLang}
-            onChange={event => changeLanguage(event.target.value as SupportedLanguage)}
-            aria-label={t('common.language')}
-          >
-            {languageOptions.map(option => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
+            onChange={value => changeLanguage(value as SupportedLanguage)}
+            options={languageOptions.map(opt => ({ value: opt.value, label: opt.label }))}
+            ariaLabel={t('common.language')}
+          />
         </div>
 
         <form onSubmit={handleSubmit} className="login-form">

--- a/dashboard/src/pages/Logs.css
+++ b/dashboard/src/pages/Logs.css
@@ -83,17 +83,8 @@
   color: var(--text-muted);
 }
 
-.logs-page .filter-group select{
-  padding: 0.75rem 0;
-  border: none;
-  background: none;
-  font-size: 0.9375rem;
-  color: var(--text-primary);
-  cursor: pointer;
-}
-
-.logs-page .filter-group select:focus{
-  outline: none;
+.logs-page .filter-group .custom-select{
+  flex: 1;
 }
 
 .logs-page .logs-table-container{
@@ -297,9 +288,8 @@
     justify-content: space-between;
   }
 
-  .logs-page .filter-group select{
+  .logs-page .filter-group .custom-select{
     flex: 1;
-    padding: 0.75rem 0;
   }
 
   .logs-page .logs-table-container{

--- a/dashboard/src/pages/Logs.tsx
+++ b/dashboard/src/pages/Logs.tsx
@@ -6,6 +6,7 @@ import { auditApi } from '../services/api';
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { useLogsQuery } from '../hooks/queries';
 import { PageHeader } from '../components/PageHeader';
+import { CustomSelect } from '../components/CustomSelect';
 import { pageWindow } from '../utils/pageWindow';
 import './Logs.css';
 
@@ -153,18 +154,19 @@ export function Logs() {
 
         <div className="filter-group">
           <Filter size={16} />
-          <select
+          <CustomSelect
             value={severityFilter}
-            onChange={e => {
-              setSeverityFilter(e.target.value);
+            onChange={value => {
+              setSeverityFilter(value);
               setPage(1);
             }}
-          >
-            <option value="all">{t('logs.severity.all')}</option>
-            <option value="info">{t('logs.severity.info')}</option>
-            <option value="warn">{t('logs.severity.warn')}</option>
-            <option value="error">{t('logs.severity.error')}</option>
-          </select>
+            options={[
+              { value: 'all', label: t('logs.severity.all') },
+              { value: 'info', label: t('logs.severity.info') },
+              { value: 'warn', label: t('logs.severity.warn') },
+              { value: 'error', label: t('logs.severity.error') },
+            ]}
+          />
         </div>
       </div>
 

--- a/dashboard/src/pages/Sessions.css
+++ b/dashboard/src/pages/Sessions.css
@@ -87,19 +87,8 @@
   color: var(--text-muted);
 }
 
-.sessions-page .filter-group select {
-  padding: 0.75rem 0;
-  border: none;
-  background: none;
-  background-image: none;
-  font-size: 0.9375rem;
-  color: var(--text-primary);
-  cursor: pointer;
-}
-
-.sessions-page .filter-group select:focus {
-  outline: none;
-  box-shadow: none;
+.sessions-page .filter-group .custom-select {
+  flex: 1;
 }
 
 .sessions-page .sessions-grid {
@@ -268,7 +257,7 @@
     justify-content: space-between;
   }
 
-  .sessions-page .filter-group select {
+  .sessions-page .filter-group .custom-select {
     flex: 1;
   }
 

--- a/dashboard/src/pages/Sessions.tsx
+++ b/dashboard/src/pages/Sessions.tsx
@@ -9,6 +9,7 @@ import { useToast } from '../components/Toast';
 import { useWebSocket } from '../hooks/useWebSocket';
 import { useRole } from '../hooks/useRole';
 import { PageHeader } from '../components/PageHeader';
+import { CustomSelect } from '../components/CustomSelect';
 import './Sessions.css';
 
 export function Sessions() {
@@ -354,12 +355,16 @@ export function Sessions() {
 
         <div className="filter-group">
           <Filter size={16} />
-          <select value={statusFilter} onChange={e => setStatusFilter(e.target.value)}>
-            <option value="all">{t('sessions.filter.all')}</option>
-            <option value="active">{t('sessions.filter.active')}</option>
-            <option value="inactive">{t('sessions.filter.inactive')}</option>
-            <option value="connecting">{t('sessions.filter.connecting')}</option>
-          </select>
+          <CustomSelect
+            value={statusFilter}
+            onChange={setStatusFilter}
+            options={[
+              { value: 'all', label: t('sessions.filter.all') },
+              { value: 'active', label: t('sessions.filter.active') },
+              { value: 'inactive', label: t('sessions.filter.inactive') },
+              { value: 'connecting', label: t('sessions.filter.connecting') },
+            ]}
+          />
         </div>
       </div>
 


### PR DESCRIPTION
## Description
Replaces native HTML `<select>` elements in the dashboard with a reusable
`CustomSelect` component that matches the existing design system (colors,
typography, spacing, border radius, animations, dark/light themes).

### Changes
- **New:** `CustomSelect` component with keyboard navigation, ARIA
  accessibility, theme support, responsive design, RTL support
- **Sessions:** "All Status" filter → CustomSelect
- **Logs:** "All Severities" filter → CustomSelect  
- **Login:** Language picker → CustomSelect
- No changes to sidebar (already uses custom menus)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor (UI consistency, no breaking changes)

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] Lint passes (0 errors, 2 pre-existing warnings)
- [x] Build passes (tsc + vite)
- [x] Self-reviewed

## Screenshots (if applicable)
<img width="1920" height="959" alt="image" src="https://github.com/user-attachments/assets/836a31e2-88ff-41f3-9fed-699d12ff38e6" />
<img width="1920" height="954" alt="image" src="https://github.com/user-attachments/assets/25f0f524-c1c2-457b-9226-a24498e58b0c" />
<img width="1920" height="947" alt="image" src="https://github.com/user-attachments/assets/ee1ffe9a-1529-48ac-9c71-093da14a5200" />

## Related Issues
Closes #
