### PR TITLE
fix(dashboard): warn when the production CSP upgrade blanks a plain-HTTP dashboard (#731)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -332,10 +332,15 @@ API_MASTER_KEY=
 # so re-issue keys after enabling. Leave unset to keep the current (unpeppered) behaviour.
 # API_KEY_PEPPER=
 
+# Browsers auto-upgrade http:// to https:// for the dashboard (CSP upgrade-insecure-requests).
+# On by default in production, which is correct behind a TLS-terminating reverse proxy.
+# Set false when serving the dashboard over plain HTTP (e.g. a trusted private network, or a
+# direct host:port deployment) — otherwise the browser upgrades the UI's own scripts to https,
+# the non-TLS server can't answer, and the dashboard renders a BLANK WHITE SCREEN. (#611, #731)
+# CSP_UPGRADE_INSECURE_REQUESTS=false
+
 # =============================================================================
 # DEVELOPER SETTINGS
 # =============================================================================
 ENABLE_SWAGGER=true                 # Enable API documentation at /api/docs (set false to disable on exposed deployments)
 BODY_SIZE_LIMIT=25mb                # Max request body size (base64 media sends ride in the JSON body)
-# CSP_UPGRADE_INSECURE_REQUESTS=false # Set false for an HTTP-only deployment on a trusted private network
-                                    # (default: on in production). Stops the browser upgrading the dashboard to https.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Where no request was made, no code is shown rather than a fabricated one. This is what made a plain
   `500` get reported as a mystery `400` in #750. Fixes #750.
 
+- **A production boot that serves the dashboard over plain HTTP now warns about the CSP upgrade that
+  blanks it.** In production OpenWA emits `upgrade-insecure-requests`, which is correct behind a
+  TLS-terminating reverse proxy — the shipped `docker-compose.yml` topology — but silently breaks a
+  direct-HTTP deployment: the browser upgrades the dashboard's own script fetches to `https://`, the
+  non-TLS server cannot answer them, no JavaScript runs, and the UI renders a blank white screen. The
+  failure happens entirely in the browser, so the server log stayed clean and the operator had nothing
+  to go on; the existing `CSP_UPGRADE_INSECURE_REQUESTS=false` opt-out was documented only under
+  `.env.example`'s "Developer settings" heading, where a production operator had no reason to look.
+  Boot now names the setting when the trap is possible, `.env.example` documents it under Security with
+  the symptom spelled out, and `docs/12-troubleshooting-faq.md` gains a "Dashboard renders a blank white
+  screen" entry. The warning cannot distinguish direct HTTP from a TLS proxy at boot (Express
+  `trust proxy` is off), so it fires for both and tells a proxied operator to ignore it. The CSP default
+  is unchanged. (#731)
+- **The startup banner now advertises `BASE_URL` instead of a hardcoded `localhost`.** The
+  `🚀 running on`, `📚 Swagger docs`, and `🖥️ Dashboard` lines printed `http://localhost:${PORT}` as a
+  literal, regardless of where the instance was actually reachable — contradicting the `AuthService`
+  banner directly above them, which already honoured `BASE_URL`. Two adjacent log lines could therefore
+  report different URLs for the same server, which read as "the UI is pinned to localhost" and sent #731
+  chasing `BASE_URL`/`BIND_HOST`/`API_PORT` rather than the actual cause. (#731)
+
 - **The dashboard now clears a message deleted for everyone while the thread is open (whatsapp-web.js).**
   `message.revoked` carries `revokedId` — the id of the original deleted message, which whatsapp-web.js
   resolves separately from the event's own `id` — but the dashboard's WebSocket projection dropped the

--- a/docs/12-troubleshooting-faq.md
+++ b/docs/12-troubleshooting-faq.md
@@ -156,6 +156,39 @@ docker compose pull            # Get latest image
 docker compose up -d
 ```
 
+### Issue: Dashboard Renders a Blank White Screen
+
+**Symptoms:**
+- The API is healthy (`curl http://<host>:2785/api/health` returns `200`) but the dashboard is blank
+- The startup log says `🖥️ Dashboard: serving bundled UI at …` — the UI *is* being served
+- The browser console shows script-loading errors; DevTools → Network shows the `/assets/*.js`
+  requests going to `https://` even though you opened the page over `http://`
+- You reach the instance directly over plain HTTP (a host:port allocation, a private network, a
+  panel like Pterodactyl) rather than through a TLS-terminating reverse proxy
+
+**Cause:** In production OpenWA sends the CSP `upgrade-insecure-requests` directive, which tells the
+browser to upgrade every sub-resource fetch to HTTPS. That is correct behind a TLS proxy. Over plain
+HTTP the browser upgrades the dashboard's own script requests to `https://`, the non-TLS server
+cannot answer them, no JavaScript runs, and React never mounts — a blank page. The failure happens
+in the browser, so the server log stays clean.
+
+**Solution:**
+
+```bash
+# Opt out, then fully restart the container (not just reload)
+CSP_UPGRADE_INSECURE_REQUESTS=false
+
+# Confirm it actually reached the process
+docker compose exec openwa printenv NODE_ENV CSP_UPGRADE_INSECURE_REQUESTS
+```
+
+A production boot that serves the dashboard with the opt-out unset prints a warning naming this
+setting. If you are behind a TLS proxy, ignore that warning — the directive is doing its job.
+
+> The alternative is to front OpenWA with a TLS-terminating reverse proxy (the shipped
+> `docker-compose.yml` topology), which serves the dashboard over HTTPS and makes the upgrade a
+> no-op.
+
 ### Issue: Session Won't Connect
 
 **Symptoms:**

--- a/src/config/bootstrap-security.spec.ts
+++ b/src/config/bootstrap-security.spec.ts
@@ -3,6 +3,7 @@ import {
   isSwaggerEnabled,
   isValidationErrorDetailEnabled,
   isUpgradeInsecureRequestsEnabled,
+  isDashboardCspUpgradeTrapLikely,
   resolveBodyLimit,
   assertNoDefaultSecretsInProduction,
   isApiKeyPepperMissingInProduction,
@@ -61,6 +62,23 @@ describe('isUpgradeInsecureRequestsEnabled', () => {
   it('treats any non-"true"/"false" value as unset (falls back to NODE_ENV)', () => {
     expect(isUpgradeInsecureRequestsEnabled('', 'production')).toBe(true);
     expect(isUpgradeInsecureRequestsEnabled('1', 'development')).toBe(false);
+  });
+});
+
+describe('isDashboardCspUpgradeTrapLikely', () => {
+  it('flags a production instance serving the dashboard with the opt-out unset (#731)', () => {
+    expect(isDashboardCspUpgradeTrapLikely({ nodeEnv: 'production', dashboardServed: true })).toBe(true);
+  });
+  it('stays quiet once the operator opts out', () => {
+    expect(isDashboardCspUpgradeTrapLikely({ nodeEnv: 'production', cspEnv: 'false', dashboardServed: true })).toBe(
+      false,
+    );
+  });
+  it('stays quiet when no dashboard is served (API-only: no UI to break)', () => {
+    expect(isDashboardCspUpgradeTrapLikely({ nodeEnv: 'production', dashboardServed: false })).toBe(false);
+  });
+  it('stays quiet outside production, where the directive is already off', () => {
+    expect(isDashboardCspUpgradeTrapLikely({ nodeEnv: 'development', dashboardServed: true })).toBe(false);
   });
 });
 

--- a/src/config/bootstrap-security.ts
+++ b/src/config/bootstrap-security.ts
@@ -71,6 +71,24 @@ export function isUpgradeInsecureRequestsEnabled(cspEnv?: string, nodeEnv?: stri
 }
 
 /**
+ * Whether a boot is likely walking into the #731 blank-dashboard trap: production serves the bundled
+ * UI with `upgrade-insecure-requests` on, so a browser reaching it over plain HTTP silently upgrades
+ * the UI's own script fetches to https:// and renders a blank page. The server never sees the failed
+ * request (it dies in the browser), so a boot warning is the only pointer we can give.
+ *
+ * This cannot distinguish direct-HTTP (broken) from behind-a-TLS-proxy (correct) — Express `trust
+ * proxy` is off, so at boot there is no signal either way. It deliberately fires for both; the
+ * warning text tells a proxied operator to ignore it.
+ */
+export function isDashboardCspUpgradeTrapLikely(env: {
+  nodeEnv?: string;
+  cspEnv?: string;
+  dashboardServed: boolean;
+}): boolean {
+  return env.dashboardServed && isUpgradeInsecureRequestsEnabled(env.cspEnv, env.nodeEnv);
+}
+
+/**
  * Request body-size cap (DoS hardening). Default is media-aware (base64 sends ride in the JSON body).
  * A value the body-size parser can't understand (e.g. 'unlimited', 'none', a typo) resolves to a null
  * limit downstream, which SILENTLY DISABLES the cap — so an unparseable value falls back to the default

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ import {
   isSwaggerEnabled,
   isValidationErrorDetailEnabled,
   isUpgradeInsecureRequestsEnabled,
+  isDashboardCspUpgradeTrapLikely,
   resolveBodyLimit,
   assertNoDefaultSecretsInProduction,
   isApiKeyPepperMissingInProduction,
@@ -259,9 +260,14 @@ async function bootstrap() {
   const port = process.env.PORT || 2785;
   await app.listen(port);
 
-  console.log(`🚀 OpenWA is running on: http://localhost:${port}`);
+  // Advertise the configured public URL, matching the AuthService banner (auth.service.ts). A bare
+  // `localhost` literal here contradicted that banner and read as "the UI is pinned to localhost",
+  // sending #731 chasing BASE_URL/BIND_HOST/API_PORT instead of the real cause.
+  const publicUrl = process.env.BASE_URL || `http://localhost:${port}`;
+
+  console.log(`🚀 OpenWA is running on: ${publicUrl}`);
   if (swaggerEnabled) {
-    console.log(`📚 Swagger docs: http://localhost:${port}/api/docs`);
+    console.log(`📚 Swagger docs: ${publicUrl}/api/docs`);
   }
 
   // Make the dashboard-serving outcome explicit so a missing build (no UI on `/`)
@@ -269,11 +275,30 @@ async function bootstrap() {
   if (!dashboardServingEnabled) {
     console.log('🖥️  Dashboard: serving disabled (SERVE_DASHBOARD=false); API only');
   } else if (dashboardBuildPresent) {
-    console.log(`🖥️  Dashboard: serving bundled UI at http://localhost:${port}`);
+    console.log(`🖥️  Dashboard: serving bundled UI at ${publicUrl}`);
   } else {
     console.warn(
       `⚠️  Dashboard: no build at ${DASHBOARD_DIST} - UI disabled (API still serves /api). ` +
         'Run `npm run build:all` to bundle it, or use the Vite dev server (`npm run dev`).',
+    );
+  }
+
+  // The upgrade-insecure-requests trap (#731): the browser upgrades the UI's own script fetches to
+  // https and a non-TLS server can't answer them, so the dashboard renders blank with nothing in the
+  // server log. We can't tell a TLS proxy from direct HTTP at boot (`trust proxy` is off), so this
+  // fires for both and the text says who should ignore it.
+  if (
+    isDashboardCspUpgradeTrapLikely({
+      nodeEnv: process.env.NODE_ENV,
+      cspEnv: process.env.CSP_UPGRADE_INSECURE_REQUESTS,
+      dashboardServed: dashboardServingEnabled && dashboardBuildPresent,
+    })
+  ) {
+    console.warn(
+      '⚠️  Dashboard: CSP upgrade-insecure-requests is ON (production default). If this instance is ' +
+        "reached over plain HTTP, the browser will upgrade the UI's scripts to https:// and the " +
+        'dashboard will render blank. Behind a TLS proxy? Ignore this. Serving direct HTTP? Set ' +
+        'CSP_UPGRADE_INSECURE_REQUESTS=false.',
     );
   }
 }


### PR DESCRIPTION
## Problem

A production instance that serves the bundled dashboard over plain HTTP renders a blank white screen with no diagnostic trail.

In production OpenWA emits the CSP `upgrade-insecure-requests` directive (added in #611). That is correct behind a TLS-terminating reverse proxy — the shipped `docker-compose.yml` topology — but on a direct-HTTP deployment the browser upgrades the dashboard's own `/assets/*.js` fetches to `https://`, the non-TLS server cannot complete the handshake, no JavaScript executes, and React never mounts.

Three properties made this unusually hard to diagnose:

1. **The server cannot observe it.** The upgrade happens in the browser; the failed HTTPS request never reaches the process. Logs stay clean.
2. **The one relevant log line lied.** `main.ts` printed `serving bundled UI at http://localhost:${PORT}` as a literal, regardless of where the instance was actually reachable — while the `AuthService` banner directly above it already honoured `BASE_URL`. Two adjacent lines could report different URLs for the same server.
3. **The opt-out was undiscoverable.** `CSP_UPGRADE_INSECURE_REQUESTS=false` existed and was accurately documented, but sat under `.env.example`'s "Developer settings" heading, which a production operator has no reason to read.

In #731 the reporter concluded the UI was hardcoded to `localhost` — the log line's fault — and spent the investigation on `BASE_URL` / `BIND_HOST` / `API_PORT`, all dead ends.

## Changes

- **`isDashboardCspUpgradeTrapLikely`** (`src/config/bootstrap-security.ts`) — pure predicate: production + dashboard served + opt-out unset. Delegates to `isUpgradeInsecureRequestsEnabled` rather than reimplementing its exact-string contract, so the semantics stay in one place. Lives here, not inline in `main.ts`, because this file's predicates are unit-tested and `main.ts` is not.
- **Startup warning** (`src/main.ts`) — fires in the existing dashboard-logging block, reusing the already-exported `dashboardServingEnabled` / `dashboardBuildPresent` guards.
- **Banner honours `BASE_URL`** (`src/main.ts`) — the `🚀 running on`, `📚 Swagger docs`, and `🖥️ Dashboard` lines now follow the pattern already established in `auth.service.ts`.
- **Docs** — `.env.example` moves the setting from "Developer settings" to Security and names the symptom; `docs/12-troubleshooting-faq.md` gains a "Dashboard renders a blank white screen" entry, which is where someone hitting this actually searches.

## Design note: the warning is deliberately imprecise

Express `trust proxy` is not enabled, so at boot the process **cannot** distinguish direct HTTP (broken) from behind-a-TLS-proxy (correct) — both satisfy identical preconditions. The warning therefore fires for both, and its text tells a proxied operator to ignore it.

That trade-off is intentional. Enabling `trust proxy` would allow precise detection but is security-sensitive (IP spoofing) and interacts with `proxy-aware-throttler.guard.ts` — the wrong risk tail for what is fundamentally a discoverability problem. The cost here is one ignorable line per boot for correctly-configured operators; the benefit is a pointer for OpenWA's only zero-trace failure class.

**The CSP default is unchanged.** It is correct for the TLS-proxy majority; flipping it would weaken them to serve a minority.

## Verification

- `isDashboardCspUpgradeTrapLikely` unit tests, written first and watched fail: trap fires / opt-out silences / API-only silences / non-production silences.
- Full suite: 2442 passing.
- Manual boot, all three scenarios confirmed against a real build:
  - production + opt-out unset → warning appears
  - `CSP_UPGRADE_INSECURE_REQUESTS=false` → warning gone
  - `BASE_URL=https://wa.example.com` → all three lines print the public URL, matching the `AuthService` banner instead of contradicting it
- Backend lint + build, dashboard build + lint: clean (pre-existing warnings only).

Closes #731.
