### PR TITLE
fix(wwjs): close the two gaps that let a half-patched backport latch in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The whatsapp-web.js backport can no longer latch in a half-patched dependency.** The patcher proves a
+  tree is whole before standing down, and #759 added that check precisely so a run that died mid-apply
+  could not be mistaken for an upstream fix. The proof was incomplete in the one place it mattered most.
+  `REQUIRED_SITES` asserted the eight structure constructors but not `src/util/Injected/Utils.js` — the
+  browser-side normalizer every inbound message crosses on its way to Node, and the **last** of the
+  twelve files `patch` writes, one after the `Message.js` the stand-down check keys on. A run that died in
+  that window left a tree where every assertion passed, so each later run stood down as healthy while the
+  primary normalizer was permanently absent — the exact latch the check exists to prevent. `Client.js` and
+  `GroupChat.js` normalize ids too and were likewise unasserted; all three are now covered. Separately,
+  the half-patched error was the only one of the four not marked as leaving a partial tree, so
+  `--best-effort` — the `npm install` path — downgraded it to a warning and exited 0, waving through the
+  one tree that flag's own contract says it must never accept. Both are regression-tested, including the
+  `--best-effort` path.
+
 - **The Message Tester no longer invents HTTP status codes.** Its result banner rendered one of two
   hardcoded strings — `200 OK - Success` or `400 - Failed` — for every outcome, in all eleven locales.
   Neither number was ever read from the response. Send routes return **201**, not 200, so the success

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,11 +54,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   twelve files `patch` writes, one after the `Message.js` the stand-down check keys on. A run that died in
   that window left a tree where every assertion passed, so each later run stood down as healthy while the
   primary normalizer was permanently absent — the exact latch the check exists to prevent. `Client.js` and
-  `GroupChat.js` normalize ids too and were likewise unasserted; all three are now covered. Separately,
-  the half-patched error was the only one of the four not marked as leaving a partial tree, so
-  `--best-effort` — the `npm install` path — downgraded it to a warning and exited 0, waving through the
-  one tree that flag's own contract says it must never accept. Both are regression-tested, including the
-  `--best-effort` path.
+  `GroupChat.js` normalize ids too and were likewise unasserted; all three are now covered. The Docker
+  image build runs the patcher directly, so it now fails the build on such a tree instead of shipping it.
+  Separately, the half-patched error was the only one of the four not marked as leaving a partial tree, so
+  `--best-effort` downgraded it to a warning; it now exits non-zero like the other three. Note this makes
+  the tree *reported* on the `npm install` path rather than rejected there — the `postinstall` hook
+  discards the patcher's exit code, so the install still succeeds; that is pre-existing and deliberately
+  untouched, since failing `npm install` outright is the trade the flag exists to avoid. Both fixes are
+  regression-tested, including the `--best-effort` path.
 
 - **The Message Tester no longer invents HTTP status codes.** Its result banner rendered one of two
   hardcoded strings — `200 OK - Success` or `400 - Failed` — for every outcome, in all eleven locales.

--- a/scripts/patch-wwebjs-201832.js
+++ b/scripts/patch-wwebjs-201832.js
@@ -39,6 +39,14 @@ const EXPECTED_REJECTS = new Set(['src/structures/Contact.js.rej']);
 // Every normalization site the backport must land, so a hunk that fails to apply can never pass
 // unnoticed. `patch` always writes a .rej for a hunk it couldn't place, but a hunk placed at the
 // WRONG offset would be silent — these assertions are what close that gap.
