### PR TITLE
docs(api): correct the send-response semantics from #739

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Corrected the send-response documentation (docs only).** The guidance added in #739 overstated what a
+  stalled send tells you: it said a message resting at `sent` for a recipient you have never reached is
+  "almost certainly a number that is not on WhatsApp." That inference does not hold in the other
+  direction — a *registered* recipient whose device has not come online since the send stays at `sent`
+  indefinitely too, by design, so the state is not diagnostic on its own. The unevidenced claim that an
+  unregistered recipient is "the most common cause" of a send that never arrives is gone, as is the
+  description of what the message looks like in a WhatsApp client, which is not ours to assert. The
+  section also claimed *every* send route returns `201` with `{ messageId, timestamp }`; `POST send-bulk`
+  returns `202` with a batch envelope, and the `status/send-*` routes return a `statusId` and an ISO
+  timestamp rather than a `messageId` and epoch seconds. Both exceptions are now stated where the rule
+  is. Finally, the documented `status` lifecycle omitted its terminal error state: WhatsApp reporting an
+  error for a message advances it to `failed` and dispatches a `message.failed` webhook, on both engines
+  — that signal existed all along and is now written down. No behavior change. Refs #738.
+
 ### Fixed
 
 - **The dashboard now clears a message deleted for everyone while the thread is open (whatsapp-web.js).**

--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -165,12 +165,18 @@ The contract is engine-neutral: pass neutral `@c.us` WIDs and the active engine 
 
 ### Send response: `201` means accepted, not delivered
 
-Every send route returns **HTTP 201** with `{ "messageId", "timestamp" }` as soon as the gateway hands the message to the WhatsApp client. This confirms the send was *accepted* — it does **not** confirm the recipient received it. Two consequences worth knowing:
+Single-recipient send routes under `/messages` return **HTTP 201** with `{ "messageId", "timestamp" }` as soon as the gateway hands the message to the WhatsApp client. This confirms the send was *accepted* — it does **not** confirm the recipient received it. Two routes differ: `POST send-bulk` returns **202** with a batch envelope (`{ batchId, status, totalMessages, … }`), and the `status/send-*` routes return **201** with `{ statusId, timestamp, expiresAt }` — a `statusId`, not a `messageId`, and an ISO timestamp rather than epoch seconds.
 
-1. **WhatsApp does not reject an unregistered recipient synchronously.** A message to a number that is not on WhatsApp still returns `201` with a valid `messageId`, but never delivers (it sits at a single grey tick and may surface an error in the chat). This is the most common cause of a "successful send that never arrived" for a number you have not messaged before.
+Two consequences worth knowing:
+
+1. **WhatsApp does not reject an unregistered recipient synchronously.** A message to a number that is not on WhatsApp still returns `201` with a valid `messageId`. Whether it later delivers, stalls, or is reported as an error reaches you asynchronously, if at all.
 2. **There is no synchronous delivery confirmation on either engine** (whatsapp-web.js or Baileys), so the `201` cannot be made to mean "delivered."
 
-**Before sending to a new number**, confirm it is a registered WhatsApp account with `GET /api/sessions/:sessionId/contacts/check/:number` (returns `{ exists, whatsappId }`; see the Contacts reference). For real delivery state, track the stored message's `status`, which advances asynchronously through `sent → delivered → read` (or `failed`) as WhatsApp sends acks — see the message shape under the Messages reference. A message that stays at `sent` indefinitely for a recipient you have never reached is almost certainly a number that is not on WhatsApp.
+**Before sending to a new number**, you can confirm it is a registered WhatsApp account with `GET /api/sessions/:sessionId/contacts/check/:number` (returns `{ exists, whatsappId }`; see the Contacts reference).
+
+**For real delivery state**, track the stored message's `status`, which advances asynchronously as WhatsApp sends acks: `sent → delivered → read`, or `failed` when WhatsApp reports an error for the message — which also dispatches a `message.failed` webhook. See the message shape under the Messages reference.
+
+A message resting at `sent` is **not** diagnostic on its own. It means no ack has advanced it yet, and a registered recipient whose device has not come online since the send stays at `sent` indefinitely too — that is the designed behavior, not a fault. Use `contacts/check` to tell an unregistered number apart from a registered one that simply has not received yet.
 
 ## 6.4 REST API Reference
 
@@ -711,7 +717,7 @@ Delete a session.
 
 ### 6.4.2 Messages
 
