### PR TITLE
fix(engine): address 1:1 Baileys sends to the contact's LID when mapped

### DIFF
--- a/src/engine/adapters/baileys.adapter.spec.ts
+++ b/src/engine/adapters/baileys.adapter.spec.ts
@@ -43,6 +43,7 @@ class FakeSock extends EventEmitter {
   public newsletterMetadata = jest.fn();
   public newsletterFollow = jest.fn().mockResolvedValue(undefined);
   public newsletterUnfollow = jest.fn().mockResolvedValue(undefined);
+  public signalRepository: { lidMapping: { getLIDForPN: jest.Mock } } | undefined;
   fire(event: string, arg: unknown): void {
     this.emitter.emit(event, arg);
   }
@@ -578,6 +579,7 @@ describe('BaileysAdapter location + contact + poll sends', () => {
 describe('BaileysAdapter messaging', () => {
   beforeEach(() => {
     fakeSock.user = { id: '628999:1@s.whatsapp.net', name: 'Me' };
+    fakeSock.signalRepository = undefined;
     fakeSock.resetEmitter();
     jest.clearAllMocks();
   });
@@ -624,6 +626,23 @@ describe('BaileysAdapter messaging', () => {
     await new Promise(resolve => setImmediate(resolve));
 
     expect(onMessageCreate).not.toHaveBeenCalled();
+  });
+
+  it('sendTextMessage resolves a phone-dialect 1:1 id to the known LID (463 tctoken fix)', async () => {
+    fakeSock.sendMessage.mockResolvedValue({ key: { id: 'OUT1' }, messageTimestamp: 1700000001 });
+    fakeSock.signalRepository = { lidMapping: { getLIDForPN: jest.fn().mockResolvedValue('484848@lid') } };
+    const adapter = await readyAdapter();
+    await adapter.sendTextMessage('628111@c.us', 'hello');
+    expect(fakeSock.signalRepository.lidMapping.getLIDForPN).toHaveBeenCalledWith('628111@s.whatsapp.net');
+    expect(fakeSock.sendMessage).toHaveBeenCalledWith('484848@lid', { text: 'hello' });
+  });
+
+  it('sendTextMessage keeps the phone jid when no LID mapping is known', async () => {
+    fakeSock.sendMessage.mockResolvedValue({ key: { id: 'OUT1' }, messageTimestamp: 1700000001 });
+    fakeSock.signalRepository = { lidMapping: { getLIDForPN: jest.fn().mockResolvedValue(null) } };
+    const adapter = await readyAdapter();
+    await adapter.sendTextMessage('628111@c.us', 'hello');
+    expect(fakeSock.sendMessage).toHaveBeenCalledWith('628111@c.us', { text: 'hello' });
   });
 
   it('sendTextMessage honors the chat disappearing timer when one is cached (#473)', async () => {

--- a/src/engine/adapters/baileys.adapter.ts
+++ b/src/engine/adapters/baileys.adapter.ts
@@ -506,11 +506,12 @@ export class BaileysAdapter implements IWhatsAppEngine {
 
   async sendTextMessage(chatId: string, text: string, mentions?: string[]): Promise<MessageResult> {
     this.ensureReady();
-    const options = this.withEphemeral(chatId);
+    const jid = await this.toDeliverableJid(chatId);
+    const options = this.withEphemeral(jid);
     const content = { text, ...this.withMentions(mentions) };
     const sent = options
-      ? await this.sock!.sendMessage(chatId, content, options)
-      : await this.sock!.sendMessage(chatId, content);
+      ? await this.sock!.sendMessage(jid, content, options)
+      : await this.sock!.sendMessage(jid, content);
     if (sent) {
       void this.config.messageStore?.put(this.config.dbSessionId, sent).catch(err =>
         this.logger.warn('Failed to persist sent message to store', {
@@ -544,7 +545,7 @@ export class BaileysAdapter implements IWhatsAppEngine {
     this.ensureReady();
     const presence = state === 'typing' ? 'composing' : state === 'recording' ? 'recording' : 'paused';
     try {
-      await this.sock!.sendPresenceUpdate(presence, chatId);
+      await this.sock!.sendPresenceUpdate(presence, await this.toDeliverableJid(chatId));
     } catch (error) {
       // Presence is best-effort — a failure here must never surface as a 500 on the direct typing
       // endpoint or MCP tool (mirrors the whatsapp-web.js adapter; #583 R4). A migrated contact can
@@ -1520,6 +1521,26 @@ export class BaileysAdapter implements IWhatsAppEngine {
    * `undefined` keeps the send a 2-arg call, identical to before. React/delete/status do not route
    * through here, so they are excluded by construction (reactions are NOT excluded by Baileys' guard).
    */
+  /**
+   * Resolve a 1:1 phone-dialect chat id (`@c.us` / `@s.whatsapp.net`) to the contact's `@lid` when the
+   * mapping is known. WhatsApp rejects PN-addressed 1:1 sends to LID-migrated accounts with ack error
+   * 463 ("missing tctoken" — the privacy token is stored and honored under the LID), while the very
+   * same send addressed to the LID delivers (verified live). Groups, broadcast, already-lid and
+   * unmapped ids pass through unchanged, reproducing the previous behavior.
+   */
+  private async toDeliverableJid(chatId: string): Promise<string> {
+    if (!chatId.endsWith('@c.us') && !chatId.endsWith('@s.whatsapp.net')) {
+      return chatId;
+    }
+    try {
+      const pn = this.sessionStore.toEngineJid(chatId);
+      const lid = await this.sock?.signalRepository?.lidMapping?.getLIDForPN(pn);
+      return lid ?? chatId;
+    } catch {
+      return chatId; // resolution is best-effort; an unmapped contact sends to the PN as before
+    }
+  }
+
   private withEphemeral(
     chatId: string,
     options?: MiscMessageGenerationOptions,
@@ -1537,10 +1558,11 @@ export class BaileysAdapter implements IWhatsAppEngine {
     content: AnyMessageContent,
     options?: MiscMessageGenerationOptions,
   ): Promise<MessageResult> {
-    const merged = this.withEphemeral(chatId, options);
+    const jid = await this.toDeliverableJid(chatId);
+    const merged = this.withEphemeral(jid, options);
     const sent = merged
-      ? await this.sock!.sendMessage(chatId, content, merged)
-      : await this.sock!.sendMessage(chatId, content);
+      ? await this.sock!.sendMessage(jid, content, merged)
+      : await this.sock!.sendMessage(jid, content);
     if (sent) {
       void this.config.messageStore?.put(this.config.dbSessionId, sent).catch(err =>
         this.logger.warn('Failed to persist sent message to store', {


### PR DESCRIPTION
## Problem

On the Baileys engine, every 1:1 send addressed by phone number (`<phone>@c.us` / `<phone>@s.whatsapp.net`) to a LID-migrated contact is rejected by WhatsApp with **ack error 463** (`NackCallerReachoutTimelocked` / "account restricted or missing tctoken"), even when:

- the account is healthy (the same message sent from the paired phone delivers), and
- a valid, fresh `tctoken` for the contact is present in the auth store (Baileys 7.0.0-rc13 stores and attaches it).

The send API still returns a `messageId` (Baileys generates it locally), so the failure is silent from the caller's perspective — the message is simply never delivered. This matches the open upstream investigation in WhiskeySockets/Baileys#2698.

Verified live against a production number: the identical message sent to `<phone>@s.whatsapp.net` gets ack error 463; sent to the contact's `<lid>@lid` it is delivered and read.

## Fix

Resolve phone-dialect 1:1 chat ids to the contact's LID at the adapter's send boundary, using the same mapping the Baileys send path itself consults (`sock.signalRepository.lidMapping.getLIDForPN`):

- new `toDeliverableJid()` helper in `baileys.adapter.ts`
- applied in `sendTextMessage`, `sendContent` (all media/location/contact/poll sends route through it) and `sendChatState` (presence to a migrated contact previously failed with "No LID for user")

Groups, broadcast, already-`@lid` and unmapped ids pass through unchanged, so behavior for non-migrated contacts is identical to before. Resolution is best-effort: any lookup error falls back to the phone jid.

## Tests

- 2 new specs: phone-dialect id resolves to the LID when mapped; passes through when unmapped
- full `baileys.adapter.spec.ts` suite green (120/120), `tsc --noEmit` clean
- live E2E on a real session: inbound message → API reply → delivery + read receipts, no 463

🤖 Generated with [Claude Code](https://claude.com/claude-code)
