### PR TITLE
fix(session): map outer init-hang timeout to 504 too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Engine auth-timeout now returns a diagnostic 504 instead of a bare 500.** When the WhatsApp Web
-  engine's internal authentication poll exhausts its timeout (default 30s) — e.g. the session proxy
-  is unreachable, so the browser launches but no QR is ever delivered — `POST /api/sessions/:id/start`
-  previously let the primitive `'auth timeout'` string escape to NestJS's default handler as a
-  meaningless `500 Internal Server Error`. It now maps to `504 Gateway Timeout` with a message
-  pointing at the proxy / network-egress / firewall causes and the `WWEBJS_AUTH_TIMEOUT_MS` knob for
-  legitimately slow first boots. The outer engine-init hang deadline (`EngineInitTimeoutError`) still
-  surfaces as 500 and is tracked separately.
+- **Engine start timeouts now return a diagnostic 504 instead of a bare 500.** Two
+  `POST /api/sessions/:id/start` failure modes previously escaped to NestJS's default handler as a
+  meaningless `500 Internal Server Error`: (1) the **auth-timeout** — whatsapp-web.js throws the
+  primitive string `'auth timeout'` when its login poll exhausts `authTimeoutMs` (default 30s), e.g.
+  an unreachable session proxy means the browser launches but no QR is ever delivered; and (2) the
+  **outer init-hang deadline** (`EngineInitTimeoutError`) — a wedged `initialize()` that never settles
+  within `max(60s, WWEBJS_AUTH_TIMEOUT_MS+30s)`, usually a container memory/resource limit or a stalled
+  Chromium. Both now map to `504 Gateway Timeout` with a diagnostic message (proxy/network vs resource
+  limits respectively) and the `WWEBJS_AUTH_TIMEOUT_MS` knob for slow first boots. Engine cleanup
+  (force-destroy + evict + status) still runs before mapping; generic non-timeout init rejections
+  (e.g. "chromium launch failed") still propagate untouched.
 
 ## [0.8.17] - 2026-07-13
 

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -3,7 +3,7 @@ import { getRepositoryToken, getDataSourceToken } from '@nestjs/typeorm';
 import { Repository, DataSource, In } from 'typeorm';
 import { NotFoundException, ConflictException, BadRequestException, HttpException, HttpStatus } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { SessionService, ACK_RECONCILE_DELAY_MS, EngineInitTimeoutError } from './session.service';
+import { SessionService, ACK_RECONCILE_DELAY_MS } from './session.service';
 import { Session, SessionStatus } from './entities/session.entity';
 import { Message, MessageStatus } from '../message/entities/message.entity';
 import { MessageBatch } from '../message/entities/message-batch.entity';
