### PR TITLE
fix(dashboard): dark theme covers all surfaces + wider plugin install modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The **"Install a plugin" modal is wider on desktop** (480px → 680px) to give the plugin catalog list more room, while still collapsing to a full-width bottom sheet on small screens.
+
+### Fixed
+
+- **The dark theme now covers every dashboard surface.** A number of components used hardcoded colors instead of the theme's CSS variables, so several surfaces stayed light in dark mode — most visibly the Infrastructure "Database Migrations" card, plus status/severity badges, toasts, danger-hover states, and toggle tracks across most pages. They now use the theme tokens (and translucent semantic fills) so they follow the active theme in both light and dark. A new `--info` token themes the blue badges (permission, SQLite, info logs, qr-ready pill) that previously had no theme-aware color, and the root `<html>` background no longer stays white when the dark theme is selected on a light-OS device (visible on overscroll).
+
 ## [0.8.8] - 2026-07-05
 
 ### Added

--- a/dashboard/src/App.css
+++ b/dashboard/src/App.css
@@ -14,6 +14,7 @@
   --error: #ef4444;
   --success: #22c55e;
   --warning: #f59e0b;
+  --info: #2563eb; /* Blue 600 — info/permission/log badges + qr-ready pill; no palette blue token */
   --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
   --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
   --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
@@ -69,6 +70,7 @@
   --text-secondary: #cbd5e1; /* Slate 300 */
   --text-muted: #64748b; /* Slate 500 */
   --border: #334155; /* Slate 700 */
+  --info: #60a5fa; /* Blue 400 — lighter so it reads over the dark translucent-blue tints */
   --primary-soft: color-mix(in srgb, var(--primary) 18%, transparent);
   --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.3);
   --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.3), 0 2px 4px -2px rgb(0 0 0 / 0.3);
@@ -94,6 +96,7 @@
     --text-secondary: #cbd5e1;
     --text-muted: #64748b;
     --border: #334155;
+    --info: #60a5fa;
     --primary-soft: color-mix(in srgb, var(--primary) 18%, transparent);
     --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.3);
     --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.3), 0 2px 4px -2px rgb(0 0 0 / 0.3);
@@ -158,11 +161,11 @@ a:hover {
 }
 
 .error-banner svg {
-  color: #ef4444;
+  color: var(--error);
 }
 
 .error-banner-text {
-  color: #ef4444;
+  color: var(--error);
 }
 
 /* yarl theme — match dashboard dark palette. */

--- a/dashboard/src/components/ErrorBoundary.tsx
+++ b/dashboard/src/components/ErrorBoundary.tsx
@@ -35,18 +35,18 @@ export class ErrorBoundary extends Component<Props, State> {
         <div style={{
           display: 'flex', flexDirection: 'column', alignItems: 'center',
           justifyContent: 'center', minHeight: '100vh', padding: '2rem',
-          fontFamily: 'system-ui, sans-serif', color: '#374151',
+          fontFamily: 'system-ui, sans-serif', color: 'var(--text-primary)',
         }}>
-          <AlertCircle size={48} style={{ color: '#DC2626', marginBottom: '1rem' }} />
+          <AlertCircle size={48} style={{ color: 'var(--error)', marginBottom: '1rem' }} />
           <h1 style={{ fontSize: '1.5rem', marginBottom: '0.5rem' }}>{i18n.t('errorBoundary.title')}</h1>
-          <p style={{ color: '#6B7280', marginBottom: '1.5rem', textAlign: 'center' }}>
+          <p style={{ color: 'var(--text-muted)', marginBottom: '1.5rem', textAlign: 'center' }}>
             {i18n.t('errorBoundary.description')}
           </p>
           <button
             onClick={this.handleReload}
             style={{
               display: 'flex', alignItems: 'center', gap: '0.5rem',
-              padding: '0.75rem 1.5rem', backgroundColor: '#2563EB',
+              padding: '0.75rem 1.5rem', backgroundColor: 'var(--primary)',
               color: 'white', border: 'none', borderRadius: '0.5rem',
               cursor: 'pointer', fontSize: '1rem',
             }}

--- a/dashboard/src/components/Layout.css
+++ b/dashboard/src/components/Layout.css
@@ -453,9 +453,9 @@
 }
 
 .logout-btn:hover {
-  background: #fee2e2;
-  border-color: #fecaca;
-  color: #dc2626;
+  background: rgba(239, 68, 68, 0.12);
+  border-color: rgba(239, 68, 68, 0.3);
+  color: var(--error);
 }
 
 /* ==================== Main Content ==================== */

