### PR TITLE
fix(config): don't ship a default S3_ENDPOINT in .env.example (#735)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -214,7 +214,7 @@ STORAGE_LOCAL_PATH=./data/media
 # S3/MinIO settings (if STORAGE_TYPE=s3, auto-configured if MINIO_BUILTIN=true)
 # S3_ENDPOINT is OPTIONAL: leave it unset for standard AWS S3 (derived from region); set it only for
 # an S3-compatible store (MinIO, R2, …), which also enables path-style addressing.
-S3_ENDPOINT=http://localhost:9000
+# S3_ENDPOINT=http://localhost:9000   # uncomment / set ONLY for an S3-compatible store (MinIO, R2)
 S3_BUCKET=openwa
 S3_REGION=us-east-1
 # MUST set strong, unique values before using S3/MinIO — no defaults shipped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `endpoint` and `forcePathStyle` are now applied only when an endpoint is configured, so AWS S3 uses
   its default virtual-hosted addressing while MinIO-compatible stores keep path-style.
 
+- **`.env.example` no longer ships a default `S3_ENDPOINT`.** The template's pre-filled
+  `http://localhost:9000` silently re-routed a copy-paste AWS S3 config to MinIO/path-style mode and the
+  local fallback; it is now commented out so the default is AWS virtual-hosted mode (#735 follow-up).
+
 - **WhatsApp Engine selection on the Infrastructure page no longer reverts to the running engine.**
   The engine radio was re-stamped from the live `/engines/current` value on every emission, so a late
   first resolution (or a window-focus refetch) overwrote an operator's in-progress, unsaved selection


### PR DESCRIPTION
Follow-up to #742, found in the post-merge self-review.

## The defect

`#742` made `S3_ENDPOINT` optional so standard AWS S3 (endpoint derived from region) initializes correctly. It also added a comment to `.env.example` saying to leave `S3_ENDPOINT` unset for AWS S3 — but left the template's pre-filled `S3_ENDPOINT=http://localhost:9000` in place. Since presence of an endpoint now routes to MinIO/path-style mode (`endpoint` + `forcePathStyle`), an operator who copies `.env.example` → `.env`, sets `STORAGE_TYPE=s3` + real AWS credentials, and leaves the shipped endpoint untouched gets the `S3Client` built against `localhost:9000`. `HeadBucket` fails, `s3Available` stays `false`, and every media read/write silently falls back to local disk — the exact #735 silent-local-fallback, reproduced through the template.

The code fix, `docker-compose.yml` (`S3_ENDPOINT=${S3_ENDPOINT:-}`), and `docs/03-system-architecture.md` (which omits the endpoint for the AWS example) are all correct; only `.env.example` contradicted them.

## The fix

Comment out the shipped default so the template routes to AWS virtual-hosted mode by default. MinIO/R2 users set it explicitly, as the compose and doc examples already show. One-line change, no code or runtime behavior impact (`STORAGE_TYPE=local` is the shipped default, so `S3_ENDPOINT` is inert until S3 is selected).

## Verification

Source-traced end-to-end (the failure chain above is confirmed against HEAD). Template-only change; the S3 init spec (`storage.service.s3.spec.ts`) already covers both the AWS-no-endpoint and MinIO-with-endpoint code paths.