### PR TITLE
fix(session): self-heal reconnects so a transient drop never ends the…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A transient drop no longer ends a WhatsApp session permanently — it self-heals.** Both reconnect
+  layers previously gave up terminally (→ `FAILED`, manual restart required) after **5 consecutive
+  failed reconnects**: with the default 5s base and exponential backoff that was only ~3 minutes of a
+  WhatsApp/network outage before the session was declared dead and would *not* recover on its own even
+  once connectivity returned — the common "session got disconnected after a few hours and stayed down"
+  symptom. Both the Baileys adapter's internal loop and the session-service orchestration (whatsapp-web.js)
+  now **retry indefinitely with capped exponential backoff**: the delay escalates for the first
+  `maxReconnectAttempts` drops, then plateaus (30s for Baileys, the configured ceiling for whatsapp-web.js)
+  and keeps retrying, so the session reconnects automatically whenever the link comes back. The attempt
+  counter still resets to `0` on every successful connect, and the reconnect-driven `connect()` that
+  rejects before a socket exists now reschedules instead of hanging. `maxReconnectAttempts: 0` still means
+  "auto-reconnect disabled" (left disconnected for a manual restart), and a genuine WhatsApp logout (device
+  unlinked, `loggedOut`/`auth_failure`) is still terminal — that correctly requires re-scanning the QR.
+
 - **Engine start timeouts now return a diagnostic 504 instead of a bare 500.** Two
   `POST /api/sessions/:id/start` failure modes previously escaped to NestJS's default handler as a
   meaningless `500 Internal Server Error`: (1) the **auth-timeout** — whatsapp-web.js throws the

--- a/src/engine/adapters/baileys.adapter.spec.ts
+++ b/src/engine/adapters/baileys.adapter.spec.ts
@@ -344,59 +344,67 @@ describe('BaileysAdapter lifecycle hardening — I4 reconnect backoff', () => {
     jest.useRealTimers();
   });
 
