### PR TITLE
chore(deps): drop @types/adm-zip + note CVE-2026-39244 (adm-zip 0.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   message category after picking a file now clears it so stale bytes aren't routed to the wrong
   endpoint.
 
+### Security
+
+- **Plugin archive extraction hardened against CVE-2026-39244 (adm-zip declared-size zip-bomb OOM).**
+  The `adm-zip` bump to `0.6.0` in #728 brings upstream's fix for CVE-2026-39244: a crafted archive
+  declaring a huge entry size could drive an unbounded `Buffer.alloc` and exhaust memory during
+  extraction. This closes the declared-size allocation vector on the plugin marketplace install path
+  (`src/modules/plugins/plugin-installer.ts`), complementing the project's own `readEntryData()` guard
+  that already caps *decompressed* bytes via zlib `maxOutputLength`. The two adm-zip 0.6.0 behavior
+  changes (`extractEntryTo` subdirectory preservation, non-fatal `utimes`) touch APIs this project does
+  not use. The now-redundant `@types/adm-zip` devDependency is dropped as well — adm-zip 0.6.0 ships its
+  own `types.d.ts`.
+
 ## [0.8.17] - 2026-07-13
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,6 @@
         "@nestjs/cli": "^11.0.24",
         "@nestjs/schematics": "^11.0.0",
         "@nestjs/testing": "^11.1.28",
-        "@types/adm-zip": "^0.5.8",
         "@types/archiver": "^8.0.0",
         "@types/dockerode": "^4.0.1",
         "@types/express": "^5.0.0",
@@ -4373,16 +4372,6 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@types/adm-zip": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.8.tgz",
-      "integrity": "sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/archiver": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     "@nestjs/cli": "^11.0.24",
     "@nestjs/schematics": "^11.0.0",
     "@nestjs/testing": "^11.1.28",
-    "@types/adm-zip": "^0.5.8",
     "@types/archiver": "^8.0.0",
     "@types/dockerode": "^4.0.1",
     "@types/express": "^5.0.0",


### PR DESCRIPTION
Follow-up to #728 (the root minor/patch dependabot bundle), which bumped adm-zip to 0.6.0.

## What
- **Drop `@types/adm-zip`** from devDependencies. adm-zip 0.6.0 ships its own `types.d.ts` (via the package `types` field) with the same `declare namespace AdmZip { interface IZipEntry ... } ... export = AdmZip;` shape as the @types package, so the separately-versioned @types/adm-zip is now dead weight.
- **Document CVE-2026-39244** under `[Unreleased] / Security`. The adm-zip 0.6.0 bump fixed a declared-size zip-bomb OOM (a crafted archive with a huge declared entry size drove an unbounded `Buffer.alloc`) on the plugin marketplace install path, complementing the existing `readEntryData()` zlib `maxOutputLength` cap on decompressed bytes.

## Verification
- `npm run build` (tsc) is green with `@types/adm-zip` removed — `plugin-installer.ts` resolves `AdmZip.IZipEntry` from adm-zip's bundled types.
- The two adm-zip 0.6.0 behavior changes (`extractEntryTo` subdirectory preservation, non-fatal `utimes`) touch APIs this project does not use, so the bump itself (already on main via #728) is behavior-neutral here.

## Scope
Root `package.json` + root `package-lock.json` + `CHANGELOG.md` only. Dashboard untouched.