### PR TITLE
chore(sdk): gate the Go SDK in CI and changelog it

### DIFF
--- a/.github/workflows/sdk-ci.yml
+++ b/.github/workflows/sdk-ci.yml
@@ -28,6 +28,9 @@ jobs:
           cache-dependency-path: sdk/javascript/package-lock.json
       - run: npm ci
       - run: npm test
+      # The build tsconfigs exclude test/, and vitest strips types without checking them, so the
+      # type-level wire contract in test/*.test-d.ts only gates if tsc runs over test/ too (#754).
+      - run: npm run typecheck
       - run: npm run build
       - run: npm run smoke # dual CJS+ESM consumable — must run after build
 
@@ -73,3 +76,25 @@ jobs:
           java-version: '17'
           cache: maven
       - run: mvn -B verify
+
+  go:
+    name: Go SDK
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdk/go
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22' # the go.mod minimum, so CI gates what the SDK claims to support
+          cache: false # stdlib-only, no go.sum to cache
+      - name: gofmt
+        run: |
+          if [ -n "$(gofmt -l .)" ]; then
+            echo 'Unformatted files:'
+            gofmt -l .
+            exit 1
+          fi
+      - run: go vet ./...
+      - run: go test -race ./...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Official Go SDK (`sdk/go`).** Hand-written, stdlib-only (no third-party dependencies) Go client
+  covering the user-facing API surface, joining the JavaScript/Python/PHP/Java clients. Entry point is
+  `openwa.New(baseURL, apiKey, opts...)`, which returns a concurrency-safe `*Client` whose exported
+  fields group the API by domain (`Sessions`, `Messages`, `Contacts`, `Groups`, `Webhooks`, `Chats`,
+  `Status`, `Labels`, `Channels`, `Catalog`, `Templates`, `Health`, `Search`, `Auth`). Every network
+  method is context-first; configuration and dependency injection go through functional options
+  (`WithHTTPClient`, `WithTransport`, `WithLogger`, `WithRetry`, `WithMiddleware`, `WithTimeout`,
+  `WithUserAgent`, `WithHeader`, `WithInsecureHTTP`). Errors are typed: match the sentinels with
+  `errors.Is` (`ErrBadRequest`, `ErrUnauthorized`, `ErrForbidden`, `ErrNotFound`, `ErrConflict`,
+  `ErrRateLimited`, `ErrNotImplemented`) or unwrap the concrete `*APIError` with `errors.As`. Retries
+  are opt-in (`WithRetry`), honour `Retry-After`, rewind request bodies via `GetBody`, and are skipped
+  for non-idempotent methods on network errors so a dropped connection cannot replay a send. Redirects
+  are never followed, so the bearer-equivalent `X-API-Key` is never re-sent to a redirect target. A
+  `TestRouting` table asserts the exact method and path of every service call, and the suite runs in CI
+  (`gofmt`/`go vet`/`go test -race`) on both SDK and server-contract changes, so route drift fails at
+  test time. Requires Go 1.22+. Thanks @Revelts.
+
 ### Changed
 
 - **Send-response semantics clarified (docs only).** The send endpoints' Swagger response and `docs/06` now state explicitly that `201` means the gateway accepted the message for sending — not that the recipient received it — and that WhatsApp does not reject an unregistered recipient synchronously, so a message to a number that is not on WhatsApp still returns `201` with a `messageId` but never delivers. `GET /sessions/{id}/contacts/check/{number}` is cross-referenced as the way to pre-validate a new recipient, and the async message `status` lifecycle (`sent → delivered → read`, or `failed`) as the source of real delivery state. No behavior change. Refs #738.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The dashboard now clears a message deleted for everyone while the thread is open (whatsapp-web.js).**
+  `message.revoked` carries `revokedId` — the id of the original deleted message, which whatsapp-web.js
+  resolves separately from the event's own `id` — but the dashboard's WebSocket projection dropped the
+  field and matched its message cache on `id` alone. Persistence was always correct (the backend keys
+  its `UPDATE` on `revokedId`), and webhook/API consumers already received the field; only the live
+  dashboard view was affected, where `staleTime: Infinity` meant an already-open thread kept rendering
+  the deleted message's original text until a reload, reconnect, or cache eviction. The projection now
+  forwards `revokedId`, and the cache lookup matches on either candidate id (against both the row id
+  and `waMessageId`), which keeps the Baileys path — where the two ids are identical — unchanged. When
+  whatsapp-web.js cannot resolve the original (it is no longer in its local store) `revokedId` is
+  absent and the lookup falls back to `id`, as before. Refs #755.
+
 - **Engine start timeouts now return a diagnostic 504 instead of a bare 500.** Two
   `POST /api/sessions/:id/start` failure modes previously escaped to NestJS's default handler as a
   meaningless `500 Internal Server Error`: (1) the **auth-timeout** — whatsapp-web.js throws the

