### PR TITLE
feat(i18n): add Korean (ko) locale for the dashboard

### DIFF
--- a/dashboard/src/i18n/index.ts
+++ b/dashboard/src/i18n/index.ts
@@ -11,8 +11,9 @@ import te from './locales/te.json';
 import fr from './locales/fr.json';
 import it from './locales/it.json';
 import ptBR from './locales/pt-BR.json';
+import ko from './locales/ko.json';
 
-export const supportedLanguages = ['en', 'es', 'he', 'zh-CN', 'zh-HK', 'ar', 'te', 'fr', 'it', 'pt-BR'] as const;
+export const supportedLanguages = ['en', 'es', 'he', 'zh-CN', 'zh-HK', 'ar', 'te', 'fr', 'it', 'pt-BR', 'ko'] as const;
 export type SupportedLanguage = (typeof supportedLanguages)[number];
 
 export const rtlLanguages: SupportedLanguage[] = ['he', 'ar'];
@@ -28,6 +29,7 @@ export const languageOptions: Array<{ value: SupportedLanguage; label: string; c
   { value: 'fr', label: 'Français', compactLabel: 'FR' },
   { value: 'it', label: 'Italiano', compactLabel: 'IT' },
   { value: 'pt-BR', label: 'Português (Brasil)', compactLabel: 'PT' },
+  { value: 'ko', label: '한국어', compactLabel: 'KO' },
 ];
 
 export function resolveSupportedLanguage(lang?: string): SupportedLanguage {
@@ -61,6 +63,7 @@ void i18n
       fr: { translation: fr },
       it: { translation: it },
       'pt-BR': { translation: ptBR },
+      ko: { translation: ko },
     },
     fallbackLng: 'en',
     supportedLngs: supportedLanguages as unknown as string[],

