### PR TITLE
fix(dashboard): stop the Message Tester inventing HTTP status codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The Message Tester no longer invents HTTP status codes.** Its result banner rendered one of two
+  hardcoded strings — `200 OK - Success` or `400 - Failed` — for every outcome, in all eleven locales.
+  Neither number was ever read from the response. Send routes return **201**, not 200, so the success
+  banner was wrong on every successful send; and *any* failure displayed `400`, including a server 500
+  and the recipient pre-check that short-circuits in the browser without issuing a request at all. The
+  banner now states the outcome and, when a request actually reached the gateway, the real status the
+  gateway returned — which `services/api.ts` already attaches to the error for exactly this purpose.
+  Where no request was made, no code is shown rather than a fabricated one. This is what made a plain
+  `500` get reported as a mystery `400` in #750. Fixes #750.
+
 - **The dashboard now clears a message deleted for everyone while the thread is open (whatsapp-web.js).**
   `message.revoked` carries `revokedId` — the id of the original deleted message, which whatsapp-web.js
   resolves separately from the event's own `id` — but the dashboard's WebSocket projection dropped the

--- a/dashboard/src/i18n/locales/ar.json
+++ b/dashboard/src/i18n/locales/ar.json
@@ -552,8 +552,8 @@
     "sending": "جارٍ الإرسال...",
     "viewOnly": "للعرض فقط",
     "responseEmpty": "أرسل رسالة لرؤية استجابة API",