--- a/dashboard/src/hooks/useWebSocket.ts
+++ b/dashboard/src/hooks/useWebSocket.ts
@@ -44,6 +44,11 @@ interface MessageReactionEvent {
 interface MessageRevokedEvent {
   sessionId: string;
   id: string;
+  /**
+   * Id of the ORIGINAL deleted message. Optional: whatsapp-web.js can only resolve it when the
+   * original is still in its local store, and Baileys sets it identical to `id`.
+   */
+  revokedId?: string;
   chatId: string;
   from: string;
   to: string;
@@ -218,6 +223,9 @@ export function useWebSocket(events: WebSocketEvents = {}) {
           events.onMessageRevoked?.({
             sessionId,
             id: String(data.id),
+            // Not String()-coerced like its neighbours: the field is optional on the wire, and
+            // String(undefined) would yield the truthy literal "undefined" and defeat the fallback.
+            revokedId: typeof data.revokedId === 'string' ? data.revokedId : undefined,
             chatId: String(data.chatId),
             from: String(data.from),
             to: String(data.to),

--- a/dashboard/src/pages/Chats.tsx
+++ b/dashboard/src/pages/Chats.tsx
@@ -26,7 +26,7 @@ import {
   type MessageType,
   type SearchHit,
 } from '../services/api';
-import { mergeDeliveryStatus, type ChatMessageView } from '../utils/chatMessages';
+import { mergeDeliveryStatus, findRevokedIndex, type ChatMessageView } from '../utils/chatMessages';
 import { useWebSocket } from '../hooks/useWebSocket';
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { useRole } from '../hooks/useRole';
@@ -330,17 +330,18 @@ export function Chats() {
   );
 
   const handleIncomingMessageRevoked = useCallback(
-    (event: { sessionId: string; id: string; type: string }) => {
+    (event: { sessionId: string; id: string; revokedId?: string; type: string }) => {
       if (event.sessionId !== selectedSessionId) return;
 
-      // Walk every cached chat under this session, find the message by id or waMessageId and zero it
-      // — the backend emits an empty body; the localized "deleted" label is rendered below.
+      // Walk every cached chat under this session, find the deleted message and zero it — the
+      // backend emits an empty body; the localized "deleted" label is rendered below. Matching is
+      // in findRevokedIndex: the event carries two candidate ids and wwebjs's `id` alone can miss.
       const caches = queryClient.getQueriesData<ChatMessageView[]>({
         queryKey: ['messages', event.sessionId],
       });
       for (const [key, list] of caches) {
         if (!list) continue;
-        const idx = list.findIndex(m => m.id === event.id || m.waMessageId === event.id);
+        const idx = findRevokedIndex(list, event);
         if (idx === -1) continue;
         const target = list[idx];
         const next = list.slice();

--- a/dashboard/src/utils/chatMessages.test.ts
+++ b/dashboard/src/utils/chatMessages.test.ts
@@ -91,6 +91,7 @@ import {
   replaceMessageById,
   updateMessageById,
   removeMessageById,
+  findRevokedIndex,
   type ChatMessageView,
 } from './chatMessages.ts';
 
@@ -196,4 +197,39 @@ test('removeMessageById is a no-op when id is not present', () => {
   const before = [msg({ id: 'm-1' })];
   const after = removeMessageById(before, 'missing');
   assert.deepEqual(after, before);
+});
+
+// message.revoked carries TWO candidate ids: `id` and `revokedId` (the original deleted message,
+// when the engine could resolve it). Match on either — see findRevokedIndex for why not `?? `.
+
+test('findRevokedIndex matches the original via revokedId when it differs from id (wwebjs)', () => {
+  const list = [msg({ id: 'row-1', waMessageId: 'ORIGINAL' })];
+  assert.equal(findRevokedIndex(list, { id: 'REVOKE_NOTIF', revokedId: 'ORIGINAL' }), 0);
+});
+
+test('findRevokedIndex still matches when id === revokedId (Baileys — guards the working path)', () => {
+  const list = [msg({ id: 'row-1', waMessageId: 'ORIGINAL' })];
+  assert.equal(findRevokedIndex(list, { id: 'ORIGINAL', revokedId: 'ORIGINAL' }), 0);
+});
+
+test('findRevokedIndex matches on id when revokedId is absent (original not in the engine store)', () => {
+  const list = [msg({ id: 'row-1', waMessageId: 'ORIGINAL' })];
+  assert.equal(findRevokedIndex(list, { id: 'ORIGINAL' }), 0);
+});
+
+test('findRevokedIndex matches the DB row id, not just waMessageId', () => {
+  const list = [msg({ id: 'row-1', waMessageId: 'ORIGINAL' })];
+  assert.equal(findRevokedIndex(list, { id: 'row-1' }), 0);
+});
+
+test('findRevokedIndex returns -1 when neither id matches', () => {
+  const list = [msg({ id: 'row-1', waMessageId: 'ORIGINAL' })];
+  assert.equal(findRevokedIndex(list, { id: 'REVOKE_NOTIF', revokedId: 'OTHER' }), -1);
+});
+
+test('findRevokedIndex ignores an undefined revokedId rather than matching a row with no waMessageId', () => {
+  // A row whose waMessageId is undefined must not be matched by an absent revokedId (undefined ===
+  // undefined would otherwise revoke an arbitrary bubble).
+  const list = [msg({ id: 'row-1', waMessageId: undefined })];
+  assert.equal(findRevokedIndex(list, { id: 'REVOKE_NOTIF' }), -1);
 });

--- a/dashboard/src/utils/chatMessages.ts
+++ b/dashboard/src/utils/chatMessages.ts
@@ -140,3 +140,29 @@ export function removeMessageById(
   if (!list.some(m => m.id === id)) return list;
   return list.filter(m => m.id !== id);
 }
+
+/**
+ * Locate the message a `message.revoked` event refers to. Returns -1 if it isn't cached.
+ *
+ * The event carries two candidate ids: `id`, and `revokedId` — the ORIGINAL deleted message, which
+ * whatsapp-web.js resolves separately because its revoke event can carry an id of its own that never
+ * matches a stored row. Baileys sets the two identically, and wwebjs leaves `revokedId` undefined
+ * when the original isn't in its local store.
+ *
+ * Both candidates are tried rather than preferring `revokedId` (the `revokedId ?? id` shape the
+ * backend uses to key its own UPDATE): matching either id is a superset that stays correct whichever
+ * of the two the cached row was stored under, so it cannot regress the Baileys path. Each candidate
+ * is checked against both the DB row id and `waMessageId` — a live WS message and its persisted copy
+ * are keyed differently. `revokedId` is guarded because an undefined one would otherwise match a row
+ * whose `waMessageId` is also undefined.
+ */
+export function findRevokedIndex(
+  list: ChatMessageView[],
+  event: { id: string; revokedId?: string },
+): number {
+  const matches = (m: ChatMessageView, candidate: string): boolean =>
+    m.id === candidate || m.waMessageId === candidate;
+  return list.findIndex(
+    m => matches(m, event.id) || (event.revokedId !== undefined && matches(m, event.revokedId)),
+  );
+}


### PR DESCRIPTION
Follow-up to #720, which added the Go SDK but landed without a CI job or a changelog entry.

## Changes

- **`sdk-ci.yml`: add the Go job.** Mirrors the existing per-SDK jobs: `gofmt` (fails on unformatted
  files), `go vet ./...`, `go test -race ./...`, working-directory `sdk/go`. The workflow's path
  filters already cover `sdk/**` plus the server contract surfaces (`src/**/dto/**`,
  `src/**/*.controller.ts`, the engine interface), so the SDK's `TestRouting` drift gate now re-runs
  whenever a controller or DTO changes — which is the point of that table.

  Caching is disabled deliberately: the SDK is stdlib-only, so there is no `go.sum` to cache and
  pointing `cache-dependency-path` at the absent file fails the step.

  `go-version` is pinned to `1.22` — the `go.mod` minimum — so CI gates the version the SDK claims to
  support rather than whatever is newest.

- **`CHANGELOG.md`: record the Go SDK** under `[Unreleased] → Added`, with contributor credit.

## Verification

`gofmt -l .` clean, `go vet ./...` clean, `go test -race ./...` passing (79.7% coverage) against the
merged SDK tree; the workflow YAML parses and resolves to five jobs.