--- a/dashboard/src/i18n/locales/ko.json
+++ b/dashboard/src/i18n/locales/ko.json
@@ -1,0 +1,850 @@
+{
+  "toast": {
+    "connectionLost": {
+      "title": "서버 연결 끊김",
+      "message": "백엔드 서버에 연결할 수 없습니다. 서버가 실행 중인지 확인해 주세요."
+    }
+  },
+  "common": {
+    "appName": "OpenWA",
+    "appSubtitle": "WhatsApp API",
+    "loading": "로딩 중...",
+    "save": "저장",
+    "cancel": "취소",
+    "delete": "삭제",
+    "edit": "편집",
+    "create": "생성",
+    "close": "닫기",
+    "showApiKey": "API 키 표시",
+    "hideApiKey": "API 키 숨기기",
+    "submit": "제출",
+    "confirm": "확인",
+    "search": "검색",
+    "filter": "필터",
+    "actions": "작업",
+    "status": "상태",
+    "name": "이름",
+    "role": "역할",
+    "type": "유형",
+    "url": "URL",
+    "port": "포트",
+    "host": "호스트",
+    "username": "사용자 이름",
+    "password": "비밀번호",
+    "active": "활성",
+    "inactive": "비활성",
+    "enabled": "사용함",
+    "disabled": "사용 안 함",
+    "connected": "연결됨",
+    "disconnected": "연결 끊김",
+    "never": "없음",
+    "justNow": "방금 전",
+    "minAgo": "{{count}}분 전",
+    "hoursAgo": "{{count}}시간 전",
+    "optional": "선택 사항",
+    "language": "언어",
+    "english": "English",
+    "hebrew": "עברית",
+    "back": "뒤로",
+    "next": "다음",
+    "previous": "이전",
+    "expand": "펼치기",
+    "collapse": "접기",
+    "logout": "로그아웃",
+    "refresh": "새로고침",
+    "errorGeneric": "오류가 발생했습니다",
+    "unknownError": "알 수 없는 오류",
+    "retry": "다시 시도"
+  },
+  "theme": {
+    "light": "라이트",
+    "dark": "다크",
+    "system": "시스템",
+    "label": "테마: {{value}}",
+    "appearance": "화면 모드",
+    "mode": "모드",
+    "palette": "팔레트"
+  },
+  "nav": {
+    "dashboard": "대시보드",
+    "sessions": "세션",
+    "chats": "채팅",
+    "webhooks": "웹훅",
+    "templates": "템플릿",
+    "apiKeys": "API 키",
+    "messageTester": "메시지 테스터",
+    "infrastructure": "인프라",
+    "plugins": "플러그인",
+    "logs": "로그"
+  },
+  "chats": {
+    "media": {
+      "location": "위치",
+      "call": "통화",
+      "callMissed": "부재중 전화",
+      "callVideo": "영상 통화",
+      "callVideoMissed": "부재중 영상 통화",
+      "omitted": "미디어",
+      "image": "이미지"
+    },
+    "subtitle": "실시간으로 WhatsApp 메시지를 보내고 답장하세요",
+    "noSessionsTitle": "연결된 세션 없음",
+    "noSessionsDesc": "채팅 기능을 사용하려면 먼저 <1>세션</1> 메뉴에서 WhatsApp 세션을 연결해 주세요.",
+    "sessionLabel": "WhatsApp 세션",
+    "noPhone": "전화번호 없음",
+    "searchPlaceholder": "채팅 검색...",
+    "loadingChats": "채팅 불러오는 중...",
+    "empty": "채팅 없음",
+    "noMessageYet": "아직 메시지 없음",
+    "loadingMessages": "메시지 불러오는 중...",
+    "noMessagesInChat": "아직 메시지가 없습니다. 첫 메시지를 보내 대화를 시작하세요!",
+    "downloadDocument": "문서 다운로드",
+    "actions": {
+      "reply": "답장",
+      "react": "반응",
+      "delete": "메시지 삭제"
+    },
+    "replyingTo": "{{name}}님에게 답장",
+    "you": "나",
+    "youPrefix": "나: ",
+    "yesterday": "어제",
+    "attachTitle": "파일 / 이미지 보내기",
+    "emojiTitle": "이모지 선택",
+    "captionPlaceholder": "설명 추가...",
+    "messagePlaceholder": "메시지를 입력하세요...",
+    "noPermission": "메시지를 보낼 권한이 없습니다",
+    "send": "보내기",
+    "placeholderTitle": "메시지 시작하기",
+    "placeholderDesc": "읽고 답장할 대화를 선택하세요.",
+    "deleteConfirm": "모두에게서 이 메시지를 삭제할까요?",
+    "messageDeleted": "🚫 삭제된 메시지입니다",
+    "messageMasked": "🔒 연결된 기기에서는 WhatsApp이 이 메시지를 가려 표시합니다 — 기본 휴대폰을 확인하세요",
+    "errors": {
+      "loadSessions": "세션을 불러오지 못했습니다",
+      "loadChats": "채팅을 불러오지 못했습니다",
+      "loadMessages": "메시지를 불러오지 못했습니다",
+      "markRead": "채팅을 읽음으로 표시하지 못했습니다",
+      "send": "메시지를 보내지 못했습니다",
+      "react": "메시지에 반응하지 못했습니다",
+      "delete": "메시지를 삭제하지 못했습니다"
+    },
+    "loadMessagesError": "메시지를 불러올 수 없습니다. 서버 로그를 확인하세요."
+  },
+  "errorBoundary": {
+    "title": "문제가 발생했습니다",
+    "description": "대시보드에서 예기치 않은 오류가 발생했습니다.",
+    "reload": "대시보드 새로고침"
+  },
+  "login": {
+    "apiKey": "API 키",
+    "apiKeyPlaceholder": "API 키를 입력하세요",
+    "apiKeyRequired": "API 키가 필요합니다",
+    "connect": "연결",
+    "connecting": "연결하는 중...",
+    "invalidKey": "잘못된 API 키입니다",
+    "connectionError": "서버에 연결할 수 없습니다. 다시 시도해 주세요.",
+    "help": "도움이 필요하신가요?",
+    "viewDocs": "문서 보기",
+    "footer": "Yudhi Armyndharis와 OpenWA 커뮤니티가 ❤️로 만들었습니다",
+    "version": "v{{version}} · {{date}}"
+  },
+  "dashboard": {
+    "title": "대시보드",
+    "subtitle": "WhatsApp 세션 및 활동 개요",
+    "stats": {
+      "activeSessions": "활성 세션",
+      "messagesToday": "오늘의 메시지",
+      "webhooksConfigured": "설정된 웹훅",
+      "apiCalls": "API 호출 (24시간)",
+      "totalMessages": "전체 메시지"
+    },
+    "sessionsOverview": "세션 개요",
+    "showingSessions": "전체 {{total}}개 중 {{shown}}개 세션 표시",
+    "columns": {
+      "sessionId": "세션 ID",
+      "phone": "전화번호",
+      "status": "상태",
+      "lastActive": "마지막 활동",
+      "actions": "작업"
+    },
+    "noSessions": "세션이 없습니다. 세션을 생성해 시작하세요.",
+    "view": "보기",
+    "disconnect": "연결 해제",
+    "errorPrefix": "오류: {{message}}",
+    "loadError": "데이터를 불러오지 못했습니다",
+    "charts": {
+      "title": "메시지 분석",
+      "period": {
+        "24h": "24시간",
+        "7d": "7일",
+        "30d": "30일"
+      },
+      "overTime": "시간별 메시지 추이",
+      "byType": "유형별 메시지",
+      "topChats": "인기 채팅",
+      "sent": "보냄",
+      "received": "받음",
+      "messages": "메시지",
+      "empty": "이 기간에는 메시지 활동이 없습니다.",
+      "error": "메시지 분석을 불러올 수 없습니다. 서버 로그를 확인하세요."
+    }
+  },
+  "sessionStatus": {
+    "created": "새로 만듦",
+    "idle": "대기 중",
+    "initializing": "시작하는 중...",
+    "connecting": "연결하는 중...",
+    "qr_ready": "QR 스캔",
+    "ready": "연결됨",
+    "disconnected": "연결 끊김"
+  },
+  "sessions": {
+    "title": "세션",
+    "subtitle": "WhatsApp 세션과 QR 코드 연결을 관리하세요",
+    "newSession": "새 세션",
+    "searchPlaceholder": "세션 검색...",
+    "filter": {
+      "all": "전체 상태",
+      "active": "활성 (연결됨)",
+      "inactive": "비활성",
+      "connecting": "연결 중"
+    },
+    "empty": {
+      "title": "세션이 없습니다",
+      "description": "새 세션을 만들어 시작하세요"
+    },
+    "create": {
+      "title": "새 세션 만들기",
+      "label": "세션 이름",
+      "placeholder": "예: marketing-bot",
+      "hint": "소문자, 숫자, 하이픈만 사용하세요. 예: <code>customer-support</code>, <code>bot-1</code>",
+      "invalidChars": "잘못된 문자입니다. 소문자, 숫자, 하이픈만 사용할 수 있습니다.",
+      "tooLong": "이름은 50자 이하여야 합니다 ({{length}}/50).",
+      "duplicate": "같은 이름의 세션이 이미 존재합니다.",
+      "successTitle": "세션 생성 완료",
+      "successDesc": "\"{{name}}\" 세션이 생성되었습니다",
+      "errorTitle": "생성 실패",
+      "errorDefault": "세션을 생성하지 못했습니다"
+    },
+    "delete": {
+      "title": "삭제 확인",
+      "message": "<strong>\"{{name}}\"</strong> 세션을 삭제할까요?",
+      "warning": "이 작업은 되돌릴 수 없습니다.",
+      "successTitle": "세션 삭제 완료",
+      "successDescNamed": "\"{{name}}\" 세션이 삭제되었습니다",
+      "successDescGeneric": "세션이 삭제되었습니다",
+      "errorTitle": "삭제 실패",
+      "errorDefault": "세션을 삭제하지 못했습니다"
+    },
+    "qr": {
+      "title": "QR 코드 스캔",
+      "step1": "<strong>1.</strong> 휴대폰에서 WhatsApp을 여세요",
+      "step2": "<strong>2.</strong> <strong>메뉴</strong> → <strong>연결된 기기</strong>를 누르세요",
+      "step3": "<strong>3.</strong> <strong>기기 연결</strong>을 누르고 이 QR을 스캔하세요",
+      "autoRefresh": "QR 코드는 5초마다 자동으로 갱신됩니다",
+      "generating": "QR 코드를 생성하는 중...",
+      "unavailable": "아직 QR 코드를 사용할 수 없습니다. 잠시 후 다시 시도하세요.",
+      "preparing": "QR 코드를 준비하는 중...",
+      "showQr": "QR 표시",
+      "loading": "로딩 중...",
+      "scanToConnect": "QR 코드를 스캔해 연결하세요"
+    },
+    "details": {
+      "title": "세션 상세 정보",
+      "name": "이름",
+      "status": "상태",
+      "sessionId": "세션 ID",
+      "phone": "전화번호",
+      "phoneNone": "연결되지 않음",
+      "created": "생성일",
+      "lastActive": "마지막 활동"
+    },
+    "actions": {
+      "view": "보기",
+      "start": "시작",
+      "stop": "중지",
+      "reconnect": "재연결",
+      "delete": "삭제",
+      "killStuck": "강제 종료"
+    },
+    "toasts": {
+      "readyTitle": "세션 준비 완료",
+      "readyDesc": "WhatsApp 세션이 연결되었습니다",
+      "disconnectedTitle": "세션 연결 끊김",
+      "disconnectedDesc": "WhatsApp 세션 연결이 끊어졌습니다",
+      "failedTitle": "세션 실패",
+      "failedDesc": "WhatsApp 세션을 시작하지 못했습니다. 세션을 열어 원인을 확인하세요."
+    },
+    "card": {
+      "phone": "전화번호",
+      "sessionId": "세션 ID",
+      "lastActive": "마지막 활동",
+      "error": "오류"
+    },
+    "forceKill": {
+      "title": "멈춘 세션 강제 종료",
+      "message": "\"{{name}}\" 세션을 강제로 종료할까요?",
+      "warning": "WhatsApp 브라우저 프로세스를 강제로 종료합니다. 재시작 시 다시 QR을 스캔해야 할 수 있습니다.",
+      "confirm": "세션 종료",
+      "successTitle": "세션 종료 완료",
+      "success": "세션이 강제로 종료되었습니다. 지금 다시 시작할 수 있습니다.",
+      "failedTitle": "강제 종료 실패",
+      "failed": "세션을 강제로 종료하지 못했습니다."
+    },
+    "pairing": {
+      "tabQr": "QR 코드",
+      "tabPhone": "전화번호로 연결",
+      "phoneLabel": "전화번호",
+      "phonePlaceholder": "예: 919876543210",
+      "phoneHint": "국제 형식(국가 코드 + 번호)으로 숫자만 입력하세요(+, 공백, 하이픈 제외).",
+      "invalidPhone": "올바른 전화번호를 입력하세요: 6~15자리 숫자, 국가 코드로 시작, 기호 없이.",
+      "generateButton": "페어링 코드 생성",
+      "generating": "페어링 코드를 생성하는 중...",
+      "codeLabel": "내 페어링 코드",
+      "changeNumber": "번호 변경 / 새 코드 요청",
+      "instructions": "페어링 안내",
+      "step1": "<strong>1.</strong> 휴대폰에서 WhatsApp을 여세요",
+      "step2": "<strong>2.</strong> <strong>메뉴</strong> 또는 <strong>설정</strong>에서 <strong>연결된 기기</strong>를 선택하세요",
+      "step3": "<strong>3.</strong> <strong>기기 연결</strong>을 누른 다음 <strong>전화번호로 연결하기</strong>를 누르세요",
+      "step4": "<strong>4.</strong> 위에 표시된 8자리 코드를 휴대폰에 입력하세요",
+      "waitingConnection": "휴대폰이 연결되기를 기다리는 중…"
+    }
+  },
+  "webhooks": {
+    "title": "웹훅",
+    "subtitle": "실시간 이벤트 알림을 위한 HTTP 콜백을 설정하세요",
+    "addWebhook": "웹훅 추가",
+    "createTitle": "웹훅 생성",
+    "editTitle": "웹훅 편집",
+    "deleteTitle": "웹훅 삭제",
+    "deleteConfirm": "이 웹훅을 삭제할까요?",
+    "selectSession": "세션 선택...",
+    "session": "세션",
+    "events": "이벤트",
+    "available": "사용 가능한 이벤트",
+    "saveChanges": "변경 사항 저장",
+    "filters": {
+      "title": "필터 (선택 사항)",
+      "hint": "모든 조건이 일치할 때만 실행됩니다. 메시지 이벤트에 적용됩니다.",
+      "badge": "필터 {{count}}개",
+      "badge_other": "필터 {{count}}개",
+      "addCondition": "조건 추가",
+      "removeCondition": "조건 제거",
+      "caseSensitive": "대소문자 구분",
+      "contactPlaceholder": "번호 또는 WhatsApp ID...",
+      "textPlaceholder": "일치시킬 텍스트...",
+      "addValue": "\"{{value}}\" 추가",
+      "yes": "예",
+      "no": "아니요",
+      "fields": {
+        "sender": "보낸 사람",
+        "recipient": "받는 사람",
+        "body": "메시지 본문",
+        "type": "메시지 유형",
+        "isGroup": "그룹 채팅 여부",
+        "fromMe": "내가 보낸 메시지",
+        "hasMedia": "미디어 포함",
+        "mentions": "멘션"
+      },
+      "operators": {
+        "is": "다음과 같음",
+        "isNot": "다음과 같지 않음",
+        "contains": "포함",
+        "equals": "동일함"
+      }
+    },
+    "columns": {
+      "url": "URL",
+      "events": "이벤트",
+      "session": "세션",
+      "status": "상태",
+      "actions": "작업"
+    },
+    "empty": {
+      "title": "설정된 웹훅이 없습니다",
+      "description": "실시간 이벤트 알림을 받으려면 웹훅을 추가하세요"
+    },
+    "toasts": {
+      "created": "웹훅이 생성되었습니다",
+      "createFailed": "웹훅 생성 실패: {{message}}",
+      "deleted": "웹훅이 삭제되었습니다",
+      "deleteFailed": "웹훅 삭제 실패: {{message}}",
+      "updated": "웹훅이 업데이트되었습니다",
+      "updateFailed": "웹훅 업데이트 실패: {{message}}",
+      "testOk": "웹훅 테스트 성공! 상태: {{status}}",
+      "testFailed": "웹훅 테스트 실패: {{message}}",
+      "testError": "웹훅 테스트 중 오류 발생: {{message}}"
+    },
+    "actions": {
+      "test": "테스트",
+      "edit": "편집",
+      "delete": "삭제"
+    },
+    "eventDescriptions": {
+      "message.received": "메시지를 받았을 때",
+      "message.sent": "메시지를 보냈을 때",
+      "session.connected": "세션이 연결되었을 때",
+      "session.disconnected": "세션 연결이 끊어졌을 때",
+      "session.qr": "QR 코드가 생성되었을 때",
+      "all": "모든 이벤트"
+    }
+  },
+  "templates": {
+    "title": "템플릿",
+    "subtitle": "각 WhatsApp 세션에서 사용할 재사용 가능한 메시지 템플릿을 만드세요",
+    "createTitle": "템플릿 생성",
+    "editTitle": "템플릿 편집",
+    "newTemplate": "새 템플릿",
+    "createTemplate": "템플릿 생성",
+    "saveChanges": "변경 사항 저장",
+    "viewOnly": "읽기 전용",
+    "noSessions": "세션 없음",
+    "sessionHint": "{{name}}에 저장됨",
+    "namePlaceholder": "예: order-confirmation",
+    "header": "머리말",
+    "headerPlaceholder": "선택적 도입부",
+    "body": "본문",
+    "bodyPlaceholder": "안녕하세요 {{customer}}님, 주문하신 {{orderId}}가 준비되었습니다.",
+    "footer": "맺음말",
+    "footerPlaceholder": "선택적 맺음말",
+    "previewTitle": "미리보기",
+    "previewValuePlaceholder": "샘플 값",
+    "previewEmpty": "템플릿을 작성하면 여기서 미리 볼 수 있습니다.",
+    "noPlaceholders": "{{name}} 형식의 플레이스홀더로 치환을 테스트하세요.",
+    "savedTitle": "저장된 템플릿",
+    "count": "총 {{count}}개",
+    "deleteTitle": "템플릿 삭제",
+    "deleteConfirm": "\"{{name}}\" 템플릿을 삭제할까요? 이 작업은 되돌릴 수 없습니다.",
+    "actions": {
+      "copyName": "템플릿 이름 복사"
+    },
+    "empty": {
+      "title": "저장된 템플릿이 없습니다",
+      "description": "자주 쓰는 답장이나 알림을 빠르게 보내려면 재사용 가능한 템플릿을 만드세요.",
+      "noSessionsTitle": "사용 가능한 세션이 없습니다",
+      "noSessionsDesc": "템플릿을 추가하기 전에 WhatsApp 세션을 만드세요."
+    },
+    "toasts": {
+      "created": "템플릿이 생성되었습니다",
+      "createFailed": "템플릿 생성 실패: {{message}}",
+      "updated": "템플릿이 업데이트되었습니다",
+      "updateFailed": "템플릿 업데이트 실패: {{message}}",
+      "deleted": "템플릿이 삭제되었습니다",
+      "deleteFailed": "템플릿 삭제 실패: {{message}}",
+      "copied": "템플릿 이름이 복사되었습니다"
+    }
+  },
+  "apiKeys": {
+    "title": "API 키",
+    "subtitle": "인증 및 접근 제어를 위한 API 키를 관리하세요",
+    "createBtn": "API 키 생성",
+    "modalTitle": "API 키 생성",
+    "createdTitle": "API 키 생성 완료",
+    "createdHint": "지금 이 키를 복사해 두세요. 다시 확인할 수 없습니다.",
+    "namePlaceholder": "예: Production Key",
+    "rolesTitle": "역할 안내",
+    "roles": {
+      "admin": "관리자",
+      "operator": "운영자",
+      "viewer": "뷰어"
+    },
+    "roleDescriptions": {
+      "admin": "모든 리소스에 대한 전체 접근 권한",
+      "operator": "세션 및 메시지 관리",
+      "viewer": "읽기 전용 접근"
+    },
+    "columns": {
+      "name": "이름",
+      "key": "키",
+      "role": "역할",
+      "status": "상태",
+      "lastUsed": "마지막 사용",
+      "actions": "작업"
+    },
+    "statuses": {
+      "active": "활성",
+      "revoked": "취소됨"
+    },
+    "empty": {
+      "title": "생성된 API 키가 없습니다",
+      "description": "요청을 인증하려면 API 키를 생성하세요"
+    },
+    "confirm": {
+      "deleteTitle": "API 키 삭제",
+      "revokeTitle": "API 키 취소",
+      "deleteMessage": "<strong>{{name}}</strong>을(를) 영구히 삭제할까요? 이 작업은 되돌릴 수 없습니다.",
+      "revokeMessage": "<strong>{{name}}</strong>을(를) 취소할까요? 더 이상 사용할 수 없게 됩니다.",
+      "delete": "삭제",
+      "revoke": "취소"
+    },
+    "actions": {
+      "copy": "복사",
+      "revoke": "취소",
+      "delete": "삭제"
+    }
+  },
+  "logs": {
+    "title": "감사 로그",
+    "subtitle": "모든 API 작업과 시스템 이벤트를 추적하고 검토하세요",
+    "exportCsv": "CSV로 내보내기",
+    "searchPlaceholder": "로그 검색...",
+    "severity": {
+      "all": "모든 심각도",
+      "info": "정보",
+      "warn": "경고",
+      "error": "오류"
+    },
+    "columns": {
+      "timestamp": "타임스탬프",
+      "action": "작업",
+      "session": "세션",
+      "apiKey": "API 키",
+      "ip": "IP 주소",
+      "severity": "심각도"
+    },
+    "empty": {
+      "title": "로그가 없습니다",
+      "description": "작업이 수행되면 감사 로그가 여기에 표시됩니다"
+    }
+  },
+  "messageTester": {
+    "title": "메시지 테스터",
+    "subtitle": "API를 통해 테스트 메시지를 보내세요",
+    "compose": "테스트 메시지 보내기",
+    "responseTitle": "API 응답",
+    "session": "세션",
+    "noReadySessions": "준비된 세션 없음",
+    "sessionOptionPhoneNone": "전화번호 없음",
+    "recipientType": "받는 사람 유형",
+    "personal": "개인",
+    "group": "그룹",
+    "selectGroup": "그룹 선택",
+    "recipientPhone": "받는 사람 전화번호",
+    "loadingGroups": "그룹 불러오는 중...",
+    "noGroupsFound": "그룹을 찾을 수 없습니다",
+    "selectGroupHint": "내 WhatsApp에서 그룹을 선택하세요",
+    "phoneHint": "공백 없이 국제 형식으로 입력하세요",
+    "messageType": "메시지 유형",
+    "types": {
+      "text": "텍스트",
+      "image": "이미지",
+      "video": "동영상",
+      "audio": "오디오",
+      "document": "문서"
+    },
+    "messageContent": "메시지 내용",
+    "messagePlaceholder": "메시지를 입력하세요...",
+    "mediaUrl": "미디어 URL",
+    "caption": "설명",
+    "filename": "파일 이름",
+    "captionPlaceholder": "설명을 입력하세요...",
+    "filenamePlaceholder": "document.pdf",
+    "send": "메시지 보내기",
+    "sending": "보내는 중...",
+    "viewOnly": "읽기 전용",
+    "responseEmpty": "메시지를 보내면 API 응답이 여기에 표시됩니다",
+    "successLabel": "200 OK - 성공",
+    "failedLabel": "400 - 실패",
+    "response": {
+      "timestamp": "타임스탬프",
+      "messageId": "메시지 ID",
+      "error": "오류"
+    },
+    "sendFailed": "메시지를 보내지 못했습니다",
+    "notOnWhatsApp": "이 번호는 WhatsApp에 등록되어 있지 않습니다"
+  },
+  "infrastructure": {
+    "title": "인프라",
+    "subtitle": "서버, 데이터베이스, 캐시, 스토리지, 엔진 설정을 구성하세요",
+    "saveConfig": "설정 저장",
+    "saving": "저장하는 중...",
+    "server": {
+      "title": "서버 설정",
+      "production": "프로덕션",
+      "development": "개발",
+      "environment": "환경",
+      "domain": "도메인",
+      "apiPort": "API 포트",
+      "dashboardPort": "대시보드 포트",
+      "corsOrigins": "CORS 오리진",
+      "corsPlaceholder": "* 또는 쉼표로 구분된 오리진",
+      "publicApiUrl": "공개 API URL (선택 사항)",
+      "publicDashboardUrl": "공개 대시보드 URL (선택 사항)"
+    },
+    "webhook": {
+      "title": "웹훅 및 속도 제한",
+      "settings": "웹훅 설정",
+      "timeout": "제한 시간 (ms)",
+      "maxRetries": "최대 재시도 횟수",
+      "retryDelay": "재시도 지연 (ms)",
+      "rateLimit": "속도 제한",
+      "window": "시간 윈도우 (초)",
+      "maxReq": "윈도우당 최대 요청 수"
+    },
+    "database": {
+      "title": "데이터베이스 설정",
+      "sqlite": "SQLite",
+      "sqliteDesc": "로컬 파일 기반 데이터베이스",
+      "postgres": "PostgreSQL",
+      "postgresDesc": "프로덕션에 적합한 데이터베이스",
+      "useBuiltIn": "내장 PostgreSQL 컨테이너 사용",
+      "builtInDesc": "OpenWA가 PostgreSQL 컨테이너를 관리합니다",
+      "dbName": "데이터베이스 이름",
+      "schema": "스키마",
+      "schemaDesc": "PostgreSQL 스키마(SQLite에서는 무시됨). 기본값 'public'. 스키마가 이미 존재해야 합니다.",
+      "poolSize": "풀 크기",
+      "ssl": "SSL 연결",
+      "sslDesc": "안전한 데이터베이스 연결을 위해 TLS/SSL을 사용합니다",
+      "sslRejectUnauthorized": "SSL 인증서 확인",
+      "sslRejectUnauthorizedDesc": "자체 서명되었거나 유효하지 않은 인증서를 거부합니다. 자체 서명 인증서를 사용하는 관리형 Postgres(Supabase, Heroku, Render, Railway)에서는 꺼 두세요.",
+      "migrationsTitle": "데이터베이스 마이그레이션",
+      "migrationsStatus": "스키마는 TypeORM으로 자동 동기화됩니다",
+      "migrationsHint": "마이그레이션은 자동으로 관리됩니다. 수동 마이그레이션은 CLI를 사용하세요."
+    },
+    "engine": {
+      "title": "WhatsApp 엔진",
+      "subtitle": "WhatsApp 연결 엔진을 선택하고 구성하세요.",
+      "builtIn": "내장",
+      "headless": "헤드리스 모드",
+      "headlessDesc": "브라우저 UI 없이 실행합니다 (프로덕션에 권장).",
+      "sessionDataPath": "세션 데이터 경로",
+      "browserArgs": "브라우저 인수",
+      "noBrowser": "이 엔진은 WebSocket으로 연결되어 브라우저가 없으므로 헤드리스나 브라우저 인수 설정이 없습니다. 활성 엔진은 재시작 후 적용됩니다.",
+      "restartNote": "엔진 변경은 서버 재시작 후 적용됩니다.",
+      "webVersion": "WhatsApp Web 빌드",
+      "webVersionNative": "자동 (whatsapp-web.js 기본값)",
+      "webVersionSource": {
+        "pinned": "WWEBJS_WEB_VERSION으로 고정됨",
+        "auto": "자동 확인된 최신 정상 빌드",
+        "native": "whatsapp-web.js 자체 자동 선택"
+      }
+    },
+    "redis": {
+      "title": "Redis",
+      "enable": "Redis 사용",
+      "enableDesc": "캐싱, 세션 저장, BullMQ 큐에 필요합니다",
+      "useBuiltIn": "내장 Redis 컨테이너 사용",
+      "builtInDesc": "OpenWA가 Redis 컨테이너를 관리합니다",
+      "queueTitle": "BullMQ 큐 시스템 사용",
+      "queueDesc": "안정적인 메시지 및 웹훅 전달을 위해 메시지 큐를 사용합니다",
+      "statsTitle": "큐 통계",
+      "webhookQueue": "웹훅 큐",
+      "pending": "대기 중",
+      "completed": "완료됨",
+      "failed": "실패",
+      "viewBullMq": "Bull MQ 대시보드 보기",
+      "disabledTitle": "Redis 사용 안 함",
+      "disabledDesc": "캐싱, 세션 저장, BullMQ 메시지 큐를 사용하려면 Redis를 활성화하세요.",
+      "passwordOptional": "(선택 사항)",
+      "bullMqUrlCopied": "Bull MQ 대시보드 URL이 복사되었습니다",
+      "bullMqUrlHint": "ADMIN API 키로 열어 주세요 — 브라우저 탭은 인증할 수 없습니다."
+    },
+    "storage": {
+      "title": "스토리지 설정",
+      "s3Unreachable": "S3 (연결할 수 없음)",
+      "local": "로컬 파일 시스템",
+      "localDesc": "미디어 파일을 로컬에 저장합니다",
+      "s3": "Amazon S3",
+      "s3Desc": "클라우드 스토리지 (S3 호환)",
+      "useBuiltIn": "내장 MinIO 컨테이너 사용",
+      "builtInDesc": "OpenWA가 MinIO(S3 호환) 컨테이너를 관리합니다",
+      "storagePath": "스토리지 경로",
+      "bucket": "버킷 이름",
+      "region": "리전",
+      "accessKey": "액세스 키",
+      "secretKey": "시크릿 키",
+      "endpoint": "사용자 지정 엔드포인트 (선택 사항)",
+      "endpointHint": "MinIO 또는 다른 S3 호환 서비스용"
+    },
+    "statusLabels": {
+      "connected": "연결됨",
+      "disconnected": "연결 끊김",
+      "disabled": "사용 안 함"
+    },
+    "envPinNote": "환경 변수로 고정됨 — 현재 실행 중인 값이며, 해당 변수를 해제해야 대시보드 변경 사항이 적용됩니다.",
+    "migration": {
+      "title": "주의 — 데이터 백엔드가 변경됩니다",
+      "dbWarning": "새 데이터베이스는 비어 있는 상태로 시작됩니다. 지금(기존 데이터베이스에 있는 동안) 현재 데이터를 백업한 후 재시작이 끝나면 복원하세요.",
+      "storageWarning": "기존 미디어 파일은 새 스토리지 백엔드로 자동 이동되지 않으며 기존 위치에 그대로 남습니다.",
+      "downloadBackup": "먼저 백업 다운로드",
+      "backupTitle": "데이터 백업 및 복원",
+      "backupHint": "데이터베이스를 전환하기 전에 모든 데이터를 JSON으로 내보낸 후 전환이 끝나면 가져오세요. 백업에는 웹훅 시크릿과 프록시 자격 증명이 평문으로 포함되어 있으니 안전하게 보관하고 복원 후 삭제하세요.",
+      "export": "데이터 내보내기",
+      "import": "데이터 가져오기",
+      "exportFailed": "데이터를 내보내지 못했습니다",
+      "importFailed": "데이터를 가져오지 못했습니다",
+      "importOk": "데이터를 가져왔습니다",
+      "importConfirm": "가져오기를 실행하면 현재 데이터가 백업본({{rows}}행)으로 완전히 대체됩니다. 되돌릴 수 없습니다. 계속할까요?",
+      "invalidFile": "올바른 OpenWA 데이터 백업 파일이 아닙니다.",
+      "importTooLarge": "백업 파일이 요청 크기 제한을 초과합니다. 서버의 BODY_SIZE_LIMIT을 늘린 후 다시 시도하세요."
+    },
+    "restart": {
+      "idleTitle": "설정이 저장되었습니다",
+      "restartingTitle": "서버를 재시작하는 중…",
+      "waitingTitle": "잠시만 기다려 주세요…",
+      "successTitle": "서버 준비 완료",
+      "errorTitle": "재시작 실패",
+      "idleDesc": "설정이 <code>.env.generated</code>에 저장되었습니다.<br/>변경 사항을 적용하려면 서버를 재시작해야 합니다.",
+      "later": "나중에 재시작",
+      "now": "지금 재시작",
+      "restartingMsg": "서버를 재시작하는 중... {{count}}초",
+      "checking": "서버 상태를 확인하는 중...",
+      "dontClose": "이 창을 닫지 마세요",
+      "successMsg": "서버가 다시 온라인 상태입니다! 페이지가 자동으로 새로고침됩니다.",
+      "errorMsg": "서버가 30초 동안 응답하지 않았습니다. Docker 로그를 확인하고 수동으로 재시작하세요.",
+      "reload": "페이지 새로고침"
+    },
+    "toasts": {
+      "saveFailed": "저장 실패"
+    },
+    "statusLoadError": "현재 인프라 상태를 불러올 수 없습니다. 새로고침 후 다시 시도하세요."
+  },
+  "plugins": {
+    "title": "플러그인",
+    "subtitle": "확장 기능을 설치, 구성, 관리하세요",
+    "refresh": "새로고침",
+    "engineCard": "활성 WhatsApp 엔진",
+    "running": "실행 중",
+    "supportedFeatures": "지원하는 기능:",
+    "builtIn": "내장",
+    "noDescription": "설명 없음",
+    "required": "필수",
+    "active": "활성",
+    "activate": "활성화",
+    "enable": "사용",
+    "disable": "사용 안 함",
+    "healthCheck": "상태 확인",
+    "configure": "구성",
+    "available": "사용 가능",
+    "install": "플러그인 설치",
+    "uninstall": "제거",
+    "uninstallConfirm": "\"{{name}}\"을(를) 제거할까요? 관련 파일이 모두 삭제됩니다.",
+    "engineSwitchHint": "활성 엔진을 변경하려면 환경 변수에 ENGINE_TYPE을 설정하고 서버를 재시작하세요",
+    "empty": {
+      "title": "설치된 플러그인이 없습니다",
+      "description": "OpenWA의 기능을 확장하려면 플러그인을 설치하세요."
+    },
+    "config": {
+      "title": "{{name}} 구성",
+      "restartNotice": "변경 사항을 적용하려면 서버를 재시작해야 합니다",
+      "engineType": "엔진 유형",
+      "headless": "헤드리스 모드",
+      "headlessDesc": "브라우저 UI 없이 실행 (프로덕션에 권장)",
+      "sessionDataPath": "세션 데이터 경로",
+      "browserArgs": "브라우저 인수",
+      "noOptions": "이 플러그인에 사용할 수 있는 구성 옵션이 없습니다",
+      "save": "설정 저장",
+      "addItem": "추가",
+      "tabConfig": "구성",
+      "tabSessions": "세션"
+    },
+    "rail": {
+      "engine": "활성 엔진",
+      "enabled": "사용 중",
+      "installed": "설치됨",
+      "active": "활성 플러그인",
+      "none": "아직 활성화된 항목 없음"
+    },
+    "installModal": {
+      "title": "플러그인 설치",
+      "hint": "manifest.json이 포함된 .zip으로 패키징된 플러그인을 업로드하세요. 활성화되면 샌드박스에서 실행됩니다.",
+      "choose": ".zip 파일 선택…",
+      "tooLarge": "파일이 5MB 제한을 초과합니다."
+    },
+    "toasts": {
+      "errorTitle": "플러그인 오류",
+      "errorDefault": "플러그인 전환에 실패했습니다",
+      "healthOk": "상태 확인 통과",
+      "healthFail": "상태 확인 실패",
+      "healthError": "상태 확인 오류",
+      "savedTitle": "설정 저장 완료",
+      "savedDesc": "변경 사항을 적용하려면 서버를 재시작해야 합니다.",
+      "saveFailed": "저장 실패",
+      "installed": "플러그인이 설치되었습니다",
+      "installFailed": "설치 실패",
+      "uninstalled": "플러그인이 제거되었습니다",
+      "uninstallFailed": "제거 실패"
+    },
+    "sessions": {
+      "activationTitle": "실행 대상",
+      "activationDesc": "이 플러그인을 실행할 세션을 선택하세요.",
+      "allSessions": "모든 세션",
+      "specificSessions": "특정 세션",
+      "noSessions": "아직 세션이 없습니다.",
+      "saveActivation": "실행 대상 저장",
+      "perSessionTitle": "세션별 설정",
+      "perSessionDesc": "세션별로 전역 설정을 재정의합니다. 건드리지 않은 필드는 전역 값을 따릅니다.",
+      "selectSession": "세션 선택…",
+      "saveOverride": "재정의 저장",
+      "clearOverride": "재정의 지우기"
+    },
+    "instances": {
+      "title": "인스턴스",
+      "description": "이 연동을 위해 계정별 인스턴스를 프로비저닝하세요. 각 인스턴스는 고유한 서명 시크릿과 인그레스 URL을 가집니다.",
+      "create": "인스턴스 생성",
+      "empty": "아직 인스턴스가 없습니다. 인스턴스를 만들면 인그레스 URL과 시크릿을 받을 수 있습니다.",
+      "loadError": "인스턴스를 불러오지 못했습니다.",
+      "allSessions": "모든 세션",
+      "enabled": "사용함",
+      "disabled": "사용 안 함",
+      "form": {
+        "instanceId": "인스턴스 ID",
+        "instanceIdPlaceholder": "예: acme-support",
+        "instanceIdHint": "영문자, 숫자, 하이픈, 밑줄 (최대 64자).",
+        "sessionScope": "세션 범위 (선택 사항)",
+        "sessionScopePlaceholder": "모든 세션을 대상으로 하려면 비워 두세요",
+        "verifyToken": "인증 토큰 (선택 사항)",
+        "verifyTokenPlaceholder": "공급자가 인증 시 그대로 반환하는 토큰",
+        "config": "구성 (선택 사항, JSON)",
+        "configPlaceholder": "{ }"
+      },
+      "created": {
+        "title": "인스턴스 생성 완료",
+        "hint": "지금 시크릿을 복사해 두세요 — 한 번만 표시됩니다.",
+        "secret": "서명 시크릿",
+        "ingressUrls": "인그레스 URL"
+      },
+      "regenerate": {
+        "title": "시크릿 재생성",
+        "confirm": "{{id}}의 서명 시크릿을 재생성할까요? 기존 시크릿은 즉시 작동하지 않게 됩니다.",
+        "action": "재생성"
+      },
+      "edit": { "title": "{{id}} 편집" },
+      "delete": {
+        "title": "인스턴스 삭제",
+        "confirm": "{{id}} 인스턴스를 삭제할까요? 인그레스 URL과 시크릿이 즉시 작동하지 않게 됩니다.",
+        "action": "삭제"
+      },
+      "actions": {
+        "regenerate": "시크릿 재생성",
+        "edit": "편집",
+        "delete": "삭제",
+        "copy": "복사",
+        "save": "저장",
+        "enable": "사용",
+        "disable": "사용 안 함"
+      },
+      "errors": {
+        "invalidId": "인스턴스 ID는 영문자, 숫자, 하이픈, 밑줄만 사용할 수 있습니다 (최대 64자).",
+        "invalidJson": "구성은 유효한 JSON이어야 합니다.",
+        "duplicateId": "이미 같은 ID의 인스턴스가 존재합니다."
+      },
+      "toasts": {
+        "created": "인스턴스가 생성되었습니다",
+        "updated": "인스턴스가 업데이트되었습니다",
+        "deleted": "인스턴스가 삭제되었습니다",
+        "secretRegenerated": "시크릿이 재생성되었습니다",
+        "actionFailed": "작업 실패"
+      }
+    }
+  },
+  "search": {
+    "placeholder": "메시지 검색…",
+    "results": "결과 {{count}}개",
+    "empty": "메시지를 찾을 수 없습니다.",
+    "error": "검색에 실패했습니다. 다시 시도하세요.",
+    "unavailable": "검색이 설정되어 있지 않습니다.",
+    "scope": { "current": "현재 세션" },
+    "loading": "검색하는 중…"
+  }
+}

