### PR TITLE
feat(engine): delete-for-me on the Baileys engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `docs/engine-capability-matrix.md` inventories the unwired adapter-gaps as a prioritized capability
   backlog.
 
+- **Delete-for-me on the Baileys engine.** `deleteMessage(…, forEveryone=false)` now performs a
+  delete-for-me via Baileys' `chatModify({ deleteForMe })` instead of returning 501. Revoke-for-
+  everyone (`forEveryone=true`) was already wired; this completes `deleteMessage` on the Baileys
+  engine for the most common delete mode.
+
 ### Fixed
 
 - **Diagnosable failure for a stale browser profile after a binary-changing upgrade.** Upgrading

--- a/docs/engine-capability-matrix.md
+++ b/docs/engine-capability-matrix.md
@@ -97,11 +97,9 @@ The `rootCause`/`evidence` fields are hand-curated from source traces of the ins
 
 | Method | baileys | wwjs |
 |---|---|---|
-| `deleteMessage` | not-available — **adapter-gap** (partial) | supported |
 | `getChatHistory` | not-available — **library-limitation** | supported |
 | `getMessageReactions` | not-available — **library-limitation** | supported |
 
-- **`deleteMessage` (baileys, adapter-gap, partial).** Only the `forEveryone=false` (delete-for-me) branch is missing — `forEveryone=true` is already correctly wired via `sendMessage({delete})`. The library HAS delete-for-me: `chatModify({deleteForMe:{deleteMedia,key,timestamp}}, jid)` (`Types/Chat.d.ts:76` via `Socket/chats.d.ts:64`). `target.key` is already obtained via `requireStored(messageId)` and `chatModify` is already in use at `baileys.adapter.ts:820,833`. Drop the `if(!forEveryone) throw` guard at line 655 and route the false branch to `chatModify`.
 - **`getChatHistory` (baileys, library-limitation).** The only history primitive is `fetchMessageHistory(count, oldestMsgKey, oldestMsgTimestamp)` (`Socket/business.d.ts:25`) — it returns a sync-token *string*, not messages; the messages are delivered later via the `messaging-history.set` event. There is no per-chat `fetchMessages(chatId, limit)` on the socket. A synchronous `Promise<IncomingMessage[]>` for one chat would require an OpenWA-side chat-indexed store populated from `messages.upsert` + `messaging-history.set` events.
 - **`getMessageReactions` (baileys, library-limitation).** No on-demand server fetch. Reactions exist only as event-augmented state on `WAMessage.reactions` (`proto.IReaction[]` at `WAProto/index.d.ts:10623`), mutated by `updateMessageWithReaction` and surfaced via the `messages.reaction` event. The adapter already processes `reactionMessage` events (`baileys.adapter.ts:1048-1057`) and emits `onMessageReaction`, but it does **not** persist `.reactions` into its `messageStore` (early-returns at line 1058). A store-backed read would need that persistence added first; even then, only reactions observed since session start are known (no historical backfill).
 
@@ -111,16 +109,17 @@ The `rootCause`/`evidence` fields are hand-curated from source traces of the ins
 
 These are the capabilities the underlying library already supports but the OpenWA adapter does not wire. Ranked high-value + low-effort first. Each is a self-contained backlog item; an engineer can open the cited symbol and start.
 
+> **Progress.** ✅ `deleteMessage` (`forEveryone=false`, Baileys) — wired via `chatModify({ deleteForMe })`; moved to `supported`.
+
 ### Tier 1 — small effort, high value
 
 | # | Method : engine | Library call to wire | Effort | Value |
 |---|---|---|---|---|
