### PR TITLE
docs(api): clarify send 201 = accepted, not delivered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+- **Send-response semantics clarified (docs only).** The send endpoints' Swagger response and `docs/06` now state explicitly that `201` means the gateway accepted the message for sending — not that the recipient received it — and that WhatsApp does not reject an unregistered recipient synchronously, so a message to a number that is not on WhatsApp still returns `201` with a `messageId` but never delivers. `GET /sessions/{id}/contacts/check/{number}` is cross-referenced as the way to pre-validate a new recipient, and the async message `status` lifecycle (`sent → delivered → read`, or `failed`) as the source of real delivery state. No behavior change. Refs #738.
+
 
 ## [0.8.17] - 2026-07-13
 

--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -163,6 +163,15 @@ There is a **single shared media byte cap**, not a per-type table. A base64 (or 
 
 The contract is engine-neutral: pass neutral `@c.us` WIDs and the active engine (whatsapp-web.js or Baileys) de-normalizes them internally. Whether a mention surfaces a notification is ultimately client-side — outside a shared group some clients may not render it.
 
+### Send response: `201` means accepted, not delivered
+
+Every send route returns **HTTP 201** with `{ "messageId", "timestamp" }` as soon as the gateway hands the message to the WhatsApp client. This confirms the send was *accepted* — it does **not** confirm the recipient received it. Two consequences worth knowing:
+
+1. **WhatsApp does not reject an unregistered recipient synchronously.** A message to a number that is not on WhatsApp still returns `201` with a valid `messageId`, but never delivers (it sits at a single grey tick and may surface an error in the chat). This is the most common cause of a "successful send that never arrived" for a number you have not messaged before.
+2. **There is no synchronous delivery confirmation on either engine** (whatsapp-web.js or Baileys), so the `201` cannot be made to mean "delivered."
+
+**Before sending to a new number**, confirm it is a registered WhatsApp account with `GET /api/sessions/:sessionId/contacts/check/:number` (returns `{ exists, whatsappId }`; see the Contacts reference). For real delivery state, track the stored message's `status`, which advances asynchronously through `sent → delivered → read` (or `failed`) as WhatsApp sends acks — see the message shape under the Messages reference. A message that stays at `sent` indefinitely for a recipient you have never reached is almost certainly a number that is not on WhatsApp.
+
 ## 6.4 REST API Reference
 
 Every path below is prefixed with `/api`. Unless marked **public**, send `X-API-Key: <key>`; `OPERATOR`/`ADMIN` annotations require a key of at least that role. Responses are the raw payload (no envelope); list endpoints return a bare array.

--- a/openapi.json
+++ b/openapi.json
@@ -2732,6 +2732,7 @@
     },
     "/api/sessions/{sessionId}/contacts/check/{number}": {
       "get": {
+        "description": "Returns whether the number is a registered WhatsApp account and its canonical id. Use this to pre-validate a recipient before sending: the send endpoints return 201 on accepting a message even for numbers that are not on WhatsApp, so this is the only way to confirm a new number is reachable before you send to it.",
         "operationId": "ContactController_checkNumber",
         "parameters": [
           {
@@ -6077,10 +6078,12 @@
         "properties": {
           "messageId": {
             "type": "string",
+            "description": "The message id, assigned when the gateway accepts the message for sending. A 201 here means the message was handed to the WhatsApp client — it does NOT confirm delivery. WhatsApp does not reject an unregistered recipient synchronously, so a message to a number that is not on WhatsApp still returns 201 with a valid messageId but never delivers. To confirm a number is on WhatsApp before sending, use GET /api/sessions/{sessionId}/contacts/check/{number}; track real delivery via the message `status` field (sent → delivered → read).",
             "example": "true_628123456789@c.us_3EB0123456789"
           },
           "timestamp": {
             "type": "number",
+            "description": "Unix timestamp (seconds) at which the gateway accepted the message for sending.",
             "example": 1706868000
           }
         },

--- a/src/modules/contact/contact.controller.ts
+++ b/src/modules/contact/contact.controller.ts
@@ -45,7 +45,14 @@ export class ContactController {
   }
 
   @Get('check/:number')
-  @ApiOperation({ summary: 'Check if a phone number exists on WhatsApp' })
+  @ApiOperation({
+    summary: 'Check if a phone number exists on WhatsApp',
+    description:
+      'Returns whether the number is a registered WhatsApp account and its canonical id. Use this to ' +
+      'pre-validate a recipient before sending: the send endpoints return 201 on accepting a message ' +
+      'even for numbers that are not on WhatsApp, so this is the only way to confirm a new number is ' +
+      'reachable before you send to it.',
+  })
   @ApiParam({ name: 'sessionId', description: 'Session ID' })
   @ApiParam({ name: 'number', description: 'Phone number to check (e.g., 628123456789)' })
   @ApiResponse({

--- a/src/modules/message/dto/send-message.dto.ts
+++ b/src/modules/message/dto/send-message.dto.ts
@@ -117,9 +117,21 @@ export class SendAudioMessageDto extends SendMediaMessageDto {
 }
 
 export class MessageResponseDto {
-  @ApiProperty({ example: 'true_628123456789@c.us_3EB0123456789' })
+  @ApiProperty({
+    description:
+      'The message id, assigned when the gateway accepts the message for sending. A 201 here means the ' +
+      'message was handed to the WhatsApp client — it does NOT confirm delivery. WhatsApp does not reject ' +
+      'an unregistered recipient synchronously, so a message to a number that is not on WhatsApp still ' +
+      'returns 201 with a valid messageId but never delivers. To confirm a number is on WhatsApp before ' +
+      'sending, use GET /api/sessions/{sessionId}/contacts/check/{number}; track real delivery via the ' +
+      'message `status` field (sent → delivered → read).',
+    example: 'true_628123456789@c.us_3EB0123456789',
+  })
   messageId: string;
 
-  @ApiProperty({ example: 1706868000 })
+  @ApiProperty({
+    description: 'Unix timestamp (seconds) at which the gateway accepted the message for sending.',
+    example: 1706868000,
+  })
   timestamp: number;
 }


### PR DESCRIPTION
## What

Documents, with no behavior change, that the send endpoints' `201 { messageId, timestamp }` confirms the gateway **accepted** the message for sending — not that the recipient received it.

## Why

#736 reported a send returning `201` + a valid `messageId` for a new contact, with the message never delivering (yellow triangle in WhatsApp Web). The send path returns success at local message-creation time, and WhatsApp does not reject an unregistered recipient synchronously — so a message to a number that is not on WhatsApp is indistinguishable from a successful send on the API surface. This is a contract gap, not a delivery bug: the message genuinely wasn't deliverable because the number isn't a WhatsApp account.

This PR takes the documentation half of #738: make the contract honest so the next person isn't misled by the `201`, and point them at the tool that answers the real question ("is this number on WhatsApp?").

## Changes

- **`MessageResponseDto`** — describe `messageId`/`timestamp` as accepted-for-sending, call out that `201` ≠ delivered and that an unregistered recipient still returns `201`, and point to the recipient-check endpoint and the async `status` lifecycle. Defined once on the shared response schema; every send response (text, media, audio, template, …) picks it up via `$ref`.
- **`GET /sessions/{id}/contacts/check/{number}`** — note it as the pre-send recipient validation (the only way to confirm a new number is reachable, since the send itself returns `201` either way).
- **`docs/06`** — new "Send response: `201` means accepted, not delivered" subsection cross-linking the check endpoint and the `sent → delivered → read` / `failed` status lifecycle.
- Regenerated `openapi.json` (3-line delta — the shared schema definition plus the one operation description).
- CHANGELOG `[Unreleased]`.

No code or behavior changes; the send path, statuses, and error handling are untouched.

## Out of scope

#738 also proposed an opt-in `requireRegisteredRecipient` gate (→ `422` for unregistered recipients). Deferring that until there's demand — the check endpoint already lets callers self-serve, and the flag is speculative until someone asks for it.

## Verification

- `npm run openapi:check` — drift gate green (snapshot matches source).
- `npm run lint` — 0 errors.
- `npm run build` — pass.

Refs #738. Reported via #736.
