### PR TITLE
docs(message): document that outbound sends are intentionally direct, not queued

### DIFF
--- a/src/modules/message/message.service.ts
+++ b/src/modules/message/message.service.ts
@@ -25,6 +25,21 @@ export interface GetMessagesOptions {
   offset?: number;
 }
 
+/**
+ * Outbound sends are executed directly against the WhatsApp engine, not via a BullMQ queue.
+ *
+ * The engine is single-threaded per session (a Puppeteer page for the whatsapp-web.js adapter, a
+ * single socket for Baileys) and is therefore itself the serialization point for that session's
+ * outbound traffic. Routing sends through a queue would add request latency and a Redis hard
+ * dependency to the hot path for no throughput benefit — the engine cannot go faster than it
+ * already does. BullMQ is reserved for genuine side-effects that benefit from durable
+ * retry/back-pressure (webhook delivery, integration ingress); see `QUEUE_NAMES` in
+ * `queue-names.ts`, which intentionally defines no MESSAGE queue.
+ *
+ * Backpressure is applied at the edges instead: bulk sends self-throttle via
+ * `delayBetweenMessages` (default 3s) and a per-process concurrent-batch cap (see
+ * `BulkMessageService`), and the global throttler enforces per-key rate limits.
+ */
 @Injectable()
 export class MessageService {
   private readonly logger = createLogger('MessageService');


### PR DESCRIPTION
## What
A class-level comment on `MessageService` documenting that outbound sends are intentionally executed directly against the engine, not routed through BullMQ.

## Why
The message module imports no `QueueModule` and `QUEUE_NAMES` defines no `MESSAGE` queue — by design, not oversight. This keeps coming up in review, so the rationale now lives where the next reader will see it.

## The reasoning
The per-session engine is single-threaded (a Puppeteer page for the whatsapp-web.js adapter, a single socket for Baileys), so it is already the serialization point for that session's outbound traffic. A queue in front of it would add request latency and a Redis hard dependency to the hot path without any throughput gain — the engine cannot go faster than it already does. BullMQ is reserved for genuine side-effects that benefit from durable retry/back-pressure (webhook delivery, integration ingress). Backpressure is instead applied at the edges: bulk sends self-throttle via `delayBetweenMessages` + a concurrent-batch cap, and the global throttler enforces per-key rate limits.

## Scope
Comment only — no behavior, type, or runtime change.