+//
+// This list must cover every file the patch normalizes, not just the structure constructors, because
+// the skip branch below uses it to decide a half-patched tree apart from an upstream fix. `patch`
+// applies the diff in file order and Utils.js is applied LAST, one file after Message.js — which is
+// what the skip branch keys on. Omitting a file here means a run that died in that window leaves a
+// tree where every assertion passes, so every later run stands down and the missing site latches in
+// permanently. One entry per file: `siteLanded` resolves a file's marker with `.find`, so a second
+// entry for the same path would never be read.
 const REQUIRED_SITES = [
   ['src/structures/Base.js', /static _normalizeId\(id\)/],
   ['src/structures/Message.js', /this\.id = Base\._normalizeId\(data\.id\)/],
@@ -48,6 +56,11 @@ const REQUIRED_SITES = [
   ['src/structures/Broadcast.js', /this\.id = Base\._normalizeId\(data\.id\)/],
   ['src/structures/GroupNotification.js', /this\.id = Base\._normalizeId\(data\.id\)/],
   ['src/structures/ClientInfo.js', /this\.wid = Base\._normalizeId\(data\.wid\)/],
+  // The browser-side normalizer every inbound message crosses on its way to Node — the site the
+  // structure constructors above cannot cover, and the last file the patch writes.
+  ['src/util/Injected/Utils.js', /_serialized: msg\.id\.\$1/],
+  ['src/Client.js', /res\.gid\._serialized \|\| res\.gid\.\$1/],
+  ['src/structures/GroupChat.js', /pWid\._serialized \|\| pWid\.\$1/],
 ];
 
 /** Artifacts `patch` can leave behind. `.~N~` are GNU's backup-if-mismatch copies of pre-patch source. */
@@ -60,10 +73,11 @@ function siteLanded(wwjsDir, rel) {
 }
 
 /**
- * Flag an error raised once `patch` has started writing. `--best-effort` degrades on a pre-flight failure
- * (no `patch` binary — nothing ran, tree untouched) but must never swallow one of these: `patch` applies
- * hunks as it goes, so failing mid-apply leaves whatsapp-web.js half-patched — which the self-disable
- * check above reads as healthy, latching the broken tree in on every later run.
+ * Flag an error raised against a tree that is no longer pristine — either this run wrote to it, or a
+ * previous run left it half-patched. `--best-effort` degrades on a pre-flight failure (no `patch`
+ * binary — nothing ran, tree untouched) but must never swallow one of these: `patch` applies hunks as
+ * it goes, so failing mid-apply leaves whatsapp-web.js half-patched — which the self-disable check
+ * above reads as healthy, latching the broken tree in on every later run.
  */
 function partialTree(err) {
   err.leftPartialTree = true;
@@ -105,11 +119,16 @@ function applyBackport(wwjsDir = DEFAULT_WWJS, patchFile = DEFAULT_PATCH) {
     // run does not. Proving the tree is whole is what tells the two apart.
     const missing = REQUIRED_SITES.filter(([rel]) => !siteLanded(wwjsDir, rel));
     if (missing.length) {
-      throw new Error(
-        'whatsapp-web.js is PARTIALLY patched — Message.js normalizes ids but ' +
-          `${missing.map(([rel]) => rel).join(', ')} did not land. A previous run left the tree half-patched; ` +
-          'it cannot repair itself. Reinstall the dependency (`rm -rf node_modules/whatsapp-web.js && npm ci`) ' +
-          'and re-run. If the installed version genuinely ships its own fix, drop this backport instead.',
+      // `partialTree`, so `--best-effort` cannot warn past this. The tree this detects is precisely the
+      // one that flag must never wave through: half-patched, self-disable reading it as healthy, and
+      // unrepairable by any later run.
+      throw partialTree(
+        new Error(
+          'whatsapp-web.js is PARTIALLY patched — Message.js normalizes ids but ' +
+            `${missing.map(([rel]) => rel).join(', ')} did not land. A previous run left the tree half-patched; ` +
+            'it cannot repair itself. Reinstall the dependency (`rm -rf node_modules/whatsapp-web.js && npm ci`) ' +
+            'and re-run. If the installed version genuinely ships its own fix, drop this backport instead.',
+        ),
       );
     }
     return { skipped: true, reason: 'installed whatsapp-web.js already normalizes message ids' };

--- a/src/engine/adapters/wwebjs-backport-201832.spec.ts
+++ b/src/engine/adapters/wwebjs-backport-201832.spec.ts
@@ -77,9 +77,24 @@ describe('patch-wwebjs-201832 (build-time backport of upstream #201832)', () => 
     const res = applyBackport(dir);
 
     expect(res.skipped).toBe(true);
-    // Injected/Utils.js carries no REQUIRED_SITES marker, so it stays byte-identical only if the patcher
-    // truly stood down. Re-applying would reject every already-applied hunk and leave artifacts behind.
+    // Re-applying would reject every already-applied hunk and leave artifacts behind, so a byte-identical
+    // Injected/Utils.js is what proves the patcher truly stood down rather than quietly ran again.
     expect(fs.readFileSync(injected, 'utf8')).toBe(before);
+  });
+
+  it('refuses to stand down when only the last-applied file is missing', () => {
+    const dir = copyWwjs();
+    const injected = path.join(dir, 'src', 'util', 'Injected', 'Utils.js');
+    const pristine = fs.readFileSync(injected, 'utf8');
+    applyBackport(dir);
+    // `patch` writes in diff order and Injected/Utils.js is the LAST of the twelve files, one after
+    // Message.js — which is what the stand-down check keys on. A run that died in that window leaves
+    // exactly this tree: every structure constructor normalizes, so the tree reads as healthy, while the
+    // browser-side normalizer every inbound message crosses never landed. Asserting only the structure
+    // files would wave it through and latch it in for good.
+    fs.writeFileSync(injected, pristine);
+
+    expect(() => applyBackport(dir)).toThrow(/PARTIALLY patched[\s\S]*Injected\/Utils\.js/);
   });
 
   it('refuses to stand down on a half-patched tree', () => {
@@ -184,6 +199,23 @@ describe('patch-wwebjs-201832 (build-time backport of upstream #201832)', () => 
 
       expect(res.status).toBe(1);
       expect(res.stderr).toMatch(/version skew/);
+    });
+
+    it('still fails on a tree an earlier run left half-patched', () => {
+      const dir = copyWwjs();
+      const injected = path.join(dir, 'src', 'util', 'Injected', 'Utils.js');
+      const pristine = fs.readFileSync(injected, 'utf8');
+      applyBackport(dir);
+      fs.writeFileSync(injected, pristine);
+
+      // This run writes nothing itself — it only detects a tree an earlier run broke. Degrading on that
+      // is the one thing the flag must never do: it would warn, exit 0, and hand the strict run a tree
+      // whose stand-down check reads as healthy. The trade this flag makes is an UNPATCHED dep, never a
+      // half-patched one.
+      const res = spawnSync(process.execPath, [SCRIPT, '--best-effort', dir], { encoding: 'utf8' });
+
+      expect(res.status).toBe(1);
+      expect(res.stderr).toMatch(/PARTIALLY patched/);
     });
 
     it('degrades when `patch` is not installed, leaving the tree pristine', () => {


### PR DESCRIPTION
## Context

#759 added a wholeness proof to the backport patcher, so a run that died mid-apply could never be mistaken for an upstream fix and stood down on. That was the right mechanism. It had a hole in the one place it mattered most, and its escape hatch was still open.

## Gap 1 — the proof skipped the file most likely to be missing

`patch` applies the diff in file order. The twelve files end:

```
 …
10  src/structures/GroupNotification.js
11  src/structures/Message.js      <- what the stand-down check keys on
12  src/util/Injected/Utils.js     <- LAST
```

`REQUIRED_SITES` asserted the eight structure constructors. It did not assert `src/util/Injected/Utils.js` — the browser-side normalizer that **every inbound message crosses on its way to Node**:

```js
// WhatsApp Web changed _serialized to $1 in message IDs (2026-07 update).
// Normalize here so all downstream Node.js code can keep using _serialized.
if (msg.id && msg.id._serialized == null && msg.id.$1 != null) {
    msg.id = Object.assign({}, msg.id, { _serialized: msg.id.$1 });
}
```

So a run that died between file 11 and file 12 left a tree where **every assertion passed**. Each later run read `Message.js`, took the stand-down branch, and never reached the post-apply checks — leaving the primary normalizer permanently absent. That is precisely the latch the proof exists to prevent, reachable through the proof itself.

Demonstrated against the real dependency — patch fully, revert only `Utils.js`, re-run:

```
before:  {"skipped":true,"reason":"installed whatsapp-web.js already normalizes message ids"}
after:   PARTIALLY patched — Message.js normalizes ids but src/util/Injected/Utils.js did not land.
```

`Client.js` and `GroupChat.js` normalize ids too (`res.gid._serialized || res.gid.$1`, `pWid._serialized || pWid.$1`) and were likewise unasserted; all three are now covered. `index.d.ts` is deliberately excluded — its hunk only reformats a `sendReaction` signature and normalizes nothing.

## Gap 2 — `--best-effort` swallowed the half-patched tree

Of the four throws meaning "this tree is not pristine", the half-patched one was the only one not routed through `partialTree()`. So the `npm install` path warned and exited **0**:

```
$ node scripts/patch-wwebjs-201832.js <half-patched> --best-effort
patch-wwebjs-201832: skipped — whatsapp-web.js is PARTIALLY patched — …
exit 0
```

The flag's own contract, stated directly above it, says an unpatched dep is the trade it makes and that a half-patched one "is not that trade… Fail on it regardless of the flag." It was making that trade anyway. Now exits 1.

## Tests

The existing `refuses to stand down on a half-patched tree` simulated *"Message.js patched, siblings unpatched"* — which the eight-site list already caught, which is why this shipped green. The new test reverts the **last-applied** file on a fully patched tree, which is what the death window actually leaves. A second test covers the `--best-effort` path.

**Both new tests fail against the previous patcher** (2 failed / 8 passed), so they exercise the real defect rather than restating the fix.

One stale comment fixed as a consequence: the stand-down test used `Utils.js` as its canary *because* it carried no marker. It now has one; the assertion still holds for the original reason (re-applying would reject and leave artifacts), so only the rationale changed.

## Verification

- `eslint` 0 errors · `npm test` — 188 suites, **2440** passing (was 2438; +2 new)
- Patcher driven end-to-end against a copy of the installed `whatsapp-web.js` across five scenarios: fresh apply, stand-down, half-patched strict, half-patched `--best-effort`, and `patch`-absent degrade (still exits 0, tree pristine — the case the flag exists for)

Refs #747, #759.
