### PR TITLE
feat(dashboard): translate search i18n keys to 9 locales

### DIFF
--- a/dashboard/src/i18n/locales/ar.json
+++ b/dashboard/src/i18n/locales/ar.json
@@ -843,12 +843,12 @@
     }
   },
   "search": {
-    "placeholder": "Search messages…",
-    "results": "{{count}} results",
-    "empty": "No messages found.",
-    "error": "Search failed. Try again.",
-    "unavailable": "Search is not configured.",
-    "scope": { "current": "This session" },
-    "loading": "Searching…"
+    "placeholder": "ابحث في الرسائل…",
+    "results": "{{count}} نتيجة",
+    "empty": "لم يتم العثور على رسائل.",
+    "error": "فشل البحث. حاول مرة أخرى.",
+    "unavailable": "البحث غير مُكون.",
+    "scope": { "current": "هذه الجلسة" },
+    "loading": "جارٍ البحث…"
   }
 }

--- a/dashboard/src/i18n/locales/es.json
+++ b/dashboard/src/i18n/locales/es.json
@@ -839,12 +839,12 @@
     }
   },
   "search": {
-    "placeholder": "Search messages…",
-    "results": "{{count}} results",
-    "empty": "No messages found.",
-    "error": "Search failed. Try again.",
-    "unavailable": "Search is not configured.",
-    "scope": { "current": "This session" },
-    "loading": "Searching…"
+    "placeholder": "Buscar mensajes…",
+    "results": "{{count}} resultados",
+    "empty": "No se encontraron mensajes.",
+    "error": "Error en la búsqueda. Inténtalo de nuevo.",
+    "unavailable": "La búsqueda no está configurada.",
+    "scope": { "current": "Esta sesión" },
+    "loading": "Buscando…"
   }
 }

--- a/dashboard/src/i18n/locales/fr.json
+++ b/dashboard/src/i18n/locales/fr.json
@@ -839,12 +839,12 @@
     }
   },
   "search": {
-    "placeholder": "Search messages…",
-    "results": "{{count}} results",
-    "empty": "No messages found.",
-    "error": "Search failed. Try again.",
-    "unavailable": "Search is not configured.",
-    "scope": { "current": "This session" },
-    "loading": "Searching…"
+    "placeholder": "Rechercher des messages…",
+    "results": "{{count}} résultats",
+    "empty": "Aucun message trouvé.",
+    "error": "Échec de la recherche. Réessayez.",
+    "unavailable": "La recherche n'est pas configurée.",
+    "scope": { "current": "Cette session" },
+    "loading": "Recherche…"
   }
 }

--- a/dashboard/src/i18n/locales/he.json
+++ b/dashboard/src/i18n/locales/he.json
@@ -840,12 +840,12 @@
     }
   },
   "search": {
-    "placeholder": "Search messages…",
-    "results": "{{count}} results",
-    "empty": "No messages found.",
-    "error": "Search failed. Try again.",
-    "unavailable": "Search is not configured.",
-    "scope": { "current": "This session" },
-    "loading": "Searching…"
+    "placeholder": "חיפוש הודעות…",
+    "results": "{{count}} תוצאות",
+    "empty": "לא נמצאו הודעות.",
+    "error": "החיפוש נכשל. נסה שוב.",
+    "unavailable": "החיפוש אינו מוגדר.",
+    "scope": { "current": "הפעלה זו" },
+    "loading": "מחפש…"
   }
 }

--- a/dashboard/src/i18n/locales/it.json
+++ b/dashboard/src/i18n/locales/it.json
@@ -839,12 +839,12 @@
     }
   },
   "search": {
-    "placeholder": "Search messages…",
-    "results": "{{count}} results",
-    "empty": "No messages found.",
-    "error": "Search failed. Try again.",
-    "unavailable": "Search is not configured.",
-    "scope": { "current": "This session" },
-    "loading": "Searching…"
+    "placeholder": "Cerca messaggi…",
+    "results": "{{count}} risultati",
+    "empty": "Nessun messaggio trovato.",
+    "error": "Ricerca fallita. Riprova.",
+    "unavailable": "La ricerca non è configurata.",
+    "scope": { "current": "Questa sessione" },
+    "loading": "Ricerca…"
   }
 }

