### PR TITLE
feat(server): pin + expose HTTP server timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   back. The registry is also checked for stale entries (an action that is in fact emitted) and empty
   reasons, so it cannot decay into a dumping ground.
 
+- **Operator-tunable HTTP server timeouts.** The gateway now pins `requestTimeout`,
+  `headersTimeout`, and `keepAliveTimeout` on its HTTP server explicitly (previously Node's
+  implicit defaults), exposed via `REQUEST_TIMEOUT_MS` / `HEADERS_TIMEOUT_MS` /
+  `KEEPALIVE_TIMEOUT_MS` and logged at boot. Defaults match Node 22 (300s / 65s / 5s);
+  `headersTimeout` is normalized to stay above `keepAliveTimeout` (Node requires it), and the three
+  are validated as positive integers at boot.
+
 
 ## [0.8.16] - 2026-07-12
 

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -3,6 +3,17 @@ import { computeFeatureFlags } from './feature-flags';
 export default () => ({
   port: parseInt(process.env.PORT || '2785', 10),
 
+  // HTTP server timeouts (Node http.Server). Pinned explicitly so they are operator-tunable and
+  // observable at boot rather than left at Node's implicit defaults. requestTimeout defaults to
+  // Node's 300s; keepAliveTimeout to 5s; headersTimeout to 65s (a second above keepAlive — Node
+  // requires headers > keepAlive, and main.ts normalizes it anyway). Set any to 0 at your own risk;
+  // env.validation rejects 0 so a bound is never silently disabled.
+  http: {
+    requestTimeoutMs: parseInt(process.env.REQUEST_TIMEOUT_MS || '300000', 10),
+    headersTimeoutMs: parseInt(process.env.HEADERS_TIMEOUT_MS || '65000', 10),
+    keepAliveTimeoutMs: parseInt(process.env.KEEPALIVE_TIMEOUT_MS || '5000', 10),
+  },
+
   // Global message search. Opt-out via SEARCH_ENABLED=false. Provider defaults to 'auto' (the
   // built-in DB full-text provider — Postgres tsvector/GIN, SQLite FTS5); 'none' disables the
   // /search route + module at runtime while keeping the config namespace loaded.

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -148,6 +148,9 @@ export function validateEnv(config: EnvConfig): EnvConfig {
     'RATE_LIMIT_LONG_LIMIT',
     'WEBHOOK_TIMEOUT',
     'INGRESS_INSTANCE_LIMIT',
+    'REQUEST_TIMEOUT_MS',
+    'HEADERS_TIMEOUT_MS',
+    'KEEPALIVE_TIMEOUT_MS',
   ]) {
     checkPositiveInt(key);
   }

--- a/src/config/http-timeouts.spec.ts
+++ b/src/config/http-timeouts.spec.ts
@@ -1,0 +1,37 @@
+import { applyHttpTimeouts, HttpTimeoutSink } from './http-timeouts';
+
+describe('applyHttpTimeouts', () => {
+  const sink = (): HttpTimeoutSink => ({ requestTimeout: 0, headersTimeout: 0, keepAliveTimeout: 0 });
+
+  it('writes requestTimeout, headersTimeout, and keepAliveTimeout onto the server from the config', () => {
+    const s = sink();
+    applyHttpTimeouts(s, { requestTimeoutMs: 300000, headersTimeoutMs: 70000, keepAliveTimeoutMs: 5000 });
+
+    expect(s.requestTimeout).toBe(300000);
+    expect(s.headersTimeout).toBe(70000);
+    expect(s.keepAliveTimeout).toBe(5000);
+  });
+
+  it('keeps a valid headersTimeout (> keepAliveTimeout) unchanged', () => {
+    const s = sink();
+    applyHttpTimeouts(s, { requestTimeoutMs: 300000, headersTimeoutMs: 65000, keepAliveTimeoutMs: 5000 });
+    expect(s.headersTimeout).toBe(65000);
+  });
+
+  it('auto-bumps headersTimeout above keepAliveTimeout when misconfigured (Node requires headers > keepAlive)', () => {
+    const s = sink();
+    applyHttpTimeouts(s, { requestTimeoutMs: 300000, headersTimeoutMs: 5000, keepAliveTimeoutMs: 5000 });
+    expect(s.headersTimeout).toBeGreaterThan(s.keepAliveTimeout);
+  });
+
+  it('reports the resolved (post-bump) values so boot can log what was actually applied', () => {
+    const report = applyHttpTimeouts(sink(), {
+      requestTimeoutMs: 300000,
+      headersTimeoutMs: 5000,
+      keepAliveTimeoutMs: 5000,
+    });
+    expect(report.requestTimeoutMs).toBe(300000);
+    expect(report.keepAliveTimeoutMs).toBe(5000);
+    expect(report.headersTimeoutMs).toBeGreaterThan(report.keepAliveTimeoutMs);
+  });
+});

--- a/src/config/http-timeouts.ts
+++ b/src/config/http-timeouts.ts
@@ -1,0 +1,46 @@
+/**
+ * HTTP server timeout configuration + a pure applicator.
+ *
+ * Extracted from `main.ts` so the resolution rule (notably "headersTimeout must exceed
+ * keepAliveTimeout", which Node otherwise warns about and self-corrects invisibly) is unit-tested
+ * without booting the whole app.
+ */
+export interface HttpTimeoutConfig {
+  /** Hard cap on the full request duration (Node's `server.requestTimeout`). */
+  requestTimeoutMs: number;
+  /** Cap on receiving the request headers (Node's `server.headersTimeout`). */
+  headersTimeoutMs: number;
+  /** Idle keep-alive duration between requests on one connection (Node's `server.keepAliveTimeout`). */
+  keepAliveTimeoutMs: number;
+}
+
+/** The values actually written, after any normalization. */
+export type HttpTimeoutReport = HttpTimeoutConfig;
+
+/** The subset of `http.Server` this helper touches (keeps the helper testable with a plain object). */
+export interface HttpTimeoutSink {
+  requestTimeout: number;
+  headersTimeout: number;
+  keepAliveTimeout: number;
+}
+
+/**
+ * Write the configured timeouts onto the server and return the resolved values (which may differ
+ * from the request when headersTimeout had to be bumped above keepAliveTimeout). Boot logs the
+ * returned report so the applied values are observable.
+ */
+export function applyHttpTimeouts(server: HttpTimeoutSink, cfg: HttpTimeoutConfig): HttpTimeoutReport {
+  const requestTimeoutMs = Math.floor(cfg.requestTimeoutMs);
+  const keepAliveTimeoutMs = Math.floor(cfg.keepAliveTimeoutMs);
+  const requestedHeadersMs = Math.floor(cfg.headersTimeoutMs);
+  // Node requires headersTimeout > keepAliveTimeout (it logs a warning and self-corrects otherwise,
+  // which is invisible to the operator). Bump by a second rather than failing boot — the point is to
+  // make the applied values correct and observable.
+  const headersTimeoutMs = requestedHeadersMs > keepAliveTimeoutMs ? requestedHeadersMs : keepAliveTimeoutMs + 1000;
+
+  server.requestTimeout = requestTimeoutMs;
+  server.headersTimeout = headersTimeoutMs;
+  server.keepAliveTimeout = keepAliveTimeoutMs;
+
+  return { requestTimeoutMs, headersTimeoutMs, keepAliveTimeoutMs };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import { ShutdownService } from './common/services/shutdown.service';
 import { LoggerService, LogLevel, createLogger } from './common/services/logger.service';
 import { createSwaggerConfig, exemptPublicOperations } from './config/swagger.config';
 import { registerUncaughtExceptionMonitor } from './config/process-error-monitor';
+import { applyHttpTimeouts, HttpTimeoutConfig, HttpTimeoutSink } from './config/http-timeouts';
 import {
   resolveCorsPolicy,
   isSwaggerEnabled,
@@ -234,6 +235,18 @@ async function bootstrap() {
   app.use('/api/admin/queues', (req: Request, res: Response, next: NextFunction) => {
     void bullBoardAuth.use(req, res, next);
   });
+
+  // Apply explicit HTTP server timeouts so they are operator-tunable (REQUEST_TIMEOUT_MS /
+  // HEADERS_TIMEOUT_MS / KEEPALIVE_TIMEOUT_MS) and observable at boot, instead of Node's implicit
+  // defaults. Done after the adapter exists and before listen().
+  const appliedHttpTimeouts = applyHttpTimeouts(
+    app.getHttpAdapter().getInstance() as HttpTimeoutSink,
+    app.get(ConfigService).get<HttpTimeoutConfig>('http')!,
+  );
+  bootstrapLogger.log(
+    `HTTP server timeouts applied: requestTimeout=${appliedHttpTimeouts.requestTimeoutMs}ms ` +
+      `headersTimeout=${appliedHttpTimeouts.headersTimeoutMs}ms keepAliveTimeout=${appliedHttpTimeouts.keepAliveTimeoutMs}ms`,
+  );
 
   const port = process.env.PORT || 2785;
   await app.listen(port);


### PR DESCRIPTION
## What
The HTTP server now runs with explicitly pinned `requestTimeout` / `headersTimeout` / `keepAliveTimeout`, exposed as env vars and logged at boot — previously it used Node's implicit defaults.

## Why
Node's defaults (300s/60s/5s) are reasonable but invisible and not tunable. An operator behind a reverse proxy has no knob for the request lifecycle, and a misconfiguration (e.g. `headersTimeout < keepAliveTimeout`, which Node warns about and self-corrects invisibly) is silent. This makes the values explicit, observable, and adjustable.

## How
- New config namespace `http` (`configuration.ts`): `REQUEST_TIMEOUT_MS` (300000), `HEADERS_TIMEOUT_MS` (65000), `KEEPALIVE_TIMEOUT_MS` (5000).
- `applyHttpTimeouts(server, cfg)` (`config/http-timeouts.ts`) writes the three fields onto the `http.Server` and normalizes `headersTimeout` to `keepAliveTimeout + 1000` when misconfigured, returning the resolved values. Extracted as a pure helper so the rule is unit-tested without booting the app.
- `main.ts` applies it after `NestFactory.create`, before `app.listen`, and logs the applied values.
- `env.validation.ts` requires the three to be positive integers (a `0` would silently disable the bound).

## Test plan
- New `http-timeouts.spec.ts` (4 cases): writes the fields, keeps a valid headers value, auto-bumps a misconfigured one, reports resolved values. TDD: written first, watched fail against a stub, then implemented.
- Full unit suite green (2290 passed) — the three new env checks run at AppModule init via `validateEnv`, so any booting spec exercises them.

No change to default behavior (defaults match Node 22); `headersTimeout` default rises 60s → 65s to stay above `keepAliveTimeout`.
