### PR TITLE
feat(engine): channel lookup/subscribe/unsubscribe on the Baileys engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Baileys engine still cannot read stories — `fetchStatus` returns the *about* text, not stories
   (documented as a library limitation).
 
+- **Channel lookup / subscribe / unsubscribe on the Baileys engine.** `getChannelById(id)`,
+  `subscribeToChannel(inviteCode)`, and `unsubscribeFromChannel(id)` now work via Baileys
+  `newsletterMetadata` (mapped to `Channel` with optional fields), `newsletterFollow` (subscribe,
+  resolving invite→jid first), and `newsletterUnfollow` (unsubscribe, 1:1). `getChannelById` on
+  Baileys resolves ANY channel by jid (richer than the whatsapp-web.js subscribed-list lookup).
+  `getChannelMessages` remains unsupported — `newsletterFetchMessages` returns a raw BinaryNode with
+  no library parser, so it stays a documented gap rather than an unverified walk.
+
 ### Fixed
 
 - **Diagnosable failure for a stale browser profile after a binary-changing upgrade.** Upgrading

--- a/docs/engine-capability-matrix.md
+++ b/docs/engine-capability-matrix.md
@@ -28,17 +28,12 @@ The `rootCause`/`evidence` fields are hand-curated from source traces of the ins
 
 | Method | baileys | wwjs |
 |---|---|---|
-| `getChannelById` | not-available — **adapter-gap** | supported |
 | `getChannelMessages` | not-available — **adapter-gap** | supported |
 | `getSubscribedChannels` | not-available — **library-limitation** | supported |
-| `subscribeToChannel` | not-available — **adapter-gap** | supported |
-| `unsubscribeFromChannel` | not-available — **adapter-gap** | supported |
 
-- **`getChannelById` (baileys, adapter-gap).** `sock.newsletterMetadata('jid', channelId)` → `NewsletterMetadata` (`Socket/newsletter.d.ts:9`, shape at `Types/Mex.d.ts:115`). Map `{id,name,description,inviteCode:invite,subscriberCount:subscribers,picture:picture?.url,verified:verification==='VERIFIED',createdAt:creation_time}`. Note: resolves channels by raw jid including not-subscribed ones (wwjs only sees subscribed).
-- **`getChannelMessages` (baileys, adapter-gap).** `sock.newsletterFetchMessages(channelId, limit??50, 0, 0)` (`Socket/newsletter.d.ts:19`) returns the **raw `BinaryNode`** of `<message_updates>` children (`newsletter.js:149`). The fetch is one line; the real work is walking the children and mapping each to `ChannelMessage{id,body,timestamp,hasMedia}` — no library parser is exposed.
+> **Wired.** ✅ `getChannelById`, `subscribeToChannel`, `unsubscribeFromChannel` on Baileys — via `newsletterMetadata('jid'|'invite', …)` → `NewsletterMetadata` mapped to `Channel` (id/name/description/inviteCode/subscriberCount/picture/verified/createdAt), `newsletterFollow` (subscribe, invite→jid bridge), `newsletterUnfollow` (unsubscribe, 1:1). `getChannelById` on Baileys resolves ANY channel by jid (richer than the wwjs subscribed-list lookup).
+- **`getChannelMessages` (baileys, adapter-gap).** `sock.newsletterFetchMessages(channelId, limit, 0, 0)` (`Socket/newsletter.d.ts:19`) returns the **raw `BinaryNode`** of `<message_updates>` children (`newsletter.js:149`). The fetch is one line; the real work is walking the children and mapping each to `ChannelMessage{id,body,timestamp,hasMedia}` — no library parser is exposed. Not wired: a hand-written BinaryNode walk can't be verified without a live WhatsApp session, so it stays a documented gap rather than an unverified implementation.
 - **`getSubscribedChannels` (baileys, library-limitation).** No enumerate-subscribed-newsletters query in the library. All 23 `Socket/newsletter.d.ts` exports are per-jid (`newsletterMetadata` requires a key; `newsletterSubscribers(jid)` returns the count of one newsletter). The `newsletter` event surfaces jids opportunistically during live sync, but that is incremental, not a list-all. Would require a raw WMex/app-state hack against an undocumented XWAPath.