@@ -726,8 +726,12 @@ describe('SessionService', () => {
         await jest.advanceTimersByTimeAsync(60_000);
         await settled;
 
-        expect(caught).toBeInstanceOf(EngineInitTimeoutError);
-        expect(String(caught)).toMatch(/timed out after 60000ms/i);
+        // The outer init-hang deadline now maps to a diagnostic 504 (like the auth-timeout) instead of
+        // escaping as a bare 500 (#733 follow-up). Cleanup (force-destroy + evict + DISCONNECTED) still
+        // runs inside initializeEngine before the mapped error is thrown — asserted below.
+        expect(caught).toBeInstanceOf(HttpException);
+        expect((caught as HttpException).getStatus()).toBe(HttpStatus.GATEWAY_TIMEOUT);
+        expect((caught as HttpException).getResponse() as string).toMatch(/timed out after 60000ms/i);
         expect(mockEngine.forceDestroy).toHaveBeenCalled(); // wedged browser reaped
         expect(intern().engines.has('sess-uuid-1')).toBe(false); // slot freed for retry
         expect(repository.update).toHaveBeenCalledWith('sess-uuid-1', { status: SessionStatus.DISCONNECTED });
@@ -763,8 +767,9 @@ describe('SessionService', () => {
         // Past the derived 150s deadline the race finally fires.
         await jest.advanceTimersByTimeAsync(90_000); // 60s + 90s = 150s
         await settled;
-        expect(caught).toBeInstanceOf(EngineInitTimeoutError);
-        expect(String(caught)).toMatch(/timed out after 150000ms/i);
+        expect(caught).toBeInstanceOf(HttpException);
+        expect((caught as HttpException).getStatus()).toBe(HttpStatus.GATEWAY_TIMEOUT);
+        expect((caught as HttpException).getResponse() as string).toMatch(/timed out after 150000ms/i);
       } finally {
         jest.useRealTimers();
         delete process.env.WWEBJS_AUTH_TIMEOUT_MS;

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -1224,6 +1224,15 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
         // teardownEngineSafely is itself time-bound, so this can't wedge a second time.
         await this.teardownEngineSafely(id, engine, e => e.forceDestroy(), 'force-destroy');
         await this.updateStatus(id, SessionStatus.DISCONNECTED);
+        // Map to a diagnostic 504 like the auth-timeout branch below, so a wedged init doesn't escape as a
+        // bare 500 (#733 follow-up). The browser stalled mid-startup — usually a container memory/resource
+        // limit or a wedged Chromium, not a network/proxy issue (that's the auth-timeout's signature).
+        throw new HttpException(
+          `Engine initialization timed out after ${err.timeoutMs}ms — the browser process did not complete ` +
+            'startup in time (often a container memory/resource limit or a stalled Chromium, not a network ' +
+            'issue). Retry the session; for chronically slow first boots, raise WWEBJS_AUTH_TIMEOUT_MS.',
+          HttpStatus.GATEWAY_TIMEOUT,
+        );
       } else if (isAuthTimeoutRejection(err)) {
         // The engine's INTERNAL auth-timeout: whatsapp-web.js throws the primitive string 'auth timeout'
         // (see ENGINE_AUTH_TIMEOUT) when its inject poll exhausts authTimeoutMs (default 30s) — the common


### PR DESCRIPTION
## What & why

Follow-up to #740, closing the gap it explicitly deferred.

`POST /api/sessions/:id/start` had **two** engine-init timeout failure modes that escaped as a bare `500`. #740 mapped the inner one (the `whatsapp-web.js` auth-timeout). The **outer** one — `EngineInitTimeoutError`, the hang deadline that fires when `initialize()` never settles within `max(60s, WWEBJS_AUTH_TIMEOUT_MS+30s)` (a wedged browser, usually under container memory/resource pressure) — still did its cleanup and then rethrew the raw error, which NestJS's default handler rendered as a generic `500`.

This PR maps it to `504 Gateway Timeout` too, with a diagnostic that points at the right cause: **resource/memory limits or a stalled Chromium**, not the proxy/network signature of the inner auth-timeout.

## The change

In `initializeEngine`'s catch, the `EngineInitTimeoutError` branch now throws `new HttpException(msg, 504)` after its existing cleanup (force-destroy + evict + `DISCONNECTED`), instead of falling through to `throw err`. The message interpolates the actual deadline (`err.timeoutMs`) and names `WWEBJS_AUTH_TIMEOUT_MS` for chronically slow boots.

The fall-through `throw err` now only handles **generic non-timeout** rejections (e.g. `chromium launch failed`), which still propagate untouched.

## Safety: reconnect path is unaffected

`executeReconnect` also calls `initializeEngine`, but its catch (`session.service.ts:1391`) treats **every** init error uniformly — log, evict the half-built engine, schedule another reconnect attempt. It does not branch on `EngineInitTimeoutError`, so swapping that throw for an `HttpException` changes nothing there: the exception is caught and swallowed internally, and never reaches the HTTP layer. The `504` only surfaces via `start()`.

## Verification

- TDD: updated the two existing outer-timeout tests (the wedged-init case + the `WWEBJS_AUTH_TIMEOUT_MS` deadline-extension case) to the new `504` contract — watched them fail (`Received constructor: EngineInitTimeoutError`), then implemented. All cleanup assertions (force-destroy, evict, `DISCONNECTED`, no auto-reconnect, deadline math) are preserved.
- `npm run lint` — 0 errors.
- `npm run build` — clean.
- `npm test` — 2411 passed, 5 skipped.
- Replaced the now-unused `EngineInitTimeoutError` spec import (the class stays in production code as the internal timeout signal; only its rethrow is gone).

The CHANGELOG `[Unreleased] ### Fixed` entry is revised to cover both timeout variants (the earlier “outer still 500, tracked separately” caveat is resolved).

Refs #733.
