### PR TITLE
fix(docker): raise pids_limit default + make it configurable (#636)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,24 @@ PUPPETEER_ARGS=--no-sandbox,--disable-setuid-sandbox,--disable-dev-shm-usage,--d
 # Required in the Docker image and on hosts without a bundled browser (e.g. Alpine/ARM).
 # PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 
+# ── Container resource limits (docker-compose only) ───────────────────────────
+# These map to docker-compose `mem_limit` / `pids_limit` and only apply when running via the
+# bundled compose files. They are read by docker-compose.yml, not by the app process.
+# Override in your .env to tune for your fleet.
+
+# Memory ceiling for the openwa-api container. whatsapp-web.js runs a full Chromium per session, so
+# raise this for multi-session deployments (e.g. 4g). Baileys (no Chromium) is far lighter.
+OPENWA_MEM_LIMIT=2g
+
+# Per-container process (PID) ceiling — a fork-bomb guard, NOT an allocation (the kernel only
+# rejects forks once the count is reached, so a higher limit is free for light containers).
+# Default 2048 fits ~8-10 whatsapp-web.js sessions with startup-spike headroom; each Chromium is
+# itself multi-process (browser + renderer + GPU + zygote + utilities) and WhatsApp Web is
+# process-heavy, so the old default (512) could get a session's Chromium killed mid-spawn during
+# startup — surfacing in the API as a `Code: null` launch failure (#636). Baileys is single-process
+# and uses a handful of PIDs regardless. Raise for larger fleets; do NOT set -1 (drops the guard).
+OPENWA_PIDS_LIMIT=2048
+
 # Optional WhatsApp Web client version pin. Leave unset (or use "latest", "auto", or "off") to
 # let whatsapp-web.js auto-select. If sessions get stuck at "authenticating" after scanning the QR,
 # set this to a known-good version from https://github.com/wppconnect-team/wa-version (browse the

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -29,7 +29,10 @@ services:
     read_only: true
     tmpfs:
       - /tmp
-    pids_limit: 512
+    # Per-container PID ceiling (cgroup pids.max). 2048 fits several whatsapp-web.js sessions, which
+    # each run a multi-process Chromium; Baileys (no Chromium) uses far fewer. A fork-bomb guard, not
+    # an allocation — raising it is free for light containers. Do NOT use -1 (drops the guard). #636
+    pids_limit: ${OPENWA_PIDS_LIMIT:-2048}
     mem_limit: ${OPENWA_MEM_LIMIT:-2g}
     ports:
       # Bind to localhost by default; set BIND_HOST=0.0.0.0 in .env to reach it from another host.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,17 @@ services:
     read_only: true
     tmpfs:
       - /tmp
-    pids_limit: 512
+    # Per-container PID ceiling (writes the cgroup pids.max). A fork-bomb guard, NOT an allocation —
+    # the kernel only rejects new forks once the count is reached, so a higher limit is free for
+    # light containers. The old default (512, from the #243 hardening pass) was picked without
+    # accounting for Chromium's multi-process model: whatsapp-web.js runs a full Chromium instance
+    # per session (browser + renderer + GPU + zygote + utilities), and WhatsApp Web is process-heavy
+    # (service workers/iframes), so ~4 concurrent sessions already approach 512 and a new session's
+    # Chromium gets killed mid-spawn — surfacing in the API as `Code: null`. 2048 fits ~8-10 wwjs
+    # sessions with startup-spike headroom; Baileys is single-process (no Chromium) and uses far
+    # less, so the higher ceiling is a no-op there. Raise via OPENWA_PIDS_LIMIT for larger fleets;
+    # do NOT set -1 (unlimited) — that drops the fork-bomb guard. See #636.
+    pids_limit: ${OPENWA_PIDS_LIMIT:-2048}
     mem_limit: ${OPENWA_MEM_LIMIT:-2g} # tune up for many concurrent sessions
     ports:
       - '127.0.0.1:${API_PORT:-2785}:2785'

--- a/docs/12-troubleshooting-faq.md
+++ b/docs/12-troubleshooting-faq.md
@@ -274,6 +274,69 @@ will exit at startup with a clear `FATAL:` message rather than crash-looping lat
 Do **not** work around this by dropping `--no-sandbox` security hardening or using `seccomp:unconfined`
 (confirmed not to help, and it widens the attack surface).
 
+### Issue: Session fails to launch with `Failed to launch the browser process: Code: null`
+
+> **Engine:** This issue applies to the `whatsapp-web.js` engine only (Chromium/Puppeteer-based). It does not affect `ENGINE_TYPE=baileys`.
+
+**Symptoms:** The session fails within a few seconds of clicking **Start**; no QR code is ever produced. The
+session's `lastError` and the container log both show:
+
+```text
+Failed to launch the browser process:  Code: null
+```
+
+often accompanied by a wall of `ERROR:dbus/bus.cc` / `crashpad ... /sys/devices/system/cpu/...` lines.
+**Those dbus/crashpad lines are non-fatal noise** that headless Chromium always prints inside a container —
+ignore them. The actual signal is `Code: null`, which means the browser process was killed during startup
+before it could report an exit code. The cause is *not* in the log — it's a host/container resource limit,
+and there are three distinct ones. Diagnose which one before changing anything:
+
+**Cause A — per-container PID limit hit (most common under multi-session).**
+whatsapp-web.js runs a full Chromium instance per session, and Chromium is multi-process (browser + renderer
++ GPU + zygote + utilities); WhatsApp Web is itself process-heavy (service workers, iframes). A handful of
+concurrent sessions can approach the container's `pids_limit`, and the next session's Chromium gets killed
+mid-spawn when a `fork()` returns `EAGAIN`. This is silent in the log.
+
+*Diagnose:* watch the PIDS column while you click **Start**:
+
+```bash
+docker stats openwa-api   # watch the PIDS column — does it climb toward the limit right before the failure?
+```
+
+*Fix:* raise the ceiling. The bundled `docker-compose.yml` exposes it as `OPENWA_PIDS_LIMIT` (default `2048`,
+which fits ~8-10 sessions with startup-spike headroom):
+
+```bash
+OPENWA_PIDS_LIMIT=4096   # in your .env, then docker compose up -d
+```
+
+Do **not** set `-1` (unlimited) — the PID ceiling is a fork-bomb guard and should stay finite. Baileys
+(no Chromium) uses only a handful of PIDs regardless, so raising this is a no-op there.
+
+**Cause B — out-of-memory kill.**
+The container's `mem_limit` (or the host VM, e.g. Docker Desktop on macOS/Windows) ran out of RAM while
+Chromium was starting. The OOM killer sends `SIGKILL`, which Puppeteer reports as `Code: null`.
+
+*Diagnose:* check the host kernel log for an OOM kill:
+
+```bash
+dmesg -T | grep -i "killed process"          # Linux host
+# Docker Desktop: check the VM via the app, or nudge OPENWA_MEM_LIMIT up and retry
+```
+
+*Fix:* raise the ceiling (`OPENWA_MEM_LIMIT=4g` in your `.env`, or Docker Desktop → Settings → Resources →
+Memory for the VM).
+
+**Cause C — the XDG/crashpad home-dir crash.**
+If `Code: null` is accompanied by `chrome_crashpad_handler: --database is required`, that is a different,
+specific failure (Chromium can't resolve its home directory on a read-only rootfs) — see the entry
+immediately above this one for the fix. The bundled image already handles this; it only resurfaces on a
+custom container that drops the `XDG_CONFIG_HOME` / `XDG_CACHE_HOME` setup or the writable `/tmp` tmpfs.
+
+**Quick triage:** run `docker stats openwa-api`, click **Start**, and watch which resource spikes toward its
+limit the instant before the failure — that tells you A vs B. If neither moves and you see the crashpad
+`--database` line, it's C.
+
 ### Issue: Frequent Disconnections
 
 **Symptoms:**


### PR DESCRIPTION
## Summary

The bundled `docker-compose.yml` and `docker-compose.dev.yml` shipped `pids_limit: 512` since the `#243` security-hardening pass. That value was chosen as a fork-bomb guard without accounting for Chromium's multi-process model, and it's the most likely root cause of the `Failed to launch the browser process: Code: null` failures reported in #636 (and corroborated by two community comments).

## Background — why 512 is too low for the `whatsapp-web.js` engine

`whatsapp-web.js` runs a full Chromium instance **per session**, and Chromium is itself multi-process (browser + renderer + GPU + zygote + utility processes). WhatsApp Web is process-heavy on top of that (service workers, iframes, web workers), so a realistic steady-state footprint is on the order of 20–40 processes per session — with a higher spike during startup. Around 4 concurrent sessions the container approaches 512, and the next session's Chromium gets killed mid-spawn when `fork()` returns `EAGAIN`. That kill is silent in the container log (only the non-fatal `dbus`/`crashpad` noise appears); Puppeteer surfaces it as `Code: null`, and the session's `lastError` repeats the same.

This matches what `@estmi-nowtech` reported — watching `docker stats` they saw the PID count sitting near 512 with 4 sessions, and raising the limit resolved it.

## Why this is safe for the `baileys` engine

`pids_limit` writes the cgroup `pids.max` — it is a **ceiling**, not an allocation. The kernel only rejects new forks once the count is actually reached, so a higher limit is free for containers that never approach it. Baileys is single-process (WebSocket client, no Chromium) and uses only a handful of PIDs regardless of session count, so the raised default is a no-op there. No memory or PID is consumed simply by raising the ceiling.

## Changes

- **`pids_limit: 512` → `${OPENWA_PIDS_LIMIT:-2048}`** in both compose files. 2048 fits ~8–10 `whatsapp-web.js` sessions with startup-spike headroom; operators with larger fleets can raise it via `.env`. The fork-bomb guard stays finite — `-1` (unlimited) is explicitly discouraged in the comments, since that's the only value that would weaken the `#243` hardening.
- **`.env.example`** — new "Container resource limits" section documenting `OPENWA_PIDS_LIMIT` and the previously-undocumented `OPENWA_MEM_LIMIT`.
- **`docs/12-troubleshooting-faq.md`** — new entry *"Session fails to launch with `Failed to launch the browser process: Code: null`"*. This is important because `Code: null` is non-deterministic (it's reported for PID exhaustion, OOM-kill, and the XDG/crashpad crash already fixed in `#254`), so the entry walks through distinguishing the three via `docker stats` (PIDS column) and `dmesg` (OOM-killer) before recommending a fix — rather than implying a single cause.

## Why not just `-1` (unlimited)?

That would drop the fork-bomb guard that `#243` deliberately added (CIS Docker Benchmark 5.28). The guard is valuable; the only thing wrong with it was the numeric default. Keeping it finite and configurable preserves the hardening while fixing the multi-session regression.

## Out of scope

- Not bumping `mem_limit` default — OOM is cause B in the FAQ, but the right `mem_limit` is genuinely deployment-dependent and already overridable via `OPENWA_MEM_LIMIT`; documenting it is enough for now.
- No app-code changes — this is a config/docs fix. The app already handles a `FAILED` session gracefully (status, `lastError`, reconnect backoff).

Closes #636.