-| 1 | `deleteMessage` (forEveryone=false) : **baileys** | `sock.chatModify({deleteForMe:{deleteMedia:true,key,target.key,timestamp:Date.now()}}, chatId)` — drop the `!forEveryone` throw at `baileys.adapter.ts:655` | **S** | Core messaging op. Delete-for-me is heavily used; currently 501 on baileys for the most common delete mode. `chatModify` already used at lines 820/833; `target.key` already resolved. |
-| 2 | `postTextStatus` : **wwjs** | `client.sendMessage('status@broadcast', text, {extra:{backgroundColor,font}})` — routes to `sendStatusTextMsgAction` (`Utils.js:537`) | **S** | Status broadcast parity. Flagship feature currently 501 on the default engine despite the library supporting it. Document the `recipients` (statusJidList) caveat. |
-| 3 | `postImageStatus` : **wwjs** | `client.sendMessage('status@broadcast', new MessageMedia(...), {caption})` — routes to `sendStatusMediaMsgAction` (`Utils.js:565`) | **S** | Same as above for image status. |
-| 4 | `postVideoStatus` : **wwjs** | `client.sendMessage('status@broadcast', new MessageMedia(...), {caption})` — routes to `sendStatusMediaMsgAction` (`Utils.js:565`) | **S** | Same as above for video status. |
-| 5 | `addLabelToChat` : **baileys** | `await sock.addChatLabel(chatId, labelId)` (`Socket/chats.d.ts:70`) | **S** | 1:1 mapping. WhatsApp Business CRM parity. |
-| 6 | `removeLabelFromChat` : **baileys** | `await sock.removeChatLabel(chatId, labelId)` (`Socket/chats.d.ts:71`) | **S** | 1:1 mapping. Pairs with #5. |
+| 1 | `postTextStatus` : **wwjs** | `client.sendMessage('status@broadcast', text, {extra:{backgroundColor,font}})` — routes to `sendStatusTextMsgAction` (`Utils.js:537`) | **S** | Status broadcast parity. Flagship feature currently 501 on the default engine despite the library supporting it. Document the `recipients` (statusJidList) caveat. |
+| 2 | `postImageStatus` : **wwjs** | `client.sendMessage('status@broadcast', new MessageMedia(...), {caption})` — routes to `sendStatusMediaMsgAction` (`Utils.js:565`) | **S** | Same as above for image status. |
+| 3 | `postVideoStatus` : **wwjs** | `client.sendMessage('status@broadcast', new MessageMedia(...), {caption})` — routes to `sendStatusMediaMsgAction` (`Utils.js:565`) | **S** | Same as above for video status. |
+| 4 | `addLabelToChat` : **baileys** | `await sock.addChatLabel(chatId, labelId)` (`Socket/chats.d.ts:70`) | **S** | 1:1 mapping. WhatsApp Business CRM parity. |
+| 5 | `removeLabelFromChat` : **baileys** | `await sock.removeChatLabel(chatId, labelId)` (`Socket/chats.d.ts:71`) | **S** | 1:1 mapping. Pairs with #4. |
 
 ### Tier 2 — small-to-medium effort, medium-high value
 

--- a/src/engine/adapters/baileys.adapter.spec.ts
+++ b/src/engine/adapters/baileys.adapter.spec.ts
@@ -1728,9 +1728,15 @@ describe('BaileysAdapter store-backed ops', () => {
     await expect(adapter.replyToMessage('c', 'GONE', 'x')).rejects.toThrow(/not found/i);
   });
 