-  it('I4: after MAX_RECONNECT_ATTEMPTS recoverable closes → FAILED + onError, no more reconnects', async () => {
+  it('I4: recoverable closes never end the session — it self-heals, reconnecting past the old cap (no FAILED/onError)', async () => {
     const onError = jest.fn();
     const adapter = await initWithRealTimers({ onError });
 
     // Switch to fake timers AFTER initialize() has resolved.
     jest.useFakeTimers();
+    baileys().default.mockClear(); // count only the reconnect-driven socket creations
 
-    // Each close increments reconnectAttempts and schedules a timer.
-    // After the timer fires, connect() calls makeWASocket() which resets the emitter,
-    // so each reconnect cycle has exactly one listener — no accumulation across attempts.
-    // Strategy: fire close → run timers (reconnect executes, emitter reset) → fire close again → repeat.
-    for (let i = 0; i < 5 /* MAX_RECONNECT_ATTEMPTS */; i++) {
+    // Fire far more drops than the old MAX_RECONNECT_ATTEMPTS cap (5). Each close schedules a
+    // reconnect; after the timer fires, connect() re-creates the socket. A transient drop must never
+    // terminate the session — the loop keeps retrying so a long outage recovers when the link returns.
+    for (let i = 0; i < 12; i++) {
       fireRecoverableClose();
       await jest.runAllTimersAsync();
     }
 
-    // The (MAX+1)th close — reconnectAttempts is now MAX (5) → exhausted path:
-    // no reconnect scheduled, status → FAILED, onError fired exactly once.
-    fireRecoverableClose();
-    await jest.runAllTimersAsync();
-
-    expect(adapter.getStatus()).toBe(EngineStatus.FAILED);
-    expect(onError).toHaveBeenCalledTimes(1);
-    expect(onError).toHaveBeenCalledWith(expect.stringContaining('exhausted'));
+    // No terminal failure and no onError, even well past the 5-drop mark that used to give up.
+    expect(adapter.getStatus()).not.toBe(EngineStatus.FAILED);
+    expect(onError).not.toHaveBeenCalled();
+    // Reconnection is still happening: makeWASocket was re-invoked once per drop, past the old cap.
+    expect(baileys().default.mock.calls.length).toBe(12);
   });
 
-  it('I4: successful connection resets the reconnect counter (next drop can reconnect again)', async () => {
+  it('I4: a reconnect whose connect() rejects (no socket emitted) reschedules instead of hanging or FAILING', async () => {
     const onError = jest.fn();
     const adapter = await initWithRealTimers({ onError });
 
     jest.useFakeTimers();
+    baileys().default.mockClear();
+    // The next makeWASocket (reconnect #1) throws — connect() rejects before a socket exists, so no
+    // connection.update fires; only the catch's reschedule can keep the retry loop alive.
+    baileys().default.mockImplementationOnce(() => {
+      throw new Error('offline');
+    });
 
-    // Fire one recoverable drop and reconnect — increments counter to 1
-    fireRecoverableClose();
-    await jest.runAllTimersAsync();
+    fireRecoverableClose(); // schedules reconnect #1 (will throw)
+    await jest.runAllTimersAsync(); // #1 throws → reschedules #2, which succeeds
 
-    // Simulate a successful open — should reset the reconnect counter to 0
-    fakeSock.fire('connection.update', { connection: 'open' });
-    expect(adapter.getStatus()).toBe(EngineStatus.READY);
+    expect(adapter.getStatus()).not.toBe(EngineStatus.FAILED);
+    expect(onError).not.toHaveBeenCalled();
+    // makeWASocket was invoked again after the throwing attempt — the loop re-armed on connect failure.
+    expect(baileys().default.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
 
-    // Now exhaust MAX_RECONNECT_ATTEMPTS again — should work because counter was reset
-    for (let i = 0; i < 5 /* MAX_RECONNECT_ATTEMPTS */; i++) {
+  it('I4: successful connection resets the reconnect counter (next drop starts the backoff from the bottom)', async () => {
+    const adapter = await initWithRealTimers({});
+
+    jest.useFakeTimers();
+    const internals = adapter as unknown as { reconnectAttempts: number };
+
+    // A few recoverable drops climb the backoff counter.
+    for (let i = 0; i < 4; i++) {
       fireRecoverableClose();
       await jest.runAllTimersAsync();
     }
+    expect(internals.reconnectAttempts).toBeGreaterThan(0);
 
-    // (MAX+1)th drop after reset → FAILED again, onError fired exactly once
-    fireRecoverableClose();
-    await jest.runAllTimersAsync();
-
-    expect(adapter.getStatus()).toBe(EngineStatus.FAILED);
-    expect(onError).toHaveBeenCalledTimes(1);
-    expect(onError).toHaveBeenCalledWith(expect.stringContaining('exhausted'));
+    // A successful open clears it — the next transient drop restarts from the 1s backoff, not the plateau.
+    fakeSock.fire('connection.update', { connection: 'open' });
+    expect(adapter.getStatus()).toBe(EngineStatus.READY);
+    expect(internals.reconnectAttempts).toBe(0);
   });
 
   it('I4: a recoverable close after disconnect() (intentionalClose) does NOT schedule a reconnect', async () => {

--- a/src/engine/adapters/baileys.adapter.ts
+++ b/src/engine/adapters/baileys.adapter.ts
@@ -372,30 +372,40 @@ export class BaileysAdapter implements IWhatsAppEngine {
       // Do NOT fire onDisconnected here; this is a transient drop, not a terminal disconnect.
       // connect() calls setStatus(INITIALIZING) which fires onStateChanged — that is the correct signal.
       this.logger.log('Baileys connection dropped; reconnecting', { statusCode });
-
-      // I4: capped exponential backoff with in-flight timer guard.
-      if (this.reconnectAttempts >= BaileysAdapter.MAX_RECONNECT_ATTEMPTS) {
-        this.setStatus(EngineStatus.FAILED);
-        this.callbacks.onError?.(`reconnect attempts exhausted (${this.reconnectAttempts})`);
-        return;
-      }
-      this.reconnectAttempts += 1;
-      const delay = Math.min(30_000, 1_000 * 2 ** (this.reconnectAttempts - 1));
-      // Guard: if a timer is already pending, don't stack another one.
-      if (this.reconnectTimer) {
-        return;
-      }
-      this.reconnectTimer = setTimeout(() => {
-        this.reconnectTimer = undefined;
-        if (this.intentionalClose) {
-          return; // stopped while waiting — abort
-        }
-        void this.connect().catch(err => {
-          this.setStatus(EngineStatus.FAILED);
-          this.callbacks.onError?.(err instanceof Error ? err.message : String(err));
-        });
-      }, delay);
+      this.scheduleReconnect();
     }
+  }
+
+  /**
+   * Schedule the next reconnect with capped exponential backoff. The adapter retries INDEFINITELY:
+   * a transient drop (restartRequired, a network/WhatsApp blip) must never end the session — it
+   * self-heals whenever the connection returns, and the counter resets to 0 on the next 'open'. The
+   * backoff escalates for the first MAX_RECONNECT_ATTEMPTS drops, then holds at the 30s ceiling. The
+   * exponent is capped so `2 ** attempts` stays finite as the counter grows unbounded during a long
+   * outage. An in-flight timer guard keeps two back-to-back closes from stacking two reconnects.
+   */
+  private scheduleReconnect(): void {
+    if (this.intentionalClose || this.reconnectTimer) {
+      return;
+    }
+    this.reconnectAttempts += 1;
+    const exponent = Math.min(this.reconnectAttempts - 1, BaileysAdapter.MAX_RECONNECT_ATTEMPTS);
+    const delay = Math.min(30_000, 1_000 * 2 ** exponent);
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = undefined;
+      if (this.intentionalClose) {
+        return; // stopped while waiting — abort
+      }
+      void this.connect().catch(err => {
+        // A connect() that rejects before a socket exists (e.g. an offline network on lib load / auth
+        // read) emits no connection.update, so nothing else would re-arm the loop. Reschedule here so
+        // the session keeps retrying instead of hanging — mirrors the transient-drop path above.
+        this.logger.warn('Baileys reconnect attempt failed; will retry', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        this.scheduleReconnect();
+      });
+    }, delay);
   }
 
   /** Render the raw Baileys QR ref to a PNG data URL, then publish it (mirrors the whatsapp-web.js engine). */

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -1297,43 +1297,39 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
     const state = this.reconnectStates.get(id);
     if (!state) return;
 
-    if (state.attempts >= state.maxAttempts) {
-      this.logger.error(`Max reconnect attempts reached for session: ${session.name}`, undefined, {
+    // maxAttempts === 0 is the operator's explicit "disable auto-reconnect" opt-out — leave the
+    // session terminally FAILED for a manual restart. Every other value means "retry indefinitely
+    // with capped backoff": a transient drop (WhatsApp/network blip, a wedged page) must never end
+    // the session permanently — it self-heals whenever the connection returns. maxAttempts is now the
+    // number of backoff escalations before the delay plateaus, not a cap on the number of tries.
+    if (state.maxAttempts === 0) {
+      this.logger.error(`Auto-reconnect disabled for session: ${session.name}`, undefined, {
         sessionId: id,
-        attempts: state.attempts,
-        action: 'reconnect_failed',
+        action: 'reconnect_disabled',
       });
-      // Don't leave the session silently stuck DISCONNECTED — mark it terminally FAILED with a reason
-      // so findOne/findAll surface it via `lastError` and the dashboard shows it needs a restart.
-      // maxAttempts:0 means auto-reconnect is disabled, not that N attempts were tried and failed — say
-      // so instead of the misleading "failed after 0 attempts".
       this.sessionErrors.set(
         id,
-        state.maxAttempts === 0
-          ? 'Auto-reconnect is disabled (max attempts set to 0); the session was left disconnected — restart it manually.'
-          : `Reconnection failed after ${state.attempts} attempts — restart the session.`,
+        'Auto-reconnect is disabled (max attempts set to 0); the session was left disconnected — restart it manually.',
       );
       void this.updateStatus(id, SessionStatus.FAILED);
       return;
     }
 
-    // Exponential backoff: baseDelay * 2^attempts (with jitter), clamped finite + within
-    // setTimeout's safe range so the timer can't overflow and fire immediately.
-    const delay = clampReconnectDelay(
-      state.baseDelay * Math.pow(2, state.attempts) + Math.random() * 1000,
-      state.baseDelay,
-    );
+    // Exponential backoff: baseDelay * 2^attempts (with jitter), clamped finite + within setTimeout's
+    // safe range so the timer can't overflow and fire immediately. Cap the exponent at maxAttempts so
+    // the delay plateaus at a steady ceiling once escalation is done AND stays finite — an uncapped
+    // 2^attempts would overflow to Infinity, and clampReconnectDelay would then fall back to the tiny
+    // baseDelay, turning the plateau into a relaunch storm.
+    const exponent = Math.min(state.attempts, state.maxAttempts);
+    const delay = clampReconnectDelay(state.baseDelay * Math.pow(2, exponent) + Math.random() * 1000, state.baseDelay);
     state.attempts++;
 
-    this.logger.log(
-      `Scheduling reconnect attempt ${state.attempts}/${state.maxAttempts} in ${Math.round(delay / 1000)}s`,
-      {
-        sessionId: id,
-        attempt: state.attempts,
-        delayMs: delay,
-        action: 'reconnect_scheduled',
-      },
-    );
+    this.logger.log(`Scheduling reconnect attempt ${state.attempts} in ${Math.round(delay / 1000)}s`, {
+      sessionId: id,
+      attempt: state.attempts,
+      delayMs: delay,
+      action: 'reconnect_scheduled',
+    });
 
     // Clear any timer a prior scheduleReconnect left pending so two back-to-back disconnects
     // don't stack two timers (which would run executeReconnect twice and double-init the engine).


### PR DESCRIPTION
… session

Both reconnect layers gave up terminally (→ FAILED, manual restart required) after 5 consecutive failed reconnects. With the default 5s base + exponential backoff that is only ~3 minutes of a WhatsApp/network outage before the session was declared dead and would not recover on its own even once connectivity returned — the "session disconnected after a few hours and stayed down" symptom.

- baileys.adapter: extract scheduleReconnect(); retry indefinitely with a capped exponent (plateau at 30s) instead of FAILED+onError at MAX_RECONNECT_ATTEMPTS. A reconnect connect() that rejects before a socket exists (no connection.update to re-arm the loop) now reschedules instead of hanging.
- session.service scheduleReconnect: retry indefinitely for any maxAttempts > 0, capping the exponent at maxAttempts so the delay plateaus and stays finite (an uncapped 2^attempts overflows to Infinity → clampReconnectDelay falls back to the tiny baseDelay → relaunch storm). maxAttempts:0 still disables reconnect.

The attempt counter still resets to 0 on every successful connect, and a genuine WhatsApp logout (device unlinked, loggedOut/auth_failure) stays terminal.


Claude-Session: https://claude.ai/code/session_014KVBCCzYd9qsttqw9VorqB

## Description
Brief description of changes

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Lint passes
- [ ] Self-reviewed

## Screenshots (if applicable)

## Related Issues
Closes #
