### PR TITLE
test(audit): fail the build on unemitted AuditAction values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`AuditAction` emit-coverage gate.** A structural test now fails the build when an `AuditAction`
+  enum value is neither emitted at a real call site nor registered (with a reason) in a new
+  intentionally-unemitted registry. A declared audit event can no longer silently exist with no
+  emission site, and a new action cannot land without either wiring it or documenting why it is held
+  back. The registry is also checked for stale entries (an action that is in fact emitted) and empty
+  reasons, so it cannot decay into a dumping ground.
+
 
 ## [0.8.16] - 2026-07-12
 

--- a/src/modules/audit/audit-coverage.spec.ts
+++ b/src/modules/audit/audit-coverage.spec.ts
@@ -1,0 +1,66 @@
+import { AuditAction } from './entities/audit-log.entity';
+import { INTENTIONALLY_UNEMITTED_ACTIONS } from './intentionally-unemitted-actions';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Structural gate: every `AuditAction` enum member must either be emitted somewhere in
+ * `src/` (an `AuditAction.<NAME>` literal at a real call site) or be registered in
+ * `INTENTIONALLY_UNEMITTED_ACTIONS` with a reason. This keeps the audit vocabulary honest —
+ * an enum value that implies an audited event cannot silently exist with no emission site,
+ * and new values cannot be added without either wiring them or documenting why they are held back.
+ */
+const SRC_DIR = join(__dirname, '..', '..');
+
+function listTsFiles(dir: string, out: string[] = []): string[] {
+  for (const ent of readdirSync(dir, { withFileTypes: true })) {
+    if (ent.name === 'node_modules') continue;
+    const full = join(dir, ent.name);
+    if (ent.isDirectory()) {
+      listTsFiles(full, out);
+    } else if (ent.name.endsWith('.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const isExcluded = (file: string): boolean =>
+  file.endsWith('.spec.ts') ||
+  file.endsWith('.test.ts') ||
+  file.endsWith('audit-coverage.spec.ts') ||
+  file.endsWith('audit-log.entity.ts') ||
+  file.endsWith('intentionally-unemitted-actions.ts');
+
+const sourceBodies = listTsFiles(SRC_DIR)
+  .filter(file => !isExcluded(file))
+  .map(file => readFileSync(file, 'utf8'));
+
+const memberKeys = Object.keys(AuditAction) as (keyof typeof AuditAction)[];
+
+const isEmitted = (key: keyof typeof AuditAction): boolean =>
+  sourceBodies.some(body => body.includes(`AuditAction.${key}`));
+
+const memberKeyForValue = (value: string): keyof typeof AuditAction | undefined =>
+  memberKeys.find(k => AuditAction[k] === (value as AuditAction));
+
+describe('audit action emit coverage', () => {
+  it.each(memberKeys)('AuditAction.%s is emitted somewhere in src/ or registered as intentionally unemitted', key => {
+    const registered = Boolean(INTENTIONALLY_UNEMITTED_ACTIONS[AuditAction[key]]);
+    expect(isEmitted(key) || registered).toBe(true);
+  });
+
+  it('intentionally-unemitted registry has no stale entries (none is actually emitted)', () => {
+    const stale = Object.keys(INTENTIONALLY_UNEMITTED_ACTIONS)
+      .map(value => memberKeyForValue(value))
+      .filter((key): key is keyof typeof AuditAction => Boolean(key) && isEmitted(key));
+    expect(stale).toEqual([]);
+  });
+
+  it('intentionally-unemitted registry entries each carry a non-empty reason', () => {
+    const empties = Object.entries(INTENTIONALLY_UNEMITTED_ACTIONS)
+      .filter(([, reason]) => typeof reason !== 'string' || reason.trim().length === 0)
+      .map(([value]) => value);
+    expect(empties).toEqual([]);
+  });
+});

--- a/src/modules/audit/intentionally-unemitted-actions.ts
+++ b/src/modules/audit/intentionally-unemitted-actions.ts
@@ -1,0 +1,35 @@
+import { AuditAction } from './entities/audit-log.entity';
+
+/**
+ * Audit actions that are deliberately not emitted, each with the reason. The coverage gate in
+ * `audit-coverage.spec.ts` fails for any `AuditAction` that is neither emitted somewhere in `src/`
+ * nor listed here, so this registry is the only way an unemitted action can exist without failing
+ * the build — every entry is a deliberate, documented decision rather than a silent gap.
+ *
+ * The gate is honest in both directions:
+ *  - a newly-added action with no emission and no entry here fails the build;
+ *  - an entry here whose action is in fact emitted is "stale" and also fails the build.
+ *
+ * To start auditing one of these events: wire its emission at the right call site, then remove its
+ * entry here.
+ */
+export const INTENTIONALLY_UNEMITTED_ACTIONS: Partial<Record<AuditAction, string>> = {
+  [AuditAction.API_KEY_USED]:
+    'Not emitted: would fire on every authenticated request, which is too high-volume for the audit log. Authentication failures are audited (API_KEY_AUTH_FAILED); successful authentication is intentionally not.',
+  [AuditAction.SESSION_CONNECTED]:
+    'Not emitted: an engine-level lifecycle transition, redundant with sessions.status and the SessionService lastDispatchedStatus map. User-initiated lifecycle (SESSION_STARTED / SESSION_STOPPED) is audited.',
+  [AuditAction.SESSION_DISCONNECTED]:
+    'Not emitted: an engine-level lifecycle transition, redundant with sessions.status and the SessionService lastDispatchedStatus map; reconnect storms would flood the audit log.',
+  [AuditAction.MESSAGE_SENT]:
+    'Not emitted: per outbound message, fully redundant with the messages table, which persists every send with its outcome.',
+  [AuditAction.MESSAGE_FAILED]:
+    'Not emitted: per failed send, redundant with the outcome persisted on the messages table.',
+  [AuditAction.WEBHOOK_CREATED]:
+    'Not yet emitted: webhook create/delete is not currently audited. It is low-volume and security-relevant, so wiring it is a candidate for a separate enhancement; the gate will validate the emission once added, and this entry must then be removed.',
+  [AuditAction.WEBHOOK_DELETED]:
+    'Not yet emitted: webhook create/delete is not currently audited. It is low-volume and security-relevant, so wiring it is a candidate for a separate enhancement; the gate will validate the emission once added, and this entry must then be removed.',
+  [AuditAction.WEBHOOK_TRIGGERED]:
+    'Not emitted: per delivery attempt, redundant with the webhook_delivery_failures dead-letter table and the openwa_webhook_delivery_failures_total counter.',
+  [AuditAction.WEBHOOK_FAILED]:
+    'Not emitted: per failed delivery, redundant with the webhook_delivery_failures dead-letter table and the openwa_webhook_delivery_failures_total counter.',
+};


### PR DESCRIPTION
## What
A structural test that fails the build when an `AuditAction` enum value is neither emitted at a real call site nor listed — with a reason — in a new intentionally-unemitted registry.

## Why
The `AuditAction` enum is the vocabulary of events the audit log can record, but nothing asserted that every value is actually wired to an emission site. Several values had no call site — some intentionally (high-volume or redundant with other storage), some simply never wired. That gap was invisible, and nothing prevented it from growing. This makes the current state explicit and prevents drift.

## How
- `audit-coverage.spec.ts` scans `src/` for `AuditAction.<NAME>` call sites. Any member with no site must be registered in `INTENTIONALLY_UNEMITTED_ACTIONS` with a reason.
- Two honesty checks keep the registry from rotting: a value that **is** emitted must not be registered (stale), and every reason must be non-empty.
- The registry documents each deliberate non-emission — per-request/per-message/per-delivery volume, redundancy with the messages table, the webhook dead-letter table + counter, or engine lifecycle already captured by `sessions.status`.

## Scope
Additive only — a test plus a documented constant. No runtime behavior changes. Wiring the low-volume CRUD events that are currently registered as "not yet emitted" (webhook create/delete) is intentionally left to a separate change; this gate will validate the emission once added (and the registry entry must then be removed).
