### PR TITLE
fix(proxy): authenticate HTTP/HTTPS proxies via wwjs proxyAuthentication (#628)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **`GET /api/sessions/:sessionId/channels/:channelId/messages` always returned an empty array** on the whatsapp-web.js engine (#625). The adapter called `client.getChannelById()`, which does not exist in whatsapp-web.js 1.34.x, so every call threw and the error was swallowed into `[]`. Channel messages are now read from the subscribed `Channel` instance (via `getChannels()`), and an unknown/unsubscribed channel returns a `404` (`ChannelNotFoundError`) instead of a silent empty `200` — matching `GET /channels/:channelId`. Thanks @Header9968.
+- **Authenticated HTTP/HTTPS proxies now work** on the whatsapp-web.js engine (#628). Credentials were passed inside `--proxy-server`, which Chromium ignores, so a proxy with a username/password never authenticated (only IP-authorized proxies worked). The username/password are now handed to whatsapp-web.js's `proxyAuthentication` (which drives Chromium's `page.authenticate`) while `--proxy-server` gets a credential-less URL. SOCKS proxies still cannot be authenticated — Chromium does not support SOCKS proxy authentication at all — so a SOCKS proxy carrying credentials now logs a clear warning instead of failing with an opaque navigation timeout. Thanks @gudge25.
 
 ## [0.8.7] - 2026-07-03
 

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -5,6 +5,7 @@ import {
   extractLinkedParentJID,
   isHttpUrl,
   isSupportedProxyUrl,
+  buildProxyLaunchConfig,
   loadRemoteMedia,
   resolveAuthTimeoutMs,
   wwebjsAckToDeliveryStatus,
@@ -78,6 +79,36 @@ describe('isSupportedProxyUrl', () => {
 
   it.each(['not a url', 'ftp://proxy:21', 'proxy:8080', ''])('rejects %s', url => {
     expect(isSupportedProxyUrl(url)).toBe(false);
+  });
+});
+
+describe('buildProxyLaunchConfig (#628 — proxy credentials must not go into --proxy-server)', () => {
+  it('strips credentials from an HTTP proxy and returns them as proxyAuthentication', () => {
+    expect(buildProxyLaunchConfig('http://user:pass@proxy.example.com:8080')).toEqual({
+      serverArg: 'http://proxy.example.com:8080',
+      proxyAuthentication: { username: 'user', password: 'pass' },
+      socksAuthUnsupported: false,
+    });
+  });
+
+  it('URL-decodes credentials', () => {
+    const cfg = buildProxyLaunchConfig('https://us%40er:p%40ss@proxy:8443');
+    expect(cfg.serverArg).toBe('https://proxy:8443');
+    expect(cfg.proxyAuthentication).toEqual({ username: 'us@er', password: 'p@ss' });
+  });
+
+  it('flags SOCKS credentials as unsupported (Chromium cannot authenticate SOCKS) and does NOT set proxyAuthentication', () => {
+    const cfg = buildProxyLaunchConfig('socks5://user:pass@p.webshare.io:80');
+    expect(cfg.serverArg).toBe('socks5://p.webshare.io:80');
+    expect(cfg.proxyAuthentication).toBeUndefined();
+    expect(cfg.socksAuthUnsupported).toBe(true);
+  });
+
+  it('leaves a credential-less proxy untouched', () => {
+    expect(buildProxyLaunchConfig('socks5://p.webshare.io:1080')).toEqual({
+      serverArg: 'socks5://p.webshare.io:1080',
+      socksAuthUnsupported: false,
+    });
   });
 });
 

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -103,6 +103,36 @@ export function isSupportedProxyUrl(url: string): boolean {
   }
 }
 
+export interface ProxyLaunchConfig {
+  /** Credential-less `--proxy-server` value — Chromium ignores credentials embedded in this flag. */
+  serverArg: string;
+  /** Username/password for whatsapp-web.js's `proxyAuthentication` (→ `page.authenticate`, HTTP/HTTPS only). */
+  proxyAuthentication?: { username: string; password: string };
+  /** The URL carries credentials for a SOCKS proxy, which Chromium cannot authenticate at all. */
+  socksAuthUnsupported: boolean;
+}
+
+/**
+ * Split a proxy URL into a credential-less `--proxy-server` value plus, for an HTTP/HTTPS proxy, the
+ * username/password to hand to whatsapp-web.js's `proxyAuthentication` (which calls `page.authenticate`
+ * — the only way Chromium authenticates a proxy). Credentials embedded in `--proxy-server` are ignored
+ * by Chromium, and SOCKS proxies cannot be authenticated at all, so SOCKS credentials are surfaced via
+ * `socksAuthUnsupported` for the caller to warn about instead of failing with an opaque nav timeout (#628).
+ * Call only with a URL that already passed {@link isSupportedProxyUrl}.
+ */
+export function buildProxyLaunchConfig(url: string): ProxyLaunchConfig {
+  const parsed = new URL(url);
+  const serverArg = `${parsed.protocol}//${parsed.host}`;
+  const username = decodeURIComponent(parsed.username);
+  const password = decodeURIComponent(parsed.password);
+  const hasCredentials = username !== '' || password !== '';
+  const isSocks = parsed.protocol === 'socks4:' || parsed.protocol === 'socks5:';
+  if (hasCredentials && !isSocks) {
+    return { serverArg, proxyAuthentication: { username, password }, socksAuthUnsupported: false };
+  }
+  return { serverArg, socksAuthUnsupported: hasCredentials && isSocks };
+}
+
 /**
  * Whether a MediaInput's string `data` is an http(s) URL (to be fetched through the SSRF-guarded
  * loadRemoteMedia) rather than base64. Case-insensitive, matching the Baileys adapter — a mixed-case
@@ -323,12 +353,21 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
 
       // Add proxy configuration if provided — but only when the URL parses to a supported scheme, so
       // a malformed/stored proxy value can't break the Chromium launch or smuggle a non-proxy scheme.
+      let proxyAuthentication: { username: string; password: string } | undefined;
       if (this.config.proxy) {
         if (isSupportedProxyUrl(this.config.proxy.url)) {
-          puppeteerArgs.push(`--proxy-server=${this.config.proxy.url}`);
-          this.logger.log(
-            `Using proxy: ${this.config.proxy.type}://${this.config.proxy.url.replace(/:[^:@]*@/, ':***@')}`,
-          );
+          // Chromium ignores credentials in --proxy-server; pass a credential-less server and hand the
+          // username/password to wwjs's proxyAuthentication (page.authenticate) for HTTP/HTTPS proxies (#628).
+          const proxyLaunch = buildProxyLaunchConfig(this.config.proxy.url);
+          puppeteerArgs.push(`--proxy-server=${proxyLaunch.serverArg}`);
+          proxyAuthentication = proxyLaunch.proxyAuthentication;
+          if (proxyLaunch.socksAuthUnsupported) {
+            this.logger.warn(
+              `Proxy for session ${this.config.sessionId} has credentials on a SOCKS proxy, but Chromium ` +
+                `cannot authenticate SOCKS proxies. Use an IP-authorized proxy or an HTTP/HTTPS proxy instead.`,
+            );
+          }
+          this.logger.log(`Using proxy: ${proxyLaunch.serverArg}`);
         } else {
           this.logger.warn(`Ignoring invalid proxy URL for session ${this.config.sessionId}`);
         }
@@ -361,6 +400,7 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
           ...(this.config.puppeteer?.executablePath ? { executablePath: this.config.puppeteer.executablePath } : {}),
         },
         ...(authTimeoutMs !== undefined ? { authTimeoutMs } : {}),
+        ...(proxyAuthentication ? { proxyAuthentication } : {}),
         ...(versionPin ?? {}),
       });
 


### PR DESCRIPTION
## Summary

Fixes #628. On the whatsapp-web.js engine, a per-session proxy with a username/password never authenticated — only IP-authorized proxies worked.

## Root cause

The adapter passed the whole proxy URL, credentials included, to Chromium via `--proxy-server=<scheme>://user:pass@host:port`. **Chromium ignores credentials embedded in `--proxy-server`**, and for SOCKS proxies it cannot authenticate at all. So an IP-authorized proxy (no credentials) worked, while a username/password proxy failed with an opaque `Page.navigate timed out`.

## Changes

- Split the proxy URL into a **credential-less `--proxy-server` value** plus the username/password. The credentials are handed to whatsapp-web.js's built-in **`proxyAuthentication`** option, which drives Chromium's `page.authenticate` — the supported way to authenticate an **HTTP/HTTPS** proxy. Authenticated HTTP/HTTPS proxies now work.
- **SOCKS proxies with credentials** now log a clear warning ("Chromium cannot authenticate SOCKS proxies; use an IP-authorized proxy or an HTTP/HTTPS proxy") instead of failing with an opaque navigation timeout. This is a Chromium limitation (SOCKS proxy authentication is unsupported), not something the gateway can work around.
- Removed the cosmetic double-scheme (`socks5://socks5://…`) in the proxy log; it now logs the actual credential-less server.

## Notes

The credential parsing/splitting is extracted into a pure, unit-tested `buildProxyLaunchConfig()` helper (strips credentials from the server arg, URL-decodes them, and flags SOCKS-with-credentials) so the logic is covered without standing up a Chromium/Client mock.

## Verification

- New unit tests for `buildProxyLaunchConfig` (HTTP creds → `proxyAuthentication`, URL-decoding, SOCKS-creds → flagged + no auth, credential-less untouched).
- Full backend suite green (1936 tests), lint and build clean.