-    "successLabel": "200 OK - نجاح",
-    "failedLabel": "400 - فشل",
+    "successLabel": "نجاح",
+    "failedLabel": "فشل",
     "response": {
       "timestamp": "الوقت",
       "messageId": "معرّف الرسالة",

--- a/dashboard/src/i18n/locales/en.json
+++ b/dashboard/src/i18n/locales/en.json
@@ -548,8 +548,8 @@
     "sending": "Sending...",
     "viewOnly": "View Only",
     "responseEmpty": "Send a message to see the API response",
-    "successLabel": "200 OK - Success",
-    "failedLabel": "400 - Failed",
+    "successLabel": "Success",
+    "failedLabel": "Failed",
     "response": {
       "timestamp": "Timestamp",
       "messageId": "Message ID",

--- a/dashboard/src/i18n/locales/es.json
+++ b/dashboard/src/i18n/locales/es.json
@@ -503,8 +503,8 @@
     "sending": "Enviando...",
     "viewOnly": "Solo lectura",
     "responseEmpty": "Envía un mensaje para ver la respuesta de la API",
-    "successLabel": "200 OK - Éxito",
-    "failedLabel": "400 - Fallido",
+    "successLabel": "Éxito",
+    "failedLabel": "Fallido",
     "response": {
       "timestamp": "Fecha/Hora",
       "messageId": "ID de mensaje",

--- a/dashboard/src/i18n/locales/fr.json
+++ b/dashboard/src/i18n/locales/fr.json
@@ -548,8 +548,8 @@
     "sending": "Envoi...",
     "viewOnly": "Lecture seule",
     "responseEmpty": "Envoyez un message pour voir la réponse de l'API",
-    "successLabel": "200 OK - Succès",
-    "failedLabel": "400 - Échec",
+    "successLabel": "Succès",
+    "failedLabel": "Échec",
     "response": {
       "timestamp": "Horodatage",
       "messageId": "ID du message",

--- a/dashboard/src/i18n/locales/he.json
+++ b/dashboard/src/i18n/locales/he.json
@@ -549,8 +549,8 @@
     "sending": "שולח...",
     "viewOnly": "צפייה בלבד",
     "responseEmpty": "יש לשלוח הודעה כדי לראות את תגובת ה-API",
-    "successLabel": "200 OK - הצלחה",
-    "failedLabel": "400 - נכשל",
+    "successLabel": "הצלחה",
+    "failedLabel": "נכשל",
     "response": {
       "timestamp": "חותמת זמן",
       "messageId": "מזהה הודעה",

--- a/dashboard/src/i18n/locales/it.json
+++ b/dashboard/src/i18n/locales/it.json
@@ -548,8 +548,8 @@
     "sending": "Invio in corso...",
     "viewOnly": "Sola Visualizzazione",
     "responseEmpty": "Invia un messaggio per vedere la risposta delle API",
-    "successLabel": "200 OK - Successo",
-    "failedLabel": "400 - Fallito",
+    "successLabel": "Successo",
+    "failedLabel": "Fallito",
     "response": {
       "timestamp": "Timestamp",
       "messageId": "ID Messaggio",

--- a/dashboard/src/i18n/locales/ko.json
+++ b/dashboard/src/i18n/locales/ko.json
@@ -548,8 +548,8 @@
     "sending": "보내는 중...",
     "viewOnly": "읽기 전용",
     "responseEmpty": "메시지를 보내면 API 응답이 여기에 표시됩니다",
-    "successLabel": "200 OK - 성공",
-    "failedLabel": "400 - 실패",
+    "successLabel": "성공",
+    "failedLabel": "실패",
     "response": {
       "timestamp": "타임스탬프",
       "messageId": "메시지 ID",

--- a/dashboard/src/i18n/locales/pt-BR.json
+++ b/dashboard/src/i18n/locales/pt-BR.json
@@ -503,8 +503,8 @@
     "sending": "Enviando...",
     "viewOnly": "Somente leitura",
     "responseEmpty": "Envie uma mensagem para ver a resposta da API",
-    "successLabel": "200 OK - Sucesso",
-    "failedLabel": "400 - Falhou",
+    "successLabel": "Sucesso",
+    "failedLabel": "Falhou",
     "response": {
       "timestamp": "Data/Hora",
       "messageId": "ID da mensagem",

--- a/dashboard/src/i18n/locales/te.json
+++ b/dashboard/src/i18n/locales/te.json
@@ -548,8 +548,8 @@
     "sending": "పంపుతోంది...",
     "viewOnly": "చూడటానికి మాత్రమే",
     "responseEmpty": "API రెస్పాన్స్ చూడటానికి ఒక సందేశాన్ని పంపండి",
-    "successLabel": "200 OK - విజయం",
-    "failedLabel": "400 - విఫలమైంది",
+    "successLabel": "విజయం",
+    "failedLabel": "విఫలమైంది",
     "response": {
       "timestamp": "సమయము",
       "messageId": "సందేశం ID",

--- a/dashboard/src/i18n/locales/zh-CN.json
+++ b/dashboard/src/i18n/locales/zh-CN.json
@@ -548,8 +548,8 @@
     "sending": "正在发送...",
     "viewOnly": "仅查看",
     "responseEmpty": "发送消息后即可查看 API 响应",
-    "successLabel": "200 OK - 成功",
-    "failedLabel": "400 - 失败",
+    "successLabel": "成功",
+    "failedLabel": "失败",
     "response": {
       "timestamp": "时间戳",
       "messageId": "消息 ID",

--- a/dashboard/src/i18n/locales/zh-HK.json
+++ b/dashboard/src/i18n/locales/zh-HK.json
@@ -548,8 +548,8 @@
     "sending": "正在傳送...",
     "viewOnly": "僅檢視",
     "responseEmpty": "傳送訊息後即可查看 API 回應",
-    "successLabel": "200 OK - 成功",
-    "failedLabel": "400 - 失敗",
+    "successLabel": "成功",
+    "failedLabel": "失敗",
     "response": {
       "timestamp": "時間戳記",
       "messageId": "訊息 ID",

--- a/dashboard/src/pages/MessageTester.tsx
+++ b/dashboard/src/pages/MessageTester.tsx
@@ -13,6 +13,10 @@ interface ApiResponse {
   messageId?: string;
   timestamp: string;
   error?: string;
+  // The real HTTP status, carried on the Error by `request()` in services/api.ts. Absent when no
+  // request was made (the recipient pre-check below short-circuits) — the panel then shows the
+  // outcome without a code rather than inventing one.
+  status?: number;
 }
 
 const messageTypes = ['text', 'image', 'video', 'audio', 'document'] as const;
@@ -167,6 +171,7 @@ export function MessageTester() {
         success: false,
         timestamp: new Date().toISOString(),
         error: err instanceof Error ? err.message : t('messageTester.sendFailed'),
+        status: err instanceof Error ? (err as Error & { status?: number }).status : undefined,
       });
     } finally {
       setIsLoading(false);
@@ -363,6 +368,9 @@ export function MessageTester() {
                     <span>{t('messageTester.failedLabel')}</span>
                   </>
                 )}
+                {/* `.mono` keeps the code LTR inside an RTL container (ar/he) via the shared rule in
+                    index.css, so the bidi algorithm doesn't reorder it against the translated label. */}
+                {response.status !== undefined && <span className="mono">HTTP {response.status}</span>}
               </div>
 
               <div className="response-details">


### PR DESCRIPTION
Fixes #750.

## The bug

The Message Tester's result banner rendered one of two hardcoded strings for every outcome:

```json
"successLabel": "200 OK - Success",
"failedLabel": "400 - Failed",
```

Baked into all eleven locales. Neither number was ever read from the response.

Both are wrong. Send routes return **201**, not 200 — so the success banner misreported every successful send. And the failure banner claimed **400** for any failure at all: a 500 from the gateway, a 413 on an oversized upload, a 403 from a viewer-role key, and even the recipient pre-check that short-circuits in the browser **without issuing a request**.

## Why it matters — this is #750

The reporter on #750 filed "sending message is working but i am getting 400 as response", with reproduction steps that are literally *use the Message Tester*. There was never a server 400. On v0.7.20 an unguarded id read threw a `TypeError`, NestJS turned it into a **500**, and the tester relabelled it `400` on the way to the screen. The 500 itself is already fixed (#762); the relabelling was not, and it is what turned a legible error into a bug report.

## The fix

State the outcome, and the real status **only when a request actually reached the gateway**. `services/api.ts` already attaches it to the Error, for exactly this reason — its own comment says it exists "so callers can tell apart a permission 403 from a real server 5xx instead of guessing from text." This is the first caller to use it.

Where no request was made, no code is shown, rather than a fabricated one. The eleven locale strings keep their translated word and lose the invented number; no keys added or removed, so locale parity is untouched.

The code renders through the existing `.mono` class, which `index.css` already isolates as LTR inside RTL containers — so it reads correctly in `ar`/`he` rather than being reordered by the bidi algorithm.

## Verification

- `npm run i18n:check` — parity passed, all 683 keys present across 11 locales
- `eslint` — 0 errors
- `npm run build` (dashboard) — clean
- Call chain traced: `messageApi.sendText` / `contactApi.checkNumber` → `request()` → `err.status = response.status` on `!response.ok`

**Not verified live:** exercising the banner in a browser needs a session in `ready` state, which needs a linked WhatsApp account. The render path is a single `!== undefined` branch over a value whose origin is traced above, but it has not been observed on screen.

## Noted, not changed

`success` is computed as `!!result.messageId`. Since #762, a send whose `Message` came back but whose id could not be read returns `messageId: ''` — dispatch proven, id unreadable — which is falsy, so the banner would say "Failed" for a message that was in fact sent. That is a real reporting gap, but fixing it means deciding what the tester *should* claim when dispatch is proven and the id is not readable. Left alone deliberately; happy to take it in a follow-up.
