### PR TITLE
ci: align Docker gate with the release gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,8 +187,7 @@ jobs:
   docker:
     name: Docker Build
     runs-on: ubuntu-latest
-    needs: [build]
-    if: github.event_name == 'push'
+    needs: [build, test-postgres]
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
The CI Docker job only ran on push and did not depend on the PostgreSQL migration job, so a migration regression could reach the `:latest` image without the Postgres gate running. The release workflow already gates its Docker build on `test-postgres`; this mirrors that gate in CI and runs the Docker job on pull requests too.