### PR TITLE
feat(engine): chat labels on the Baileys engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   broadcasts to the account's status-privacy audience; a one-time warning is logged). The Baileys
   engine continues to honor `recipients`.
 
+- **Chat labels on the Baileys engine.** `addLabelToChat` and `removeLabelFromChat` now work on
+  the Baileys engine — 1:1 to `sock.addChatLabel(chatId, labelId)` / `sock.removeChatLabel(chatId,
+  labelId)` instead of returning 501. WhatsApp-Business-only (rejects on personal accounts). Label
+  *listing* (`getLabels` / `getLabelById` / `getChatLabels`) remains unavailable on Baileys (no
+  first-class library API — see `docs/engine-capability-matrix.md`).
+
 ### Fixed
 
 - **Diagnosable failure for a stale browser profile after a binary-changing upgrade.** Upgrading

--- a/docs/engine-capability-matrix.md
+++ b/docs/engine-capability-matrix.md
@@ -44,13 +44,11 @@ The `rootCause`/`evidence` fields are hand-curated from source traces of the ins
 
 | Method | baileys | wwjs |
 |---|---|---|
-| `addLabelToChat` | not-available — **adapter-gap** | supported |
-| `removeLabelFromChat` | not-available — **adapter-gap** | supported |
 | `getLabels` | not-available — **library-limitation** | supported |
 | `getLabelById` | not-available — **library-limitation** | supported |
 | `getChatLabels` | not-available — **library-limitation** | supported |
 
-- **`addLabelToChat` / `removeLabelFromChat` (baileys, adapter-gap).** 1:1 — `sock.addChatLabel(jid,labelId)` / `sock.removeChatLabel(jid,labelId)` (`Socket/chats.d.ts:70-71`, also `business.d.ts:163-164`), both `Promise<void>`. WhatsApp-Business-only op (rejects on personal accounts). Do **not** use `addLabel(jid, LabelActionBody)` (`chats.d.ts:69`) — that creates/edits the label *definition*, not the chat association.
+> **Wired.** ✅ `addLabelToChat` / `removeLabelFromChat` on the Baileys engine — 1:1 to `sock.addChatLabel(chatId, labelId)` / `sock.removeChatLabel(chatId, labelId)` (`Socket/chats.d.ts:70-71`). WhatsApp-Business-only (rejects on personal accounts). Do **not** use `addLabel(jid, LabelActionBody)` (`chats.d.ts:69`) — that creates/edits the label *definition*, not the chat association.
 - **`getLabels` / `getLabelById` / `getChatLabels` (baileys, library-limitation).** No label read/fetch symbol anywhere in `lib/**/*.d.ts` (`Types/Label.d.ts` has only the interface + `LabelColor` enum; `chats.d.ts`/`business.d.ts` expose only writes). Label data does arrive via app-state sync (`messaging-history.set`), so a determined adapter could capture+cache labels from the event stream — but that is a relay/cache hack, not a first-class getter, and there is no network fetch to seed/refresh it on demand.
 
 ### Catalog / Products / Orders (WhatsApp Business)
@@ -108,12 +106,12 @@ These are the capabilities the underlying library already supports but the OpenW
 
 > **Progress.** ✅ `deleteMessage` (`forEveryone=false`, Baileys) — wired via `chatModify({ deleteForMe })`; moved to `supported`.
 
-### Tier 1 — small effort, high value
+### Tier 1 — small effort, high value ✅ shipped
 
-| # | Method : engine | Library call to wire | Effort | Value |
-|---|---|---|---|---|
-| 1 | `addLabelToChat` : **baileys** | `await sock.addChatLabel(chatId, labelId)` (`Socket/chats.d.ts:70`) | **S** | 1:1 mapping. WhatsApp Business CRM parity. |
-| 2 | `removeLabelFromChat` : **baileys** | `await sock.removeChatLabel(chatId, labelId)` (`Socket/chats.d.ts:71`) | **S** | 1:1 mapping. Pairs with #1. |
+All Tier-1 adapter-gaps have been wired:
+- ✅ `deleteMessage(forEveryone=false)` — Baileys (`chatModify({ deleteForMe })`)
+- ✅ `postTextStatus` / `postImageStatus` / `postVideoStatus` — whatsapp-web.js (`sendMessage('status@broadcast', …)`; `recipients` not honored)
+- ✅ `addLabelToChat` / `removeLabelFromChat` — Baileys (`addChatLabel` / `removeChatLabel`; WhatsApp-Business-only)
 
 ### Tier 2 — small-to-medium effort, medium-high value
 

