### PR TITLE
docs(session): stop the proxy placeholder from misleading users

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,7 +113,8 @@ OPENWA_PIDS_LIMIT=2048
 # NOTE: the Baileys engine is loaded lazily (dynamic import, only when ENGINE_TYPE=baileys), so there is no
 # global Node.js version floor. Node.js 22 LTS is recommended for all deployments.
 BAILEYS_AUTH_DIR=./data/baileys
-# NOTE: proxy (PROXY_URL/PROXY_TYPE) is not yet supported by the baileys engine; it is ignored.
+# NOTE: proxy egress is configured PER SESSION via the proxyUrl/proxyType fields on
+# POST /api/sessions (whatsapp-web.js engine only), NOT via environment variables.
 # Pull the FULL message-history archive on connect (large). Off by default: the engine still enables the
 # initial sync (contacts, chats, recent messages, lid mappings) without downloading the entire history.
 BAILEYS_SYNC_FULL_HISTORY=false

--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -367,19 +367,33 @@ Create a new WhatsApp session.
 | --- | --- | --- | --- | --- |
 | `name` | string | Yes | `@IsString`; length 3–50; `@Matches(/^[a-zA-Z0-9-]+$/)` (letters, numbers, hyphens only) | Unique session name; duplicate → `409` |
 | `config` | object | No | `@IsOptional` (arbitrary object, no shape validation) | Opaque engine config; defaults to `{}`; never returned by read routes |
-| `proxyUrl` | string | No | `@IsOptional`; `@IsString`; max 255; `@IsUrl` (protocols `http`/`https`/`socks4`/`socks5`, `require_protocol`, `require_tld:false`, `allow_underscores`) | Per-session proxy egress; credentialed `http://user:pass@host` and single-label hosts allowed; not SSRF-blocked |
+| `proxyUrl` | string | No | `@IsOptional`; `@IsString`; max 255; `@IsUrl` (protocols `http`/`https`/`socks4`/`socks5`, `require_protocol`, `require_tld:false`, `allow_underscores`) | Per-session proxy egress; credentialed `http://user:pass@host` and single-label hosts allowed; not SSRF-blocked. ⚠ **Must be a real, reachable proxy** — an unreachable value silently blocks the WhatsApp WebSocket (no QR, start → `504`); leave unset unless you need it. See "Per-session egress proxy" below. |
 | `proxyType` | `http` \| `https` \| `socks4` \| `socks5` | No | `@IsOptional`; `@IsIn([...])` | Proxy protocol |
 
 ```json
 {
   "name": "my-bot",
-  "config": { "autoReconnect": true },
-  "proxyUrl": "http://proxy.example.com:8080",
-  "proxyType": "http"
+  "config": { "autoReconnect": true }
 }
 ```
 
 Minimal: `{ "name": "my-bot" }`.
+
+**Optional — per-session egress proxy.** Route a session's traffic through a proxy only if your
+network cannot reach WhatsApp directly. Set `proxyUrl`/`proxyType` on the same request:
+
+```json
+{
+  "name": "my-bot",
+  "proxyUrl": "http://user:pass@your-real-proxy.host:8080",
+  "proxyType": "http"
+}
+```
+
+> ⚠ `proxyUrl` **must point at a real, reachable proxy server.** A placeholder or unreachable value
+> (e.g. `http://proxy.example.com:8080`) launches the engine pinned to a dead proxy, so the WhatsApp
+> WebSocket never connects, **no QR code is ever delivered**, and `POST /api/sessions/:id/start`
+> returns `504 Gateway Timeout` after ~30s. Leave `proxyUrl` unset unless you genuinely need a proxy.
 
 **Response** `201`
 
@@ -391,8 +405,8 @@ Minimal: `{ "name": "my-bot" }`.
   "phone": null,
   "pushName": null,
   "config": { "autoReconnect": true },
-  "proxyUrl": "http://proxy.example.com:8080",
-  "proxyType": "http",
+  "proxyUrl": null,
+  "proxyType": null,
   "connectedAt": null,
   "lastActiveAt": null,
   "createdAt": "2026-06-25T09:00:00.000Z",

--- a/docs/07-api-collection.md
+++ b/docs/07-api-collection.md
@@ -98,7 +98,18 @@ Create a new session (OPERATOR).
 curl -X POST "$BASE/api/sessions" \
   -H "X-API-Key: $API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{ "name": "my-bot", "config": { "autoReconnect": true }, "proxyUrl": "http://proxy.example.com:8080", "proxyType": "http" }'
+  -d '{ "name": "my-bot" }'
+```
+
+With an optional per-session egress proxy — only if your network can't reach WhatsApp directly. The
+proxy **must be a real, reachable host**; an unreachable value silently blocks the WhatsApp WebSocket
+(no QR is ever delivered) and `POST /api/sessions/:id/start` returns `504` after ~30s:
+
+```bash
+curl -X POST "$BASE/api/sessions" \
+  -H "X-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "name": "my-bot", "proxyUrl": "http://user:pass@your-real-proxy.host:8080", "proxyType": "http" }'
 ```
 
 #### POST /api/sessions/:id/start

--- a/docs/12-troubleshooting-faq.md
+++ b/docs/12-troubleshooting-faq.md
@@ -197,6 +197,31 @@ export PROXY_URL=http://proxy:8080
 docker compose up -d
 ```
 