--- a/dashboard/src/i18n/locales/ko.json
+++ b/dashboard/src/i18n/locales/ko.json
@@ -463,7 +463,7 @@
     },
     "statuses": {
       "active": "활성",
-      "revoked": "취소됨"
+      "revoked": "폐기됨"
     },
     "empty": {
       "title": "생성된 API 키가 없습니다",
@@ -471,15 +471,15 @@
     },
     "confirm": {
       "deleteTitle": "API 키 삭제",
-      "revokeTitle": "API 키 취소",
+      "revokeTitle": "API 키 폐기",
       "deleteMessage": "<strong>{{name}}</strong>을(를) 영구히 삭제할까요? 이 작업은 되돌릴 수 없습니다.",
-      "revokeMessage": "<strong>{{name}}</strong>을(를) 취소할까요? 더 이상 사용할 수 없게 됩니다.",
+      "revokeMessage": "<strong>{{name}}</strong>을(를) 폐기할까요? 더 이상 사용할 수 없게 됩니다.",
       "delete": "삭제",
-      "revoke": "취소"
+      "revoke": "폐기"
     },
     "actions": {
       "copy": "복사",
-      "revoke": "취소",
+      "revoke": "폐기",
       "delete": "삭제"
     }
   },


### PR DESCRIPTION
## Motivation

This adds Korean (`ko`) translation support — to help Korean-speaking users use this
open-source project more comfortably in their own language.
(한국 사람들의 오픈소스 이용에 도움이 되게 하기 위해서 한글화 작업을 하였습니다.)

## Changes

- Add `dashboard/src/i18n/locales/ko.json` with a full Korean translation of all 678 dashboard UI strings (parity with `en.json`), preserving every `{{placeholder}}` interpolation token and inline HTML/Trans markup (`<strong>`, `<code>`, `<br/>`, `<1>…</1>`) exactly.
- Register `ko` in `dashboard/src/i18n/index.ts`: import the locale file, add it to `supportedLanguages`, `resources`, and `languageOptions` (label `한국어` / compact `KO`), following the same pattern as the existing es/he/zh-CN/zh-HK/ar/te/fr/it/pt-BR locales.

## Testing

- `npm run i18n:check` (dashboard's locale parity script) passes: all 678 keys present in `ko.json`, no placeholder mismatches.
- `npm run build` (tsc + vite build) succeeds.
- `npm run lint` passes (only 2 pre-existing, unrelated warnings in other files).
- `npm run test:unit` passes (87/87).