### PR TITLE
fix(session): map WA auth-timeout to 504 instead of bare 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 
+### Fixed
+
+- **Engine auth-timeout now returns a diagnostic 504 instead of a bare 500.** When the WhatsApp Web
+  engine's internal authentication poll exhausts its timeout (default 30s) — e.g. the session proxy
+  is unreachable, so the browser launches but no QR is ever delivered — `POST /api/sessions/:id/start`
+  previously let the primitive `'auth timeout'` string escape to NestJS's default handler as a
+  meaningless `500 Internal Server Error`. It now maps to `504 Gateway Timeout` with a message
+  pointing at the proxy / network-egress / firewall causes and the `WWEBJS_AUTH_TIMEOUT_MS` knob for
+  legitimately slow first boots. The outer engine-init hang deadline (`EngineInitTimeoutError`) still
+  surfaces as 500 and is tracked separately.
+
 ## [0.8.17] - 2026-07-13
 
 ### Added

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken, getDataSourceToken } from '@nestjs/typeorm';
 import { Repository, DataSource, In } from 'typeorm';
-import { NotFoundException, ConflictException, BadRequestException } from '@nestjs/common';
+import { NotFoundException, ConflictException, BadRequestException, HttpException, HttpStatus } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { SessionService, ACK_RECONCILE_DELAY_MS, EngineInitTimeoutError } from './session.service';
 import { Session, SessionStatus } from './entities/session.entity';
