### PR TITLE
fix(dashboard): stop the Logs CSV export truncating at 200 rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Logs CSV export truncated at 200 rows.** The export loop requested 500-row pages and treated any
+  short page as the last one, but `GET /audit` clamps `limit` to `MAX_AUDIT_PAGE_SIZE` (200) — so the
+  first page always looked short and every export stopped at 200 rows regardless of how much history
+  matched. Pagination now terminates on the server-reported `total` (and on empty pages) instead of on
+  a guessed page size, so the export can no longer be truncated by a server-side clamp. Thanks
+  @kabir74705 for the report and the original fix.
+
 ### Added
 
 - **Official Go SDK (`sdk/go`).** Hand-written, stdlib-only (no third-party dependencies) Go client

--- a/dashboard/src/pages/Logs.tsx
+++ b/dashboard/src/pages/Logs.tsx
@@ -8,6 +8,7 @@ import { useLogsQuery } from '../hooks/queries';
 import { PageHeader } from '../components/PageHeader';
 import { CustomSelect } from '../components/CustomSelect';
 import { pageWindow } from '../utils/pageWindow';
+import { fetchAllPages } from '../utils/fetchAllPages';
 import './Logs.css';
 
 export function Logs() {
@@ -87,17 +88,10 @@ export function Logs() {
   const handleExportCsv = async () => {
     if (exporting) return;
     setExporting(true);
-    const PAGE = 500;
-    const CAP = 50000;
     try {
-      const all: AuditLog[] = [];
-      let offset = 0;
-      for (;;) {
-        const res = await auditApi.list({ severity: severityParam, limit: PAGE, offset });
-        all.push(...res.data);
-        offset += res.data.length;
-        if (res.data.length < PAGE || offset >= res.total || all.length >= CAP) break;
-      }
+      const all = await fetchAllPages<AuditLog>((limit, offset) =>
+        auditApi.list({ severity: severityParam, limit, offset }),
+      );
       const q = searchQuery.toLowerCase();
       const rows = q
         ? all.filter(l => l.action.toLowerCase().includes(q) || (l.errorMessage || '').toLowerCase().includes(q))

--- a/dashboard/src/utils/fetchAllPages.test.ts
+++ b/dashboard/src/utils/fetchAllPages.test.ts
@@ -1,0 +1,55 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { fetchAllPages } from './fetchAllPages.ts';
+
+/** Fake page source: holds `total` rows, but never returns more than `serverMax` per call. */
+function fakeSource(total: number, serverMax: number) {
+  const calls: Array<{ limit: number; offset: number }> = [];
+  const fetchPage = async (limit: number, offset: number) => {
+    calls.push({ limit, offset });
+    const take = Math.min(limit, serverMax);
+    const data = Array.from({ length: Math.max(0, Math.min(take, total - offset)) }, (_, i) => offset + i);
+    return { data, total };
+  };
+  return { fetchPage, calls };
+}
+
+test('walks every page when the server clamps below the requested size', async () => {
+  // The shipped bug: requesting 500 against a server that clamps to 200 stopped after one page.
+  const { fetchPage, calls } = fakeSource(650, 200);
+  const rows = await fetchAllPages(fetchPage, { pageSize: 500 });
+  assert.equal(rows.length, 650);
+  assert.deepEqual(rows.slice(0, 3), [0, 1, 2]);
+  assert.equal(calls.length, 4);
+});
+
+test('stops once total is reached without an extra empty request', async () => {
+  const { fetchPage, calls } = fakeSource(400, 200);
+  const rows = await fetchAllPages(fetchPage, { pageSize: 200 });
+  assert.equal(rows.length, 400);
+  assert.equal(calls.length, 2);
+});
+
+test('stops on an empty page even if total over-reports', async () => {
+  // Guards the infinite loop: a stale/wrong `total` must not keep the loop spinning.
+  const { fetchPage, calls } = fakeSource(50, 200);
+  const rows = await fetchAllPages(async (limit, offset) => {
+    const page = await fetchPage(limit, offset);
+    return { data: page.data, total: 9999 };
+  });
+  assert.equal(rows.length, 50);
+  assert.equal(calls.length, 2);
+});
+
+test('honours the safety cap', async () => {
+  const { fetchPage } = fakeSource(10_000, 200);
+  const rows = await fetchAllPages(fetchPage, { pageSize: 200, maxItems: 500 });
+  assert.equal(rows.length, 600); // stops at the first page that crosses the cap
+});
+
+test('returns an empty list when there is nothing to export', async () => {
+  const { fetchPage, calls } = fakeSource(0, 200);
+  const rows = await fetchAllPages(fetchPage);
+  assert.deepEqual(rows, []);
+  assert.equal(calls.length, 1);
+});

--- a/dashboard/src/utils/fetchAllPages.ts
+++ b/dashboard/src/utils/fetchAllPages.ts
@@ -1,0 +1,32 @@
+interface Page<T> {
+  data: T[];
+  total: number;
+}
+
+interface FetchAllPagesOptions {
+  pageSize?: number;
+  maxItems?: number;
+}
+
+/**
+ * Walk an offset-paginated list endpoint to completion.
+ *
+ * Termination is driven by the server's own `total` and by short/empty pages — never by comparing
+ * the returned page length against the *requested* size. Endpoints clamp `limit` server-side (audit
+ * caps at MAX_AUDIT_PAGE_SIZE), so a `page.length < requested` test reads a clamped first page as
+ * "last page" and silently truncates the result.
+ */
+export async function fetchAllPages<T>(
+  fetchPage: (limit: number, offset: number) => Promise<Page<T>>,
+  { pageSize = 200, maxItems = 50_000 }: FetchAllPagesOptions = {},
+): Promise<T[]> {
+  const all: T[] = [];
+  let offset = 0;
+  for (;;) {
+    const { data, total } = await fetchPage(pageSize, offset);
+    all.push(...data);
+    offset += data.length;
+    if (data.length === 0 || offset >= total || all.length >= maxItems) break;
+  }
+  return all;
+}


### PR DESCRIPTION
## Problem

The Logs page CSV export silently stopped at 200 rows on every export, no matter how much audit history matched the filter.

The loop requested 500-row pages and treated any page shorter than 500 as the last one:

```ts
const PAGE = 500;
const res = await auditApi.list({ severity: severityParam, limit: PAGE, offset });
if (res.data.length < PAGE || offset >= res.total || all.length >= CAP) break;
```

But `GET /audit` clamps the page size server-side (`audit.service.ts`):

```ts
const take = Math.min(requested, MAX_AUDIT_PAGE_SIZE); // 200
```

So the first page always came back with 200 rows, `200 < 500` was always true, and the loop always broke after one request. The `offset >= res.total` condition — the one that was actually correct — never got a chance to run.

## Fix

Terminate on the server-reported `total` and on empty pages, rather than on a comparison against the requested page size. Page size becomes a request hint, not a correctness input.

The obvious minimal fix is `PAGE = 200`, but that hardcodes a backend constant into the dashboard: the day `MAX_AUDIT_PAGE_SIZE` moves, the export silently truncates again with nothing to catch it. Driving the loop off `total` is immune to the clamp entirely.

Extracted as `fetchAllPages` with tests covering the clamped-page case (the shipped bug), an over-reported `total` (infinite-loop guard), the safety cap, and the empty case.

## Verification

- `npm run test:unit` — 109 pass, 0 fail (5 new)
- `npm run lint` — 0 errors
- `npm run build` — clean

Dashboard-only; no backend changes.

## Credit

Reported by @kabir74705 in #749, along with the original `PAGE = 200` fix.