### PR TITLE
fix(engine): advise on stale browser profile after a binary-changing upgrade (#708)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Diagnosable failure for a stale browser profile after a binary-changing upgrade.** Upgrading
+  across the v0.8.12 amd64 browser-binary switch (Debian Chromium → Chrome for Testing, #663) — or any
+  later change to the Chromium/Chrome binary — can leave an already-authenticated `whatsapp-web.js`
+  session's persistent browser profile incompatible with the new binary: on the next start the page
+  context is destroyed during injection and the engine fails with Puppeteer's opaque
+  `Execution context was destroyed`, which reads like a Puppeteer bug and gave no hint that the stale
+  profile was the cause. The `whatsapp-web.js` adapter now detects that error in its `initialize()`
+  catch and logs an advisory pointing the operator at the remedy (delete the session profile dir and
+  re-scan); the error still propagates unchanged, so existing failure handling is unaffected. The
+  profile is not auto-recovered — a tainted profile is not safely portable across Chromium major
+  versions (clearing only the cache subdirs is insufficient), so a one-time re-authentication is
+  required. [#708]
+
 - **OpenAPI export script under current env validation.** `scripts/export-openapi.ts` had been broken
   since the SQLite `DATABASE_NAME` file-path validation tightened (it pinned an in-memory data DB,
   which that rule rejects). The data connection now uses a temp-dir SQLite file that is removed on

--- a/docs/12-troubleshooting-faq.md
+++ b/docs/12-troubleshooting-faq.md
@@ -341,6 +341,44 @@ If `Code: null` happens on Kubernetes, and the host kernel logs or `dmesg` shows
 limit the instant before the failure — that tells you A vs B. If neither moves and you see the crashpad
 `--database` line, it's C. If running in K8s as non-root with the Debian `chromium` package, it is likely D.
 
+### Issue: `Execution context was destroyed` on the first start after an upgrade
+
+> **Engine:** This issue applies to the `whatsapp-web.js` engine only (Chromium/Puppeteer-based). It does not affect `ENGINE_TYPE=baileys`.
+
+**Symptoms:** A `whatsapp-web.js` session that was already authenticated fails within seconds of
+**Start** after upgrading OpenWA — no QR is produced — and the session's `lastError` / container log
+show:
+
+```text
+Protocol error (Runtime.callFunctionOn): Execution context was destroyed.
+```
+
+**Cause:** The session's persistent browser profile (`<SESSION_DATA_PATH>/session-<name>`, created by
+whatsapp-web.js's `LocalAuth`) was built with a different Chromium/Chrome binary than the one the new
+image runs. A browser profile carries binary-bound state (page caches, GPU shader caches, IndexedDB /
+Local Storage version markers) that is not safely portable across Chromium major versions or binary
+flavours; loading the stale profile destroys the page context during `Client.inject()`. The dominant
+trigger today is the **v0.8.12** amd64 switch from Debian's `chromium` package to Chrome for Testing
+(#663), but the same symptom can follow any future change to the bundled browser binary. The error
+reads like a Puppeteer bug and gives no hint that the profile is the cause — the adapter now logs an
+advisory when it detects this error.
+
+**Fix:** delete the affected session's profile dir and start the session again to scan a new QR. The
+profile cannot be salvaged — clearing only the cache subdirs (`Cache`, `GPUCache`, `Code Cache`, …) is
+**not** enough, the taint is deeper than the caches — so a one-time re-authentication is required.
+
+The profile dir is named after the session **name**, while the REST API addresses a session by its
+**id** (a UUID) — so the two placeholders below are different values:
+
+```bash
+docker exec openwa-api rm -rf /app/data/sessions/session-<name>
+# then POST /sessions/<id>/force-kill and POST /sessions/<id>/start (the session's UUID id), and scan the new QR
+```
+
+Re-creating the session (`DELETE /sessions/<id>`) also purges its profile dir; create it again and
+scan. Messages are unaffected — they live in the database, not the browser profile — so nothing is lost
+except the WhatsApp pairing, which must be re-scanned.
+
 ### Issue: Frequent Disconnections
 
 **Symptoms:**

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -5,6 +5,7 @@ import {
   extractLinkedParentJID,
   isHttpUrl,
   isSupportedProxyUrl,
+  isExecutionContextDestroyedError,
   buildProxyLaunchConfig,
   loadRemoteMedia,
   resolveAuthTimeoutMs,
@@ -81,6 +82,35 @@ describe('isSupportedProxyUrl', () => {
   it.each(['not a url', 'ftp://proxy:21', 'proxy:8080', ''])('rejects %s', url => {
     expect(isSupportedProxyUrl(url)).toBe(false);
   });
+});
+
+describe('isExecutionContextDestroyedError (#708 — Puppeteer context loss during initialize)', () => {
+  it('matches the bare Puppeteer error', () => {
+    expect(isExecutionContextDestroyedError('Execution context was destroyed')).toBe(true);
+  });
+
+  it('matches the Runtime.callFunctionOn form (the stale-profile signature during inject)', () => {
+    expect(
+      isExecutionContextDestroyedError('Protocol error (Runtime.callFunctionOn): Execution context was destroyed.'),
+    ).toBe(true);
+  });
+
+  it('matches the "most likely because of a navigation" variant', () => {
+    expect(
+      isExecutionContextDestroyedError('Execution context was destroyed, most likely because of a navigation.'),
+    ).toBe(true);
+  });
+
+  it('is case-insensitive', () => {
+    expect(isExecutionContextDestroyedError('EXECUTION CONTEXT WAS DESTROYED')).toBe(true);
+  });
+
+  it.each(['Failed to launch the browser process:  Code: null', 'Target closed', 'Navigation timeout exceeded', ''])(
+    'does not match unrelated initialize errors (%s)',
+    reason => {
+      expect(isExecutionContextDestroyedError(reason)).toBe(false);
+    },
+  );
 });
 
 describe('buildProxyLaunchConfig (#628 — proxy credentials must not go into --proxy-server)', () => {

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -144,6 +144,18 @@ export function isHttpUrl(value: string): boolean {
 }
 
 /**
+ * Detect Puppeteer's "Execution context was destroyed" error. During `Client.inject()` this is most
+ * often a persistent browser profile left stale by an OpenWA upgrade that changed the Chromium/Chrome
+ * binary (e.g. the v0.8.12 amd64 Debian Chromium → Chrome for Testing switch, #663 / #708) — but it is
+ * not exclusively that: Puppeteer also raises it on a page navigation or a renderer crash (see
+ * puppeteer-core `ExecutionContext` / `IsolatedWorld`), so the caller advises rather than asserts.
+ * Pure so the detection is unit-testable without mocking the whatsapp-web.js `Client`.
+ */
+export function isExecutionContextDestroyedError(reason: string): boolean {
+  return /execution context was destroyed/i.test(reason);
+}
+
+/**
  * Fetch remote media for sending, with an SSRF host guard, a byte cap, and a timeout.
  * The guard runs BEFORE any network call, so an internal/reserved URL throws `SsrfBlockedError`
  * and no outbound socket is opened. The byte cap (node-fetch `size`) and `AbortSignal` timeout
@@ -431,6 +443,24 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     } catch (error) {
       this.setStatus(EngineStatus.FAILED);
       const reason = error instanceof Error ? error.message : String(error);
+      if (isExecutionContextDestroyedError(reason)) {
+        // #708: Puppeteer's "Execution context was destroyed" during inject reads like a Puppeteer bug.
+        // During initialize() its dominant cause is a browser profile left stale by an upgrade that
+        // changed the Chromium/Chrome binary (e.g. v0.8.12 amd64: Debian Chromium → Chrome for Testing,
+        // #663) — but it can also follow a page navigation or a renderer crash, so advise, don't assert.
+        // The profile dir is the same one clearLocalAuth() removes on a clean re-pair. Safe to compute
+        // here: sessionDataPath is a required config field already resolved in the try block above, so
+        // this can't throw and mask the original error we are about to rethrow.
+        this.logger.warn(
+          `"${reason}" during initialize. If this followed an OpenWA upgrade that changed the ` +
+            `Chromium/Chrome binary (v0.8.12 amd64 switched Debian Chromium → Chrome for Testing), the ` +
+            `session's browser profile is likely stale — delete the profile dir ` +
+            `"${path.join(path.resolve(this.config.sessionDataPath), `session-${this.config.sessionId}`)}" ` +
+            `and start again to re-scan. If no upgrade happened, Puppeteer also raises this on a page ` +
+            `navigation or renderer crash (check for memory pressure or a WhatsApp Web reload). ` +
+            `See docs/12-troubleshooting-faq.md.`,
+        );
+      }
       this.callbacks.onError?.(reason);
       throw error;
     }


### PR DESCRIPTION
## Summary

Resolves #708.

Upgrading an amd64 deployment across the v0.8.12 browser-binary switch (Debian Chromium → Chrome for Testing, #663) — or any later change to the bundled Chromium/Chrome binary — can leave an already-authenticated `whatsapp-web.js` session's persistent browser profile incompatible with the new binary. On the next start, the page context is destroyed during `Client.inject()` and the engine fails with Puppeteer's opaque `Execution context was destroyed`, which reads like a Puppeteer bug and gives the operator no hint that the stale profile is the cause. As reported in #708, the only recovery is to delete the session's profile directory and re-scan a QR — and nothing in the logs pointed there.

## What this changes

- **`whatsapp-web.js` adapter** — a pure predicate `isExecutionContextDestroyedError(reason)` detects the error signature in the `initialize()` catch and logs a single advisory pointing the operator at the remedy (delete the profile dir, re-scan). The message is hedged: during `initialize()` the dominant cause is a stale profile after a binary change, but Puppeteer also raises the same string for page navigations and renderer crashes, so the advisory names those alternatives rather than asserting the profile is at fault.
- **No behavioral change to the failure path.** The error still sets the session `FAILED`, fires `onError`, and propagates to `SessionService.start()`'s existing `forceDestroy` recovery exactly as before. The #667 init-timeout race scoping is untouched. The advisory is purely additive diagnostic logging.

## Why not auto-recover

A tainted browser profile is not safely portable across Chromium major versions or binary flavours — the incompatibility runs deeper than the cache subdirectories (`Cache`, `GPUCache`, `Code Cache`, …), so clearing only those is insufficient (confirmed in the issue: it restored `qr_ready` on the old binary but still crashed on the new one). Reliable recovery requires a one-time re-authentication, which is destructive and therefore must stay an explicit operator action. Detect-and-advise at the single init chokepoint is the proportionate fix; auto-detecting via a persisted binary marker would add state and edge cases for a one-time upgrade event.

## Safety

The advisory branch sits inside an existing `catch`, so the critical question is whether it can throw and mask the original error. It cannot: `sessionDataPath` is a required config field with a default at every construction site and is already resolved in the `try` block immediately above, and `logger.warn` is console output with no side effects (no webhooks/audit/metrics). The predicate is unit-tested against the three real strings `puppeteer-core` 24.38.0 emits, plus negatives.

## Verification

- `npm run lint` — 0 errors (4 pre-existing warnings in `baileys.adapter.ts`, untouched)
- `npm run build` — clean
- `npm test` — 2309 passed, 0 failed

## Docs

CHANGELOG `[Unreleased] → Fixed` entry (with an upgrade note), plus a Symptoms/Cause/Fix entry in `docs/12-troubleshooting-faq.md`.