-- **`subscribeToChannel` (baileys, adapter-gap).** Two-step: `newsletterFollow(jid)` (`Socket/newsletter.d.ts:10`) needs a jid, but OpenWA takes an invite code — bridge via `newsletterMetadata('invite', inviteCode).id` first, then `newsletterFollow`.
-- **`unsubscribeFromChannel` (baileys, adapter-gap).** 1:1 — `await sock.newsletterUnfollow(channelId)` (`Socket/newsletter.d.ts:11`). `channelId` is already the `@newsletter` jid, no resolution needed.
 
 ### Labels (WhatsApp Business)
 
@@ -107,14 +102,11 @@ All Tier-1 adapter-gaps have been wired:
 - ✅ `deleteMessage(forEveryone=false)` — Baileys (`chatModify({ deleteForMe })`)
 - ✅ `postTextStatus` / `postImageStatus` / `postVideoStatus` — whatsapp-web.js (`sendMessage('status@broadcast', …)`; `recipients` not honored)
 - ✅ `addLabelToChat` / `removeLabelFromChat` — Baileys (`addChatLabel` / `removeChatLabel`; WhatsApp-Business-only)
+- ✅ `getChannelById` / `subscribeToChannel` / `unsubscribeFromChannel` — Baileys (`newsletterMetadata` / `newsletterFollow` / `newsletterUnfollow`)
 
 ### Tier 2 — small-to-medium effort, medium-high value
 
-| # | Method : engine | Library call to wire | Effort | Value |
-|---|---|---|---|---|
-| 7 | `getChannelById` : **baileys** | `sock.newsletterMetadata('jid', channelId)` → map `NewsletterMetadata` (`Socket/newsletter.d.ts:9`) | **S** | Channel/newsletter parity. ~1-liner field map. |
-| 8 | `unsubscribeFromChannel` : **baileys** | `await sock.newsletterUnfollow(channelId)` (`Socket/newsletter.d.ts:11`) | **S** | 1:1, no jid resolution needed. |
-| 9 | `subscribeToChannel` : **baileys** | 2-step: `newsletterMetadata('invite',code).id` then `newsletterFollow(jid)` (`Socket/newsletter.d.ts:9,10`) | **S** | Channel growth (join by invite code). |
+_All Tier-2 items wired (see progress above). Remaining channel work is Tier 3: `getChannelMessages` (raw BinaryNode, no library parser)._
 
 ### Tier 3 — medium effort
 