--- a/dashboard/src/i18n/locales/pt-BR.json
+++ b/dashboard/src/i18n/locales/pt-BR.json
@@ -839,12 +839,12 @@
     }
   },
   "search": {
-    "placeholder": "Search messages…",
-    "results": "{{count}} results",
-    "empty": "No messages found.",
-    "error": "Search failed. Try again.",
-    "unavailable": "Search is not configured.",
-    "scope": { "current": "This session" },
-    "loading": "Searching…"
+    "placeholder": "Pesquisar mensagens…",
+    "results": "{{count}} resultados",
+    "empty": "Nenhuma mensagem encontrada.",
+    "error": "Falha na pesquisa. Tente novamente.",
+    "unavailable": "A pesquisa não está configurada.",
+    "scope": { "current": "Esta sessão" },
+    "loading": "Pesquisando…"
   }
 }

--- a/dashboard/src/i18n/locales/te.json
+++ b/dashboard/src/i18n/locales/te.json
@@ -839,12 +839,12 @@
     }
   },
   "search": {
-    "placeholder": "Search messages…",
-    "results": "{{count}} results",
-    "empty": "No messages found.",
-    "error": "Search failed. Try again.",
-    "unavailable": "Search is not configured.",
-    "scope": { "current": "This session" },
-    "loading": "Searching…"
+    "placeholder": "సందేశాలను శోధించండి…",
+    "results": "{{count}} ఫలితాలు",
+    "empty": "ఏ సందేశాలు కనుగొనబడలేదు.",
+    "error": "శోధన విఫలమైంది. మళ్ళీ ప్రయత్నించండి.",
+    "unavailable": "శోధన ఆకృతీకరించబడలేదు.",
+    "scope": { "current": "ఈ సెషన్" },
+    "loading": "శోధిస్తోంది…"
   }
 }

--- a/dashboard/src/i18n/locales/zh-CN.json
+++ b/dashboard/src/i18n/locales/zh-CN.json
@@ -839,12 +839,12 @@
     }
   },
   "search": {
-    "placeholder": "Search messages…",
-    "results": "{{count}} results",
-    "empty": "No messages found.",
-    "error": "Search failed. Try again.",
-    "unavailable": "Search is not configured.",
-    "scope": { "current": "This session" },
-    "loading": "Searching…"
+    "placeholder": "搜索消息…",
+    "results": "{{count}} 条结果",
+    "empty": "未找到消息。",
+    "error": "搜索失败。请重试。",
+    "unavailable": "搜索未配置。",
+    "scope": { "current": "当前会话" },
+    "loading": "搜索中…"
   }
 }

--- a/dashboard/src/i18n/locales/zh-HK.json
+++ b/dashboard/src/i18n/locales/zh-HK.json
@@ -839,12 +839,12 @@
     }
   },
   "search": {
-    "placeholder": "Search messages…",
-    "results": "{{count}} results",
-    "empty": "No messages found.",
-    "error": "Search failed. Try again.",
-    "unavailable": "Search is not configured.",
-    "scope": { "current": "This session" },
-    "loading": "Searching…"
+    "placeholder": "搜尋訊息…",
+    "results": "{{count}} 個結果",
+    "empty": "未找到訊息。",
+    "error": "搜尋失敗。請重試。",
+    "unavailable": "搜尋未設定。",
+    "scope": { "current": "目前工作階段" },
+    "loading": "搜尋中…"
   }
 }


### PR DESCRIPTION
## Summary

The global search panel (#668) shipped its `search` i18n block with English placeholder values across all 9 non-English locales. This PR replaces those placeholders with proper native translations.

## Changes

Updates the `search` block (`placeholder`, `results`, `empty`, `error`, `unavailable`, `loading`, and `scope.current`) in:

- `ar.json` (Arabic)
- `es.json` (Spanish)
- `fr.json` (French)
- `he.json` (Hebrew)
- `it.json` (Italian)
- `pt-BR.json` (Portuguese - Brazil)
- `te.json` (Telugu)
- `zh-CN.json` (Chinese - Simplified)
- `zh-HK.json` (Chinese - Hong Kong)

`en.json` is the source and is unchanged. The `{{count}}` interpolation placeholder is preserved in every locale.

## Verification

- `npm run i18n:check` — parity passes (all 678 keys present per locale; no new untranslated warnings)
- `npm run build` — passes
- `npm run lint` — passes (0 errors)
- All 10 locale JSON files validated as parseable JSON