--- a/dashboard/src/components/Toast.css
+++ b/dashboard/src/components/Toast.css
@@ -14,7 +14,7 @@
   align-items: flex-start;
   gap: 0.75rem;
   padding: 1rem 1.25rem;
-  background: white;
+  background: var(--bg-card);
   border-radius: 12px;
   box-shadow:
     0 10px 40px rgba(0, 0, 0, 0.12),
@@ -79,13 +79,13 @@
 .toast-title {
   font-weight: 600;
   font-size: 0.9375rem;
-  color: #1e293b;
+  color: var(--text-primary);
   line-height: 1.4;
 }
 
 .toast-message {
   font-size: 0.8125rem;
-  color: #64748b;
+  color: var(--text-secondary);
   margin-top: 0.25rem;
   line-height: 1.5;
 }
@@ -100,12 +100,12 @@
   border-radius: 6px;
   border: none;
   background: transparent;
-  color: #94a3b8;
+  color: var(--text-muted);
   cursor: pointer;
   transition: all 0.15s ease;
 }
 
 .toast-close:hover {
-  background: #f1f5f9;
-  color: #475569;
+  background: var(--bg-light);
+  color: var(--text-secondary);
 }

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -190,6 +190,14 @@ select:disabled {
   overflow: hidden;
 }
 
