### PR TITLE
chore(sdk): gate the Go SDK in CI and changelog it

### DIFF
--- a/.github/workflows/sdk-ci.yml
+++ b/.github/workflows/sdk-ci.yml
@@ -28,6 +28,9 @@ jobs:
           cache-dependency-path: sdk/javascript/package-lock.json
       - run: npm ci
       - run: npm test
+      # The build tsconfigs exclude test/, and vitest strips types without checking them, so the
+      # type-level wire contract in test/*.test-d.ts only gates if tsc runs over test/ too (#754).
+      - run: npm run typecheck
       - run: npm run build
       - run: npm run smoke # dual CJS+ESM consumable — must run after build
 
@@ -73,3 +76,25 @@ jobs:
           java-version: '17'
           cache: maven
       - run: mvn -B verify
+
+  go:
+    name: Go SDK
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdk/go
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22' # the go.mod minimum, so CI gates what the SDK claims to support
+          cache: false # stdlib-only, no go.sum to cache
+      - name: gofmt
+        run: |
+          if [ -n "$(gofmt -l .)" ]; then
+            echo 'Unformatted files:'
+            gofmt -l .
+            exit 1
+          fi
+      - run: go vet ./...
+      - run: go test -race ./...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Official Go SDK (`sdk/go`).** Hand-written, stdlib-only (no third-party dependencies) Go client
+  covering the user-facing API surface, joining the JavaScript/Python/PHP/Java clients. Entry point is
+  `openwa.New(baseURL, apiKey, opts...)`, which returns a concurrency-safe `*Client` whose exported
+  fields group the API by domain (`Sessions`, `Messages`, `Contacts`, `Groups`, `Webhooks`, `Chats`,
+  `Status`, `Labels`, `Channels`, `Catalog`, `Templates`, `Health`, `Search`, `Auth`). Every network
+  method is context-first; configuration and dependency injection go through functional options
+  (`WithHTTPClient`, `WithTransport`, `WithLogger`, `WithRetry`, `WithMiddleware`, `WithTimeout`,
+  `WithUserAgent`, `WithHeader`, `WithInsecureHTTP`). Errors are typed: match the sentinels with
+  `errors.Is` (`ErrBadRequest`, `ErrUnauthorized`, `ErrForbidden`, `ErrNotFound`, `ErrConflict`,
+  `ErrRateLimited`, `ErrNotImplemented`) or unwrap the concrete `*APIError` with `errors.As`. Retries
+  are opt-in (`WithRetry`), honour `Retry-After`, rewind request bodies via `GetBody`, and are skipped
+  for non-idempotent methods on network errors so a dropped connection cannot replay a send. Redirects
+  are never followed, so the bearer-equivalent `X-API-Key` is never re-sent to a redirect target. A
+  `TestRouting` table asserts the exact method and path of every service call, and the suite runs in CI
+  (`gofmt`/`go vet`/`go test -race`) on both SDK and server-contract changes, so route drift fails at
+  test time. Requires Go 1.22+. Thanks @Revelts.
+
 ### Changed
 
 ### Fixed


### PR DESCRIPTION
Follow-up to #720, which added the Go SDK but landed without a CI job or a changelog entry. The SDK CI
run on that merge confirms the gap: it completed in 20s with four jobs (JavaScript/Python/PHP/Java) —
no Go.

## Changes

- **`sdk-ci.yml`: add the Go job.** Mirrors the existing per-SDK jobs: `gofmt` (fails on unformatted
  files), `go vet ./...`, `go test -race ./...`, working-directory `sdk/go`. The workflow's path
  filters already cover `sdk/**` plus the server contract surfaces (`src/**/dto/**`,
  `src/**/*.controller.ts`, the engine interface), so the SDK's `TestRouting` drift gate now re-runs
  whenever a controller or DTO changes — which is the point of that table.

  Caching is disabled deliberately: the SDK is stdlib-only, so there is no `go.sum` to cache and
  pointing `cache-dependency-path` at the absent file fails the step.

  `go-version` is pinned to `1.22` — the `go.mod` minimum — so CI gates the version the SDK claims to
  support rather than whatever is newest.

- **`CHANGELOG.md`: record the Go SDK** under `[Unreleased] → Added`, with contributor credit.

## Verification

`gofmt -l .` clean, `go vet ./...` clean, `go test -race ./...` passing (79.7% coverage) against the
merged SDK tree. This PR touching `sdk-ci.yml` is itself the first real exercise of the new job.