### PR TITLE
fix(message): prefer base64 over url when both are provided (#670)

### DIFF
--- a/src/modules/message/message.service.spec.ts
+++ b/src/modules/message/message.service.spec.ts
@@ -855,6 +855,27 @@ describe('MessageService', () => {
         }),
       ).rejects.toThrow('mimetype is required when using base64 data');
     });
+
+    it('prefers base64 over url when both are provided (#670)', async () => {
+      // When both are sent, base64 is the explicit local payload and must win over `url` — otherwise
+      // a stale `url` is fetched and silently shadows the image. This aligns the send selection with
+      // the base64-first persisted metadata and the `@ValidateIf((o) => !o.base64)` intent on `url`.
+      await service.sendImage('sess-1', {
+        chatId: '628123456789@c.us',
+        url: 'https://example.com/img.jpg',
+        base64: 'iVBORw0KGgoAAAAN...',
+        mimetype: 'image/png',
+      });
+
+      expect(mockEngine.sendImageMessage).toHaveBeenCalledWith(
+        '628123456789@c.us',
+        expect.objectContaining({ data: 'iVBORw0KGgoAAAAN...' }),
+      );
+      expect(mockEngine.sendImageMessage).not.toHaveBeenCalledWith(
+        '628123456789@c.us',
+        expect.objectContaining({ data: 'https://example.com/img.jpg' }),
+      );
+    });
   });
 
   // ── reactToMessage / deleteMessage ────────────────────────────────

--- a/src/modules/message/message.service.ts
+++ b/src/modules/message/message.service.ts
@@ -677,7 +677,11 @@ export class MessageService {
 
     return {
       mimetype: dto.mimetype || 'application/octet-stream',
-      data: dto.url || dto.base64!,
+      // base64 wins over url when both are present: it is the explicit local payload, and a stale
+      // `url` (e.g. a Swagger/example default left in the body) must not be fetched in its place.
+      // Aligns the send selection with the base64-first persisted metadata and the url field's
+      // `@ValidateIf((o) => !o.base64)` (which skips @IsUrl when base64 is present) — #670.
+      data: dto.base64 || dto.url!,
       filename: dto.filename,
       caption: dto.caption,
       mentions: dto.mentions,


### PR DESCRIPTION
## Summary

When a `send-image` (and other media) request carries **both** `url` and `base64`, the server now sends the base64 payload instead of fetching the URL.

## Problem

`buildMediaInput` resolved the media source as `data: dto.url || dto.base64`, so `url` won when both were present. The `url` field's validator is `@IsOptional() @IsUrl() @ValidateIf((o) => !o.base64)` — meaning `@IsUrl` is **skipped** whenever `base64` is supplied. Combined, a stale `url` left in the request body (e.g. the `https://example.com/image.jpg` example value) was fetched unvalidated and could 404, silently shadowing the supplied base64 image. This matches the stack trace reported in #670 (`Media fetch failed with status 404` from `loadRemoteMedia`).

A raw base64 string cannot start with `http(s)://` (`:` is outside the base64 alphabet), and both engine adapters already guard the remote fetch behind an `isHttpUrl` check — so the 404 is only reachable when a `url` is actually present in `data`.

## Fix

Flip the precedence in `buildMediaInput` to `data: dto.base64 || dto.url`. Base64 is the explicit local payload and wins; a stale `url` is ignored. This also aligns the send path with the already-base64-first persisted media metadata (`finalDto.base64 || finalDto.url`) and with the `@ValidateIf` intent that treats `base64` as the primary source when present.

The change is at the single shared selection point, so it covers both the whatsapp-web.js and Baileys adapters — both already route the resolved `data` correctly (fetch only when `isHttpUrl`, else decode base64).

## Behavior

- `url` only → unchanged (sent as URL)
- `base64` only → unchanged (sent as base64)
- both → base64 wins (previously: url won and was fetched)

Sending both fields is undocumented/ambiguous (the DTO implies mutual exclusivity via `ValidateIf`), so this is a patch-level robustness fix.

## Verification

- New regression test: `prefers base64 over url when both are provided (#670)` — fails before the one-line flip, passes after.
- Full backend gate green: `npm run lint`, `npm run build`, `npm test` (2093 passed, 0 failed).

## Notes

Not auto-closing #670 — asked the reporter for their exact request body to confirm this is their scenario. The hardening is valid regardless of their answer.

Refs #670