+/* The install-plugin modal holds the catalog list — a bit wider on desktop for comfortable reading.
+   The responsive rules below (<=768px: 95% width; <=480px: full-width bottom sheet) still apply, so
+   it stays responsive on small screens. Lives here (global modal styles) rather than in a page CSS
+   so it isn't subject to the page-root scoping rule. */
+.modal.install-modal {
+  max-width: 680px;
+}
+
 @keyframes slideUp {
   from {
     opacity: 0;

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -92,15 +92,23 @@ button:focus:not(:focus-visible) {
   outline: none;
 }
 
+html {
+  /* Root/overscroll background follows the app theme token, so an explicit dark theme on a
+     light-OS device doesn't reveal a white <html> background above/below the body (overscroll). */
+  background-color: var(--bg-light);
+}
+
 @media (prefers-color-scheme: light) {
-  :root {
+  /* Guarded with :not([data-theme='dark']): when the OS prefers light but the user explicitly
+     picked the dark theme, the app's own choice must win (otherwise the root is force-whitened). */
+  :root:not([data-theme='dark']) {
     color: #213547;
     background-color: #ffffff;
   }
   a:hover {
     color: #747bff;
   }
-  button {
+  :root:not([data-theme='dark']) button {
     background-color: #f9f9f9;
   }
 }
@@ -291,13 +299,13 @@ select:disabled {
 }
 
 .btn-icon:hover {
-  background: #fee2e2;
-  border-color: #fecaca;
-  color: #dc2626;
+  background: rgba(239, 68, 68, 0.12);
+  border-color: rgba(239, 68, 68, 0.3);
+  color: var(--error);
 }
 
 .btn-icon:hover svg {
-  stroke: #dc2626;
+  stroke: var(--error);
 }
 
 /* Secondary Button */

--- a/dashboard/src/pages/ApiKeys.css
+++ b/dashboard/src/pages/ApiKeys.css
@@ -84,7 +84,7 @@
 }
 
 .api-keys-page .keys-table tbody tr.table-row:nth-child(even){
-  background: rgba(0, 0, 0, 0.02);
+  background: rgba(148, 163, 184, 0.08);
 }
 
 .api-keys-page .keys-table tbody tr.table-row:nth-child(even):hover{
@@ -136,8 +136,8 @@
 .api-keys-page .permission-badge{
   font-size: 0.6875rem;
   padding: 0.25rem 0.5rem;
-  background: #e0f2fe;
-  color: #0369a1;
+  background: rgba(59, 130, 246, 0.12);
+  color: var(--info);
   border-radius: 4px;
   font-weight: 500;
   white-space: nowrap;
@@ -178,9 +178,9 @@
 }
 
 .api-keys-page .icon-btn.danger:hover{
-  background: #fee2e2;
-  border-color: #fecaca;
-  color: #dc2626;
+  background: rgba(239, 68, 68, 0.12);
+  border-color: rgba(239, 68, 68, 0.3);
+  color: var(--error);
 }
 
 .api-keys-page .permissions-reference{
@@ -267,7 +267,7 @@
 }
 
 .api-keys-page .confirm-warning-icon{
-  color: #f59e0b;
+  color: var(--warning);
 }
 
 .api-keys-page .confirm-message{
@@ -284,7 +284,7 @@
 
 .api-keys-page .btn-danger{
   padding: 0.75rem 1.25rem;
-  background: #dc2626;
+  background: var(--error);
   color: white;
   border: none;
   border-radius: 8px;
@@ -413,8 +413,8 @@
   }
 
   .api-keys-page .status-badge.inactive{
-    background: #fee2e2;
-    color: #dc2626;
+    background: rgba(239, 68, 68, 0.12);
+    color: var(--error);
   }
 
   /* Actions cell - bottom with separator */

--- a/dashboard/src/pages/Chats.css
+++ b/dashboard/src/pages/Chats.css
@@ -102,7 +102,7 @@
 }
 
 .chats-page .chats-list::-webkit-scrollbar-thumb, .chats-page .room-messages::-webkit-scrollbar-thumb{
-  background: rgba(0, 0, 0, 0.1);
+  background: var(--border);
   border-radius: 3px;
 }
 
@@ -641,8 +641,8 @@
 }
 
 .chats-page .btn-remove-attachment:hover{
-  background: #fee2e2;
-  color: #dc2626;
+  background: rgba(239, 68, 68, 0.12);
+  color: var(--error);
 }
 
 .chats-page .chats-emoji-picker{
@@ -846,8 +846,8 @@
 }
 
 .chats-page .action-btn.delete-btn:hover{
-  color: #dc2626;
-  background: #fee2e2;
+  color: var(--error);
+  background: rgba(239, 68, 68, 0.12);
 }
 
 /* Reaction Quick Popover */

--- a/dashboard/src/pages/Dashboard.css
+++ b/dashboard/src/pages/Dashboard.css
@@ -104,7 +104,7 @@
 }
 
 .dashboard .stat-trend.down{
-  color: #ef4444;
+  color: var(--error);
 }
 
 .dashboard .sessions-section{
@@ -209,12 +209,12 @@
 }
 
 .dashboard .status-pill.connecting{
-  background: #fef3c7;
-  color: #d97706;
+  background: rgba(245, 158, 11, 0.15);
+  color: var(--warning);
 }
 
 .dashboard .status-pill.disconnected{
-  background: #f3f4f6;
+  background: var(--bg-light);
   color: var(--text-muted);
 }
 
@@ -247,13 +247,13 @@
 }
 
 .dashboard .btn-sm.danger{
-  color: #dc2626;
-  border-color: #fecaca;
-  background: #fef2f2;
+  color: var(--error);
+  border-color: rgba(239, 68, 68, 0.3);
+  background: rgba(239, 68, 68, 0.12);
 }
 
 .dashboard .btn-sm.danger:hover{
-  background: #fee2e2;
+  background: rgba(239, 68, 68, 0.18);
 }
 
 @media (max-width: 1200px) {

--- a/dashboard/src/pages/Dashboard.tsx
+++ b/dashboard/src/pages/Dashboard.tsx
@@ -85,7 +85,7 @@ export function Dashboard() {
   if (error) {
     return (
       <div className="dashboard" style={{ padding: '2rem' }}>
-        <div style={{ background: '#FEE2E2', padding: '1rem', borderRadius: '8px', color: '#DC2626' }}>
+        <div style={{ background: 'rgba(239, 68, 68, 0.12)', padding: '1rem', borderRadius: '8px', color: 'var(--error)' }}>
           {t('dashboard.errorPrefix', { message: error })}
         </div>
       </div>

--- a/dashboard/src/pages/Infrastructure.css
+++ b/dashboard/src/pages/Infrastructure.css
@@ -76,20 +76,20 @@
 }
 
 .infrastructure-page .status-indicator.disconnected{
-  background: #fee2e2;
-  color: #dc2626;
+  background: rgba(239, 68, 68, 0.12);
+  color: var(--error);
 }
 
 .infrastructure-page .status-indicator.sqlite{
-  background: #e0f2fe;
-  color: #0369a1;
+  background: rgba(59, 130, 246, 0.12);
+  color: var(--info);
 }
 
 .infrastructure-page .warning-badge{
   font-size: 0.75rem;
   padding: 0.375rem 0.75rem;
-  background: #fef3c7;
-  color: #d97706;
+  background: rgba(245, 158, 11, 0.15);
+  color: var(--warning);
   border-radius: 6px;
 }
 
@@ -231,7 +231,7 @@
 .infrastructure-page .toggle-info small{
   font-size: 0.75rem;
   font-weight: 400;
-  color: #64748b; /* Slate 500 */
+  color: var(--text-muted); /* Slate 500 */
   opacity: 0.85;
 }
 
@@ -254,7 +254,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: #e5e7eb;
+  background: var(--border);
   border-radius: 26px;
   transition: all 0.2s;
 }
@@ -393,10 +393,10 @@
 }
 
 .infrastructure-page .stat-item.pending .value{
-  color: #d97706;
+  color: var(--warning);
 }
 .infrastructure-page .stat-item.pending .label{
-  color: #d97706;
+  color: var(--warning);
 }
 .infrastructure-page .stat-item.completed .value{
   color: var(--primary);
@@ -405,10 +405,10 @@
   color: var(--primary);
 }
 .infrastructure-page .stat-item.failed .value{
-  color: #dc2626;
+  color: var(--error);
 }
 .infrastructure-page .stat-item.failed .label{
-  color: #dc2626;
+  color: var(--error);
 }
 
 .infrastructure-page .queue-actions{
@@ -466,8 +466,8 @@
   gap: 0.5rem;
   padding: 0.625rem 1rem;
   background: transparent;
-  color: #dc2626;
-  border: 1px solid #dc2626;
+  color: var(--error);
+  border: 1px solid var(--error);
   border-radius: var(--radius);
   font-size: 0.875rem;
   font-weight: 500;
@@ -476,7 +476,7 @@
 }
 
 .infrastructure-page .btn-danger-outline:hover{
-  background: #fee2e2;
+  background: rgba(239, 68, 68, 0.12);
 }
 
 /* Footer */

--- a/dashboard/src/pages/Infrastructure.tsx
+++ b/dashboard/src/pages/Infrastructure.tsx
@@ -608,20 +608,20 @@ export function Infrastructure() {
             style={{
               padding: '2.5rem',
               textAlign: 'center',
-              background: '#F8FAFC',
+              background: 'var(--bg-light)',
               borderRadius: '12px',
-              border: '1px dashed #E2E8F0',
+              border: '1px dashed var(--border)',
               marginTop: '1rem',
             }}
           >
-            <Database size={32} style={{ color: '#22C55E', marginBottom: '1rem', opacity: 0.7 }} />
-            <p style={{ margin: 0, color: '#475569', fontSize: '0.9375rem', fontWeight: 500 }}>
+            <Database size={32} style={{ color: 'var(--success)', marginBottom: '1rem', opacity: 0.7 }} />
+            <p style={{ margin: 0, color: 'var(--text-secondary)', fontSize: '0.9375rem', fontWeight: 500 }}>
               {t('infrastructure.database.migrationsTitle')}
             </p>
             <p
               style={{
                 margin: '0.75rem 0 0',
-                color: '#22C55E',
+                color: 'var(--success)',
                 fontSize: '0.875rem',
                 fontWeight: 500,
                 display: 'flex',
@@ -633,7 +633,7 @@ export function Infrastructure() {
               <CheckCircle size={16} />
               {t('infrastructure.database.migrationsStatus')}
             </p>
-            <p style={{ margin: '0.5rem 0 0', color: '#64748B', fontSize: '0.8125rem', lineHeight: 1.5 }}>
+            <p style={{ margin: '0.5rem 0 0', color: 'var(--text-muted)', fontSize: '0.8125rem', lineHeight: 1.5 }}>
               {t('infrastructure.database.migrationsHint')}
             </p>
           </div>
@@ -747,12 +747,12 @@ export function Infrastructure() {
               </div>
             </div>
           ) : (
-            <p style={{ margin: '0.5rem 0 0', color: '#64748B', fontSize: '0.8125rem', lineHeight: 1.5 }}>
+            <p style={{ margin: '0.5rem 0 0', color: 'var(--text-muted)', fontSize: '0.8125rem', lineHeight: 1.5 }}>
               {t('infrastructure.engine.noBrowser')}
             </p>
           )}
 
-          <p style={{ margin: '1rem 0 0', color: '#64748B', fontSize: '0.8125rem', lineHeight: 1.5 }}>
+          <p style={{ margin: '1rem 0 0', color: 'var(--text-muted)', fontSize: '0.8125rem', lineHeight: 1.5 }}>
             {t('infrastructure.engine.restartNote')}
           </p>
         </section>
@@ -919,17 +919,17 @@ export function Infrastructure() {
               style={{
                 padding: '2.5rem',
                 textAlign: 'center',
-                background: '#F8FAFC',
+                background: 'var(--bg-light)',
                 borderRadius: '12px',
-                border: '1px dashed #E2E8F0',
+                border: '1px dashed var(--border)',
                 marginTop: '1rem',
               }}
             >
-              <Server size={32} style={{ color: '#94A3B8', marginBottom: '1rem', opacity: 0.5 }} />
-              <p style={{ margin: 0, color: '#475569', fontSize: '0.9375rem', fontWeight: 500 }}>
+              <Server size={32} style={{ color: 'var(--text-muted)', marginBottom: '1rem', opacity: 0.5 }} />
+              <p style={{ margin: 0, color: 'var(--text-secondary)', fontSize: '0.9375rem', fontWeight: 500 }}>
                 {t('infrastructure.redis.disabledTitle')}
               </p>
-              <p style={{ margin: '0.5rem 0 0', color: '#64748B', fontSize: '0.8125rem', lineHeight: 1.5 }}>
+              <p style={{ margin: '0.5rem 0 0', color: 'var(--text-muted)', fontSize: '0.8125rem', lineHeight: 1.5 }}>
                 {t('infrastructure.redis.disabledDesc')}
               </p>
             </div>
@@ -1080,7 +1080,7 @@ export function Infrastructure() {
             <div className="modal-body" style={{ padding: '2rem' }}>
               {restartStatus === 'idle' && (
                 <>
-                  <p style={{ fontSize: '1rem', color: '#475569', marginBottom: '1.5rem' }}>
+                  <p style={{ fontSize: '1rem', color: 'var(--text-secondary)', marginBottom: '1.5rem' }}>
                     <Trans i18nKey="infrastructure.restart.idleDesc" components={{ code: <code />, br: <br /> }} />
                   </p>
                   {(dbSwitch || storageSwitch) && (
@@ -1113,8 +1113,8 @@ export function Infrastructure() {
               {(restartStatus === 'restarting' || restartStatus === 'waiting') && (
                 <>
                   <div style={{ marginBottom: '1.5rem' }}>
-                    <Loader2 className="animate-spin" size={48} style={{ color: '#22C55E', marginBottom: '1rem' }} />
-                    <p style={{ fontSize: '1.125rem', color: '#1E293B', fontWeight: 500 }}>
+                    <Loader2 className="animate-spin" size={48} style={{ color: 'var(--success)', marginBottom: '1rem' }} />
+                    <p style={{ fontSize: '1.125rem', color: 'var(--text-primary)', fontWeight: 500 }}>
                       {restartCountdown > 0
                         ? t('infrastructure.restart.restartingMsg', { count: restartCountdown })
                         : t('infrastructure.restart.checking')}
@@ -1124,7 +1124,7 @@ export function Infrastructure() {
                     style={{
                       width: '100%',
                       height: '8px',
-                      background: '#E2E8F0',
+                      background: 'var(--border)',
                       borderRadius: '4px',
                       overflow: 'hidden',
                     }}
@@ -1138,7 +1138,7 @@ export function Infrastructure() {
                       }}
                     />
                   </div>
-                  <p style={{ marginTop: '1rem', fontSize: '0.875rem', color: '#64748B' }}>
+                  <p style={{ marginTop: '1rem', fontSize: '0.875rem', color: 'var(--text-muted)' }}>
                     {t('infrastructure.restart.dontClose')}
                   </p>
                 </>
@@ -1146,8 +1146,8 @@ export function Infrastructure() {
 
               {restartStatus === 'success' && (
                 <>
-                  <CheckCircle size={48} style={{ color: '#22C55E', marginBottom: '1rem' }} />
-                  <p style={{ fontSize: '1rem', color: '#475569' }}>
+                  <CheckCircle size={48} style={{ color: 'var(--success)', marginBottom: '1rem' }} />
+                  <p style={{ fontSize: '1rem', color: 'var(--text-secondary)' }}>
                     {t('infrastructure.restart.successMsg')}
                   </p>
                 </>
@@ -1155,7 +1155,7 @@ export function Infrastructure() {
 
               {restartStatus === 'error' && (
                 <>
-                  <p style={{ fontSize: '1rem', color: '#DC2626', marginBottom: '1rem' }}>
+                  <p style={{ fontSize: '1rem', color: 'var(--error)', marginBottom: '1rem' }}>
                     {t('infrastructure.restart.errorMsg')}
                   </p>
                   <button className="btn-primary" onClick={() => window.location.reload()}>

--- a/dashboard/src/pages/Logs.css
+++ b/dashboard/src/pages/Logs.css
@@ -189,18 +189,18 @@
 }
 
 .logs-page .severity-badge.info{
-  background: #dbeafe;
-  color: #1d4ed8;
+  background: rgba(59, 130, 246, 0.12);
+  color: var(--info);
 }
 
 .logs-page .severity-badge.warn{
-  background: #fef3c7;
-  color: #d97706;
+  background: rgba(245, 158, 11, 0.15);
+  color: var(--warning);
 }
 
 .logs-page .severity-badge.error{
-  background: #fee2e2;
-  color: #dc2626;
+  background: rgba(239, 68, 68, 0.12);
+  color: var(--error);
 }
 
 .logs-page .pagination{

--- a/dashboard/src/pages/MessageTester.css
+++ b/dashboard/src/pages/MessageTester.css
@@ -146,8 +146,8 @@
 }
 
 .message-tester .response-status.error{
-  background: #FEE2E2;
-  color: #DC2626;
+  background: rgba(239, 68, 68, 0.12);
+  color: var(--error);
 }
 
 .message-tester .response-details{

--- a/dashboard/src/pages/MessageTester.tsx
+++ b/dashboard/src/pages/MessageTester.tsx
@@ -284,7 +284,7 @@ export function MessageTester() {
                 {response.error && (
                   <div className="detail-row">
                     <span className="detail-label">{t('messageTester.response.error')}</span>
-                    <span className="detail-value" style={{ color: '#DC2626' }}>
+                    <span className="detail-value" style={{ color: 'var(--error)' }}>
                       {response.error}
                     </span>
                   </div>

--- a/dashboard/src/pages/Plugins.css
+++ b/dashboard/src/pages/Plugins.css
@@ -435,7 +435,7 @@
   border: 1px solid rgba(251, 191, 36, 0.3);
   border-radius: 8px;
   margin-bottom: 1.5rem;
-  color: #d97706;
+  color: var(--warning);
   font-size: 0.875rem;
 }
 
@@ -637,7 +637,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: #cbd5e1;
+  background-color: var(--border);
   transition: 0.3s;
   border-radius: 26px;
 }
@@ -1135,4 +1135,11 @@
   gap: 6px;
   color: var(--text-secondary, #6b7280);
   font-size: 0.85rem;
+}
+
+/* The install modal holds the plugin catalog list — give it more room on desktop for comfortable
+   reading. The shared .modal responsive rules still apply below it (<=768px: 95% width;
+   <=480px: full-width bottom sheet), so it stays responsive on small screens. */
+.modal.install-modal {
+  max-width: 680px;
 }

--- a/dashboard/src/pages/Plugins.css
+++ b/dashboard/src/pages/Plugins.css
@@ -1136,10 +1136,3 @@
   color: var(--text-secondary, #6b7280);
   font-size: 0.85rem;
 }
-
-/* The install modal holds the plugin catalog list — give it more room on desktop for comfortable
-   reading. The shared .modal responsive rules still apply below it (<=768px: 95% width;
-   <=480px: full-width bottom sheet), so it stays responsive on small screens. */
-.modal.install-modal {
-  max-width: 680px;
-}

--- a/dashboard/src/pages/Sessions.css
+++ b/dashboard/src/pages/Sessions.css
@@ -225,12 +225,12 @@
 }
 
 .sessions-page .btn-action.danger {
-  color: #dc2626;
+  color: var(--error);
 }
 
 .sessions-page .btn-action.danger:hover {
-  background: #fee2e2;
-  border-color: #fecaca;
+  background: rgba(239, 68, 68, 0.12);
+  border-color: rgba(239, 68, 68, 0.3);
 }
 
 @media (max-width: 1400px) {
@@ -424,7 +424,7 @@
 .sessions-page .input-error {
   margin: 0.5rem 0 0;
   font-size: 0.75rem;
-  color: #dc2626;
+  color: var(--error);
   font-weight: 500;
 }
 
@@ -546,17 +546,17 @@
 
 .sessions-page .status-badge.connected {
   background: rgba(34, 197, 94, 0.1);
-  color: #16a34a;
+  color: var(--success);
 }
 
 .sessions-page .status-badge.disconnected {
   background: rgba(107, 114, 128, 0.1);
-  color: #6b7280;
+  color: var(--text-secondary);
 }
 
 .sessions-page .status-badge.connecting {
   background: rgba(234, 179, 8, 0.1);
-  color: #ca8a04;
+  color: var(--warning);
 }
 
 .sessions-page .status-badge::before {
@@ -625,13 +625,13 @@
 }
 
 .sessions-page .btn-close:hover {
-  background: #fee2e2;
-  border-color: #fecaca;
-  color: #dc2626;
+  background: rgba(239, 68, 68, 0.12);
+  border-color: rgba(239, 68, 68, 0.3);
+  color: var(--error);
 }
 
 .sessions-page .btn-close:hover svg {
-  stroke: #dc2626;
+  stroke: var(--error);
 }
 
 /* QR Modal Specific */
@@ -699,28 +699,28 @@
 .sessions-page .status-pill.created,
 .sessions-page .status-pill.idle {
   background: rgba(107, 114, 128, 0.1);
-  color: #6b7280;
+  color: var(--text-secondary);
 }
 
 .sessions-page .status-pill.initializing,
 .sessions-page .status-pill.connecting {
   background: rgba(234, 179, 8, 0.1);
-  color: #ca8a04;
+  color: var(--warning);
 }
 
 .sessions-page .status-pill.qr_ready {
   background: rgba(59, 130, 246, 0.1);
-  color: #2563eb;
+  color: var(--info);
 }
 
 .sessions-page .status-pill.ready {
   background: rgba(34, 197, 94, 0.1);
-  color: #16a34a;
+  color: var(--success);
 }
 
 .sessions-page .status-pill.disconnected {
   background: rgba(239, 68, 68, 0.1);
-  color: #dc2626;
+  color: var(--error);
 }
 
 /* Small Button for QR Placeholder */

--- a/dashboard/src/pages/Sessions.tsx
+++ b/dashboard/src/pages/Sessions.tsx
@@ -366,10 +366,10 @@ export function Sessions() {
       {error && (
         <div
           style={{
-            background: '#FEE2E2',
+            background: 'rgba(239, 68, 68, 0.12)',
             padding: '1rem',
             borderRadius: '8px',
-            color: '#DC2626',
+            color: 'var(--error)',
             marginBottom: '1rem',
           }}
         >
@@ -445,7 +445,7 @@ export function Sessions() {
                 <span className="session-name">{qrData.sessionName}</span>
               </div>
               <button className="btn-close" onClick={handleCloseQRModal} aria-label={t('common.close')}>
-                <X size={20} color="#64748b" />
+                <X size={20} color="var(--text-muted)" />
               </button>
             </div>
             <div className="modal-body" style={{ textAlign: 'center' }}>

--- a/dashboard/src/pages/Templates.css
+++ b/dashboard/src/pages/Templates.css
@@ -362,9 +362,9 @@
 }
 
 .templates-page .icon-btn.danger:hover{
-  border-color: #fecaca;
-  background: #fee2e2;
-  color: #dc2626;
+  border-color: rgba(239, 68, 68, 0.3);
+  background: rgba(239, 68, 68, 0.12);
+  color: var(--error);
 }
 
 .templates-page .btn-danger{
@@ -374,7 +374,7 @@
   padding: 0.75rem 1.25rem;
   border: none;
   border-radius: var(--radius);
-  background: #dc2626;
+  background: var(--error);
   color: white;
   font-size: 0.9375rem;
   font-weight: 600;
@@ -400,15 +400,15 @@
 }
 
 .templates-page .toast.success{
-  border: 1px solid #a7f3d0;
-  background: #ecfdf5;
-  color: #047857;
+  border: 1px solid rgba(37, 211, 102, 0.3);
+  background: rgba(37, 211, 102, 0.12);
+  color: var(--success);
 }
 
 .templates-page .toast.error{
-  border: 1px solid #fecaca;
-  background: #fef2f2;
-  color: #dc2626;
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  background: rgba(239, 68, 68, 0.12);
+  color: var(--error);
 }
 
 .templates-page .toast-close{

--- a/dashboard/src/pages/Webhooks.css
+++ b/dashboard/src/pages/Webhooks.css
@@ -345,9 +345,9 @@
 }
 
 .webhooks-page .icon-btn.danger:hover{
-  background: #fee2e2;
-  border-color: #fecaca;
-  color: #dc2626;
+  background: rgba(239, 68, 68, 0.12);
+  border-color: rgba(239, 68, 68, 0.3);
+  color: var(--error);
 }
 
 .webhooks-page .events-reference{
@@ -544,15 +544,15 @@
 }
 
 .webhooks-page .toast.success{
-  background: #ecfdf5;
-  border: 1px solid #a7f3d0;
-  color: #047857;
+  background: rgba(37, 211, 102, 0.12);
+  border: 1px solid rgba(37, 211, 102, 0.3);
+  color: var(--success);
 }
 
 .webhooks-page .toast.error{
-  background: #fef2f2;
-  border: 1px solid #fecaca;
-  color: #dc2626;
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  color: var(--error);
 }
 
 .webhooks-page .toast-close{
@@ -574,7 +574,7 @@
   align-items: center;
   gap: 0.5rem;
   padding: 0.75rem 1.25rem;
-  background: #dc2626;
+  background: var(--error);
   color: white;
   border: none;
   border-radius: var(--radius);
@@ -649,7 +649,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: #cbd5e1;
+  background-color: var(--border);
   transition: 0.3s;
   border-radius: 26px;
 }


### PR DESCRIPTION
## Summary

Several dashboard surfaces stayed light when the dark theme was active, because a number of components used hardcoded colors instead of the CSS-variable theme tokens. The most visible case was the Infrastructure **Database Migrations** card, but the same pattern affected status/severity badges, toasts, danger-hover states, and toggle tracks across most pages.

This moves those surfaces onto the theme system so they follow the active theme in both light and dark, and makes the plugin install modal a bit wider on desktop.

## Changes

- **Theme tokens everywhere:** replaced hardcoded background/text/border literals and light semantic tints (e.g. `#fee2e2`, `#fef3c7`, `#e0f2fe`) with the existing tokens (`--bg-*`, `--text-*`, `--border`) and translucent semantic fills that read correctly on both themes.
- **New `--info` token:** the blue badges (permission, SQLite, info logs, qr-ready pill) had no theme-aware color and stayed dark-blue on dark backgrounds. Added `--info` (light `#2563eb` / dark `#60a5fa`) and pointed those badges at it.
- **Root background:** the light-preference media query force-whitened the `<html>` element even when the user explicitly picked the dark theme on a light-OS device (visible on overscroll). Guarded it with `:not([data-theme='dark'])` and made the root follow the theme token.
- **Inline-style leaks:** fixed a few components (Infrastructure migrations/empty-state cards, error banners, modal close icons) whose inline literal colors could never adapt to the theme.
- **Install-a-plugin modal:** widened from 480px to 680px on desktop for the catalog list; the shared responsive rules still apply (full-width bottom sheet on small screens).

## Verification

- Dashboard build + lint pass.
- Swept every main page in dark mode: no light background patches remain, and the `<html>` root now follows the theme.
- Confirmed light mode is unchanged and the modal stays responsive down to phone widths with no horizontal overflow.
