### PR TITLE
feat/session webhook events

### DIFF
--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -43,7 +43,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit {
     private readonly eventsGateway: EventsGateway,
     private readonly webhookService: WebhookService,
     private readonly hookManager: HookManager,
-  ) {}
+  ) { }
 
   /**
    * On backend startup, reset all active session statuses to disconnected
@@ -486,6 +486,12 @@ export class SessionService implements OnModuleDestroy, OnModuleInit {
       status,
       action: 'status_update',
     });
+
+    // Dispatch webhook
+    void this.webhookService.dispatch(id, 'session.status', {
+      status,
+    });
+
     // Emit real-time event to connected WebSocket clients
     this.eventsGateway.emitSessionStatus(id, status);
   }

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -43,7 +43,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit {
     private readonly eventsGateway: EventsGateway,
     private readonly webhookService: WebhookService,
     private readonly hookManager: HookManager,
-  ) { }
+  ) {}
 
   /**
    * On backend startup, reset all active session statuses to disconnected


### PR DESCRIPTION
## Description
this PR adds webhook dispatch support for the `session.status` event.

changes:
- added `session.status` webhook dispatch whenever a session status changes.

This allows the webhook subscribers to receive session status updates as expected.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] Lint passes
- [x] Self-reviewed

## Screenshots (if applicable)
N/A

## Related Issues
N/A