+### Issue: No QR code appears, or `POST /api/sessions/:id/start` returns `504`
+
+**Symptoms:**
+- `POST /api/sessions/:id/start` returns `504 Gateway Timeout`
+  (`WhatsApp Web authentication timed out...`)
+- No QR code is ever produced — `GET /api/sessions/:id/qr` never has one
+- Engine log shows `Session engine failed: auth timeout` after ~30s
+
+**Cause:** The session was created with a `proxyUrl` that doesn't resolve to a real, reachable proxy
+(e.g. the `http://proxy.example.com:8080` placeholder copied from an example). The engine launches
+Chromium pinned to that proxy, the WhatsApp WebSocket can never connect, no QR is produced, and the
+auth poll times out.
+
+**Fix:** Don't set a proxy unless your network actually requires one. Recreate the session without
+`proxyUrl`, or set it to a real, reachable proxy server:
+
+```bash
+# No proxy needed (the common case):
+curl -X POST "$BASE/api/sessions" -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
+  -d '{ "name": "my-bot" }'
+```
+
+> ℹ️ Proxy egress for the `whatsapp-web.js` engine is configured **per session** via the
+> `proxyUrl`/`proxyType` fields on `POST /api/sessions` — not via environment variables.
+
 ### Issue: Session stuck at `authenticating`, never reaches `ready`
 
 > **Engine:** This issue applies to the `whatsapp-web.js` engine only. If you are using `ENGINE_TYPE=baileys`, skip this section.

--- a/openapi.json
+++ b/openapi.json
@@ -5627,8 +5627,7 @@
           },
           "proxyUrl": {
             "type": "string",
-            "description": "Proxy URL for this session (e.g., http://user:pass@proxy.example.com:8080)",
-            "example": "http://proxy.example.com:8080"
+            "description": "Optional per-session egress proxy URL (http/https/socks4/socks5; credentialed form \"http://user:pass@host\" allowed). Must be a REAL, REACHABLE proxy — an unreachable value silently blocks the WhatsApp WebSocket (no QR is ever delivered) and the session start times out (~30s → 504 Gateway Timeout). Leave unset unless your network cannot reach WhatsApp directly."
           },
           "proxyType": {
             "type": "string",

--- a/src/modules/session/dto/create-session.dto.ts
+++ b/src/modules/session/dto/create-session.dto.ts
@@ -25,8 +25,11 @@ export class CreateSessionDto {
 
   // Phase 3: Proxy per session
   @ApiPropertyOptional({
-    description: 'Proxy URL for this session (e.g., http://user:pass@proxy.example.com:8080)',
-    example: 'http://proxy.example.com:8080',
+    description:
+      'Optional per-session egress proxy URL (http/https/socks4/socks5; credentialed form ' +
+      '"http://user:pass@host" allowed). Must be a REAL, REACHABLE proxy — an unreachable value ' +
+      'silently blocks the WhatsApp WebSocket (no QR is ever delivered) and the session start times ' +
+      'out (~30s → 504 Gateway Timeout). Leave unset unless your network cannot reach WhatsApp directly.',
   })
   @IsOptional()
   @IsString()


### PR DESCRIPTION
## What & why

`#733` reported a `500` on `POST /api/sessions/:id/start`. Root cause: the reporter created the session with a proxy URL of `http://proxy.example.com:8080` — a **dead placeholder** that our own docs and Swagger UI presented as the primary create-session example value. Copying it verbatim pins Chromium to a non-existent proxy, blocks the WhatsApp WebSocket, delivers no QR, and times out on start.

This PR removes that placeholder from every user-facing surface where it could be copy-pasted, and adds the reachability guidance that was missing.

## Changes

- **Swagger DTO (`create-session.dto.ts`)** — the actual copy source (the reporter used `/api/docs`). Removed the misleading `example: 'http://proxy.example.com:8080'` so Swagger no longer prefills it, and rewrote the `description` to state the field is optional and **must be a real, reachable proxy** (else no QR, start → `504`). `openapi.json` regenerated; `openapi:check` drift gate is green.
- **`docs/06-api-specification.md`** — `{"name":"my-bot"}` is now the primary create example. The proxy moved into a clearly-labeled *Optional — per-session egress proxy* subsection with a blockquote warning. Added a short ⚠ on the `proxyUrl` table row. Response example shows `proxyUrl: null`.
- **`docs/07-api-collection.md`** — the single `POST /api/sessions` curl is now the minimal body; a second, clearly-labeled curl covers the optional-proxy case with the reachability caveat.
- **`docs/12-troubleshooting-faq.md`** — new *“No QR code appears, or `/start` returns `504`”* entry pointing at the dead-proxy cause and fix, including the note that proxy egress is configured **per session via the REST body, not environment variables**.
- **`.env.example`** — the stale comment claimed `PROXY_URL`/`PROXY_TYPE` are “not yet supported by the baileys engine; it is ignored”, implying they work elsewhere. They are **not read by any engine** (`grep` confirms zero `process.env.*PROXY*` reads); proxy egress is per-session. Comment corrected.

The remaining `proxy.example.com` mentions are intentional (the new warnings cite it as the value *not* to use) or inert test fixtures validating URL parsing.

## Verification

- `npm run lint` — 0 errors.
- `npm run build` — clean.
- `npm run openapi:export` + `npm run openapi:check` — regenerated and drift gate green.
- `npm test` — 2410 passed, 5 skipped.
- Swept `docs/`, `src/`, `openapi.json`, `.env.example`: no hazardous placeholder remains.

No behavior change; documentation and Swagger metadata only. Complements #740 (which turns the resulting auth-timeout into a diagnostic `504`).

Refs #733.
