### PR TITLE
fix(wwjs): stop two unguarded id reads failing quietly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   whatsapp-web.js cannot resolve the original (it is no longer in its local store) `revokedId` is
   absent and the lookup falls back to `id`, as before. Refs #755.
 
+- **A failed group creation now reports why it failed.** `whatsapp-web.js` signals a failed
+  `createGroup` by *resolving* with a plain string (`'CreateGroupError: …'`) instead of throwing, and
+  its typings say so (`Promise<CreateGroupResult | string>`) — but the adapter cast that union away and
+  read `.gid` off the string, so the reason upstream gave us was replaced by an opaque
+  `TypeError`. The union is handled, and an unreadable group id now fails loudly rather than being
+  coerced through `String()` into the literal id `"undefined"`. The status is unchanged (the group
+  genuinely wasn't created, so it was always a 500); the error text is now the real one.
+
+- **An ack whose message id can't be read is dropped instead of silently advancing nothing.** On a
+  WhatsApp Web build that renames the id field (#747), the id reached the status `UPDATE` as
+  `undefined`, which TypeORM sends as `waMessageId = NULL` — matching no row, since `x = NULL` is never
+  true. The ack advanced nothing, burned its one-shot retry, and left only a misleading "no status row
+  advanced" line behind. It is now dropped at the adapter boundary, where the reason is still visible.
+
 - **A send whose message can't be read back no longer crashes, and never claims a delivery it can't
   prove.** `whatsapp-web.js`'s `Client.sendMessage()` can *resolve* with `undefined` instead of
   throwing, while its typings declare `Promise<Message>` — so the adapter's `msg.id._serialized` reads

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -2060,3 +2060,82 @@ describe('WhatsAppWebJsAdapter send-result contract', () => {
     expect(res).toEqual({ id: 'true_621@c.us_XYZ', timestamp: 1700000002 });
   });
 });
