### PR TITLE
feat(cache): add support for Redis username authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -194,6 +194,7 @@ REDIS_HOST=localhost
 REDIS_PORT=6379
 # Fail Redis queue/cache connection attempts after this many ms.
 REDIS_CONNECT_TIMEOUT_MS=5000
+# REDIS_USERNAME=
 # REDIS_PASSWORD=
 
 # =============================================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Redis authentication via username.** Added support for `REDIS_USERNAME` to configure Redis connections that require a username.
+
 ## [0.8.11] - 2026-07-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Redis authentication via username.** Added support for `REDIS_USERNAME` to configure Redis connections that require a username.
+- **Redis authentication via username.** Added support for `REDIS_USERNAME` to configure the Redis cache connection and BullMQ queue connections that require a username.
 
 ## [0.8.11] - 2026-07-08
 

--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -3793,6 +3793,7 @@ Merge-save infrastructure config to `data/.env.generated` (a `0600` secret file)
 | `database.sslRejectUnauthorized` | boolean | No | — | Only written when `sslEnabled` is true; default true |
 | `redis.enabled` / `.builtIn` | boolean | No | — | `builtIn`+enabled forces `redis` container + profile |
 | `redis.host` / `.port` | string | No | `port` is a string | Defaults `localhost`/`6379` |
+| `redis.username` | string | No | — | Redis ACL username |
 | `redis.password` | string | No | secret | Empty keeps existing |
 | `queue.enabled` | boolean | No | — | Writes `QUEUE_ENABLED` |
 | `storage.type` | `'local' \| 's3'` | No | — | `local` drops stale S3 keys; `s3` drops `STORAGE_LOCAL_PATH` |

--- a/docs/14-migration-guide.md
+++ b/docs/14-migration-guide.md
@@ -194,6 +194,7 @@ REDIS_ENABLED=true
 REDIS_BUILTIN=false      # false = external Redis
 REDIS_HOST=your-redis-host.com
 REDIS_PORT=6379