-  it('deleteMessage for-me (forEveryone=false) is not supported', async () => {
+  it('deleteMessage for-me (forEveryone=false) deletes via chatModify({ deleteForMe })', async () => {
+    fakeStore.getMessage.mockResolvedValue({ ...stored, messageTimestamp: 1700000007 });
     const adapter = await ready();
-    await expect(adapter.deleteMessage('c', 'TARGET', false)).rejects.toBeInstanceOf(EngineNotSupportedError);
+    await adapter.deleteMessage('628111@s.whatsapp.net', 'TARGET', false);
+    expect(fakeSock.chatModify).toHaveBeenCalledWith(
+      { deleteForMe: { deleteMedia: true, key: stored.key, timestamp: 1700000007 } },
+      '628111@s.whatsapp.net',
+    );
+    expect(fakeSock.sendMessage).not.toHaveBeenCalled();
   });
 
   it('populates the store on an inbound message', async () => {

--- a/src/engine/adapters/baileys.adapter.ts
+++ b/src/engine/adapters/baileys.adapter.ts
@@ -650,12 +650,23 @@ export class BaileysAdapter implements IWhatsAppEngine {
 
   async deleteMessage(chatId: string, messageId: string, forEveryone = true): Promise<void> {
     this.ensureReady();
-    if (!forEveryone) {
-      // Baileys only supports revoke-for-everyone via sendMessage; delete-for-me is not implemented.
-      throw new EngineNotSupportedError('deleteMessage (delete-for-me)');
-    }
     const target = await this.requireStored(messageId);
-    await this.sock!.sendMessage(chatId, { delete: target.key });
+    if (forEveryone) {
+      await this.sock!.sendMessage(chatId, { delete: target.key });
+      return;
+    }
+    // Delete-for-me (revoke on this device only): Baileys exposes it as a chat modification, not a
+    // sendMessage. The stored message timestamp (epoch seconds) is part of the payload.
+    await this.sock!.chatModify(
+      {
+        deleteForMe: {
+          deleteMedia: true,
+          key: target.key,
+          timestamp: this.toUnixSeconds(target.messageTimestamp),
+        },
+      },
+      chatId,
+    );
   }
 
   // ----- Groups -----

--- a/src/engine/engine-capability-matrix.ts
+++ b/src/engine/engine-capability-matrix.ts
@@ -64,12 +64,7 @@ export const ENGINE_CAPABILITY_MATRIX: Record<string, MethodCapability> = {
   checkNumberExists: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   createGroup: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   deleteChat: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
-  deleteMessage: {
-    wwjs: { status: 'supported' },
-    baileys: { status: 'not-available', rootCause: 'adapter-gap' },
-    evidence:
-      'baileys forEveryone=true already wired (sendMessage({delete})); forEveryone=false throws at baileys.adapter.ts:655 — library has chatModify({deleteForMe}) (Types/Chat.d.ts:76 via Socket/chats.d.ts:64, already used @baileys.adapter.ts:820,833); wwjs Message.delete (Message.js)',
-  },
+  deleteMessage: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   deleteStatus: {
     wwjs: { status: 'not-available', rootCause: 'adapter-gap' },
     baileys: { status: 'supported' },


### PR DESCRIPTION
## What
`deleteMessage(…, forEveryone=false)` on the Baileys engine now performs a **delete-for-me** via `sock.chatModify({ deleteForMe })` instead of returning 501. Matrix + roadmap doc updated to mark it `supported`.

## Why
This was the first item on the unwired-capability roadmap (`docs/engine-capability-matrix.md`) — a core messaging op that 501'd on Baileys for the most common delete mode (delete-for-me), even though the library supports it. `forEveryone=true` (revoke) was already wired; this completes `deleteMessage`.

## How
- `requireStored(messageId)` already resolves the target message key (used by the revoke path). The delete-for-me branch now calls `sock.chatModify({ deleteForMe: { deleteMedia: true, key: target.key, timestamp: toUnixSeconds(target.messageTimestamp) } }, chatId)`. `chatModify({ deleteForMe })` was already in use elsewhere in the adapter, so the symbol is known-good here; `toUnixSeconds` already coerces Baileys' `number | Long` timestamp.

## Test plan
- The existing `forEveryone=false` test was flipped from "rejects with EngineNotSupportedError" to "calls `chatModify` with the `{ deleteForMe }` shape and does NOT call `sendMessage`" — TDD: watched it fail (RED, throws), then wired (GREEN).
- Full Baileys adapter spec green (116), drift gate green (72 — invariant holds with the new `supported` status), full gate green (lint, `tsc -p tsconfig.json`, format, `nest build`, 2391 tests).

First of the roadmap's Tier-1 adapter-gaps; the rest (wwjs status-posts, Baileys labels/channels) follow the same wire + test + update-matrix pattern.
