### PR TITLE
fix(dashboard): apply live revocations via revokedId, not the event id alone (#755)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The dashboard now clears a message deleted for everyone while the thread is open (whatsapp-web.js).**
+  `message.revoked` carries `revokedId` — the id of the original deleted message, which whatsapp-web.js
+  resolves separately from the event's own `id` — but the dashboard's WebSocket projection dropped the
+  field and matched its message cache on `id` alone. Persistence was always correct (the backend keys
+  its `UPDATE` on `revokedId`), and webhook/API consumers already received the field; only the live
+  dashboard view was affected, where `staleTime: Infinity` meant an already-open thread kept rendering
+  the deleted message's original text until a reload, reconnect, or cache eviction. The projection now
+  forwards `revokedId`, and the cache lookup matches on either candidate id (against both the row id
+  and `waMessageId`), which keeps the Baileys path — where the two ids are identical — unchanged. When
+  whatsapp-web.js cannot resolve the original (it is no longer in its local store) `revokedId` is
+  absent and the lookup falls back to `id`, as before. Refs #755.
+
 ### Security
 
 ## [0.8.18] - 2026-07-17

--- a/dashboard/src/hooks/useWebSocket.ts
+++ b/dashboard/src/hooks/useWebSocket.ts
@@ -44,6 +44,11 @@ interface MessageReactionEvent {
 interface MessageRevokedEvent {
   sessionId: string;
   id: string;
+  /**
+   * Id of the ORIGINAL deleted message. Optional: whatsapp-web.js can only resolve it when the
+   * original is still in its local store, and Baileys sets it identical to `id`.
+   */
+  revokedId?: string;
   chatId: string;
   from: string;
   to: string;
@@ -218,6 +223,9 @@ export function useWebSocket(events: WebSocketEvents = {}) {
           events.onMessageRevoked?.({
             sessionId,
             id: String(data.id),
+            // Not String()-coerced like its neighbours: the field is optional on the wire, and
+            // String(undefined) would yield the truthy literal "undefined" and defeat the fallback.
+            revokedId: typeof data.revokedId === 'string' ? data.revokedId : undefined,
             chatId: String(data.chatId),
             from: String(data.from),
             to: String(data.to),

--- a/dashboard/src/pages/Chats.tsx
+++ b/dashboard/src/pages/Chats.tsx
@@ -26,7 +26,7 @@ import {
   type MessageType,
   type SearchHit,
 } from '../services/api';
-import { mergeDeliveryStatus, type ChatMessageView } from '../utils/chatMessages';
+import { mergeDeliveryStatus, findRevokedIndex, type ChatMessageView } from '../utils/chatMessages';
 import { useWebSocket } from '../hooks/useWebSocket';
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { useRole } from '../hooks/useRole';
@@ -330,17 +330,18 @@ export function Chats() {
   );
 
   const handleIncomingMessageRevoked = useCallback(
-    (event: { sessionId: string; id: string; type: string }) => {
+    (event: { sessionId: string; id: string; revokedId?: string; type: string }) => {
       if (event.sessionId !== selectedSessionId) return;
 
-      // Walk every cached chat under this session, find the message by id or waMessageId and zero it
-      // — the backend emits an empty body; the localized "deleted" label is rendered below.
+      // Walk every cached chat under this session, find the deleted message and zero it — the
+      // backend emits an empty body; the localized "deleted" label is rendered below. Matching is
+      // in findRevokedIndex: the event carries two candidate ids and wwebjs's `id` alone can miss.
       const caches = queryClient.getQueriesData<ChatMessageView[]>({
         queryKey: ['messages', event.sessionId],
       });
       for (const [key, list] of caches) {
         if (!list) continue;
-        const idx = list.findIndex(m => m.id === event.id || m.waMessageId === event.id);
+        const idx = findRevokedIndex(list, event);
         if (idx === -1) continue;
         const target = list[idx];
         const next = list.slice();

--- a/dashboard/src/utils/chatMessages.test.ts
+++ b/dashboard/src/utils/chatMessages.test.ts
@@ -91,6 +91,7 @@ import {
   replaceMessageById,
   updateMessageById,
   removeMessageById,
+  findRevokedIndex,
   type ChatMessageView,
 } from './chatMessages.ts';
 
@@ -196,4 +197,39 @@ test('removeMessageById is a no-op when id is not present', () => {
   const before = [msg({ id: 'm-1' })];
   const after = removeMessageById(before, 'missing');
   assert.deepEqual(after, before);
+});
+
+// message.revoked carries TWO candidate ids: `id` and `revokedId` (the original deleted message,
+// when the engine could resolve it). Match on either — see findRevokedIndex for why not `?? `.
+
+test('findRevokedIndex matches the original via revokedId when it differs from id (wwebjs)', () => {
+  const list = [msg({ id: 'row-1', waMessageId: 'ORIGINAL' })];
+  assert.equal(findRevokedIndex(list, { id: 'REVOKE_NOTIF', revokedId: 'ORIGINAL' }), 0);
+});
+
+test('findRevokedIndex still matches when id === revokedId (Baileys — guards the working path)', () => {
+  const list = [msg({ id: 'row-1', waMessageId: 'ORIGINAL' })];
+  assert.equal(findRevokedIndex(list, { id: 'ORIGINAL', revokedId: 'ORIGINAL' }), 0);
+});
+
+test('findRevokedIndex matches on id when revokedId is absent (original not in the engine store)', () => {
+  const list = [msg({ id: 'row-1', waMessageId: 'ORIGINAL' })];
+  assert.equal(findRevokedIndex(list, { id: 'ORIGINAL' }), 0);
+});
+
+test('findRevokedIndex matches the DB row id, not just waMessageId', () => {
+  const list = [msg({ id: 'row-1', waMessageId: 'ORIGINAL' })];
+  assert.equal(findRevokedIndex(list, { id: 'row-1' }), 0);
+});
+
+test('findRevokedIndex returns -1 when neither id matches', () => {
+  const list = [msg({ id: 'row-1', waMessageId: 'ORIGINAL' })];
+  assert.equal(findRevokedIndex(list, { id: 'REVOKE_NOTIF', revokedId: 'OTHER' }), -1);
+});
+
+test('findRevokedIndex ignores an undefined revokedId rather than matching a row with no waMessageId', () => {
+  // A row whose waMessageId is undefined must not be matched by an absent revokedId (undefined ===
+  // undefined would otherwise revoke an arbitrary bubble).
+  const list = [msg({ id: 'row-1', waMessageId: undefined })];
+  assert.equal(findRevokedIndex(list, { id: 'REVOKE_NOTIF' }), -1);
 });

--- a/dashboard/src/utils/chatMessages.ts
+++ b/dashboard/src/utils/chatMessages.ts
@@ -140,3 +140,29 @@ export function removeMessageById(
   if (!list.some(m => m.id === id)) return list;
   return list.filter(m => m.id !== id);
 }
+
+/**
+ * Locate the message a `message.revoked` event refers to. Returns -1 if it isn't cached.
+ *
+ * The event carries two candidate ids: `id`, and `revokedId` — the ORIGINAL deleted message, which
+ * whatsapp-web.js resolves separately because its revoke event can carry an id of its own that never
+ * matches a stored row. Baileys sets the two identically, and wwebjs leaves `revokedId` undefined
+ * when the original isn't in its local store.
+ *
+ * Both candidates are tried rather than preferring `revokedId` (the `revokedId ?? id` shape the
+ * backend uses to key its own UPDATE): matching either id is a superset that stays correct whichever
+ * of the two the cached row was stored under, so it cannot regress the Baileys path. Each candidate
+ * is checked against both the DB row id and `waMessageId` — a live WS message and its persisted copy
+ * are keyed differently. `revokedId` is guarded because an undefined one would otherwise match a row
+ * whose `waMessageId` is also undefined.
+ */
+export function findRevokedIndex(
+  list: ChatMessageView[],
+  event: { id: string; revokedId?: string },
+): number {
+  const matches = (m: ChatMessageView, candidate: string): boolean =>
+    m.id === candidate || m.waMessageId === candidate;
+  return list.findIndex(
+    m => matches(m, event.id) || (event.revokedId !== undefined && matches(m, event.revokedId)),
+  );
+}


### PR DESCRIPTION
Closes #755.

## What was wrong

`message.revoked` carries two candidate ids: `id`, and `revokedId` — the original deleted message, which whatsapp-web.js resolves separately because its revoke event can carry an id of its own that never matches a stored row. #567 added the field across the engine, the interface contract and the docs, and the backend keys its `UPDATE` on `revokedId ?? id`.

It never reached the WebSocket consumer that ships in this repo. `useWebSocket.ts` hand-builds the revoked event from a fixed allowlist of 8 fields and `revokedId` was not one of them, so the field died at the dashboard boundary despite arriving intact on the wire — `session.service.ts` emits the raw payload and the gateway filters nothing. `revokedId` appeared zero times anywhere under `dashboard/src`. The omission was silent by construction: the projection is an allowlist, so there was no type error and no failing test.

The result is a live-view-only defect. Persistence was always correct and webhook/API consumers already received the field, but the dashboard cache matched on `event.id`, and `useChatMessages` sets `staleTime: Infinity` — so an already-open thread kept rendering a deleted message's original text until a reload, a WebSocket reconnect, or gcTime eviction. Not a data-integrity problem, but a message deleted for everyone stayed visible to the operator.

## The change

Forward `revokedId` through the projection, and match the cache on **either** candidate id, against both the row id and `waMessageId`.

Matching either — rather than mirroring the backend's `revokedId ?? id` preference — is deliberate. The OR-match is a strict superset of the previous behavior: it stays correct whichever id the cached row was stored under, and it cannot regress the Baileys path, where the two ids are identical. Preferring `revokedId` would instead depend on an assumption about whatsapp-web.js's revoke id that the upstream source does not state unconditionally (`Client.js` only diverges the two ids when `protocolMessageKey` is present). The OR-match is correct either way, so it does not need that assumption to hold.

Where whatsapp-web.js cannot resolve the original — it is no longer in its local store — `revokedId` is absent and the lookup falls back to `id`, exactly as before. That subset is not fixable dashboard-side and is not claimed to be: the backend's `UPDATE` also falls back to `id` there, so the row is left unflagged and no refetch heals it. This narrows the defect rather than eliminating it.

`revokedId` is projected as `typeof data.revokedId === 'string' ? data.revokedId : undefined` rather than with the `String()` coercion its neighbours use — the field is optional on the wire, and `String(undefined)` yields the truthy literal `"undefined"`, which would silently defeat the fallback.

## Tests

The lookup is extracted as a pure `findRevokedIndex` so it is unit-testable without React, following the existing `decideRestoreTarget` / `reconnectState` pattern — the dashboard test runner is bare `node:test` with no DOM, and `useWebSocket.ts` is not importable under it.

Six cases: the whatsapp-web.js shape (`id` != `revokedId`), a Baileys control asserting the currently-working path does not regress, the absent-`revokedId` fallback, matching against the DB row id as well as `waMessageId`, the no-match case, and a guard that an undefined `revokedId` cannot match a row whose `waMessageId` is also undefined.

Dashboard 104/104 tests, build and lint clean; backend build and lint clean.

## Scope

Dashboard-only; no backend, API, webhook, SDK or docs change. `docs/06-api-specification.md` already documents `revokedId` and the reconcile guidance, so no docs fix was needed. Independent of the #747 backport work.