@@ -418,6 +418,26 @@ describe('SessionService', () => {
       // time out, leaving the process orphaned (the actual bug this test now guards against).
       expect(mockEngine.forceDestroy).toHaveBeenCalled();
       expect(mockEngine.destroy).not.toHaveBeenCalled();
+    });
+
+    it('maps a whatsapp-web.js auth timeout (bare string) to HTTP 504, not a bare 500 (#733)', async () => {
+      (repository.findOne as jest.Mock).mockResolvedValue(createMockSession());
+      (repository.update as jest.Mock).mockResolvedValue({ affected: 1 });
+      (engineFactory.create as jest.Mock).mockClear().mockReturnValue(mockEngine);
+      // whatsapp-web.js throws the PRIMITIVE STRING 'auth timeout' (not an Error) when its inject poll
+      // for WA Web's login bootstrap times out — e.g. a dead/unreachable proxy (the proxy.example.com
+      // placeholder) blocks the WebSocket so no QR is ever delivered. This must surface as a diagnostic
+      // 504, not escape as a meaningless bare 500.
+      mockEngine.initialize.mockRejectedValueOnce('auth timeout');
+
+      let caught: unknown;
+      try {
+        await service.start('sess-uuid-1');
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(HttpException);
+      expect((caught as HttpException).getStatus()).toBe(HttpStatus.GATEWAY_TIMEOUT);
     });
 
     it('allows a fresh start after the previous one completed (reservation is cleared)', async () => {

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -3,6 +3,8 @@ import {
   NotFoundException,
   ConflictException,
   BadRequestException,
+  HttpException,
+  HttpStatus,
   OnModuleDestroy,
   OnModuleInit,
   OnApplicationBootstrap,
@@ -110,6 +112,26 @@ export class EngineInitTimeoutError extends Error {
     super(`engine.initialize() timed out after ${timeoutMs}ms`);
     this.name = 'EngineInitTimeoutError';
   }
+}
+
+/**
+ * whatsapp-web.js throws this primitive STRING (not an Error) from its inject() auth poll when WA Web's
+ * login bootstrap doesn't complete within authTimeoutMs (default 30s). Match it defensively as both the
+ * bare string and an Error carrying the same message, since the library's throw shape isn't contracted.
+ */
+const ENGINE_AUTH_TIMEOUT = 'auth timeout';
+
+/**
+ * Diagnostic surfaced when the engine's internal auth-timeout fires (#733): points at the usual cause
+ * (the session proxy / network egress / firewall blocking WhatsApp so no QR is ever delivered) and the
+ * WWEBJS_AUTH_TIMEOUT_MS knob for legitimately slow first boots.
+ */
+const ENGINE_AUTH_TIMEOUT_MESSAGE =
+  'WhatsApp Web authentication timed out. Verify the session proxy URL and network egress can reach ' +
+  'WhatsApp; for slow first boots, raise WWEBJS_AUTH_TIMEOUT_MS.';
+
+function isAuthTimeoutRejection(err: unknown): boolean {
+  return err === ENGINE_AUTH_TIMEOUT || (err instanceof Error && err.message === ENGINE_AUTH_TIMEOUT);
 }
 
 @Injectable()
@@ -1202,6 +1224,14 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
         // teardownEngineSafely is itself time-bound, so this can't wedge a second time.
         await this.teardownEngineSafely(id, engine, e => e.forceDestroy(), 'force-destroy');
         await this.updateStatus(id, SessionStatus.DISCONNECTED);
+      } else if (isAuthTimeoutRejection(err)) {
+        // The engine's INTERNAL auth-timeout: whatsapp-web.js throws the primitive string 'auth timeout'
+        // (see ENGINE_AUTH_TIMEOUT) when its inject poll exhausts authTimeoutMs (default 30s) — the common
+        // pre-QR failure when the browser launched but couldn't reach WhatsApp, e.g. a dead/unreachable
+        // session proxy (#733). onError already evicted the engine + wrote FAILED before this catch ran, so
+        // only the HTTP mapping remains: surface a diagnostic 504 instead of letting the bare string escape
+        // to NestJS's default handler as a meaningless 500.
+        throw new HttpException(ENGINE_AUTH_TIMEOUT_MESSAGE, HttpStatus.GATEWAY_TIMEOUT);
       }
       throw err;
     } finally {


### PR DESCRIPTION
## What & why

`POST /api/sessions/:id/start` returned a meaningless `500 Internal Server Error` whenever the WhatsApp Web engine's internal auth poll timed out — the common pre-QR failure where the browser launches but can't reach WhatsApp (e.g. an unreachable session proxy, so no QR is ever delivered).

Root cause: `whatsapp-web.js` throws the **primitive string `'auth timeout'`** (not an `Error`) when its `inject()` poll exhausts `authTimeoutMs` (default 30s). That string reached `initializeEngine`'s catch, where only the outer hang deadline (`EngineInitTimeoutError`) was special-cased — so the bare string fell through to `throw err`, bubbled up through `start()` and the controller (no try/catch), and hit NestJS's default `ExceptionsHandler`, which renders any non-`HttpException` as a generic 500.

## The change

In `initializeEngine`'s catch, detect the auth-timeout rejection (defensively, as both the bare string and an `Error` carrying the same message) and map it to **`504 Gateway Timeout`** with a diagnostic message pointing at the likely causes (session proxy / network egress / firewall) and the `WWEBJS_AUTH_TIMEOUT_MS` knob for legitimately slow first boots. The controller is unchanged — NestJS maps the `HttpException` automatically.

This matches the existing pattern in `session.service.ts`, which already throws `HttpException` subclasses (`BadRequestException`, `NotFoundException`, `ConflictException`) directly from the service.

## Scope

Only the **inner** engine auth-timeout is mapped here (the reported case in #733). The **outer** init-hang deadline (`EngineInitTimeoutError`) still surfaces as 500 and is left for a separate change — its cleanup semantics differ and it's a rarer failure mode (a wedged init under container memory pressure). Noted in the CHANGELOG entry.

The auth-timeout cleanup itself is unchanged: `onError` already evicts the engine and writes `FAILED` before the catch runs, and `start()`'s catch still owns the orphan case when `onError` hasn't run.

## Verification

- TDD: wrote the failing test first (engine rejects with the bare string `'auth timeout'` → asserted `HttpException` with status 504), watched it fail (`Received value: "auth timeout"`), then implemented.
- `npm run lint` — 0 errors (4 pre-existing warnings in `baileys.adapter.ts`, unrelated).
- `npm run build` — clean.
- `npm test` — 2411 passed, 5 skipped.

## Relation to #733

This is the secondary improvement promised in the issue reply: when this class of failure happens, callers now get a status and message that points at the cause instead of a bare 500. It does **not** auto-close #733 — the reporter's primary problem is a dead placeholder proxy in their session config, which only they can correct.

Refs #733.
