### PR TITLE
fix: session-init hang on OOM + pre-existing spec typecheck errors

### DIFF
--- a/src/core/plugins/plugin-net.spec.ts
+++ b/src/core/plugins/plugin-net.spec.ts
@@ -6,7 +6,9 @@ function fakeSafeFetch(response: Response, sink: { init?: RequestInit }): typeof
   return (<T>(_url: string, init: RequestInit, use: (r: Response) => Promise<T> | T): Promise<T> => {
     sink.init = init;
     return Promise.resolve(use(response));
-  }) as typeof withSafeFetch;
+    // withSafeFetch's real signature types `use`'s Response as undici's (which adds fields like
+    // `textStream` the DOM lib type lacks) — bridge through unknown for this intentional test double.
+  }) as unknown as typeof withSafeFetch;
 }
 
 function cannedResponse(body: string, headers: Record<string, string>, status = 200): Response {

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -304,6 +304,11 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
           // Only override the executable when explicitly configured; otherwise let
           // whatsapp-web.js fall back to Puppeteer's bundled Chromium.
           ...(this.config.puppeteer?.executablePath ? { executablePath: this.config.puppeteer.executablePath } : {}),
+          // Puppeteer's default (180000ms) lets a dead/OOM-killed Chromium's CDP calls (e.g.
+          // getChats/getGroups, observed as "Runtime.callFunctionOn timed out" in prod logs) hang
+          // 3 minutes before failing. Shortened to fail fast; session.service.ts's initializeEngine
+          // timeout (60s) is the primary guard against a wedged initial launch/navigation.
+          protocolTimeout: 60_000,
         },
         ...(authTimeoutMs !== undefined ? { authTimeoutMs } : {}),
         ...(versionPin ?? {}),

--- a/src/modules/audit/audit.controller.spec.ts
+++ b/src/modules/audit/audit.controller.spec.ts
@@ -11,7 +11,7 @@ describe('AuditController access control', () => {
     // Read the handler off the prototype as an opaque object so the lint unbound-method rule
     // (which guards against detached method `this`) doesn't fire on a metadata-only lookup.
     const proto = AuditController.prototype as unknown as Record<string, object>;
-    const role = new Reflector().get<ApiKeyRole | undefined>(REQUIRED_ROLE_KEY, proto.findAll);
+    const role = new Reflector().get<ApiKeyRole | undefined>(REQUIRED_ROLE_KEY, proto.findAll as unknown as Function);
     expect(role).toBe(ApiKeyRole.ADMIN);
   });
 });

--- a/src/modules/infra/infra.controller.spec.ts
+++ b/src/modules/infra/infra.controller.spec.ts
@@ -60,7 +60,7 @@ describe('InfraController access control (Vuln 2)', () => {
 
   it.each(adminOnly)('%s requires the ADMIN role', method => {
     const handler = InfraController.prototype[method as keyof InfraController] as object;
-    const role = reflector.get<ApiKeyRole | undefined>(REQUIRED_ROLE_KEY, handler);
+    const role = reflector.get<ApiKeyRole | undefined>(REQUIRED_ROLE_KEY, handler as unknown as Function);
     expect(role).toBe(ApiKeyRole.ADMIN);
   });
 });

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -1214,7 +1214,7 @@ describe('SessionService', () => {
           driverError: { code: 'SQLITE_CONSTRAINT_UNIQUE', message: 'UNIQUE constraint failed' },
         }); // re-fire
 
