### PR TITLE
fix: 2 release-blockers from the pre-release review

### DIFF
--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -1164,6 +1164,26 @@ describe('WhatsAppWebJsAdapter status methods', () => {
       }),
     );
   });
+
+  it('getContactStatus returns [] for a contact with no active story (empty Broadcast, no 500)', async () => {
+    // getBroadcastById for a contact not currently posting resolves an "empty" Broadcast: the
+    // Broadcast constructor only _patches when data is truthy, so id/msgs/getContact are undefined.
+    const getBroadcastById = jest.fn().mockResolvedValue({ msgs: undefined });
+    const result = await readyAdapter({ sendMessage: jest.fn(), getBroadcastById }).getContactStatus(
+      '628999@s.whatsapp.net',
+    );
+    expect(getBroadcastById).toHaveBeenCalledWith('628999@s.whatsapp.net');
+    expect(result).toEqual([]);
+  });
+
+  it('getContactStatuses skips empty Broadcasts in the plural path (no crash)', async () => {
+    const getBroadcasts = jest.fn().mockResolvedValue([
+      { msgs: undefined }, // a contact whose story expired / phantom entry
+      storyBroadcast,
+    ]);
+    const result = await readyAdapter({ sendMessage: jest.fn(), getBroadcasts }).getContactStatuses();
+    expect(result).toHaveLength(2); // only the populated broadcast maps
+  });
 });
 
 describe('resolveWebVersionPin (#251/#488 — explicit pin + auto-resolve current WA-Web build)', () => {

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -1736,23 +1736,31 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
 
   async getContactStatus(contactId: string): Promise<Status[]> {
     this.ensureReady();
-    return this.collectStatuses([await this.client!.getBroadcastById(contactId)]);
+    // A contact with no active 24h story resolves to an "empty" Broadcast (id/msgs/getContact
+    // undefined — Broadcast._patch only runs when data is truthy). That is the common case, so guard
+    // it: return [] rather than dereferencing undefined inside collectStatuses (→ 500).
+    const broadcast = await this.client!.getBroadcastById(contactId);
+    return broadcast?.msgs?.length ? this.collectStatuses([broadcast]) : [];
   }
 
   /**
    * Map whatsapp-web.js story Broadcasts (+ their Messages) into the neutral Status shape. Each
    * Broadcast is one contact's story (its `msgs`); we flatten across broadcasts. type collapses to
    * the Status union (image/video, else text — audio/other stories are rare and become 'text').
-   * expiresAt is timestamp + 24h (WhatsApp status TTL).
+   * expiresAt is timestamp + 24h (WhatsApp status TTL). Broadcasts without msgs are skipped (a story
+   * that expired between getBroadcasts and here, or a phantom entry).
    */
   private async collectStatuses(
     broadcasts: ReadonlyArray<{
-      msgs: Message[];
+      msgs?: Message[];
       getContact: () => Promise<{ id: { _serialized: string }; name?: string; pushname?: string }>;
     }>,
   ): Promise<Status[]> {
     const statuses: Status[] = [];
     for (const broadcast of broadcasts) {
+      if (!broadcast?.msgs?.length) {
+        continue;
+      }
       const contact = await broadcast.getContact();
       const contactSummary = {
         id: contact.id._serialized,

--- a/src/main.ts
+++ b/src/main.ts
@@ -243,9 +243,12 @@ async function bootstrap() {
 
   // Apply explicit HTTP server timeouts so they are operator-tunable (REQUEST_TIMEOUT_MS /
   // HEADERS_TIMEOUT_MS / KEEPALIVE_TIMEOUT_MS) and observable at boot, instead of Node's implicit
-  // defaults. Done after the adapter exists and before listen().
+  // defaults. Done after the adapter exists and before listen(). Target MUST be the http.Server
+  // (app.getHttpServer()) — NOT getHttpAdapter().getInstance(), which is the Express APPLICATION
+  // (a function with no requestTimeout/headersTimeout/keepAliveTimeout props); writing onto it is
+  // inert. The timeouts only take effect on the real server.
   const appliedHttpTimeouts = applyHttpTimeouts(
-    app.getHttpAdapter().getInstance() as HttpTimeoutSink,
+    app.getHttpServer() as HttpTimeoutSink,
     app.get(ConfigService).get<HttpTimeoutConfig>('http')!,
   );
   bootstrapLogger.log(


### PR DESCRIPTION
## What
Fixes the 2 P1 release-blockers found by the pre-release deep review (7-cluster adversarial source-trace):

1. **`getContactStatus` 500s for a contact with no active story** (the common case). `getBroadcastById` returns an "empty" Broadcast for a contact not currently posting (the Broadcast constructor only `_patch`es when data is truthy → `id`/`msgs`/`getContact` undefined); `collectStatuses` dereferenced them → `TypeError`. Now `getContactStatus` returns `[]` for an empty Broadcast, and `collectStatuses` skips no-`msgs` Broadcasts in the plural path too (expired/phantom entries). +2 specs.
2. **HTTP server timeouts were inert.** `#703` targeted `app.getHttpAdapter().getInstance()` — which is the **Express application** (a function with no timeout props), not the `http.Server`. The assignments were no-ops while the boot log claimed they applied. Now targets `app.getHttpServer()` (the real server). The pure-function spec (`http-timeouts.spec.ts`) doesn't catch this wiring, so a comment explains the target so it isn't reintroduced.

## Why
Both are real bugs (verified against source before fixing) in brand-new features from this batch. The first fails on the first real `getContactStatus` call (most contacts have no active story at any moment); the second ships a non-functional feature with a misleading log line. Both block the release.

## Test plan
- New specs: empty-Broadcast singular → `[]`; empty-Broadcast-in-plural → skipped (only the populated one maps).
- Full wwjs spec 160, full gate green (lint, `tsc -p tsconfig.json`, format, build, 2410 tests). The drift-gate + matrix unaffected (both methods stay `supported`).
