### PR TITLE
fix(message): treat poll as a first-class message type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Native WhatsApp polls** via `POST /api/sessions/:sessionId/messages/send-poll`: question, 2–12 options and an optional `allowMultipleAnswers` flag (default single choice), implemented on both engines (whatsapp-web.js `Poll`, Baileys `poll` content with `selectableCount` 1/0). The message history stores the poll question as the body so the log stays readable.
+- **Native WhatsApp polls** via `POST /api/sessions/:sessionId/messages/send-poll`: question, 2–12 options and an optional `allowMultipleAnswers` flag (default single choice), implemented on both engines (whatsapp-web.js `Poll`, Baileys `poll` content with `selectableCount` 1/0). The message history stores the poll question as the body so the log stays readable. Polls are a first-class `poll` message type end to end — both engines map incoming poll messages to it, so the websocket/webhook events, persisted rows, and dashboard all report `poll` consistently. Thanks @alejo117.
 
 ## [0.8.7] - 2026-07-03
 

--- a/dashboard/src/components/DashboardCharts.tsx
+++ b/dashboard/src/components/DashboardCharts.tsx
@@ -35,6 +35,7 @@ const TYPE_COLORS: Record<string, string> = {
   video: '#14b8a6',
   sticker: '#ef4444',
   location: '#84cc16',
+  poll: '#6366f1',
   revoked: '#f43f5e',
   masked: '#8b5cf6',
   unknown: '#64748b',

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -140,6 +140,7 @@ export const MESSAGE_TYPES = [
   'sticker',
   'location',
   'contact',
+  'poll',
   'call',
   'revoked',
   'masked',

--- a/src/engine/adapters/baileys-message-mapper.spec.ts
+++ b/src/engine/adapters/baileys-message-mapper.spec.ts
@@ -29,7 +29,10 @@ describe('mapBaileysMessageType (baileys content-type -> neutral MessageType)', 
     // its own `masked` type so it is distinguishable from a genuinely unparseable message (#574).
     ['placeholderMessage', false, 'masked'],
     [undefined, false, 'unknown'],
-    ['pollCreationMessage', false, 'unknown'],
+    // Native polls surface as their own `poll` type (WhatsApp bumps the content key across versions).
+    ['pollCreationMessage', false, 'poll'],
+    ['pollCreationMessageV2', false, 'poll'],
+    ['pollCreationMessageV3', false, 'poll'],
     // Regression trap: calls arrive via the `call` socket event, never as a message content type,
     // so any call-ish token must stay 'unknown' (no accidental mapping).
     ['callLogMessage', false, 'unknown'],

--- a/src/engine/adapters/baileys-message-mapper.ts
+++ b/src/engine/adapters/baileys-message-mapper.ts
@@ -32,6 +32,11 @@ export function mapBaileysMessageType(contentType: string | undefined, isPtt = f
     case 'contactMessage':
     case 'contactsArrayMessage':
       return 'contact';
+    case 'pollCreationMessage':
+    case 'pollCreationMessageV2':
+    case 'pollCreationMessageV3':
+      // Native polls; WhatsApp bumps the content key across versions, all map to the same neutral type.
+      return 'poll';
     case 'interactiveMessage':
     case 'buttonsMessage':
     case 'templateMessage':

--- a/src/engine/adapters/message-mapper.spec.ts
+++ b/src/engine/adapters/message-mapper.spec.ts
@@ -124,6 +124,7 @@ describe('mapWwebjsMessageType (engine type-token -> neutral MessageType boundar
     ['multi_vcard', 'contact'],
     ['call_log', 'call'],
     ['revoked', 'revoked'],
+    ['poll_creation', 'poll'],
     ['e2e_notification', 'unknown'], // any unmapped wwebjs type
   ])('maps wwebjs type %s -> %s', (raw, expected) => {
     expect(mapWwebjsMessageType(raw)).toBe(expected);

--- a/src/engine/adapters/message-mapper.ts
+++ b/src/engine/adapters/message-mapper.ts
@@ -29,6 +29,8 @@ export function mapWwebjsMessageType(raw: string): MessageType {
       return 'contact';
     case 'call_log':
       return 'call';
+    case 'poll_creation':
+      return 'poll';
     case 'revoked':
       return 'revoked';
     default:

--- a/src/engine/interfaces/whatsapp-engine.interface.ts
+++ b/src/engine/interfaces/whatsapp-engine.interface.ts
@@ -55,6 +55,7 @@ export type MessageType =
   | 'sticker'
   | 'location'
   | 'contact'
+  | 'poll'
   | 'call'
   | 'revoked'
   // A message WhatsApp deliberately withheld from linked/companion devices (e.g. high-security

--- a/src/modules/message/message.service.spec.ts
+++ b/src/modules/message/message.service.spec.ts
@@ -649,6 +649,10 @@ describe('MessageService', () => {
         options: ['Park', 'Beach'],
         allowMultipleAnswers: false,
       });
+      // A poll has no plain-text body, so it is persisted as type 'poll' with the question as the body.
+      expect(repository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'poll', body: '📊 Where should we meet?' }),
+      );
     });
 
     it('should pass allowMultipleAnswers through to the engine', async () => {


### PR DESCRIPTION
## Summary

Follow-up to #622 (native WhatsApp polls). That change persists outgoing polls with `type: 'poll'`, but `'poll'` was never added to the engine-neutral `MessageType` union, so the reported type diverged depending on how a client observed the same message:

- `GET /messages` and chat history returned `type: 'poll'` (the persisted value).
- The live `message.sent` websocket/webhook event is built from the adapter type mappers, which had no poll case, so it reported `type: 'unknown'`.
- The dashboard coerced the persisted `'poll'` back to `'unknown'` via `asMessageType()`.

The value degraded gracefully (the `📊 <question>` body still rendered), but one message reporting two different types breaks the invariant the codebase documents in `api.ts` — that persisted rows, the `message.sent`/`message.received` payloads, and the websocket all share the same neutral type values.

## Changes

- Add `'poll'` to the `MessageType` union (`whatsapp-engine.interface.ts`).
- Map incoming poll messages to `'poll'` in both adapters' mappers — whatsapp-web.js `poll_creation`, and Baileys `pollCreationMessage` / `pollCreationMessageV2` / `pollCreationMessageV3` (WhatsApp bumps the content key across versions).
- Mirror `'poll'` in the dashboard `MESSAGE_TYPES` so it is no longer coerced to `unknown`, and give it a stable color in the stats chart.
- Add a persistence assertion to the `sendPoll` service spec (it previously only checked the engine-call args, not the persisted `type`/`body`).

With this, sent and received polls report `poll` consistently across REST, the websocket, webhooks, and the dashboard.

## Verification

- Backend: `npm run lint` + `npm run build` clean; full Jest suite green (1927 tests, incl. updated mapper and service specs).
- Dashboard: `npm run build`, `npm run lint`, and `npm run i18n:check` all pass.