-      const msg = {
+      const msg: IncomingMessage = {
         id: 'wa-1',
         from: 'peer@c.us',
         to: 'me@c.us',

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -529,7 +529,16 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
     // initializes, so writing INITIALIZING afterwards would clobber that progress.
     await this.updateStatus(id, SessionStatus.INITIALIZING);
 
-    await engine.initialize({
+    // engine.initialize() launches Chromium and navigates to WhatsApp Web with no internal
+    // timeout of its own (whatsapp-web.js disables Puppeteer's navigation timeout and its
+    // web-version-cache fetch has none either). If Chromium is killed mid-navigation (e.g. an
+    // OOM-kill under memory pressure — observed 2026-07-08, 3x same day) this await never
+    // resolves or rejects, wedging the session in INITIALIZING forever with no error logged.
+    // Race it against a timeout so a wedged init fails fast instead: executeReconnect()'s
+    // existing catch already retries on any thrown error here, and start()'s caller sees the
+    // rejection surfaced as an API error rather than a silently hung request.
+    const engineInitTimeoutMs = 60_000;
+    const initPromise = engine.initialize({
       onQRCode: (qr: string): void => {
         if (!this.isLiveEngine(id, engine)) return;
         this.logger.log('QR code generated', {
@@ -938,6 +947,36 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
         void this.updateStatus(id, SessionStatus.FAILED);
       },
     });
+    // Mark the promise handled now in case it loses the race below and rejects later — otherwise
+    // that late rejection would be unhandled (Promise.race doesn't cancel the losing promise).
+    initPromise.catch(() => undefined);
+
+    let initTimer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        initPromise,
+        new Promise<never>((_, reject) => {
+          initTimer = setTimeout(
+            () => reject(new Error(`engine.initialize() timed out after ${engineInitTimeoutMs}ms`)),
+            engineInitTimeoutMs,
+          );
+        }),
+      ]);
+    } catch (err) {
+      this.logger.error(`Engine initialization failed for session ${session.name}`, String(err), {
+        sessionId: id,
+        action: 'engine_init_failed',
+      });
+      this.sessionErrors.set(id, err instanceof Error ? err.message : String(err));
+      // Best-effort: force-kill whatever got launched so a retry doesn't collide with an orphaned
+      // browser. teardownEngineSafely is itself time-bound, so this can't wedge a second time.
+      await this.teardownEngineSafely(id, engine, e => e.forceDestroy(), 'force-destroy');
+      this.engines.delete(id);
+      await this.updateStatus(id, SessionStatus.DISCONNECTED);
+      throw err;
+    } finally {
+      if (initTimer) clearTimeout(initTimer);
+    }
   }
 
   /**

--- a/src/modules/settings/settings.controller.spec.ts
+++ b/src/modules/settings/settings.controller.spec.ts
@@ -23,12 +23,12 @@ describe('SettingsController', () => {
   // read-only at runtime, so the write path must say so (501) rather than fake success.
   it('PUT /settings is read-only and throws 501 instead of a false-success 200', () => {
     const controller = new SettingsController(configStub);
-    expect(() => controller.update({})).toThrow(NotImplementedException);
+    expect(() => controller.update()).toThrow(NotImplementedException);
   });
 
   it('PUT /settings still requires the ADMIN role', () => {
     const proto = SettingsController.prototype as unknown as Record<string, object>;
-    const role = new Reflector().get<ApiKeyRole | undefined>(REQUIRED_ROLE_KEY, proto.update);
+    const role = new Reflector().get<ApiKeyRole | undefined>(REQUIRED_ROLE_KEY, proto.update as unknown as Function);
     expect(role).toBe(ApiKeyRole.ADMIN);
   });
 });

--- a/src/modules/stats/stats.controller.spec.ts
+++ b/src/modules/stats/stats.controller.spec.ts
@@ -14,12 +14,15 @@ describe('StatsController access control', () => {
   const proto = StatsController.prototype as unknown as Record<string, object>;
 
   it.each(['getOverview', 'getMessageStats'] as const)('global stats route %s requires ADMIN', method => {
-    const role = reflector.get<ApiKeyRole | undefined>(REQUIRED_ROLE_KEY, proto[method]);
+    const role = reflector.get<ApiKeyRole | undefined>(REQUIRED_ROLE_KEY, proto[method] as unknown as Function);
     expect(role).toBe(ApiKeyRole.ADMIN);
   });
 
   it('per-session stats is not globally ADMIN-gated (scope-enforced by its :sessionId param)', () => {
-    const role = reflector.get<ApiKeyRole | undefined>(REQUIRED_ROLE_KEY, proto.getSessionStats);
+    const role = reflector.get<ApiKeyRole | undefined>(
+      REQUIRED_ROLE_KEY,
+      proto.getSessionStats as unknown as Function,
+    );
     expect(role).toBeUndefined();
   });
 });

--- a/src/modules/webhook/webhook.controller.spec.ts
+++ b/src/modules/webhook/webhook.controller.spec.ts
@@ -63,7 +63,7 @@ describe('Webhook controllers (secret leak + read authz)', () => {
   it('findOne does not return secret or headers, but keeps safe fields', async () => {
     (service.findOne as jest.Mock).mockResolvedValue(createSecretWebhook());
 
-    const result = await controller.findOne('wh-uuid-1');
+    const result = await controller.findOne('sess-1', 'wh-uuid-1');
 
     expect(result).not.toHaveProperty('secret');
     expect(result).not.toHaveProperty('headers');
@@ -113,7 +113,7 @@ describe('Webhook controllers (secret leak + read authz)', () => {
   it('update response returns no secret/headers', async () => {
     (service.update as jest.Mock).mockResolvedValue(createSecretWebhook({ url: 'https://new.example.com/hook' }));
 
-    const result = await controller.update('wh-uuid-1', { url: 'https://new.example.com/hook' });
+    const result = await controller.update('sess-1', 'wh-uuid-1', { url: 'https://new.example.com/hook' });
 
     expect(result).not.toHaveProperty('secret');
     expect(result).not.toHaveProperty('headers');


### PR DESCRIPTION
## Summary

- **Session init can hang forever with no error.** `engine.initialize()` in `session.service.ts` is awaited with no timeout, and neither whatsapp-web.js nor Puppeteer time-bound the initial launch/navigation (`page.goto` is called with `timeout: 0`, and the web-version-cache fetch has none either). If Chromium dies mid-navigation — in our case, OOM-killed under container memory pressure — the session sits wedged in `INITIALIZING` indefinitely, and `GET /sessions/:id/qr` 400s forever with nothing in the logs to explain why. Reproduced in production: three same-day hangs each coincided with a `dmesg`-confirmed OOM-kill inside the container's memory cgroup.
- Fixed by racing `engine.initialize()` against a 60s timeout. On timeout it force-kills the wedged engine, marks the session `DISCONNECTED`, and rethrows — which plugs into the existing retry path (`executeReconnect()`'s catch already reschedules with backoff), and surfaces the failure to a manual `POST /start` caller instead of hanging the request.
- Also set `protocolTimeout: 60000` on the Puppeteer launch options (default 180s let a dead browser's CDP calls, e.g. `getChats`/`getGroups`, hang 3 minutes before failing).
- Separately: fixed 12 pre-existing `tsc --noEmit` errors across 7 spec files (unrelated to the above, found while verifying the build). Each fix is explained in its commit.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Full suite green: 111 suites / 1374 tests (`npx jest`, Node 22.19.0 — this project's `undici` requires ≥22.19.0)
- [x] Docker image rebuilt and redeployed in production; both live sessions auto-reconnected cleanly on restart