### PR TITLE
docs(integration): correct ingress ordering guarantee to best-effort

### DIFF
--- a/docs/25-integration-fabric.md
+++ b/docs/25-integration-fabric.md
@@ -145,7 +145,7 @@ Four tables live on the data connection, each created by a hand-authored dual-di
 ## 25.7 Scale and durability
 
 Persist-before-acknowledge; at-least-once collapsed to exactly-once via deduplication and the queue job
-id; per-conversation FIFO ordering via an advisory lock (P1); per-instance fairness via a token bucket
+id; best-effort per-conversation ordering via an advisory lock (P1) — strict FIFO is not preserved across a queue retry or a redrive (inbound arrives over unordered HTTP and is a reconcile trigger, not an ordered source of truth); per-instance fairness via a token bucket
 that sheds a noisy tenant at the edge (P1); a dead-letter record with a redrive endpoint (P1). All shared
 state lives in Redis and PostgreSQL rather than in per-plugin files or the in-memory hook bus, so the
 design can scale to multiple nodes later without re-plumbing (the initial implementation runs on a single


### PR DESCRIPTION
## Description

The **Scale and durability** summary in `docs/25-integration-fabric.md` (§25.7) stated:

> per-conversation FIFO ordering via an advisory lock (P1)

This is stronger than what the code and the design spec actually deliver. The advisory `KeyedAsyncLock` serializes same-conversation dispatches **as they reach the worker**, but strict FIFO is **not** preserved across a BullMQ retry or a redrive: a retried (or redriven) job re-enters the lock at the conversation's current tail and can overtake a same-conversation successor that dispatched during the backoff window.

This is a deliberate tradeoff, already documented in two places:

- `ingress.processor.ts:26-35` — *`Strict end-to-end order is NOT preserved across a BullMQ retry … acceptable because ingress order is best-effort regardless: the provider delivers over unordered HTTP.`*
- The design spec — inbound events are reconcile triggers, not an ordered source of truth.

This PR reconciles the docs summary with that caveat so it no longer over-promises a guarantee the system does not provide. No code or behavior change.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist
- [x] Documentation updated
- [x] Self-reviewed