### PR TITLE
fix(dashboard): don't persist a guessed engine when the running engine is unknown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,25 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **Logs CSV export truncated at 200 rows.** The export loop requested 500-row pages and treated any
-  short page as the last one, but `GET /audit` clamps `limit` to `MAX_AUDIT_PAGE_SIZE` (200) — so the
-  first page always looked short and every export stopped at 200 rows regardless of how much history
-  matched. Pagination now terminates on the server-reported `total` (and on empty pages) instead of on
-  a guessed page size, so the export can no longer be truncated by a server-side clamp. Thanks
-  @kabir74705 for the report and the original fix.
-
-- **Dashboard overstated connected sessions and showed a fabricated trend.** The "Active Sessions" KPI
-  read `stats.active`, which counts running engine instances — including `initializing`, `qr_ready`,
-  and `connecting` — so it reported sessions that could not yet send or receive as active. The green
-  "+N" trend arrow beneath it was not a delta at all: it rendered the current READY count as though it
-  were a period-over-period gain, so a steady deployment appeared to be permanently growing. The card
-  now reports the READY count (relabelled "Connected Sessions") with a plain `{running} running ·
-  {total} total` breakdown, and the fake trend indicator is gone. Thanks @kabir74705 for spotting both.
-
 ### Added
-
 - **Official Go SDK (`sdk/go`).** Hand-written, stdlib-only (no third-party dependencies) Go client
   covering the user-facing API surface, joining the JavaScript/Python/PHP/Java clients. Entry point is
   `openwa.New(baseURL, apiKey, opts...)`, which returns a concurrency-safe `*Client` whose exported
@@ -46,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   test time. Requires Go 1.22+. Thanks @Revelts.
 
 ### Changed
-
 - **v0.8.18's whatsapp-web.js id-rename fix also restored the Chats page (docs only).** The v0.8.18 entry
   credits that fix with repairing inbound media downloads, message ids, acks, reply quoting, and reactions,
   but never mentions `GET /sessions/{id}/chats` — which the same patch repaired as well. The rename broke the
@@ -128,6 +109,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   — that signal existed all along and is now written down. No behavior change. Refs #738.
 
 ### Fixed
+- **Logs CSV export truncated at 200 rows.** The export loop requested 500-row pages and treated any
+  short page as the last one, but `GET /audit` clamps `limit` to `MAX_AUDIT_PAGE_SIZE` (200) — so the
+  first page always looked short and every export stopped at 200 rows regardless of how much history
+  matched. Pagination now terminates on the server-reported `total` (and on empty pages) instead of on
+  a guessed page size, so the export can no longer be truncated by a server-side clamp. Thanks
+  @kabir74705 for the report and the original fix.
+
+- **Dashboard overstated connected sessions and showed a fabricated trend.** The "Active Sessions" KPI
+  read `stats.active`, which counts running engine instances — including `initializing`, `qr_ready`,
+  and `connecting` — so it reported sessions that could not yet send or receive as active. The green
+  "+N" trend arrow beneath it was not a delta at all: it rendered the current READY count as though it
+  were a period-over-period gain, so a steady deployment appeared to be permanently growing. The card
+  now reports the READY count (relabelled "Connected Sessions") with a plain `{running} running ·
+  {total} total` breakdown, and the fake trend indicator is gone. Thanks @kabir74705 for spotting both.
 
 - **The whatsapp-web.js backport can no longer latch in a half-patched dependency.** The patcher proves a
   tree is whole before standing down, and #759 added that check precisely so a run that died mid-apply
