### PR TITLE
fix(audit): correct type-narrowing in the emit-coverage spec

### DIFF
--- a/src/modules/audit/audit-coverage.spec.ts
+++ b/src/modules/audit/audit-coverage.spec.ts
@@ -38,8 +38,8 @@ const sourceBodies = listTsFiles(SRC_DIR)
 
 const memberKeys = Object.keys(AuditAction) as (keyof typeof AuditAction)[];
 
-const isEmitted = (key: keyof typeof AuditAction): boolean =>
-  sourceBodies.some(body => body.includes(`AuditAction.${key}`));
+const isEmitted = (key: keyof typeof AuditAction | undefined): boolean =>
+  key !== undefined && sourceBodies.some(body => body.includes(`AuditAction.${key}`));
 
 const memberKeyForValue = (value: string): keyof typeof AuditAction | undefined =>
   memberKeys.find(k => AuditAction[k] === (value as AuditAction));


### PR DESCRIPTION
Main is red: the audit-coverage spec (from the emit-coverage gate) passed a possibly-undefined key into `isEmitted`, which the full-program typecheck (`tsconfig.json`, includes specs) rejects but the build typecheck (`tsconfig.build.json`, excludes specs) missed. `isEmitted` now accepts `undefined` and short-circuits. Verified with `tsc --noEmit -p tsconfig.json` (the exact CI command) + the 25 spec tests.