### PR TITLE
fix(dashboard): display selected state for webhook events

### DIFF
--- a/dashboard/src/pages/Webhooks.css
+++ b/dashboard/src/pages/Webhooks.css
@@ -220,6 +220,9 @@
   border-radius: 6px;
   cursor: pointer;
   transition: all 0.2s;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
 }
 
 .webhooks-page .modal-body .event-tag:hover{
@@ -228,6 +231,32 @@
 }
 
 .webhooks-page .modal-body .event-tag.selected{
+  background: var(--primary);
+  color: white;
+  border-color: var(--primary);
+}
+
+.webhooks-page .modal-body .event-tag .tag-check-icon {
+  flex-shrink: 0;
+  display: inline-block;
+}
+
+/* Ensure modal event tags have proper unselected & selected styles in dark mode */
+.webhooks-page [data-theme='dark'] .modal-body .event-tag,
+:root:not([data-theme='light']) .webhooks-page .modal-body .event-tag {
+  background: var(--bg-light);
+  color: var(--text-secondary);
+  border-color: var(--border);
+}
+
+.webhooks-page [data-theme='dark'] .modal-body .event-tag:hover,
+:root:not([data-theme='light']) .webhooks-page .modal-body .event-tag:hover {
+  border-color: var(--primary);
+  color: var(--primary);
+}
+
+.webhooks-page [data-theme='dark'] .modal-body .event-tag.selected,
+:root:not([data-theme='light']) .webhooks-page .modal-body .event-tag.selected {
   background: var(--primary);
   color: white;
   border-color: var(--primary);

--- a/dashboard/src/pages/Webhooks.tsx
+++ b/dashboard/src/pages/Webhooks.tsx
@@ -337,16 +337,20 @@ export function Webhooks() {
               />
               <label>{t('webhooks.events')}</label>
               <div className="event-tags">
-                {availableEventNames.map(name => (
-                  <button
-                    key={name}
-                    type="button"
-                    className={`event-tag ${newWebhook.events.includes(name) ? 'selected' : ''}`}
-                    onClick={() => toggleNewEvent(name)}
-                  >
-                    {name}
-                  </button>
-                ))}
+                {availableEventNames.map(name => {
+                  const isSelected = newWebhook.events.includes(name);
+                  return (
+                    <button
+                      key={name}
+                      type="button"
+                      className={`event-tag ${isSelected ? 'selected' : ''}`}
+                      onClick={() => toggleNewEvent(name)}
+                    >
+                      {isSelected && <Check size={12} className="tag-check-icon" />}
+                      {name}
+                    </button>
+                  );
+                })}
               </div>
               {supportsFilters(newWebhook.events) && (
                 <FilterBuilder
@@ -386,16 +390,20 @@ export function Webhooks() {
               />
               <label>{t('webhooks.events')}</label>
               <div className="event-tags">
-                {availableEventNames.map(name => (
-                  <button
-                    key={name}
-                    type="button"
-                    className={`event-tag ${editWebhook.events.includes(name) ? 'selected' : ''}`}
-                    onClick={() => toggleEditEvent(name)}
-                  >
-                    {name}
-                  </button>
-                ))}
+                {availableEventNames.map(name => {
+                  const isSelected = editWebhook.events.includes(name);
+                  return (
+                    <button
+                      key={name}
+                      type="button"
+                      className={`event-tag ${isSelected ? 'selected' : ''}`}
+                      onClick={() => toggleEditEvent(name)}
+                    >
+                      {isSelected && <Check size={12} className="tag-check-icon" />}
+                      {name}
+                    </button>
+                  );
+                })}
               </div>
               {supportsFilters(editWebhook.events) && (
                 <FilterBuilder


### PR DESCRIPTION
## Summary

This PR fixes the visual state of the webhook event selector in the dashboard.

## Problem

While creating a webhook, selecting events correctly updated the underlying data and the webhook was created with the selected events. However, the dashboard did not visually indicate which events were selected, making it appear as though the selection had not been registered.

## Solution

Updated the event selection component so that selected events are visually highlighted whenever events are selected or deselected.

## Testing

- Manually verified that selected events are visually highlighted.
- Manually verified that webhook creation continues to work as expected.
- No backend or API changes.

Fixes #653