### PR TITLE
docs(session): correct init-timeout teardown comment + warn against porting the reorder

### DIFF
--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -1186,13 +1186,17 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
           action: 'engine_init_timeout',
         });
         this.sessionErrors.set(id, err.message);
-        // Evict from the map BEFORE tearing down. forceDestroy() drives the adapter to
-        // EngineStatus.DISCONNECTED, which fires onStateChanged synchronously; while the engine is
-        // still in the map that callback would pass the isLiveEngine guard and run (and the same
-        // window admits onError/onDisconnected, which could write FAILED or schedule a reconnect
-        // against this path). Deleting first makes isLiveEngine return false so no teardown-induced
-        // callback can race the DISCONNECTED write below — the canonical delete-before-teardown used
-        // at evictAndForceDestroy(), start()'s catch, and stop().
+        // Evict from the map BEFORE tearing down. forceDestroy() → beginClientTeardown → setStatus
+        // fires onStateChanged SYNCHRONOUSLY while the engine is still live, so isLiveEngine would
+        // pass and the callback would run a redundant DISCONNECTED write against this path; removing
+        // the engine first makes isLiveEngine return false. Unlike delete()/stop()/forceKill(), this
+        // path has no stoppingSessions + cancelReconnect wrap to fall back on. Matches the canonical
+        // delete-before-teardown at evictAndForceDestroy() and start()'s catch.
+        //
+        // Do NOT port this reorder to delete()/stop()/forceKill(): there, engines.has(id) staying
+        // TRUE for the duration of the teardown await is the sole deterministic block on a concurrent
+        // start() (start() clears stoppingSessions rather than rejecting on it), so delete-first would
+        // open a start()-during-teardown orphan-engine window. Verified in the teardown-ordering audit.
         this.engines.delete(id);
         // Force-kill whatever got launched so a retry doesn't collide with an orphaned browser.
         // teardownEngineSafely is itself time-bound, so this can't wedge a second time.


### PR DESCRIPTION
## Summary

Comment-only accuracy fix to the `initializeEngine()` timeout-catch comment added in #697. No behavior change.

A source-traced audit of every engine-teardown site in `SessionService` (both adapters) found the #697 comment was inaccurate in two ways, and — importantly — its framing invited a reorder that would **regress**:

1. **Overstated the callback risk.** The comment claimed the teardown window "admits `onError`/`onDisconnected`, which could write `FAILED` or schedule a reconnect." Primary-source verification shows neither fires during any teardown: the only synchronous callback is `onStateChanged(DISCONNECTED)` (`beginClientTeardown` → `setStatus`). `onError` is unreachable from teardown; `onDisconnected` does not fire during `destroy` in either adapter (wwjs `Client.destroy()` never emits `'disconnected'`; Baileys `intentionalClose` short-circuits the close handler).
2. **Misnamed a peer.** `stop()` is teardown-first, not delete-first. Only `evictAndForceDestroy()` and `start()`'s catch are canonical delete-first.

**Why this matters (the warning):** porting the delete-first reorder to `delete()`/`stop()`/`forceKill()` — which the old comment's broad framing invites — would regress. `start()` gates entry only on `engines.has(id)` and **clears** `stoppingSessions` instead of rejecting on it, so `engines.has(id)=TRUE` for the duration of those sites' teardown await is the sole deterministic block on a concurrent `start()`; delete-first would open a start()-during-teardown orphan-engine window (a `start()` that passes the gate, launches Chromium, then gets orphaned when `delete()` removes the row + purges the auth dir).

The corrected comment states the real (narrower) reason delete-first is right *here* (no `stoppingSessions`/`cancelReconnect` wrap, unlike the guarded teardown-first sites) and explicitly warns against porting it.

The `#697` delete-first at this site stays correct for this path; the audit confirmed it does not regress. The guarded teardown-first sites (`delete`/`stop`/`forceKill`) stay teardown-first, intentionally.

## Test plan

- [x] Comment-only; `tsc --noEmit` clean, ESLint clean on the file.
- [x] CI (full suite) via `gh pr checks` before merge.

Refs #696, #697.