@@ -191,6 +186,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   report different URLs for the same server, which read as "the UI is pinned to localhost" and sent #731
   chasing `BASE_URL`/`BIND_HOST`/`API_PORT` rather than the actual cause. (#731)
 
+- **Saving Infrastructure no longer persists a guessed engine when the running engine is unknown.** The
+  engine radio falls back to its `whatsapp-web.js` default until `/infra/engines/current` resolves; if that
+  request failed, saving wrote that default as `ENGINE_TYPE`, silently switching a Baileys deployment on
+  the next restart. The save payload now omits `engine.type` unless the radio actually seeded from the
+  running engine or the operator picked one — the backend leaves a saved `ENGINE_TYPE` untouched when the
+  field is absent, so an unrelated save can no longer flip the engine.
+
 - **The dashboard now clears a message deleted for everyone while the thread is open (whatsapp-web.js).**
   `message.revoked` carries `revokedId` — the id of the original deleted message, which whatsapp-web.js
   resolves separately from the event's own `id` — but the dashboard's WebSocket projection dropped the
@@ -230,6 +232,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `(sessionId, waMessageId)` unique index and silently drop a bulk row. Refs #757.
 
 ### Security
+
 
 ## [0.8.18] - 2026-07-17
 

--- a/dashboard/src/pages/Infrastructure.tsx
+++ b/dashboard/src/pages/Infrastructure.tsx
@@ -161,6 +161,10 @@ export function Infrastructure() {
   const engineHydrated = useRef(false);
   const engineTouched = useRef(false);
 
+  /** Whether engineConfig.type reflects a real value (seeded from the running engine or user-picked)
+   * rather than the useState default — the save payload omits `type` when it doesn't. */
+  const engineTypeKnown = (): boolean => engineHydrated.current || engineTouched.current;
+
   // LIVE indicators (not editable) — always reflect the running process, every refetch.
   useEffect(() => {
     if (!infraStatus) return;
@@ -300,7 +304,11 @@ export function Infrastructure() {
         redis: { enabled: redisEnabled, ...redisConfig },
         queue: { enabled: queueEnabled },
         storage: { ...storageConfig },
-        engine: { ...engineConfig },
+        // Only send `type` once we actually know it — either the radio seeded from the running engine
+        // or the operator picked one. If /engines/current never resolved (endpoint down), engineConfig.type
+        // still holds its useState default, and sending that would persist ENGINE_TYPE and silently flip
+        // the engine on the next restart. The backend treats an absent `type` as "leave ENGINE_TYPE alone".
+        engine: engineTypeKnown() ? { ...engineConfig } : { ...engineConfig, type: undefined },
       };
 
       const result = await infraApi.saveConfig(payload);


### PR DESCRIPTION
Hardening follow-up to #742, from the post-merge review of that PR.

## The defect

The Infrastructure engine radio holds its `useState` default (`whatsapp-web.js`) until `/infra/engines/current` resolves and seeds it. That endpoint is trivial and synchronous, and the form gates on the much slower `/infra/status`, so the window is normally zero-width — but if `/infra/engines/current` actually *fails* (transient 5xx; react-query is configured with `retry: 1`), `currentEngine` stays empty and the radio keeps its default.

Saving in that state sent `engine.type: 'whatsapp-web.js'`, which `saveConfig` persisted as `ENGINE_TYPE`. A Baileys deployment would then boot whatsapp-web.js on the next restart — from a save the operator made for an unrelated field (database, Redis, storage), with no warning.

This is latent and pre-existing (#742 narrowed the window rather than widening it), so it is filed separately as hardening rather than a regression fix.

## The fix

Omit `engine.type` from the save payload unless the value is actually known — i.e. the radio seeded from the running engine (`engineHydrated`) or the operator picked one (`engineTouched`).

This fits the existing contract with no changes to it:
- `saveConfig` only writes `ENGINE_TYPE` inside `if (config.engine.type)` (`infra.controller.ts:688`), and writes `{ ...existing, ...updates }` (`:714`) — so an absent `type` **preserves** the saved `ENGINE_TYPE` rather than clearing it. `staleKeys` only drops db/storage mode-switch keys, never `ENGINE_TYPE`.
- `SaveConfigPayload.engine.type` is already optional (`api.ts:301`), and `JSON.stringify` drops `undefined`, so the field is genuinely absent on the wire.

Blocking Save instead would have been the wrong trade: it would penalize an operator editing unrelated settings for an unrelated endpoint failure. Omitting the field lets the save succeed while leaving the engine exactly as it is.

## Behavior

| Scenario | `type` sent | Result |
|---|---|---|
| Normal (radio seeded) | yes | `ENGINE_TYPE` = running/selected engine (unchanged) |
| Operator picks an engine | yes | `ENGINE_TYPE` = their choice (unchanged) |
| `/engines/current` failed, operator saves | **omitted** | saved `ENGINE_TYPE` **preserved** (was: default written, engine flipped on restart) |

## Verification

Source-traced end-to-end through `handleSaveConfig` → `infraApi.saveConfig` → `saveConfig` → `.env.generated` merge (the table above is confirmed against the backend, not assumed). Dashboard `tsc -b && vite build` green; lint clean.