+
+describe('WhatsAppWebJsAdapter message_ack (unreadable id)', () => {
+  const wireAckHandler = (): { onMessageAck: jest.Mock; client: EventEmitter } => {
+    const adapter = new WhatsAppWebJsAdapter({
+      sessionId: 'sess-ack-test',
+      sessionDataPath: './data/sessions',
+      puppeteer: {},
+    });
+    const client = Object.assign(new EventEmitter(), {
+      info: { wid: { _serialized: 'me@c.us', user: '628123' }, pushname: 'Tester' },
+      getState: jest.fn().mockResolvedValue(WAState.CONNECTED),
+      pupPage: { evaluate: jest.fn().mockResolvedValue(true) },
+    });
+    (adapter as unknown as { client: unknown }).client = client;
+    const onMessageAck = jest.fn();
+    (adapter as unknown as { callbacks: unknown }).callbacks = { onMessageAck };
+    (adapter as unknown as { setupEventHandlers: () => void }).setupEventHandlers();
+    return { onMessageAck, client };
+  };
+
+  it('forwards the ack on a healthy build', () => {
+    const { onMessageAck, client } = wireAckHandler();
+
+    client.emit('message_ack', { id: { _serialized: 'ACKED_MSG' } }, 3);
+
+    expect(onMessageAck).toHaveBeenCalledWith('ACKED_MSG', expect.any(String));
+  });
+
+  it('drops an ack whose id cannot be read instead of passing undefined on', () => {
+    // An undefined id reaches the ack UPDATE as `waMessageId = NULL`, which matches nothing (`x = NULL`
+    // is never true in SQL). The ack would advance no row and still burn its one-shot retry, leaving the
+    // message at SENT with only a misleading "no status row advanced" in the log.
+    const { onMessageAck, client } = wireAckHandler();
+
+    client.emit('message_ack', { id: { someFutureName: 'x' } }, 3);
+
+    expect(onMessageAck).not.toHaveBeenCalled();
+  });
+});
+
+describe('WhatsAppWebJsAdapter createGroup (failure shapes)', () => {
+  const readyAdapter = (client: unknown): WhatsAppWebJsAdapter => {
+    const adapter = new WhatsAppWebJsAdapter({ sessionId: 's', sessionDataPath: './data/sessions', puppeteer: {} });
+    (adapter as unknown as { status: EngineStatus }).status = EngineStatus.READY;
+    (adapter as unknown as { client: unknown }).client = client;
+    return adapter;
+  };
+
+  it("surfaces the engine's reason when creation fails", async () => {
+    // whatsapp-web.js RESOLVES with a plain string on failure rather than throwing (Client.js:2376).
+    // Reading `.gid` off it produced an opaque TypeError and threw the actual reason away.
+    const createGroup = jest
+      .fn()
+      .mockResolvedValue('CreateGroupError: An unknown error occupied while creating a group');
+
+    await expect(readyAdapter({ createGroup }).createGroup('team', ['628123@c.us'])).rejects.toThrow(
+      /CreateGroupError/,
+    );
+  });
+
+  it('never returns a placeholder when the group id cannot be read', async () => {
+    // The old `String(gid._serialized)` coerced an unreadable id into the literal string "undefined"
+    // and handed it back as a real, addressable group id.
+    const createGroup = jest.fn().mockResolvedValue({ gid: { someFutureName: 'x' } });
+
+    const call = readyAdapter({ createGroup }).createGroup('team', ['628123@c.us']);
+
+    await expect(call).rejects.toThrow(/id could not be read/);
+    await expect(call).rejects.not.toThrow(/undefined/);
+  });
+
+  it('returns the group on success', async () => {
+    const createGroup = jest.fn().mockResolvedValue({ gid: { _serialized: '120363000@g.us' } });
+
+    const res = await readyAdapter({ createGroup }).createGroup('team', ['628123@c.us', '628124@c.us']);
+
+    expect(res).toEqual({ id: '120363000@g.us', name: 'team', participantsCount: 2 });
+  });
+});

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -596,9 +596,20 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     });
 
     this.client.on('message_ack', (msg, ack) => {
+      // An unreadable id (a WhatsApp Web build renaming the field, as in #747) would reach the ack
+      // UPDATE as undefined, which TypeORM sends as `waMessageId = NULL` — matching nothing, since
+      // `x = NULL` is never true. The ack then silently advances no row AND burns its one-shot retry,
+      // so the message stays at SENT with only a misleading "no status row advanced" in the log. Drop
+      // it here, where the reason is still visible. (Note this differs from the reaction path below,
+      // where `findOne` DROPS an undefined key instead of nulling it and matches an arbitrary row.)
+      const ackId = (msg.id as unknown as SerializedWid | undefined)?._serialized;
+      if (!ackId) {
+        this.logger.warn('Dropping an ack whose message id could not be read', { ack });
+        return;
+      }
       // Map the whatsapp-web.js MessageAck integer to the neutral DeliveryStatus here, at the
       // adapter boundary, so no downstream consumer ever sees engine-specific ack codes.
-      this.callbacks.onMessageAck?.(msg.id._serialized, wwebjsAckToDeliveryStatus(ack));
+      this.callbacks.onMessageAck?.(ackId, wwebjsAckToDeliveryStatus(ack));
     });
 
     this.client.on('message_revoke_everyone', (after, before) => {
@@ -1316,7 +1327,20 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     const participantIds = participants.map(p => (p.includes('@') ? p : `${p}@c.us`));
     const result = await this.client!.createGroup(name, participantIds);
 
-    const groupId = String((result as unknown as GroupCreateResult).gid._serialized);
+    // whatsapp-web.js reports a failed creation by RESOLVING with a plain string
+    // ('CreateGroupError: …', Client.js:2376) rather than throwing, and its own typings say so
+    // (`Promise<CreateGroupResult | string>`). Reading `.gid` straight off that string threw an opaque
+    // TypeError and discarded the reason upstream actually gave us; surface it instead.
+    if (typeof result === 'string') {
+      throw new Error(result);
+    }
+    const gid = (result as unknown as GroupCreateResult).gid as SerializedWid | undefined;
+    const groupId = gid?._serialized ?? gid?.$1;
+    // A group id is not ack-safe the way a message id is: there is no empty-sentinel equivalent, and any
+    // placeholder would be handed back as a real, addressable group. Fail instead of inventing one.
+    if (!groupId) {
+      throw new Error('the group was created but its id could not be read');
+    }
     return {
       id: groupId,
       name: name,


### PR DESCRIPTION
The two follow-ups left out of #762 to keep it reviewable. Both are real and both are smaller than they first looked — that's stated up front, because the inflated version got talked about before it got checked.

## `createGroup` — the failure reason was being thrown away

whatsapp-web.js reports a failed creation by **resolving with a plain string** rather than throwing, and its typings say so:

```ts
createGroup(...): Promise<CreateGroupResult | string>   // index.d.ts
return 'CreateGroupError: An unknown error occupied while creating a group';   // Client.js:2376
```

An `as unknown as` cast hid that union, so the failure path read `.gid` off a string and raised an opaque `TypeError` — discarding the reason upstream actually handed us.

**The status was never wrong.** The group genuinely wasn't created, so 500 is correct. This is a diagnostics fix, not a correctness one, and it's deliberately not bundled at the same severity as #762's delivered-but-500.

The `String()` wrapper goes with it. On an unreadable id it produced the literal string `"undefined"` and returned it as a real, addressable group id — `String(undefined) === "undefined"`. **Not reachable today**: `gid` is a Wid, and #747's rename hit MsgKey only (Wid still sets `_serialized`). So it's a guard against the shape, not a live bug. Unlike a message id there's no ack-safe empty sentinel for a group, so it fails rather than inventing one.

## `message_ack` — a silent no-op, not a mass update

An unreadable id reached the status `UPDATE` as `undefined`. The concern was that TypeORM drops the key, leaving `WHERE sessionId = X AND status IN (...)` — a session-wide update. **That is not what happens**, verified against the installed TypeORM rather than assumed:

```sql
-- update({ sessionId, waMessageId: undefined, status: In([...]) })  → coerced to NULL
UPDATE "messages" SET "status" = ? WHERE ("sessionId" = ? AND "waMessageId" = ? AND "status" IN (?))
-- PARAMETERS: ["delivered","s1",null,"sent"]   → affected: 0

-- findOne({ sessionId, waMessageId: undefined })  → key DROPPED
SELECT ... WHERE (("sessionId" = ?)) LIMIT 1   -- ["s1"]   → matches an ARBITRARY row
```

So `update()` nulls an undefined key and matches nothing (`x = NULL` is never true), while `findOne()` drops it. The adapter's reaction handler guards the `findOne` shape and is correct as-is; only the wording implying both APIs behave alike was wrong.

The real defect is smaller but still real: the ack advances no row, **burns its one-shot retry**, and leaves a misleading `no status row advanced` as the only trace. It's now dropped at the adapter boundary where the reason is still visible.

## Verification

2438 tests pass; build, lint and format clean. Neither path had **any** test before this. Five added — **three fail against the pre-fix source**; the two that pass either way are healthy-path controls.