--- a/src/engine/adapters/baileys.adapter.spec.ts
+++ b/src/engine/adapters/baileys.adapter.spec.ts
@@ -40,6 +40,9 @@ class FakeSock extends EventEmitter {
   public chatModify = jest.fn().mockResolvedValue(undefined);
   public addChatLabel = jest.fn().mockResolvedValue(undefined);
   public removeChatLabel = jest.fn().mockResolvedValue(undefined);
+  public newsletterMetadata = jest.fn();
+  public newsletterFollow = jest.fn().mockResolvedValue(undefined);
+  public newsletterUnfollow = jest.fn().mockResolvedValue(undefined);
   fire(event: string, arg: unknown): void {
     this.emitter.emit(event, arg);
   }
@@ -89,6 +92,7 @@ import { BaileysAdapter } from './baileys.adapter';
 import { EngineStatus, EngineEventCallbacks } from '../interfaces/whatsapp-engine.interface';
 import { EngineNotReadyError } from '../../common/errors/engine-not-ready.error';
 import { EngineNotSupportedError } from '../../common/errors/engine-not-supported.error';
+import { ChannelNotFoundError } from '../../common/errors/channel-not-found.error';
 import { loadRemoteMediaBuffer } from '../../common/media/load-remote-media';
 
 const fakeStore = {
@@ -1751,6 +1755,64 @@ describe('BaileysAdapter store-backed ops', () => {
     const adapter = await ready();
     await adapter.removeLabelFromChat('628111@s.whatsapp.net', 'LABEL8');
     expect(fakeSock.removeChatLabel).toHaveBeenCalledWith('628111@s.whatsapp.net', 'LABEL8');
+  });
+
+  it('getChannelById maps newsletterMetadata(jid) → Channel (optionals only when present)', async () => {
+    fakeSock.newsletterMetadata.mockResolvedValue({
+      id: '120363N@newsletter',
+      name: 'Announcements',
+      description: 'News',
+      invite: 'ABC123',
+      subscribers: 421,
+      picture: { url: 'https://x/p.png' },
+      verification: 'VERIFIED',
+      creation_time: 1700000000,
+    });
+    const adapter = await ready();
+    const channel = await adapter.getChannelById('120363N@newsletter');
+    expect(fakeSock.newsletterMetadata).toHaveBeenCalledWith('jid', '120363N@newsletter');
+    expect(channel).toEqual({
+      id: '120363N@newsletter',
+      name: 'Announcements',
+      description: 'News',
+      inviteCode: 'ABC123',
+      subscriberCount: 421,
+      picture: 'https://x/p.png',
+      verified: true,
+      createdAt: 1700000000,
+    });
+  });
+
+  it('getChannelById returns null when newsletterMetadata resolves null', async () => {
+    fakeSock.newsletterMetadata.mockResolvedValue(null);
+    const adapter = await ready();
+    expect(await adapter.getChannelById('unknown@newsletter')).toBeNull();
+  });
+
+  it('subscribeToChannel resolves invite→jid via newsletterMetadata then follows', async () => {
+    fakeSock.newsletterMetadata.mockResolvedValue({ id: '120363S@newsletter', name: 'Solo', invite: 'CODE1' });
+    const adapter = await ready();
+    const channel = await adapter.subscribeToChannel('CODE1');
+    expect(fakeSock.newsletterMetadata).toHaveBeenCalledWith('invite', 'CODE1');
+    expect(fakeSock.newsletterFollow).toHaveBeenCalledWith('120363S@newsletter');
+    expect(channel).toEqual({ id: '120363S@newsletter', name: 'Solo', inviteCode: 'CODE1' });
+  });
+
+  it('subscribeToChannel throws ChannelNotFoundError when the invite resolves null', async () => {
+    fakeSock.newsletterMetadata.mockResolvedValue(null);
+    const adapter = await ready();
+    await expect(adapter.subscribeToChannel('BADCODE')).rejects.toBeInstanceOf(ChannelNotFoundError);
+  });
+
+  it('unsubscribeFromChannel wires 1:1 to sock.newsletterUnfollow(channelId)', async () => {
+    const adapter = await ready();
+    await adapter.unsubscribeFromChannel('120363U@newsletter');
+    expect(fakeSock.newsletterUnfollow).toHaveBeenCalledWith('120363U@newsletter');
+  });
+
+  it('getChannelMessages remains unsupported (raw BinaryNode — no library parser)', async () => {
+    const adapter = await ready();
+    await expect(adapter.getChannelMessages('120363M@newsletter', 10)).rejects.toBeInstanceOf(EngineNotSupportedError);
   });
 
   it('populates the store on an inbound message', async () => {

--- a/src/engine/adapters/baileys.adapter.ts
+++ b/src/engine/adapters/baileys.adapter.ts
@@ -39,6 +39,7 @@ import { loadRemoteMediaBuffer } from '../../common/media/load-remote-media';
 import { EngineNotReadyError } from '../../common/errors/engine-not-ready.error';
 import { EngineNotSupportedError } from '../../common/errors/engine-not-supported.error';
 import { MessageNotFoundError } from '../../common/errors/message-not-found.error';
+import { ChannelNotFoundError } from '../../common/errors/channel-not-found.error';
 import { createLogger } from '../../common/services/logger.service';
 import { BaileysAdapterConfig, BaileysLogger } from '../types/baileys.types';
 import { BaileysSessionStore } from './baileys-session-store';
@@ -880,17 +881,59 @@ export class BaileysAdapter implements IWhatsAppEngine {
   getSubscribedChannels(): Promise<Channel[]> {
     return this.unsupported('getSubscribedChannels');
   }
-  getChannelById(_channelId: string): Promise<Channel | null> {
-    return this.unsupported('getChannelById');
+  async getChannelById(channelId: string): Promise<Channel | null> {
+    this.ensureReady();
+    // newsletterMetadata resolves ANY channel by jid (richer than the wwjs subscribed-list lookup).
+    const meta = await this.sock!.newsletterMetadata('jid', channelId);
+    return meta ? this.toChannel(meta) : null;
   }
-  subscribeToChannel(_inviteCode: string): Promise<Channel> {
-    return this.unsupported('subscribeToChannel');
+
+  async subscribeToChannel(inviteCode: string): Promise<Channel> {
+    this.ensureReady();
+    const meta = await this.sock!.newsletterMetadata('invite', inviteCode);
+    if (!meta) {
+      throw new ChannelNotFoundError(inviteCode);
+    }
+    await this.sock!.newsletterFollow(meta.id);
+    return this.toChannel(meta);
   }
-  unsubscribeFromChannel(_channelId: string): Promise<void> {
-    return this.unsupported('unsubscribeFromChannel');
+
+  async unsubscribeFromChannel(channelId: string): Promise<void> {
+    this.ensureReady();
+    await this.sock!.newsletterUnfollow(channelId);
   }
+
+  // getChannelMessages is not wired: Baileys' newsletterFetchMessages returns the RAW query
+  // BinaryNode with no library parser, so mapping it to ChannelMessage[] needs a verified
+  // BinaryNode walk (or a live spike) that can't be validated without a WhatsApp session. Kept as a
+  // documented adapter-gap in the engine capability matrix rather than shipped as an unverified walk.
   getChannelMessages(_channelId: string, _limit?: number): Promise<ChannelMessage[]> {
     return this.unsupported('getChannelMessages');
+  }
+
+  /** Map a Baileys NewsletterMetadata to the neutral Channel shape (optionals only when present). */
+  private toChannel(meta: {
+    id: string;
+    name: string;
+    description?: string;
+    invite?: string;
+    creation_time?: number;
+    subscribers?: number;
+    picture?: { url?: string };
+    verification?: string;
+    thread_metadata?: { creation_time?: number };
+  }): Channel {
+    const createdAt = meta.creation_time ?? meta.thread_metadata?.creation_time;
+    return {
+      id: meta.id,
+      name: meta.name,
+      ...(meta.description ? { description: meta.description } : {}),
+      ...(meta.invite ? { inviteCode: meta.invite } : {}),
+      ...(meta.subscribers !== undefined ? { subscriberCount: meta.subscribers } : {}),
+      ...(meta.picture?.url ? { picture: meta.picture.url } : {}),
+      ...(meta.verification ? { verified: meta.verification === 'VERIFIED' } : {}),
+      ...(createdAt !== undefined ? { createdAt } : {}),
+    };
   }
   getContactStatuses(): Promise<Status[]> {
     return this.unsupported('getContactStatuses');

--- a/src/engine/engine-capability-matrix.ts
+++ b/src/engine/engine-capability-matrix.ts
@@ -72,12 +72,7 @@ export const ENGINE_CAPABILITY_MATRIX: Record<string, MethodCapability> = {
     evidence:
       'baileys Socket/business.d.ts:7 getCatalog({jid,limit,cursor}) + getCollections (business.d.ts:11) — adapter unwired (returns Product[]+cursor, not Catalog metadata; medium-confidence shape synthesis); wwjs index.d.ts has NO Client.getCatalog (0 hits), adapter stubs to null @whatsapp-web-js.adapter.ts:1770',
   },
-  getChannelById: {
-    wwjs: { status: 'supported' },
-    baileys: { status: 'not-available', rootCause: 'adapter-gap' },
-    evidence:
-      'baileys Socket/newsletter.d.ts:9 newsletterMetadata(type,key) → NewsletterMetadata (Mex.d.ts:115) — adapter unwired; wwjs resolves via getChannels() find-by-id @whatsapp-web-js.adapter.ts:1562',
-  },
+  getChannelById: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   getChannelMessages: {
     wwjs: { status: 'supported' },
     baileys: { status: 'not-available', rootCause: 'adapter-gap' },
@@ -195,17 +190,7 @@ export const ENGINE_CAPABILITY_MATRIX: Record<string, MethodCapability> = {
   sendVideoMessage: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   setGroupDescription: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   setGroupSubject: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
-  subscribeToChannel: {
-    wwjs: { status: 'supported' },
-    baileys: { status: 'not-available', rootCause: 'adapter-gap' },
-    evidence:
-      'baileys Socket/newsletter.d.ts:10 newsletterFollow(jid) needs a jid — bridge via newsletterMetadata("invite",code).id (2-step); adapter unwired; wwjs Client.subscribeToChannel (Client.js:2529)',
-  },
+  subscribeToChannel: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   unblockContact: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
-  unsubscribeFromChannel: {
-    wwjs: { status: 'supported' },
-    baileys: { status: 'not-available', rootCause: 'adapter-gap' },
-    evidence:
-      'baileys Socket/newsletter.d.ts:11 newsletterUnfollow(jid) — channelId is the @newsletter jid, maps 1:1; adapter unwired; wwjs Client.unsubscribeFromChannel (Client.js:2550)',
-  },
+  unsubscribeFromChannel: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
 };


### PR DESCRIPTION
## What
`getChannelById`, `subscribeToChannel`, `unsubscribeFromChannel` on the Baileys engine now work via the Baileys newsletter socket. `getChannelMessages` is intentionally left unsupported (documented). Matrix + roadmap doc updated.

## Why
These are the last Tier-1/Tier-2 items on the unwired-capability roadmap (`docs/engine-capability-matrix.md`) with verified library support. The Baileys newsletter socket exposes typed primitives (`newsletterMetadata`/`Follow`/`Unfollow`), so the wiring is verifiable.

## How
- `getChannelById(id)` → `newsletterMetadata('jid', id)` → `NewsletterMetadata` mapped to `Channel` (id/name + optionals: description, inviteCode, subscriberCount, picture, verified, createdAt). Resolves ANY channel by jid (richer than wwjs's subscribed-list lookup).
- `subscribeToChannel(inviteCode)` → 2-step: `newsletterMetadata('invite', code)` (throw `ChannelNotFoundError` if null) then `newsletterFollow(jid)`; returns the mapped `Channel`.
- `unsubscribeFromChannel(id)` → 1:1 `newsletterUnfollow(id)`.
- `getChannelMessages` **stays unsupported**: `newsletterFetchMessages` returns the raw query `BinaryNode` with **no library parser** (verified — Baileys has `parseNewsletterMetadata`/`parseNewsletterCreateResponse` but nothing for messages). Hand-walking the BinaryNode can't be verified without a live WA session, so per the verify-don't-assume rule it remains a documented gap rather than an unverified implementation.

## Test plan
- 6 new Baileys adapter tests: getChannelById mapping (optionals only when present) + null→null; subscribeToChannel (invite→jid→follow + returns Channel) + null-invite→ChannelNotFoundError; unsubscribe 1:1; getChannelMessages still throws. TDD against the FakeSock newsletter mocks.
- Drift gate green (72), full gate green (`npm run lint`, `tsc -p tsconfig.json`, format, build, dashboard build, 2401 tests).
