### PR TITLE
feat(engine): status delete on the whatsapp-web.js engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   *listing* (`getLabels` / `getLabelById` / `getChatLabels`) remains unavailable on Baileys (no
   first-class library API — see `docs/engine-capability-matrix.md`).
 
+- **Status delete on the whatsapp-web.js engine.** `deleteStatus(statusId)` now works on
+  whatsapp-web.js via `client.revokeStatusMessage(statusId)` instead of returning 501 — completing
+  the status lifecycle (post + delete) on the default engine. Own-status only (the library revokes
+  the caller's own status posts).
+
 ### Fixed
 
 - **Diagnosable failure for a stale browser profile after a binary-changing upgrade.** Upgrading

--- a/docs/engine-capability-matrix.md
+++ b/docs/engine-capability-matrix.md
@@ -70,12 +70,7 @@ The `rootCause`/`evidence` fields are hand-curated from source traces of the ins
 
 ### Status — post / delete
 
-| Method | baileys | wwjs |
-|---|---|---|
-| `deleteStatus` | supported (caveat) | not-available — **adapter-gap** |
-
-> **Wired.** ✅ `postTextStatus` / `postImageStatus` / `postVideoStatus` on whatsapp-web.js — routed via `sendMessage('status@broadcast', …)` (`{ extra: { backgroundColor, fontStyle } }` for text; `{ caption }` for media). **Caveat:** whatsapp-web.js has no status-recipient arg, so `StatusPostOptions.recipients` is not honored on this engine (it broadcasts to the account's status-privacy audience; a one-time warning is logged). The Baileys engine honors `recipients` (`statusJidList`).
-- **`deleteStatus` (wwjs, adapter-gap).** `client.revokeStatusMessage(statusId)` exists (`index.d.ts:139`; `Client.js:2795` → `WAWebRevokeStatusAction`). Revokes OWN status only (throws if `!msg.id.fromMe || !msg.id.remote.isStatus()`). Adapter throws instead of calling it.
+> **Wired.** ✅ `postTextStatus` / `postImageStatus` / `postVideoStatus` + `deleteStatus` on whatsapp-web.js. Posts route via `sendMessage('status@broadcast', …)` (`{ extra: { backgroundColor, fontStyle } }` for text; `{ caption }` for media); `deleteStatus` calls `revokeStatusMessage(statusId)` (own-status only). **Caveat:** whatsapp-web.js has no status-recipient arg, so `StatusPostOptions.recipients` is not honored on this engine (it broadcasts to the account's status-privacy audience; a one-time warning is logged). The Baileys engine honors `recipients` (`statusJidList`).
 - **`deleteStatus` (baileys) caveat.** Marked `supported` (no throw), but the adapter self-describes its `sendMessage(status@broadcast,{delete})` revoke shape as *empirically unverified* (`baileys.adapter.ts:909-911`) — only posting was live-spiked. May need a fallback to `EngineNotSupportedError` if WA rejects the shape.
 
 ### Status — read (contact stories)
@@ -120,9 +115,8 @@ All Tier-1 adapter-gaps have been wired:
 | 7 | `getChannelById` : **baileys** | `sock.newsletterMetadata('jid', channelId)` → map `NewsletterMetadata` (`Socket/newsletter.d.ts:9`) | **S** | Channel/newsletter parity. ~1-liner field map. |
 | 8 | `unsubscribeFromChannel` : **baileys** | `await sock.newsletterUnfollow(channelId)` (`Socket/newsletter.d.ts:11`) | **S** | 1:1, no jid resolution needed. |
 | 9 | `subscribeToChannel` : **baileys** | 2-step: `newsletterMetadata('invite',code).id` then `newsletterFollow(jid)` (`Socket/newsletter.d.ts:9,10`) | **S** | Channel growth (join by invite code). |
-| 10 | `deleteStatus` : **wwjs** | `await client.revokeStatusMessage(statusId)` (`index.d.ts:139`) | **S** | Completes the wwjs status lifecycle (post + delete). Own-status only. |
-| 11 | `getContactStatuses` : **wwjs** | `client.getBroadcasts()` → flatten `Broadcast.msgs` to `Status[]` (`index.d.ts:133`) | **M** | Read contact stories on the default engine. Adapter already has the stub; replace `[]` with the call + mapping. |
-| 12 | `getContactStatus` : **wwjs** | `client.getBroadcastById(contactId)` → map `Broadcast.msgs` (`index.d.ts:136`) | **M** | Per-contact story read. Pairs with #11. |
+| 10 | `getContactStatuses` : **wwjs** | `client.getBroadcasts()` → flatten `Broadcast.msgs` to `Status[]` (`index.d.ts:133`) | **M** | Read contact stories on the default engine. Adapter already has the stub; replace `[]` with the call + mapping. |
+| 11 | `getContactStatus` : **wwjs** | `client.getBroadcastById(contactId)` → map `Broadcast.msgs` (`index.d.ts:136`) | **M** | Per-contact story read. Pairs with #10. |
 
 ### Tier 3 — medium effort
 

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -1122,10 +1122,10 @@ describe('WhatsAppWebJsAdapter status methods', () => {
     },
   );
 
-  it('deleteStatus is still not supported (separate gap — revokeStatusMessage)', async () => {
-    await expect(readyAdapter({ sendMessage: jest.fn() }).deleteStatus('STATUS1')).rejects.toBeInstanceOf(
-      EngineNotSupportedError,
-    );
+  it('deleteStatus revokes via client.revokeStatusMessage(statusId)', async () => {
+    const revokeStatusMessage = jest.fn().mockResolvedValue(undefined);
+    await readyAdapter({ sendMessage: jest.fn(), revokeStatusMessage }).deleteStatus('STATUS1');
+    expect(revokeStatusMessage).toHaveBeenCalledWith('STATUS1');
   });
 });
 

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -17,7 +17,6 @@ import * as fs from 'fs';
 import * as qrcode from 'qrcode';
 import { UnprocessableEntityException } from '@nestjs/common';
 import { EngineNotReadyError } from '../../common/errors/engine-not-ready.error';
-import { EngineNotSupportedError } from '../../common/errors/engine-not-supported.error';
 import { ChannelNotFoundError } from '../../common/errors/channel-not-found.error';
 import { ChannelMediaNotSupportedError } from '../../common/errors/channel-media-not-supported.error';
 import { EngineStatus } from '../interfaces/whatsapp-engine.interface';

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -1805,9 +1805,12 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     );
   }
 
-  async deleteStatus(_statusId: string): Promise<void> {
+  async deleteStatus(statusId: string): Promise<void> {
     this.ensureReady();
-    throw new EngineNotSupportedError('deleteStatus');
+    // Revokes the caller's own status post. revokeStatusMessage resolves the message by id and
+    // throws if it isn't fromMe/isn't a status — the statusId returned by postText/Image/VideoStatus
+    // (msg.id._serialized) is the id it expects.
+    await this.client!.revokeStatusMessage(statusId);
   }
 
   // ========== Catalog (Phase 3) ==========

--- a/src/engine/engine-capability-matrix.ts
+++ b/src/engine/engine-capability-matrix.ts
@@ -60,12 +60,7 @@ export const ENGINE_CAPABILITY_MATRIX: Record<string, MethodCapability> = {
   createGroup: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   deleteChat: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   deleteMessage: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
-  deleteStatus: {
-    wwjs: { status: 'not-available', rootCause: 'adapter-gap' },
-    baileys: { status: 'supported' },
-    evidence:
-      'wwjs Client.revokeStatusMessage (index.d.ts:139; Client.js:2795 WAWebRevokeStatusAction.sendStatusRevokeMsgAction) — adapter throws instead of calling it; baileys sendMessage(status@broadcast,{delete}) @baileys.adapter.ts:913 (self-described empirically-unverified revoke shape)',
-  },
+  deleteStatus: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   demoteParticipants: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   destroy: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   disconnect: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },


### PR DESCRIPTION
## What
`deleteStatus(statusId)` now works on **whatsapp-web.js** — 1:1 to `client.revokeStatusMessage(statusId)`. Matrix entry flips to `supported`. Completes the wwjs status lifecycle (post + delete).

## Why
Tier-2 roadmap item. A single-symbol wiring (`revokeStatusMessage(messageId): Promise<void>`, `index.d.ts:139`) the adapter wasn't calling. The statusId returned by `postText/Image/VideoStatus` (`msg.id._serialized`) is exactly what `revokeStatusMessage` expects (it resolves the message by id + checks `fromMe`/`isStatus`).

## Test plan
- Flipped the prior "deleteStatus still throws" test to assert `revokeStatusMessage('STATUS1')` is called. RED → GREEN.
- Drift gate green (deleteStatus:wwjs flipped to supported; invariant holds), full gate green (lint, `tsc -p tsconfig.json`, format, `nest build`, 2393 tests).
