### PR TITLE
fix(plugins): fail-fast hooks/webhooks on a dead worker (crash hot-path stall)

### DIFF
--- a/src/core/plugins/plugin-loader.service.ts
+++ b/src/core/plugins/plugin-loader.service.ts
@@ -979,6 +979,18 @@ export class PluginLoaderService implements OnModuleInit, OnModuleDestroy {
       // ran, making this a harmless no-op.
       unregisterPluginSearchProvider(this.getSearchRegistry(), pluginId);
       if (intentional) return; // routine disable/enable-failure already logged and expected
+      // Unexpected crash after a successful enable: the worker is gone. Drop the dead host +
+      // unregister the hook shims (so they don't keep dispatching into the dead worker) + mark the
+      // plugin ERROR so the dashboard reflects reality. The dispatchHook/dispatchWebhook dead-checks
+      // fail-fast; this cleanup is the root-cause fix (it also makes the shim's !liveHost guard fire).
+      const crashed = this.plugins.get(pluginId);
+      if (crashed) {
+        crashed.status = PluginStatus.ERROR;
+        crashed.error = `worker exited unexpectedly (code ${code})`;
+        this.pluginStorage.setPluginStatus(pluginId, PluginStatus.ERROR);
+      }
+      this.hookManager.unregisterPlugin(pluginId);
+      this.sandboxHosts.delete(pluginId);
       this.logger.warn(`Sandboxed plugin ${pluginId} worker exited unexpectedly (code ${code})`, {
         pluginId,
         code,

--- a/src/core/plugins/sandbox/plugin-worker-host.spec.ts
+++ b/src/core/plugins/sandbox/plugin-worker-host.spec.ts
@@ -526,4 +526,50 @@ describe('PluginWorkerHost', () => {
       await expect(exec).resolves.toEqual({ continue: true, data: { n: 1 } });
     });
   });
+
+  describe('post-crash dead-check (fail-fast, no stall)', () => {
+    it('dispatchHook resolves {continue:true} immediately when the worker is already dead', async () => {
+      jest.useFakeTimers();
+      try {
+        const ch = new FakeChannel();
+        const host = new PluginWorkerHost(ch);
+        ch.crash(1); // worker dead — handleExit sets this.dead
+        // Without the dead-check this awaits the full timeoutMs (the setTimeout never fires under fake
+        // timers → the test hangs). With it, resolves synchronously.
+        const result = await host.dispatchHook({
+          event: 'message:sending',
+          data: {},
+          source: 'test',
+          timeoutMs: 5000,
+        });
+        expect(result).toEqual({ continue: true });
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('dispatchWebhook resolves {ok:false,status:502} immediately when the worker is already dead', async () => {
+      jest.useFakeTimers();
+      try {
+        const ch = new FakeChannel();
+        const host = new PluginWorkerHost(ch);
+        ch.crash(1);
+        const result = await host.dispatchWebhook({
+          instanceId: 'i',
+          route: 'r',
+          method: 'POST',
+          headers: {},
+          query: {},
+          body: '',
+          rawBody: '',
+          verified: true,
+          deliveryId: 'd',
+          timeoutMs: 5000,
+        });
+        expect(result).toEqual({ ok: false, status: 502 });
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+  });
 });

--- a/src/core/plugins/sandbox/plugin-worker-host.ts
+++ b/src/core/plugins/sandbox/plugin-worker-host.ts
@@ -127,6 +127,11 @@ export class PluginWorkerHost {
     timeoutMs: number;
     onTimeout?: () => void;
   }): Promise<{ continue: boolean; data?: unknown }> {
+    // Fail fast on a dead worker: a post-crash dispatchHook (the hook shim still holds the stale host
+    // reference) would otherwise post to the dead worker and stall the chain for the full timeout before
+    // resolving. The fail-open { continue: true } matches what the per-call timeout + the in-flight
+    // crash-drain already produce.
+    if (this.dead) return Promise.resolve({ continue: true });
     const id = this.nextId++;
     this.incInFlightHook(options.event);
     return new Promise(resolve => {
@@ -175,6 +180,9 @@ export class PluginWorkerHost {
     timeoutMs: number;
     onTimeout?: () => void;
   }): Promise<{ status: number; headers?: Record<string, string>; body?: string; ok: boolean; error?: string }> {
+    // Fail fast on a dead worker — mirrors the in-flight crash-drain's 502 (handleExit) so a post-crash
+    // dispatchWebhook returns immediately instead of waiting the full timeout for a worker that's gone.
+    if (this.dead) return Promise.resolve({ ok: false, status: 502 });
     const id = this.nextId++;
     return new Promise(resolve => {
       const timer = setTimeout(() => {


### PR DESCRIPTION
A sandboxed plugin that crashed after a successful enable left its hook shims live with a stale reference to the dead `PluginWorkerHost` in `sandboxHosts`. The shim's `!liveHost` guard never fired (the dead host wasn't removed), so it called `dispatchHook()` on the dead worker — and `dispatchHook` lacked the dead-check that `dispatchSearch`/`load`/`runLifecycle`/`healthCheck` all have. The hook posted to the dead worker and stalled the sequential hook chain for the full `SANDBOX_HOOK_TIMEOUT_MS` (5s) before the per-call timeout resolved `{continue:true}`.

For a plugin subscribed to `message:sending` (awaited on every outbound send), this meant a flat **5-second latency on every `sendText`/media API call** for every session the plugin was active on — silent, non-self-healing (until manual disable/restart). Inbound messages were likewise delayed.

**Fix:**
- Add the missing dead-checks to `dispatchHook` (`{continue:true}` fail-open) and `dispatchWebhook` (`{ok:false, status:502}`), mirroring the 5 existing guards. Fail-fast, zero stall.
- In `onWorkerExit`'s crash branch (after the `intentional` early-return): mark the plugin `ERROR` + persist, `hookManager.unregisterPlugin` (drop the stale shims), and `sandboxHosts.delete` (drop the dead host). This is the root-cause cleanup — it also makes the shim's `!liveHost` guard fire. The deliberate-disable path takes the `intentional=true` early-return and is unaffected.

**Tests:** post-crash `dispatchHook` + `dispatchWebhook` resolve immediately (not after the timeout) — proving the stall is gone. Full sandbox suite (78) + lint + build green.