### PR TITLE
ci(release): boot-smoke the published image on amd64 + arm64 before Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,11 +195,12 @@ jobs:
   release:
     name: GitHub Release
     runs-on: ubuntu-latest
-    # Gate the public Release on every CI-strength job AND a successfully built+pushed image, so a tag
-    # never produces a GitHub Release without passing the same gate CI enforces plus a matching
-    # container image (the docker job also builds the dashboard, which the gates above verify
-    # separately). Trades a few minutes of buildx latency for release/image consistency.
-    needs: [lint, test, test-postgres, dashboard, build, docker]
+    # Gate the public Release on every CI-strength job AND a successfully built+pushed image that
+    # also boots, so a tag never produces a GitHub Release without passing the same gate CI enforces,
+    # a matching container image, and a runtime boot check on both architectures (boot-smoke runs the
+    # published image on amd64 + arm64). Trades a few minutes of buildx/boot latency for release
+    # safety.
+    needs: [lint, test, test-postgres, dashboard, build, docker, boot-smoke]
     steps:
       - uses: actions/checkout@v7
         with:
@@ -278,3 +279,66 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # ──── Boot Smoke (amd64 + arm64) ──────────────────────────────────
+  # The docker job proves the image BUILDS for both architectures; this proves the just-pushed image
+  # actually BOOTS and serves the liveness endpoint on both. A boot regression that only surfaces at
+  # runtime on one architecture (e.g. a native-dep/Chromium SIGTRAP on arm64 that a clean build still
+  # produces) cannot reach a public Release. Runs the published image — not a rebuild — against the
+  # dependency-free /api/health/live (NOT /ready, which needs a DB and would conflate boot failure
+  # with database setup). Both architectures are tried even if the first fails, so logs name both.
+  boot-smoke:
+    name: Boot smoke (amd64 + arm64)
+    runs-on: ubuntu-latest
+    needs: [docker]
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve published image ref
+        id: image
+        # metadata-action publishes the {{version}} tag (e.g. 0.8.16) from the v-prefixed git tag, so
+        # strip the leading "v" to match it. github.repository is trusted; the tag derives from the
+        # pushed git ref, not from untrusted input.
+        env:
+          REPO: ${{ github.repository }}
+        run: echo "ref=ghcr.io/${REPO}:${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Boot + liveness check on each architecture
+        env:
+          IMAGE: ${{ steps.image.outputs.ref }}
+        run: |
+          exit_code=0
+          for platform in linux/amd64 linux/arm64; do
+            echo "::group::boot-smoke $platform"
+            docker rm -f openwa-smoke >/dev/null 2>&1 || true
+            if ! docker run --rm --platform "$platform" -d -p 2785:2785 --name openwa-smoke "$IMAGE" >/dev/null; then
+              echo "FAIL: $platform — could not start container (image pull/run error)"
+              exit_code=1
+              echo "::endgroup::"
+              continue
+            fi
+            ok=""
+            for i in $(seq 1 40); do
+              if curl -sf http://127.0.0.1:2785/api/health/live >/dev/null 2>&1; then ok=1; break; fi
+              sleep 5
+            done
+            if [ -n "$ok" ]; then
+              echo "OK: $platform — /api/health/live returned 200"
+            else
+              echo "FAIL: $platform — /api/health/live did not return 200 within ~200s; container logs follow:"
+              docker logs openwa-smoke 2>&1 | tail -60 || true
+              exit_code=1
+            fi
+            docker stop openwa-smoke >/dev/null 2>&1 || true
+            docker rm -f openwa-smoke >/dev/null 2>&1 || true
+            echo "::endgroup::"
+          done
+          exit "$exit_code"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the machine-readable contract can never silently drift from the code. SDK/API consumers now have a
   versioned artifact at the repo root.
 
+- **Pre-release boot smoke on amd64 + arm64.** Cutting a release tag now runs the just-published
+  image on both `linux/amd64` and `linux/arm64` (via QEMU) and polls the dependency-free
+  `/api/health/live` endpoint before the GitHub Release is created — so a runtime-only boot regression
+  on one architecture (a clean build can still produce a native-dep/Chromium SIGTRAP on arm64) cannot
+  ship under a release. The Release job waits on the new boot-smoke job.
+
 ### Fixed
 
 - **OpenAPI export script under current env validation.** `scripts/export-openapi.ts` had been broken


### PR DESCRIPTION
## What
New `boot-smoke` job in `release.yml`, gated between the docker image push and the GitHub Release: it runs the just-published image on `linux/amd64` and `linux/arm64` (the latter via QEMU) and polls the dependency-free `/api/health/live` until it returns 200. The `release` job now `needs: […, docker, boot-smoke]`.

## Why
The docker job proves the image **builds** for both architectures; nothing proved it actually **boots**. A clean multi-arch build can still produce an image that SIGTRAPs at runtime on one architecture (the exact native-dep/Chromium-on-arm64 class of regression this repo has shipped before). This gates the public Release on a real boot of the published image on both arches.

## Design choices
- Runs the **published** image (`ghcr.io/…:<version>`), not a rebuild — so it catches push/manifest problems too. The version tag is resolved by stripping the leading `v` from the git tag, matching what `docker/metadata-action` publishes as `{{version}}`.
- Polls **`/api/health/live`** (static, DB-free), not `/ready` (which needs a DB and would conflate a boot failure with database setup). 40 × 5s ≈ 200s ceiling — generous for Node booting under arm64 QEMU.
- **Both** architectures are attempted even if the first fails, and the failing one dumps its container logs, so a release-time failure names the broken arch immediately.
- No untrusted input anywhere: `${{ github.repository }}` and the git-tag-derived version are the only interpolations, threaded through `env:` (not inline in `run:`).

## Caveat
`release.yml` triggers on tag push only, so PR CI does **not** exercise this job. It's validated by a YAML parse + job-graph check (no dangling `needs`) + review of the run script; the core assumption (the image boots headless and `/live` responds) is what the existing live deployment already runs on. A worthwhile follow-up is wiring `actionlint` into `ci.yml` so workflow YAML errors are caught on PRs, not at release time.