+REDIS_USERNAME=optional
 REDIS_PASSWORD=optional
 ```
 

--- a/pr_template_draft.txt
+++ b/pr_template_draft.txt
@@ -1,0 +1,22 @@
+## Description
+Added support for Redis authentication via username. This allows the application to connect to modern managed Redis services (such as those using Redis ACLs) that require both a username and password.
+
+The username is retrieved from the `REDIS_USERNAME` environment variable, securely mapped through `ConfigService` into the global configuration, and passed to the `ioredis` instance during initialization.
+I have also added this variable to `.env.example` and documented the update in `CHANGELOG.md`.
+
+## Type of Change
+- [ ] Bug fix
+- [x] New feature
+- [ ] Breaking change
+- [x] Documentation update
+
+## Checklist
+- [ ] Tests added/updated
+- [x] Documentation updated
+- [x] Lint passes
+- [x] Self-reviewed
+
+## Screenshots (if applicable)
+
+## Related Issues
+Closes #[INSERT_ISSUE_NUMBER]

--- a/src/common/cache/cache.service.ts
+++ b/src/common/cache/cache.service.ts
@@ -71,6 +71,7 @@ export class CacheService implements OnModuleDestroy {
       this.redis = new Redis({
         host,
         port,
+        username: this.configService.get<string>('REDIS_USERNAME'),
         password: this.configService.get<string>('REDIS_PASSWORD'),
         db: this.configService.get<number>('REDIS_CACHE_DB', 1),
         lazyConnect: true,

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -11,6 +11,7 @@ export default () => ({
   redis: {
     host: process.env.REDIS_HOST || 'localhost',
     port: parseInt(process.env.REDIS_PORT || '6379', 10),
+    username: process.env.REDIS_USERNAME,
     password: process.env.REDIS_PASSWORD,
     connectTimeoutMs: parseInt(process.env.REDIS_CONNECT_TIMEOUT_MS || '5000', 10),
   },

--- a/src/modules/queue/queue.module.ts
+++ b/src/modules/queue/queue.module.ts
@@ -34,6 +34,7 @@ export { QUEUE_NAMES } from './queue-names';
         connection: {
           host: configService.get<string>('redis.host', 'localhost'),
           port: configService.get<number>('redis.port', 6379),
+          username: configService.get<string>('redis.username'),
           password: configService.get<string>('redis.password'),
           connectTimeout: configService.get<number>('redis.connectTimeoutMs', 5000),
           enableOfflineQueue: false,

--- a/src/modules/queue/redis-connection.spec.ts
+++ b/src/modules/queue/redis-connection.spec.ts
@@ -15,26 +15,30 @@ describe('workerConnectionOptions (webhook Worker connection)', () => {
     expect(opts.enableOfflineQueue).toBeUndefined();
   });
 
-  it('reads host/port/password/connectTimeout from env with safe defaults', () => {
+  it('reads host/port/username/password/connectTimeout from env with safe defaults', () => {
     process.env = { ...ORIGINAL_ENV };
     delete process.env.REDIS_HOST;
     delete process.env.REDIS_PORT;
+    delete process.env.REDIS_USERNAME;
     delete process.env.REDIS_PASSWORD;
     delete process.env.REDIS_CONNECT_TIMEOUT_MS;
     expect(workerConnectionOptions()).toEqual({
       host: 'localhost',
       port: 6379,
+      username: undefined,
       password: undefined,
       connectTimeout: 5000,
     });
 
     process.env.REDIS_HOST = 'redis.internal';
     process.env.REDIS_PORT = '6380';
+    process.env.REDIS_USERNAME = 'myuser';
     process.env.REDIS_PASSWORD = 'secret';
     process.env.REDIS_CONNECT_TIMEOUT_MS = '1234';
     expect(workerConnectionOptions()).toEqual({
       host: 'redis.internal',
       port: 6380,
+      username: 'myuser',
       password: 'secret',
       connectTimeout: 1234,
     });

--- a/src/modules/queue/redis-connection.ts
+++ b/src/modules/queue/redis-connection.ts
@@ -9,13 +9,14 @@
  * (moveToActive, lock renewal) need to tolerate a brief reconnect during a Redis blip/failover;
  * BullMQ explicitly recommends leaving the offline queue enabled for Worker connections. Because
  * @nestjs/bullmq otherwise builds the Worker from the same shared connection, the WebhookProcessor
- * overrides its connection with these options — host/port/password/timeout identical to the producer
+ * overrides its connection with these options — host/port/username/password/timeout identical to the producer
  * (same env vars, same defaults as configuration.ts), but with the offline queue left at ioredis's
  * default of `true` so a transient outage no longer throws "Stream isn't writeable" and stalls jobs.
  */
 export interface WorkerConnectionOptions {
   host: string;
   port: number;
+  username?: string;
   password?: string;
   connectTimeout: number;
 }
@@ -24,6 +25,7 @@ export function workerConnectionOptions(): WorkerConnectionOptions {
   return {
     host: process.env.REDIS_HOST || 'localhost',
     port: parseInt(process.env.REDIS_PORT || '6379', 10),
+    username: process.env.REDIS_USERNAME,
     password: process.env.REDIS_PASSWORD,
     connectTimeout: parseInt(process.env.REDIS_CONNECT_TIMEOUT_MS || '5000', 10),
   };


### PR DESCRIPTION
## Description
Added support for Redis authentication via username. This allows the application to connect to modern managed Redis services (such as those using Redis ACLs) that require both a username and password.

The username is retrieved from the `REDIS_USERNAME` environment variable, securely mapped through `ConfigService` into the global configuration, and passed to the `ioredis` instance during initialization.
I have also added this variable to `.env.example` and documented the update in `CHANGELOG.md`.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist
- [ ] Tests added/updated
- [x] Documentation updated
- [x] Lint passes
- [x] Self-reviewed

## Screenshots (if applicable)
<img width="1733" height="160" alt="Screenshot from 2026-07-08 12-18-39" src="https://github.com/user-attachments/assets/70e4f09b-11c0-4667-9118-d7b2cf8a9814" />

## Related Issues
Closes #