--- a/src/engine/adapters/baileys.adapter.spec.ts
+++ b/src/engine/adapters/baileys.adapter.spec.ts
@@ -38,6 +38,8 @@ class FakeSock extends EventEmitter {
   public updateBlockStatus = jest.fn().mockResolvedValue(undefined);
   public readMessages = jest.fn().mockResolvedValue(undefined);
   public chatModify = jest.fn().mockResolvedValue(undefined);
+  public addChatLabel = jest.fn().mockResolvedValue(undefined);
+  public removeChatLabel = jest.fn().mockResolvedValue(undefined);
   fire(event: string, arg: unknown): void {
     this.emitter.emit(event, arg);
   }
@@ -1737,6 +1739,18 @@ describe('BaileysAdapter store-backed ops', () => {
       '628111@s.whatsapp.net',
     );
     expect(fakeSock.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('addLabelToChat wires 1:1 to sock.addChatLabel(chatId, labelId)', async () => {
+    const adapter = await ready();
+    await adapter.addLabelToChat('628111@s.whatsapp.net', 'LABEL8');
+    expect(fakeSock.addChatLabel).toHaveBeenCalledWith('628111@s.whatsapp.net', 'LABEL8');
+  });
+
+  it('removeLabelFromChat wires 1:1 to sock.removeChatLabel(chatId, labelId)', async () => {
+    const adapter = await ready();
+    await adapter.removeLabelFromChat('628111@s.whatsapp.net', 'LABEL8');
+    expect(fakeSock.removeChatLabel).toHaveBeenCalledWith('628111@s.whatsapp.net', 'LABEL8');
   });
 
   it('populates the store on an inbound message', async () => {

--- a/src/engine/adapters/baileys.adapter.ts
+++ b/src/engine/adapters/baileys.adapter.ts
@@ -866,11 +866,16 @@ export class BaileysAdapter implements IWhatsAppEngine {
   getChatLabels(_chatId: string): Promise<Label[]> {
     return this.unsupported('getChatLabels');
   }
-  addLabelToChat(_chatId: string, _labelId: string): Promise<void> {
-    return this.unsupported('addLabelToChat');
+  // WhatsApp Business only — Baileys rejects these on personal accounts. The label must already
+  // exist (use getLabels on an engine that lists them); addChatLabel/removeChatLabel associate it
+  // with a chat, they do not create/edit the label definition.
+  async addLabelToChat(chatId: string, labelId: string): Promise<void> {
+    this.ensureReady();
+    await this.sock!.addChatLabel(chatId, labelId);
   }
-  removeLabelFromChat(_chatId: string, _labelId: string): Promise<void> {
-    return this.unsupported('removeLabelFromChat');
+  async removeLabelFromChat(chatId: string, labelId: string): Promise<void> {
+    this.ensureReady();
+    await this.sock!.removeChatLabel(chatId, labelId);
   }
   getSubscribedChannels(): Promise<Channel[]> {
     return this.unsupported('getSubscribedChannels');

--- a/src/engine/engine-capability-matrix.ts
+++ b/src/engine/engine-capability-matrix.ts
@@ -53,12 +53,7 @@ export interface MethodCapability {
 }
 
 export const ENGINE_CAPABILITY_MATRIX: Record<string, MethodCapability> = {
-  addLabelToChat: {
-    wwjs: { status: 'supported' },
-    baileys: { status: 'not-available', rootCause: 'adapter-gap' },
-    evidence:
-      'baileys Socket/chats.d.ts:70 addChatLabel(jid,labelId) + business.d.ts:163 — adapter throws at baileys.adapter.ts:859; wwjs Client.js:2921 addOrRemoveLabels (adapter changeChatLabel @1534)',
-  },
+  addLabelToChat: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   addParticipants: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   blockContact: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   checkNumberExists: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
@@ -175,12 +170,7 @@ export const ENGINE_CAPABILITY_MATRIX: Record<string, MethodCapability> = {
   postVideoStatus: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   promoteParticipants: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   reactToMessage: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
-  removeLabelFromChat: {
-    wwjs: { status: 'supported' },
-    baileys: { status: 'not-available', rootCause: 'adapter-gap' },
-    evidence:
-      'baileys Socket/chats.d.ts:71 removeChatLabel(jid,labelId) + business.d.ts:164 — adapter throws at baileys.adapter.ts:862; wwjs Client.js:2921 addOrRemoveLabels (adapter changeChatLabel @1534)',
-  },
+  removeLabelFromChat: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   removeParticipants: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   replyToMessage: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   requestPairingCode: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },


### PR DESCRIPTION
## What
`addLabelToChat` / `removeLabelFromChat` now work on the **Baileys engine** — 1:1 to `sock.addChatLabel(chatId, labelId)` / `sock.removeChatLabel(chatId, labelId)`. Matrix entries flip to `supported`. **This completes all Tier-1 adapter-gaps** (delete-for-me, status-posts, chat-labels).

## Why
Tier-1 #1-2 on the unwired-capability roadmap. A 1:1 param match with the Baileys API (`addChatLabel(jid, labelId)` / `removeChatLabel(jid, labelId)`, `Socket/chats.d.ts:70-71`) — the OpenWA adapter simply wasn't calling them. WhatsApp-Business-only (rejects on personal accounts); the wiring surfaces that error from the library rather than masking it as a generic 501.

## How
- Direct pass-through, matching the adapter's established pattern (`sendTextMessage` passes `chatId` straight to `sock`; only recipient *lists* get `toEngineJid`). So `addLabelToChat(chatId, labelId)` → `sock.addChatLabel(chatId, labelId)`, and the remove likewise.
- The label must already exist (this associates it with a chat; it does not create/edit the label definition — `addLabel(jid, LabelActionBody)` is a different, deliberately-not-used symbol). Label *listing* (`getLabels`/`getLabelById`/`getChatLabels`) stays unavailable on Baileys (no first-class library API — a documented library-limitation).

## Test plan
- Added `addChatLabel`/`removeChatLabel` to the spec's `FakeSock` mock + two tests asserting the 1:1 wiring (RED → GREEN). Full Baileys spec green (118), drift gate green (72), full gate green (lint, `tsc -p tsconfig.json`, format, `nest build`, 2393 tests).
- `docs/engine-capability-matrix.md` Tier-1 marked ✅ shipped (delete-for-me, status-posts, chat-labels); Tier-2 (channels, deleteStatus, contact-stories) is now the active backlog.
