### PR TITLE
fix(dashboard): report connected sessions honestly, drop the fake trend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a guessed page size, so the export can no longer be truncated by a server-side clamp. Thanks
   @kabir74705 for the report and the original fix.
 
+- **Dashboard overstated connected sessions and showed a fabricated trend.** The "Active Sessions" KPI
+  read `stats.active`, which counts running engine instances — including `initializing`, `qr_ready`,
+  and `connecting` — so it reported sessions that could not yet send or receive as active. The green
+  "+N" trend arrow beneath it was not a delta at all: it rendered the current READY count as though it
+  were a period-over-period gain, so a steady deployment appeared to be permanently growing. The card
+  now reports the READY count (relabelled "Connected Sessions") with a plain `{running} running ·
+  {total} total` breakdown, and the fake trend indicator is gone. Thanks @kabir74705 for spotting both.
+
 ### Added
 
 - **Official Go SDK (`sdk/go`).** Hand-written, stdlib-only (no third-party dependencies) Go client

--- a/dashboard/src/i18n/locales/ar.json
+++ b/dashboard/src/i18n/locales/ar.json
@@ -152,7 +152,8 @@
     "title": "لوحة التحكم",
     "subtitle": "نظرة عامة على جلسات واتساب ونشاطك",
     "stats": {
-      "activeSessions": "الجلسات النشطة",
+      "activeSessions": "الجلسات المتصلة",
+      "sessionsDetail": "{{running}} قيد التشغيل · {{total}} الإجمالي",
       "messagesToday": "رسائل اليوم",
       "webhooksConfigured": "الويب هوك المُهيّأة",
       "apiCalls": "استدعاءات API (24 ساعة)",

--- a/dashboard/src/i18n/locales/en.json
+++ b/dashboard/src/i18n/locales/en.json
@@ -152,7 +152,8 @@
     "title": "Dashboard",
     "subtitle": "Overview of your WhatsApp sessions and activity",
     "stats": {
-      "activeSessions": "Active Sessions",
+      "activeSessions": "Connected Sessions",
+      "sessionsDetail": "{{running}} running · {{total}} total",
       "messagesToday": "Messages Today",
       "webhooksConfigured": "Webhooks Configured",
       "apiCalls": "API Calls (24h)",

--- a/dashboard/src/i18n/locales/es.json
+++ b/dashboard/src/i18n/locales/es.json
@@ -152,7 +152,8 @@
     "title": "Panel",
     "subtitle": "Resumen de tus sesiones de WhatsApp y actividad",
     "stats": {
-      "activeSessions": "Sesiones activas",
+      "activeSessions": "Sesiones conectadas",
+      "sessionsDetail": "{{running}} en ejecución · {{total}} en total",
       "messagesToday": "Mensajes hoy",
       "webhooksConfigured": "Webhooks configurados",
       "apiCalls": "Llamadas API (24h)",

--- a/dashboard/src/i18n/locales/fr.json
+++ b/dashboard/src/i18n/locales/fr.json
@@ -152,7 +152,8 @@
     "title": "Tableau de bord",
     "subtitle": "Aperçu de vos sessions WhatsApp et de votre activité",
     "stats": {
-      "activeSessions": "Sessions actives",
+      "activeSessions": "Sessions connectées",
+      "sessionsDetail": "{{running}} en cours · {{total}} au total",
       "messagesToday": "Messages aujourd'hui",
       "webhooksConfigured": "Webhooks configurés",
       "apiCalls": "Appels API (24h)",

--- a/dashboard/src/i18n/locales/he.json
+++ b/dashboard/src/i18n/locales/he.json
@@ -152,7 +152,8 @@
     "title": "דאשבורד",
     "subtitle": "סקירה כללית של ה-Sessions והפעילות שלך ב-WhatsApp",
     "stats": {
-      "activeSessions": "Sessions פעילים",
+      "activeSessions": "סשנים מחוברים",
+      "sessionsDetail": "{{running}} רצים · {{total}} בסך הכול",
       "messagesToday": "הודעות היום",
       "webhooksConfigured": "Webhooks מוגדרים",
       "apiCalls": "קריאות API (24 שעות)",

--- a/dashboard/src/i18n/locales/it.json
+++ b/dashboard/src/i18n/locales/it.json
@@ -152,7 +152,8 @@
     "title": "Dashboard",
     "subtitle": "Panoramica delle sessioni WhatsApp e delle attività",
     "stats": {
-      "activeSessions": "Sessioni Attive",
+      "activeSessions": "Sessioni connesse",
+      "sessionsDetail": "{{running}} in esecuzione · {{total}} totali",
       "messagesToday": "Messaggi di Oggi",
       "webhooksConfigured": "Webhook Configurati",
       "apiCalls": "Chiamate API (24h)",

--- a/dashboard/src/i18n/locales/ko.json
+++ b/dashboard/src/i18n/locales/ko.json
@@ -152,7 +152,8 @@
     "title": "대시보드",
     "subtitle": "WhatsApp 세션 및 활동 개요",
     "stats": {
-      "activeSessions": "활성 세션",
+      "activeSessions": "연결된 세션",
+      "sessionsDetail": "{{running}} 실행 중 · 총 {{total}}",
       "messagesToday": "오늘의 메시지",
       "webhooksConfigured": "설정된 웹훅",
       "apiCalls": "API 호출 (24시간)",

--- a/dashboard/src/i18n/locales/pt-BR.json
+++ b/dashboard/src/i18n/locales/pt-BR.json
@@ -152,7 +152,8 @@
     "title": "Painel",
     "subtitle": "Resumo das suas sessões do WhatsApp e atividade",
     "stats": {
-      "activeSessions": "Sessões ativas",
+      "activeSessions": "Sessões conectadas",
+      "sessionsDetail": "{{running}} em execução · {{total}} no total",
       "messagesToday": "Mensagens hoje",
       "webhooksConfigured": "Webhooks configurados",
       "apiCalls": "Chamadas API (24h)",

--- a/dashboard/src/i18n/locales/te.json
+++ b/dashboard/src/i18n/locales/te.json
@@ -152,7 +152,8 @@
     "title": "డ్యాష్‌బోర్డ్",
     "subtitle": "మీ వాట్సాప్ సెషన్లు మరియు యాక్టివిటీ యొక్క అవలోకనం",
     "stats": {
-      "activeSessions": "యాక్టివ్ సెషన్స్",
+      "activeSessions": "కనెక్ట్ అయిన సెషన్లు",
+      "sessionsDetail": "{{running}} నడుస్తోంది · మొత్తం {{total}}",
       "messagesToday": "ఈరోజు సందేశాలు",
       "webhooksConfigured": "కాన్ఫిగర్ చేసిన వెబ్‌హుక్స్",
       "apiCalls": "API కాల్స్ (24 గంటలు)",

--- a/dashboard/src/i18n/locales/zh-CN.json
+++ b/dashboard/src/i18n/locales/zh-CN.json
@@ -152,7 +152,8 @@
     "title": "仪表盘",
     "subtitle": "查看你的 WhatsApp 会话和活动概览",
     "stats": {
-      "activeSessions": "活跃会话",
+      "activeSessions": "已连接会话",
+      "sessionsDetail": "{{running}} 运行中 · 共 {{total}}",
       "messagesToday": "今日消息",
       "webhooksConfigured": "已配置 Webhook",
       "apiCalls": "API 调用（24 小时）",

--- a/dashboard/src/i18n/locales/zh-HK.json
+++ b/dashboard/src/i18n/locales/zh-HK.json
@@ -152,7 +152,8 @@
     "title": "控制面板",
     "subtitle": "查看你的 WhatsApp 工作階段及活動概覽",
     "stats": {
-      "activeSessions": "活躍工作階段",
+      "activeSessions": "已連接工作階段",
+      "sessionsDetail": "{{running}} 運行中 · 共 {{total}}",
       "messagesToday": "今日訊息",
       "webhooksConfigured": "已設定 Webhook",
       "apiCalls": "API 呼叫（24 小時）",

--- a/dashboard/src/pages/Dashboard.css
+++ b/dashboard/src/pages/Dashboard.css
@@ -88,23 +88,13 @@
   z-index: 2;
 }
 
-.dashboard .stat-trend{
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
+.dashboard .stat-detail{
   font-size: 0.75rem;
-  font-weight: 500;
+  line-height: 1.35;
   margin-top: 0.5rem;
+  color: var(--text-muted);
   position: relative;
   z-index: 2;
-}
-
-.dashboard .stat-trend.up{
-  color: var(--primary);
-}
-
-.dashboard .stat-trend.down{
-  color: var(--error);
 }
 
 .dashboard .sessions-section{

--- a/dashboard/src/pages/Dashboard.tsx
+++ b/dashboard/src/pages/Dashboard.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react';
 import { lazyWithRetry as lazy } from '../utils/lazyWithRetry';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { MessageSquare, Send, Webhook, Activity, ArrowUpRight, ArrowDownRight, Loader2 } from 'lucide-react';
+import { MessageSquare, Send, Webhook, Activity, Loader2 } from 'lucide-react';
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import {
   useSessionsQuery,
@@ -49,15 +49,17 @@ export function Dashboard() {
 
   const statsCards = [
     {
+      // `stats.active` counts running engines — which includes initializing/qr_ready/connecting — so
+      // it overstates what an operator reads as "connected". READY is the only status where the
+      // session can actually send and receive.
       label: t('dashboard.stats.activeSessions'),
-      value: stats?.active ?? 0,
+      value: stats?.ready ?? 0,
       icon: MessageSquare,
-      trend: `+${stats?.ready ?? 0}`,
-      trendUp: true,
+      detail: stats ? t('dashboard.stats.sessionsDetail', { running: stats.active, total: stats.total }) : undefined,
     },
-    { label: t('dashboard.stats.messagesToday'), value: messagesToday, icon: Send, trend: '0', trendUp: null },
-    { label: t('dashboard.stats.webhooksConfigured'), value: webhookCount, icon: Webhook, trend: '0', trendUp: null },
-    { label: t('dashboard.stats.totalMessages'), value: totalMessages, icon: Activity, trend: '0', trendUp: null },
+    { label: t('dashboard.stats.messagesToday'), value: messagesToday, icon: Send },
+    { label: t('dashboard.stats.webhooksConfigured'), value: webhookCount, icon: Webhook },
+    { label: t('dashboard.stats.totalMessages'), value: totalMessages, icon: Activity },
   ];
 
   const formatLastActive = (date?: string) => {
@@ -105,19 +107,14 @@ export function Dashboard() {
       />
 
       <div className="stats-grid">
-        {statsCards.map(({ label, value, icon: Icon, trend, trendUp }) => (
+        {statsCards.map(({ label, value, icon: Icon, detail }) => (
           <div key={label} className="stat-card">
             <div className="stat-header">
               <span className="stat-label">{label}</span>
               <Icon size={20} className="stat-icon" />
             </div>
             <div className="stat-value">{typeof value === 'number' ? value.toLocaleString() : value}</div>
-            {trend !== '0' && (
-              <div className={`stat-trend ${trendUp ? 'up' : 'down'}`}>
-                {trendUp ? <ArrowUpRight size={14} /> : <ArrowDownRight size={14} />}
-                {trend}
-              </div>
-            )}
+            {detail && <div className="stat-detail">{detail}</div>}
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Problem

Two separate dishonesty bugs in the same dashboard KPI card.

**1. "Active Sessions" overstated what was connected.** The card read `stats.active`, which is `engines.size` (`session.service.ts`):

```ts
active: scope ? [...this.engines.keys()].filter(id => scope.includes(id)).length : this.engines.size,
ready:  byStatus[SessionStatus.READY] || 0,
```

`engines` holds every *running engine instance* — including `initializing`, `qr_ready`, and `connecting`. A session sitting on an unscanned QR code counted as "Active", so the number an operator reads as "how many sessions can send right now" was routinely too high. READY is the only status that can actually send and receive.

**2. The trend arrow was fabricated.** Beneath it:

```ts
trend: `+${stats?.ready ?? 0}`,
trendUp: true,
```

That is not a delta — it prints the *current* READY count next to a hardcoded green up-arrow. A steady deployment with 3 connected sessions permanently displayed "+3", implying growth that never happened. There is no historical series behind this card to compute a real delta from.

## Fix

- Headline is now the READY count, relabelled **"Connected Sessions"**.
- The running and total counts stay visible as a plain breakdown (`{running} running · {total} total`) rather than being dropped — the engine count is still useful, it just isn't "connected".
- The fake trend indicator is removed rather than faked. Restoring a real trend needs a historical series the API doesn't expose today; that's a separate piece of work.
- Removes the now-unused `.stat-trend` styles and arrow icon imports orphaned by the change.

Scope is deliberately limited to the KPI correctness fix. The other dashboard changes proposed in #749 (pushName display names, session-ID visibility, chart work) are UX decisions and are not included here.

## Verification

- `npm run i18n:check` — parity passes across all 11 locales
- `npm run test:unit` — 104 pass, 0 fail
- `npm run lint` — 0 errors
- `npm run build` — clean
- No orphaned references to `stat-trend` / arrow icons remain

Dashboard-only; no backend changes.

## Credit

Both bugs reported by @kabir74705 in #749. The i18n strings for all 11 locales are theirs, with one correction (`he.json` had kept "Sessions" untranslated).