-All routes are mounted under `/api/sessions/:sessionId/messages`. Reads (`GET` history, batch status, reactions) accept any valid API key (including VIEWER). All write/send routes require **API key (OPERATOR)** or higher. Send routes return `MessageResponseDto { messageId, timestamp }` (`timestamp` is an epoch **number** in seconds; there is no `status` field). The global ValidationPipe runs `whitelist` + `forbidNonWhitelisted`, so any body field not listed below is rejected with `400`.
+All routes are mounted under `/api/sessions/:sessionId/messages`. Reads (`GET` history, batch status, reactions) accept any valid API key (including VIEWER). All write/send routes require **API key (OPERATOR)** or higher. Single-recipient send routes return `MessageResponseDto { messageId, timestamp }` (`timestamp` is an epoch **number** in seconds; there is no `status` field); `POST send-bulk` instead returns `202` with `BulkMessageResponseDto`. The global ValidationPipe runs `whitelist` + `forbidNonWhitelisted`, so any body field not listed below is rejected with `400`.
 
 #### GET /api/sessions/:sessionId/messages
 

--- a/openapi.json
+++ b/openapi.json
@@ -6077,7 +6077,7 @@
         "properties": {
           "messageId": {
             "type": "string",
-            "description": "The message id, assigned when the gateway accepts the message for sending. A 201 here means the message was handed to the WhatsApp client — it does NOT confirm delivery. WhatsApp does not reject an unregistered recipient synchronously, so a message to a number that is not on WhatsApp still returns 201 with a valid messageId but never delivers. To confirm a number is on WhatsApp before sending, use GET /api/sessions/{sessionId}/contacts/check/{number}; track real delivery via the message `status` field (sent → delivered → read).",
+            "description": "The message id, assigned when the gateway accepts the message for sending. A 201 here means the message was handed to the WhatsApp client — it does NOT confirm delivery. WhatsApp does not reject an unregistered recipient synchronously, so a message to a number that is not on WhatsApp still returns 201 with a valid messageId but never delivers. To confirm a number is on WhatsApp before sending, use GET /api/sessions/{sessionId}/contacts/check/{number}; track real delivery via the message `status` field (sent → delivered → read, or failed if WhatsApp reports an error for it). A message resting at `sent` is not diagnostic on its own: a registered recipient whose device has not come online since the send stays at `sent` too.",
             "example": "true_628123456789@c.us_3EB0123456789"
           },
           "timestamp": {

--- a/src/modules/message/dto/send-message.dto.ts
+++ b/src/modules/message/dto/send-message.dto.ts
@@ -124,7 +124,9 @@ export class MessageResponseDto {
       'an unregistered recipient synchronously, so a message to a number that is not on WhatsApp still ' +
       'returns 201 with a valid messageId but never delivers. To confirm a number is on WhatsApp before ' +
       'sending, use GET /api/sessions/{sessionId}/contacts/check/{number}; track real delivery via the ' +
-      'message `status` field (sent → delivered → read).',
+      'message `status` field (sent → delivered → read, or failed if WhatsApp reports an error for it). ' +
+      'A message resting at `sent` is not diagnostic on its own: a registered recipient whose device has ' +
+      'not come online since the send stays at `sent` too.',
     example: 'true_628123456789@c.us_3EB0123456789',
   })
   messageId: string;


### PR DESCRIPTION
## Why

#739 added a "Send response: `201` means accepted, not delivered" section to `docs/06`. The core point is right and stays. Three of the statements around it do not hold up, and one of them actively misleads.

## What's wrong

**1. The stalled-send heuristic is inverted.** The section said a message resting at `sent` for a recipient you have never reached "is almost certainly a number that is not on WhatsApp." That inference only runs one way. A *registered* recipient whose device has not come online since the send stays at `sent` indefinitely too — `pending`/`sent` carry no upgrade by design (`message-status.util.ts`, and its docstring says as much). The state is not diagnostic on its own, so the advice sends people chasing the wrong theory.

**2. Two unevidenced claims about WhatsApp.** That an unregistered recipient is "the most common cause" of a send that never arrives is a frequency claim we have no data for. The description of what the message looks like in a WhatsApp client is not ours to assert either. Both are removed rather than softened.

**3. "Every send route returns HTTP 201 with `{ messageId, timestamp }`" is wrong twice.** `POST send-bulk` returns **202** with a batch envelope (`@HttpCode(HttpStatus.ACCEPTED)`, `message.controller.ts`). The `status/send-*` routes return **201** with `{ statusId, timestamp, expiresAt }` — a `statusId` rather than a `messageId`, and an ISO timestamp rather than the epoch seconds the Messages section promises. Both exceptions are now stated where the rule is, including at the scoped repetition further down.

## What's added

The documented `status` lifecycle stopped at `read` and omitted its terminal error state. WhatsApp reporting an error for a message advances it to `failed` and dispatches a `message.failed` webhook — on both engines (`ack < 0` on whatsapp-web.js, the `ERROR` receipt on Baileys), through a guarded UPDATE that only ever advances status. That signal has always existed and is regression-tested; it simply was not written down, which made the gap look larger than it was.

## Scope

Documentation and one Swagger description. **No behavior change.** `openapi.json` regenerated — 1-line delta, and it propagates to every send response via the existing `$ref`.

## Verification

- `openapi:check` green (snapshot matches the generator)
- `eslint` 0 errors
- `npm run build` clean
- `npm test` — 188 suites, 2438 tests passing

Refs #738.
