### PR TITLE
feat(engine): status posts on the whatsapp-web.js engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   everyone (`forEveryone=true`) was already wired; this completes `deleteMessage` on the Baileys
   engine for the most common delete mode.
 
+- **Status posts on the whatsapp-web.js engine.** `postTextStatus`, `postImageStatus`, and
+  `postVideoStatus` now work on whatsapp-web.js (the default engine) — they route through
+  `sendMessage('status@broadcast', …)` (text styling via `extra: { backgroundColor, fontStyle }`;
+  media via `MessageMedia` + `caption`). Previously these returned 501 on the default engine despite
+  the library supporting them; the stale "blocked upstream, #455" guard is removed (#455 is a closed
+  feature request, and whatsapp-web.js 1.34.7 ships a real status-send path). Caveat: the library has
+  no status-recipient arg, so `StatusPostOptions.recipients` is not honored on this engine (it
+  broadcasts to the account's status-privacy audience; a one-time warning is logged). The Baileys
+  engine continues to honor `recipients`.
+
 ### Fixed
 
 - **Diagnosable failure for a stale browser profile after a binary-changing upgrade.** Upgrading

--- a/docs/engine-capability-matrix.md
+++ b/docs/engine-capability-matrix.md
@@ -74,12 +74,9 @@ The `rootCause`/`evidence` fields are hand-curated from source traces of the ins
 
 | Method | baileys | wwjs |
 |---|---|---|
-| `postTextStatus` | supported | not-available — **adapter-gap** |
-| `postImageStatus` | supported | not-available — **adapter-gap** |
-| `postVideoStatus` | supported | not-available — **adapter-gap** |
 | `deleteStatus` | supported (caveat) | not-available — **adapter-gap** |
 
-- **`postTextStatus` / `postImageStatus` / `postVideoStatus` (wwjs, adapter-gap).** The library **does** support status broadcast — the wwjs adapter simply throws (`EngineNotSupportedError`, self-labelled "Baileys-only; wwebjs blocked upstream, see #455") instead of routing it. `Client.sendMessage('status@broadcast', ...)` hits the `isStatus` branch which calls `sendStatusTextMsgAction({color,font,text})` (`Utils.js:537`) for text and `sendStatusMediaMsgAction(msg, mediaUpdate)` (`Utils.js:565`) for image/video/gif/audio (`Client.js:1410-1432` allows these content types for status). Wiring: `client.sendMessage('status@broadcast', mediaOrText, { ... })`. **Caveat:** `sendStatusTextMsgAction`/`sendStatusMediaMsgAction` take no recipients arg, so wwjs always broadcasts to the account's status-privacy audience — `StatusPostOptions.recipients` (Baileys `statusJidList` allow-list) cannot be honored on wwjs.
+> **Wired.** ✅ `postTextStatus` / `postImageStatus` / `postVideoStatus` on whatsapp-web.js — routed via `sendMessage('status@broadcast', …)` (`{ extra: { backgroundColor, fontStyle } }` for text; `{ caption }` for media). **Caveat:** whatsapp-web.js has no status-recipient arg, so `StatusPostOptions.recipients` is not honored on this engine (it broadcasts to the account's status-privacy audience; a one-time warning is logged). The Baileys engine honors `recipients` (`statusJidList`).
 - **`deleteStatus` (wwjs, adapter-gap).** `client.revokeStatusMessage(statusId)` exists (`index.d.ts:139`; `Client.js:2795` → `WAWebRevokeStatusAction`). Revokes OWN status only (throws if `!msg.id.fromMe || !msg.id.remote.isStatus()`). Adapter throws instead of calling it.
 - **`deleteStatus` (baileys) caveat.** Marked `supported` (no throw), but the adapter self-describes its `sendMessage(status@broadcast,{delete})` revoke shape as *empirically unverified* (`baileys.adapter.ts:909-911`) — only posting was live-spiked. May need a fallback to `EngineNotSupportedError` if WA rejects the shape.
 
@@ -115,11 +112,8 @@ These are the capabilities the underlying library already supports but the OpenW
 
 | # | Method : engine | Library call to wire | Effort | Value |
 |---|---|---|---|---|
-| 1 | `postTextStatus` : **wwjs** | `client.sendMessage('status@broadcast', text, {extra:{backgroundColor,font}})` — routes to `sendStatusTextMsgAction` (`Utils.js:537`) | **S** | Status broadcast parity. Flagship feature currently 501 on the default engine despite the library supporting it. Document the `recipients` (statusJidList) caveat. |
-| 2 | `postImageStatus` : **wwjs** | `client.sendMessage('status@broadcast', new MessageMedia(...), {caption})` — routes to `sendStatusMediaMsgAction` (`Utils.js:565`) | **S** | Same as above for image status. |
-| 3 | `postVideoStatus` : **wwjs** | `client.sendMessage('status@broadcast', new MessageMedia(...), {caption})` — routes to `sendStatusMediaMsgAction` (`Utils.js:565`) | **S** | Same as above for video status. |
-| 4 | `addLabelToChat` : **baileys** | `await sock.addChatLabel(chatId, labelId)` (`Socket/chats.d.ts:70`) | **S** | 1:1 mapping. WhatsApp Business CRM parity. |
-| 5 | `removeLabelFromChat` : **baileys** | `await sock.removeChatLabel(chatId, labelId)` (`Socket/chats.d.ts:71`) | **S** | 1:1 mapping. Pairs with #4. |
+| 1 | `addLabelToChat` : **baileys** | `await sock.addChatLabel(chatId, labelId)` (`Socket/chats.d.ts:70`) | **S** | 1:1 mapping. WhatsApp Business CRM parity. |
+| 2 | `removeLabelFromChat` : **baileys** | `await sock.removeChatLabel(chatId, labelId)` (`Socket/chats.d.ts:71`) | **S** | 1:1 mapping. Pairs with #1. |
 
 ### Tier 2 — small-to-medium effort, medium-high value
 

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -1085,30 +1085,47 @@ describe('WhatsAppWebJsAdapter.resolveContactPhone (@lid -> phone, #263)', () =>
   });
 });
 
