### PR TITLE
docs(troubleshooting): replace non-functional export PROXY_URL snippet

### DIFF
--- a/docs/12-troubleshooting-faq.md
+++ b/docs/12-troubleshooting-faq.md
@@ -185,17 +185,18 @@ ls -la ./data/.wwebjs_auth/session-{sessionId}/
 | Auth folder corrupted | Delete and rescan |
 | Browser crash | Restart container |
 | Network issues | Check firewall/proxy |
-| WhatsApp blocked | Use proxy |
+| WhatsApp blocked | Set a per-session proxy (`proxyUrl`) |
 
 ```bash
 # Clear auth and restart
 rm -rf ./data/.wwebjs_auth/session-{sessionId}
 docker compose restart openwa
-
-# If using proxy
-export PROXY_URL=http://proxy:8080
-docker compose up -d
 ```
+
+Proxy egress (if WhatsApp is blocked on your network) is configured **per session** via the
+`proxyUrl`/`proxyType` fields on `POST /api/sessions` — it is **not** an environment variable, and an
+unreachable proxy silently blocks the WhatsApp WebSocket (see the *No QR code appears, or `/start`
+returns `504`* entry below).
 
 ### Issue: No QR code appears, or `POST /api/sessions/:id/start` returns `504`
 


### PR DESCRIPTION
## What & why

Last #733 follow-up — a pre-existing inaccuracy in the troubleshooting FAQ that the #741 sweep flagged but deliberately left out of scope (different section, different scenario).

The **“Session Won’t Connect”** Solutions block advised:

```bash
# If using proxy
export PROXY_URL=http://proxy:8080
docker compose up -d
```

But **no engine reads `PROXY_URL`** (`grep process.env.*PROXY src/` is empty) — proxy egress is configured **per session** via the `proxyUrl`/`proxyType` fields on `POST /api/sessions`. So that snippet did nothing: a user following it would believe they’d configured a proxy when they hadn’t, then hit exactly the no-QR / `504` failure #733 reported.

## The change

- Removed the dead `export PROXY_URL` snippet.
- Added a one-line note that proxy egress is per-session via the REST body, not an environment variable, with a cross-reference to the *No QR code appears, or `/start` returns `504`* entry (added in #741) for the unreachable-proxy failure.
- Updated the Solutions table row “WhatsApp blocked | Use proxy” → “Set a per-session proxy (`proxyUrl`)” so the table itself points at the real mechanism.

Docs only; no behavior change. Complements #740 / #741 / #743.

Refs #733.
