### PR TITLE
fix(wwjs): finish applying #762's honesty rule to status posts and acks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   untouched, since failing `npm install` outright is the trade the flag exists to avoid. Both fixes are
   regression-tested, including the `--best-effort` path.
 
+- **A status post no longer claims success it cannot prove, and no longer throws away a readable id.**
+  #762 established that `whatsapp-web.js` can *resolve* `undefined` instead of throwing, and that
+  reporting that as success is unrecoverable — so a send with no message back now fails loudly. Status
+  posts reach the identical `Client.js` path but were left on the old behavior: they returned **201**
+  with an empty `statusId` and a `new Date()` invented on the spot, for a status that may never have been
+  published. They now fail the same way sends do. Separately, the id was read only as `_serialized`, so
+  on a build that renamed the field to `$1` (#747) a status that posted perfectly well came back with
+  `statusId: ""` — and since `deleteStatus` takes that id as its revoke handle, the status could never be
+  taken down. The rename fallback the send path has since #762 is now applied here too. The same
+  fallback is added to the ack listener, where an unreadable id previously stranded a message at `sent`
+  forever — including the `failed` ack that is the only signal a send was rejected. Baileys is unaffected:
+  its send and status paths already agree with each other.
+
 - **The Message Tester no longer invents HTTP status codes.** Its result banner rendered one of two
   hardcoded strings — `200 OK - Success` or `400 - Failed` — for every outcome, in all eleven locales.
   Neither number was ever read from the response. Send routes return **201**, not 200, so the success

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,17 +82,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   regression-tested, including the `--best-effort` path.
 
 - **A status post no longer claims success it cannot prove, and no longer throws away a readable id.**
-  #762 established that `whatsapp-web.js` can *resolve* `undefined` instead of throwing, and that
-  reporting that as success is unrecoverable — so a send with no message back now fails loudly. Status
-  posts reach the identical `Client.js` path but were left on the old behavior: they returned **201**
-  with an empty `statusId` and a `new Date()` invented on the spot, for a status that may never have been
-  published. They now fail the same way sends do. Separately, the id was read only as `_serialized`, so
-  on a build that renamed the field to `$1` (#747) a status that posted perfectly well came back with
+  #762 established that `whatsapp-web.js` can *resolve* `undefined` instead of throwing, and that reporting
+  that as success is unrecoverable — so a send with no message back now fails loudly. Status posts were
+  left on the old behavior: they returned **201** with an empty `statusId` and a `new Date()` invented on
+  the spot, for a status that may never have been published. Their case is in fact simpler than a send's —
+  the engine returns the status model before reaching the lookup that makes a send's empty result
+  ambiguous, so no message back means nothing was posted, full stop — and it now surfaces as a `500`
+  carrying that reason rather than a fabricated success. Separately, the id was read only as `_serialized`,
+  so on a build that renamed the field to `$1` (#747) a status that posted perfectly well came back with
   `statusId: ""` — and since `deleteStatus` takes that id as its revoke handle, the status could never be
-  taken down. The rename fallback the send path has since #762 is now applied here too. The same
-  fallback is added to the ack listener, where an unreadable id previously stranded a message at `sent`
-  forever — including the `failed` ack that is the only signal a send was rejected. Baileys is unaffected:
-  its send and status paths already agree with each other.
+  taken down. The rename fallback the send path has since #762 is now applied here too. The same fallback
+  is added to the ack listener, where an unreadable id previously stranded a message at `sent` forever —
+  including the `failed` ack that is the only signal a send was rejected. Baileys is unaffected: its send
+  and status paths already agree with each other.
 
 - **The Message Tester no longer invents HTTP status codes.** Its result banner rendered one of two
   hardcoded strings — `200 OK - Success` or `400 - Failed` — for every outcome, in all eleven locales.

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -15,7 +15,7 @@ import {
 import { getEffectiveWebVersionInfo, resolveWebVersionPin, __resetWebVersionCache } from '../wa-web-version';
 import * as fs from 'fs';
 import * as qrcode from 'qrcode';
-import { UnprocessableEntityException } from '@nestjs/common';
+import { InternalServerErrorException, UnprocessableEntityException } from '@nestjs/common';
 import { EngineNotReadyError } from '../../common/errors/engine-not-ready.error';
 import { ChannelNotFoundError } from '../../common/errors/channel-not-found.error';
 import { ChannelMediaNotSupportedError } from '../../common/errors/channel-media-not-supported.error';
@@ -1145,6 +1145,10 @@ describe('WhatsAppWebJsAdapter status methods', () => {
       const adapter = readyAdapter({ sendMessage });
       const call =
         method === 'postTextStatus' ? adapter.postTextStatus('hello', options) : adapter[method](media, options);
+      // Assert the TYPE, not just the text: a bare Error is a 500 whose body says only "Internal server
+      // error" (no global filter — see message-not-found.error.spec.ts), which would silently discard
+      // the reason this throw exists to deliver.
+      await expect(call).rejects.toBeInstanceOf(InternalServerErrorException);
       await expect(call).rejects.toThrow(/may not have been published/);
     },
   );

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -1121,6 +1121,34 @@ describe('WhatsAppWebJsAdapter status methods', () => {
     },
   );
 
+  it('postTextStatus reads a renamed `$1` id when the dependency has not normalized it', async () => {
+    // The id is right there — spending the "posted, id unknown" sentinel on it would hand the caller a
+    // statusId that deleteStatus can never revoke, for a status that really is live.
+    const sendMessage = jest.fn().mockResolvedValue({ id: { $1: 'STATUS_RENAMED' }, timestamp: 1700000012 });
+    const result = await readyAdapter({ sendMessage }).postTextStatus('hello', options);
+    expect(result.statusId).toBe('STATUS_RENAMED');
+  });
+
+  it('postTextStatus reports an unreadable id as posted-id-unknown rather than inventing one', async () => {
+    const sendMessage = jest.fn().mockResolvedValue({ id: { someFutureName: 'X' }, timestamp: 1700000013 });
+    const result = await readyAdapter({ sendMessage }).postTextStatus('hello', options);
+    // A Message came back, so the post itself is proven — only the id is unreadable.
+    expect(result.statusId).toBe('');
+  });
+
+  it.each([['postTextStatus'], ['postImageStatus'], ['postVideoStatus']] as const)(
+    '%s fails rather than claim a status that may never have been published',
+    async method => {
+      // whatsapp-web.js resolves undefined when the chat could not be resolved — nothing was posted.
+      // Returning a 201 with a fabricated timestamp here is unrecoverable; a visible failure is not.
+      const sendMessage = jest.fn().mockResolvedValue(undefined);
+      const adapter = readyAdapter({ sendMessage });
+      const call =
+        method === 'postTextStatus' ? adapter.postTextStatus('hello', options) : adapter[method](media, options);
+      await expect(call).rejects.toThrow(/may not have been published/);
+    },
+  );
+
   it('deleteStatus revokes via client.revokeStatusMessage(statusId)', async () => {
     const revokeStatusMessage = jest.fn().mockResolvedValue(undefined);
     await readyAdapter({ sendMessage: jest.fn(), revokeStatusMessage }).deleteStatus('STATUS1');
@@ -2086,6 +2114,16 @@ describe('WhatsAppWebJsAdapter message_ack (unreadable id)', () => {
     client.emit('message_ack', { id: { _serialized: 'ACKED_MSG' } }, 3);
 
     expect(onMessageAck).toHaveBeenCalledWith('ACKED_MSG', expect.any(String));
+  });
+
+  it('reads a renamed `$1` id when the dependency has not normalized it', () => {
+    // The send path recovers from the rename; the ack path must too, or a message sent on an unpatched
+    // build can never leave SENT — including via `ack < 0`, the one signal that it failed outright.
+    const { onMessageAck, client } = wireAckHandler();
+
+    client.emit('message_ack', { id: { $1: 'ACKED_RENAMED' } }, 3);
+
+    expect(onMessageAck).toHaveBeenCalledWith('ACKED_RENAMED', expect.any(String));
   });
 
   it('drops an ack whose id cannot be read instead of passing undefined on', () => {

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events';
+import { InternalServerErrorException } from '@nestjs/common';
 import { Client, LocalAuth, MessageMedia, MessageTypes, WAState, type Message } from 'whatsapp-web.js';
 import * as qrcode from 'qrcode';
 import * as path from 'path';
@@ -1869,11 +1870,18 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
   }
 
   /**
-   * The status-post counterpart of `toMessageResult`, and it answers to the same rule for the same
-   * reason: `sendMessage('status@broadcast', …)` reaches the identical `Client.js` path, so an absent
-   * message is the identical ambiguity (nothing posted vs. posted-but-unreadable) and must not be
-   * reported as success. It previously fabricated one — `new Date()` for a status that may never have
-   * existed, behind a `201`.
+   * The status-post counterpart of `toMessageResult`, but its absent-message case is *narrower* than a
+   * send's. `Injected/Utils.js` builds the status model and returns it from the `isStatus` branch before
+   * ever reaching the `Msg.get` miss that makes an ordinary send ambiguous — so the only way back with no
+   * message is `Client.js`'s `if (!chat) return null`, i.e. nothing was posted at all. Not an ambiguity:
+   * a plain failure, which was previously dressed up as a `201` carrying a `new Date()` invented for a
+   * status that never existed.
+   *
+   * Thrown as an `InternalServerErrorException` rather than a bare `Error` because there is no global
+   * exception filter (see `message-not-found.error.spec.ts`), so a bare `Error` reaches the caller as
+   * `{"statusCode":500,"message":"Internal server error"}` — and unlike a send, which routes its message
+   * into the `message:failed` hook, HTTP is the only consumer a status post has. The same 500, with the
+   * reason surviving.
    *
    * A present `Message` proves the post happened, so an id it cannot read there carries the same empty
    * sentinel `toMessageResult` uses. Read `$1` before falling back to it (#747): the sentinel means
@@ -1882,7 +1890,7 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
    */
   private toStatusResult(msg: Message | undefined): StatusResult {
     if (!msg) {
-      throw new Error(
+      throw new InternalServerErrorException(
         'the engine returned no message for this status post, so it may not have been published — check your status before retrying',
       );
     }

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -602,7 +602,11 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
       // so the message stays at SENT with only a misleading "no status row advanced" in the log. Drop
       // it here, where the reason is still visible. (Note this differs from the reaction path below,
       // where `findOne` DROPS an undefined key instead of nulling it and matches an arbitrary row.)
-      const ackId = (msg.id as unknown as SerializedWid | undefined)?._serialized;
+      // Read `$1` before giving up, as the send path does (#747): a build that renamed the field still
+      // has a perfectly good id here, and dropping it strands the message at SENT — including the
+      // `ack < 0` that is the only signal a send failed.
+      const rawId = msg.id as unknown as SerializedWid | undefined;
+      const ackId = rawId?._serialized ?? rawId?.$1;
       if (!ackId) {
         this.logger.warn('Dropping an ack whose message id could not be read', { ack });
         return;
@@ -1864,10 +1868,28 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     return { id: id?._serialized ?? id?.$1 ?? '', timestamp: msg.timestamp };
   }
 
+  /**
+   * The status-post counterpart of `toMessageResult`, and it answers to the same rule for the same
+   * reason: `sendMessage('status@broadcast', …)` reaches the identical `Client.js` path, so an absent
+   * message is the identical ambiguity (nothing posted vs. posted-but-unreadable) and must not be
+   * reported as success. It previously fabricated one — `new Date()` for a status that may never have
+   * existed, behind a `201`.
+   *
+   * A present `Message` proves the post happened, so an id it cannot read there carries the same empty
+   * sentinel `toMessageResult` uses. Read `$1` before falling back to it (#747): the sentinel means
+   * "posted, id unknown", and `deleteStatus` takes this id as the revoke handle — spending it on an id
+   * that was readable all along leaves a status nothing can revoke.
+   */
   private toStatusResult(msg: Message | undefined): StatusResult {
-    const ts = msg?.timestamp ? new Date(msg.timestamp * 1000) : new Date();
+    if (!msg) {
+      throw new Error(
+        'the engine returned no message for this status post, so it may not have been published — check your status before retrying',
+      );
+    }
+    const id = msg.id as unknown as SerializedWid | undefined;
+    const ts = msg.timestamp ? new Date(msg.timestamp * 1000) : new Date();
     return {
-      statusId: msg?.id?._serialized ?? '',
+      statusId: id?._serialized ?? id?.$1 ?? '',
       timestamp: ts,
       expiresAt: new Date(ts.getTime() + 24 * 3_600_000),
     };


### PR DESCRIPTION
## The rule #762 set

`Client.sendMessage()` can **resolve** with `undefined` rather than throw. An absent message cannot distinguish *"nothing was sent"* from *"sent, id unreadable"*, and claiming success for the first is unrecoverable — so it throws. A present `Message` proves dispatch, so an id it cannot read there carries the empty sentinel, and `$1` is read before falling back to it (#747).

`toStatusResult` sits **directly beneath** `toMessageResult` and the doc-comment stating that rule. It followed none of it:

```ts
private toStatusResult(msg: Message | undefined): StatusResult {
  const ts = msg?.timestamp ? new Date(msg.timestamp * 1000) : new Date();
  return { statusId: msg?.id?._serialized ?? '', … };
}
```

## Two defects

**1. It fabricates a 201.** Status posts reach the identical `Client.js` path, so `undefined` carries the identical ambiguity. Instead of failing, it returned **201** with an empty `statusId` and a `new Date()` invented on the spot — for a status that may never have been published. Exactly what the comment above it forbids.

**2. It discards a readable id — and this is the more reachable half.** It never tries `$1`, so on a renamed build a status that posted perfectly well returns `statusId: ""`. `deleteStatus` takes that id as its revoke handle, so the status can **never be taken down**.

That half is not theoretical. Unlike an ordinary send, a status post still *succeeds* on an unpatched build: `Injected/Utils.js` returns the constructed `msg` on the status branch before ever reaching the `Msg.get` that fails elsewhere. So the one path that still works when others 500 is the one that loses its id.

## The ack listener

Same missing fallback. #765 was right to drop an unreadable id rather than pass `undefined` into an `UPDATE` that TypeORM turns into `waMessageId = NULL` — **that guard stays**. But it dropped ids readable as `$1`, stranding the message at `sent` forever, including the `ack < 0` that is the only signal a send failed outright.

## Blast radius — traced, not assumed

- **No new HTTP behavior class.** A send whose `toMessageResult` throws already surfaces as a **500**: `failSend` → `toClientFacingError` passes a plain `Error` through, and there is no global exception filter. A status post throws bare because it has nothing to persist (status echoes are deliberately not stored) and no hook to fire. Same outcome, same reason.
- **No Swagger change.** #762 did not document a 500 on the send routes; this stays consistent with that.
- **No `openapi.json` delta** — no controller or DTO touched.
- **Baileys deliberately untouched.** Its send path (`:525`, `:1578`) and status path (`:1631`) *both* use the empty sentinel, so it is self-consistent. Only whatsapp-web.js disagreed with itself, and changing Baileys would need its own analysis of what `undefined` means there.
- `!msg` is now impossible past the guard, so the `msg.timestamp ? … : new Date()` fallback now only covers a *present* message with no timestamp — where the post is proven and only the clock is unknown. Unchanged on purpose.

## Tests

Six new cases; **all six fail against the previous adapter** (5 failed / 173 passed before the ack case was added). They cover: `$1` recovered on a status post, unreadable id → sentinel, all three post methods rejecting on `undefined`, and `$1` recovered on an ack. The existing status specs pinned only happy paths, which is why this shipped green.

## Verification

- `eslint` 0 errors · `prettier` clean · `npm test` — 188 suites, **2444** passing (was 2438; +6)

Refs #747, #762, #765.