-describe('WhatsAppWebJsAdapter status methods (Baileys-only, surface HTTP 501, #455)', () => {
-  // The 4 status methods are Baileys-only; the wwebjs adapter stubs each to EngineNotSupportedError
-  // (which extends NestJS NotImplementedException -> HTTP 501). This locks the new-contract signatures
-  // (postTextStatus(text, options) / postImage|VideoStatus(media, options) / deleteStatus(statusId))
-  // so a future refactor that silently starts returning data instead of throwing is caught here.
-  const readyAdapter = (): WhatsAppWebJsAdapter => {
+describe('WhatsAppWebJsAdapter status methods', () => {
+  const readyAdapter = (client: unknown): WhatsAppWebJsAdapter => {
     const adapter = new WhatsAppWebJsAdapter({ sessionId: 's', sessionDataPath: './data/sessions', puppeteer: {} });
     (adapter as unknown as { status: EngineStatus }).status = EngineStatus.READY;
-    // ensureReady() requires both status === READY and a non-null client before the method body runs.
-    (adapter as unknown as { client: unknown }).client = {};
+    (adapter as unknown as { client: unknown }).client = client;
     return adapter;
   };
   const media = { mimetype: 'image/png', data: 'iVBOR' };
   const options = { recipients: ['628111@c.us'] };
+  const STATUS_TTL_MS = 24 * 3_600_000;
 
-  it.each([
-    ['postTextStatus', ['hello', options]] as const,
-    ['postImageStatus', [media, options]] as const,
-    ['postVideoStatus', [media, options]] as const,
-    ['deleteStatus', ['STATUS1']] as const,
-  ])('%s rejects with EngineNotSupportedError (501)', async (method, args) => {
-    await expect(
-      (readyAdapter() as unknown as Record<string, (...a: unknown[]) => Promise<unknown>>)[method](...args),
-    ).rejects.toBeInstanceOf(EngineNotSupportedError);
+  it('postTextStatus posts to status@broadcast with styling in `extra` and returns a StatusResult', async () => {
+    const sendMessage = jest.fn().mockResolvedValue({ id: { _serialized: 'STATUS1' }, timestamp: 1700000010 });
+    const result = await readyAdapter({ sendMessage }).postTextStatus('hello', {
+      ...options,
+      backgroundColor: '#ff0000',
+      font: 2,
+    });
+    expect(sendMessage).toHaveBeenCalledWith('status@broadcast', 'hello', {
+      extra: { backgroundColor: '#ff0000', fontStyle: 2 },
+    });
+    const ts = new Date(1700000010 * 1000);
+    expect(result).toEqual({ statusId: 'STATUS1', timestamp: ts, expiresAt: new Date(ts.getTime() + STATUS_TTL_MS) });
+  });
+
+  it.each([['postImageStatus'], ['postVideoStatus']] as const)(
+    '%s posts media to status@broadcast with the caption and returns a StatusResult',
+    async method => {
+      const sendMessage = jest.fn().mockResolvedValue({ id: { _serialized: 'STATUS2' }, timestamp: 1700000011 });
+      const result = await readyAdapter({ sendMessage })[method](media, { ...options, caption: 'cap' });
+      expect(sendMessage).toHaveBeenCalledWith('status@broadcast', expect.any(MessageMedia), { caption: 'cap' });
+      const ts = new Date(1700000011 * 1000);
+      expect(result.statusId).toBe('STATUS2');
+      expect(result.expiresAt).toEqual(new Date(ts.getTime() + STATUS_TTL_MS));
+    },
+  );
+
+  it('deleteStatus is still not supported (separate gap — revokeStatusMessage)', async () => {
+    await expect(readyAdapter({ sendMessage: jest.fn() }).deleteStatus('STATUS1')).rejects.toBeInstanceOf(
+      EngineNotSupportedError,
+    );
   });
 });
 

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -1743,21 +1743,66 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     return [];
   }
 
-  async postTextStatus(_text: string, _options?: StatusPostOptions): Promise<StatusResult> {
+  private warnedStatusRecipients = false;
+
+  async postTextStatus(text: string, options: StatusPostOptions): Promise<StatusResult> {
     this.ensureReady();
-    // whatsapp-web.js doesn't have native status posting
-    // This would require using the underlying WhatsApp Web API directly
-    throw new EngineNotSupportedError('postTextStatus (Baileys-only; wwebjs blocked upstream, see #455)');
+    this.warnStatusRecipientsOnce(options);
+    // whatsapp-web.js posts a text status by messaging status@broadcast with styling in `extra`
+    // (Client.js maps options.extra → page extraOptions → sendStatusTextMsgAction in Utils.js).
+    // backgroundColor is a #RRGGBB hex; font is the fontStyle index 0-7.
+    const msg = await this.client!.sendMessage('status@broadcast', text, {
+      extra: {
+        ...(options.backgroundColor !== undefined ? { backgroundColor: options.backgroundColor } : {}),
+        ...(options.font !== undefined ? { fontStyle: options.font } : {}),
+      },
+    });
+    return this.toStatusResult(msg);
   }
 
-  async postImageStatus(_media: MediaInput, _options?: StatusPostOptions): Promise<StatusResult> {
-    this.ensureReady();
-    throw new EngineNotSupportedError('postImageStatus (Baileys-only; wwebjs blocked upstream, see #455)');
+  async postImageStatus(media: MediaInput, options: StatusPostOptions): Promise<StatusResult> {
+    return this.postMediaStatus(media, options);
   }
 
-  async postVideoStatus(_media: MediaInput, _options?: StatusPostOptions): Promise<StatusResult> {
+  async postVideoStatus(media: MediaInput, options: StatusPostOptions): Promise<StatusResult> {
+    return this.postMediaStatus(media, options);
+  }
+
+  private async postMediaStatus(media: MediaInput, options: StatusPostOptions): Promise<StatusResult> {
     this.ensureReady();
-    throw new EngineNotSupportedError('postVideoStatus (Baileys-only; wwebjs blocked upstream, see #455)');
+    this.warnStatusRecipientsOnce(options);
+    const messageMedia = await this.toStatusMessageMedia(media);
+    const msg = await this.client!.sendMessage('status@broadcast', messageMedia, {
+      ...(options.caption !== undefined ? { caption: options.caption } : {}),
+    });
+    return this.toStatusResult(msg);
+  }
+
+  /** Build a MessageMedia from a MediaInput (URL → fetched, base64/Buffer → wrapped). */
+  private async toStatusMessageMedia(media: MediaInput): Promise<MessageMedia> {
+    if (typeof media.data === 'string') {
+      if (isHttpUrl(media.data)) return loadRemoteMedia(media.data);
+      return new MessageMedia(media.mimetype, media.data, media.filename);
+    }
+    return new MessageMedia(media.mimetype, media.data.toString('base64'), media.filename);
+  }
+
+  private toStatusResult(msg: Message | undefined): StatusResult {
+    const ts = msg?.timestamp ? new Date(msg.timestamp * 1000) : new Date();
+    return {
+      statusId: msg?.id?._serialized ?? '',
+      timestamp: ts,
+      expiresAt: new Date(ts.getTime() + 24 * 3_600_000),
+    };
+  }
+
+  private warnStatusRecipientsOnce(options: StatusPostOptions): void {
+    if (this.warnedStatusRecipients || !options.recipients?.length) return;
+    this.warnedStatusRecipients = true;
+    this.logger.warn(
+      "postStatus on the whatsapp-web.js engine broadcasts to the account's status-privacy audience; " +
+        'the recipients allow-list is not honored by whatsapp-web.js (it is on the Baileys engine).',
+    );
   }
 
   async deleteStatus(_statusId: string): Promise<void> {

--- a/src/engine/engine-capability-matrix.ts
+++ b/src/engine/engine-capability-matrix.ts
@@ -170,24 +170,9 @@ export const ENGINE_CAPABILITY_MATRIX: Record<string, MethodCapability> = {
   leaveGroup: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   logout: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   markUnread: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
-  postImageStatus: {
-    wwjs: { status: 'not-available', rootCause: 'adapter-gap' },
-    baileys: { status: 'supported' },
-    evidence:
-      'wwjs sendStatusMediaMsgAction (Utils.js:565) handles image status@broadcast — adapter throws "blocked upstream #455" instead of routing it; baileys postStatus({image,caption,mimetype}) @baileys.adapter.ts:888. Caveat: wwjs sendStatusMediaMsgAction has no recipients arg (statusJidList not honored)',
-  },
-  postTextStatus: {
-    wwjs: { status: 'not-available', rootCause: 'adapter-gap' },
-    baileys: { status: 'supported' },
-    evidence:
-      'wwjs sendStatusTextMsgAction({color,font,text}) (Utils.js:537) — adapter throws "blocked upstream #455" instead of routing status@broadcast text; baileys sendMessage(status@broadcast,{text},{statusJidList,...}) @baileys.adapter.ts:885. Caveat: wwjs has no recipients arg (statusJidList not honored)',
-  },
-  postVideoStatus: {
-    wwjs: { status: 'not-available', rootCause: 'adapter-gap' },
-    baileys: { status: 'supported' },
-    evidence:
-      'wwjs sendStatusMediaMsgAction (Utils.js:565) handles video/gif/audio status — adapter throws "blocked upstream #45455" instead of routing it; baileys postStatus({video,caption,mimetype}) @baileys.adapter.ts:891. Caveat: wwjs has no recipients arg (statusJidList not honored)',
-  },
+  postImageStatus: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
+  postTextStatus: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
+  postVideoStatus: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   promoteParticipants: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   reactToMessage: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   removeLabelFromChat: {


### PR DESCRIPTION
## What
`postTextStatus` / `postImageStatus` / `postVideoStatus` now work on **whatsapp-web.js (the default engine)**, routing through `sendMessage('status@broadcast', …)`. The 3 not-available matrix entries flip to `supported`; `deleteStatus:wwjs` is untouched (separate gap).

## Why
This was Tier-1 #1-3 on the unwired-capability roadmap — status broadcast is a flagship feature that 501'd on the default engine even though the library supports it. The stale adapter guard claimed *"wwebjs blocked upstream, see #455"*; verification showed **#455 is a closed feature request** and **whatsapp-web.js 1.34.7 ships a real status-send path** (`Utils.js:536-574`: `WAWebSendStatusMsgAction.sendStatusTextMsgAction` / `sendStatusMediaMsgAction`). So the wiring is justified, not a guess.

## How
- **Text**: `sendMessage('status@broadcast', text, { extra: { backgroundColor, fontStyle } })`. Verified `Client.js:1471` maps `options.extra` → page `extraOptions`; `Utils.js:538` destructures `backgroundColor` + `fontStyle`. (`font` in our DTO → `fontStyle` in the library.)
- **Image/Video**: build a `MessageMedia` from the `MediaInput` (URL/base64/Buffer — same shape as `sendMediaMessage`), then `sendMessage('status@broadcast', media, { caption })` → `sendStatusMediaMsgAction`.
- **StatusResult**: `{ statusId: msg.id._serialized, timestamp, expiresAt: +24h }` (mirrors the Baileys `toStatusResult` 24h TTL).
- **`recipients` caveat**: whatsapp-web.js has no status-recipient arg, so `StatusPostOptions.recipients` is not honored on this engine (it broadcasts to the account's status-privacy audience). A one-time-per-adapter warning is logged so callers aren't silently misled. Baileys still honors `recipients`.

## Test plan
- Replaced the old parameterized "all 4 status methods throw" test with positive tests: text-status asserts the `extra` shape + `StatusResult`; image/video assert `status@broadcast` + `MessageMedia` + caption + `StatusResult`; `deleteStatus` kept as still-throws (separate gap).
- Drift gate green (3 entries flipped to `supported`; invariant holds — they no longer throw), full gate green (lint, `tsc -p tsconfig.json`, format, `nest build`, 2391 tests).
