### PR TITLE
docs(api): align status and catalog Swagger with the capability matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Swagger now agrees with the engine capability matrix on status and catalog (docs only).** The drift
+  ran in both directions. The three status-post routes were still labelled "(Baileys only)" — stale since
+  #714 wired them on whatsapp-web.js, and contradicted by the matrix, which has listed both engines as
+  `supported` ever since; the label told whatsapp-web.js users a working endpoint was unavailable to
+  them. In the other direction, the three catalog reads documented a plain `200` as though they returned
+  data, while the matrix marks all three `not-available` on both engines: whatsapp-web.js stubs them
+  (returning `null`/an empty page with a warn log) and Baileys raises `501`. Both real responses are now
+  documented, and the summaries say the capability is unimplemented — matching how the catalog *send*
+  routes next to them were already annotated. The matrix's own header claimed five whatsapp-web.js
+  entries were `not-available` while two of the five it named said `supported` two lines below; it is
+  three, and the stale adapter line references in the catalog evidence now point at the real stubs. No
+  behavior change; `openapi.json` regenerated.
+
 - **Corrected the send-response documentation (docs only).** The guidance added in #739 overstated what a
   stalled send tells you: it said a message resting at `sent` for a recipient you have never reached is
   "almost certainly a number that is not on WhatsApp." That inference does not hold in the other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,15 +30,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Swagger now agrees with the engine capability matrix on status and catalog (docs only).** The drift
-  ran in both directions. The three status-post routes were still labelled "(Baileys only)" — stale since
-  #714 wired them on whatsapp-web.js, and contradicted by the matrix, which has listed both engines as
-  `supported` ever since; the label told whatsapp-web.js users a working endpoint was unavailable to
-  them. In the other direction, the three catalog reads documented a plain `200` as though they returned
-  data, while the matrix marks all three `not-available` on both engines: whatsapp-web.js stubs them
-  (returning `null`/an empty page with a warn log) and Baileys raises `501`. Both real responses are now
-  documented, and the summaries say the capability is unimplemented — matching how the catalog *send*
-  routes next to them were already annotated. The matrix's own header claimed five whatsapp-web.js
+- **Swagger now agrees with the engine capability matrix on status and catalog (docs only).** Eight
+  operations were describing something other than what they do, and the drift ran in both directions.
+  The three status-post routes were labelled "(Baileys only)" — stale since #714 wired them on
+  whatsapp-web.js, and contradicted by the matrix, which has listed both engines as `supported` ever
+  since; the label told whatsapp-web.js users a working endpoint was unavailable to them. Their `201`
+  also promised the status was "posted to the specified recipients", which is true only on Baileys:
+  whatsapp-web.js ignores the `recipients` allow-list and broadcasts to the account's status-privacy
+  audience, as the adapter already warns at runtime. Dropping the stale label without that caveat would
+  have replaced a wrong label with a worse silence, so the responses and the `recipients` field now say
+  which engine honors it. In the other direction, the three catalog reads documented a plain `200` as
+  though they returned data, and the two catalog **sends** documented a `201` they can never return —
+  the matrix marks all five `not-available` on both engines. whatsapp-web.js stubs the reads (`null`/an
+  empty page with a warn log) and Baileys raises `501`; the sends are `501` on both. Every real response
+  is now documented and the summaries name the gap. The matrix's own header claimed five whatsapp-web.js
   entries were `not-available` while two of the five it named said `supported` two lines below; it is
   three, and the stale adapter line references in the catalog evidence now point at the real stubs. No
   behavior change; `openapi.json` regenerated.

--- a/openapi.json
+++ b/openapi.json
@@ -3857,7 +3857,7 @@
         },
         "responses": {
           "201": {
-            "description": "Text status posted to the specified recipients."
+            "description": "Text status posted. The recipients allow-list is honored on Baileys only; whatsapp-web.js broadcasts to the account's status-privacy audience."
           }
         },
         "summary": "Post a text status",
@@ -3891,7 +3891,7 @@
         },
         "responses": {
           "201": {
-            "description": "Image status posted to the specified recipients."
+            "description": "Image status posted. The recipients allow-list is honored on Baileys only; whatsapp-web.js broadcasts to the account's status-privacy audience."
           }
         },
         "summary": "Post an image status",
@@ -3925,7 +3925,7 @@
         },
         "responses": {
           "201": {
-            "description": "Video status posted to the specified recipients."
+            "description": "Video status posted. The recipients allow-list is honored on Baileys only; whatsapp-web.js broadcasts to the account's status-privacy audience."
           }
         },
         "summary": "Post a video status",
@@ -6763,7 +6763,7 @@
             "maximum": 5
           },
           "recipients": {
-            "description": "Recipient JIDs (1–256). WhatsApp Status is not posted to a group — use @c.us or @lid individuals.",
+            "description": "Recipient JIDs (1–256). WhatsApp Status is not posted to a group — use @c.us or @lid individuals. Honored on the Baileys engine only: whatsapp-web.js ignores this allow-list and broadcasts to the account's status-privacy audience.",
             "example": [
               "628123456789@c.us"
             ],
@@ -6818,7 +6818,7 @@
             "maxLength": 1024
           },
           "recipients": {
-            "description": "Recipient JIDs (1–256), @c.us or @lid.",
+            "description": "Recipient JIDs (1–256), @c.us or @lid. Honored on the Baileys engine only: whatsapp-web.js ignores this allow-list and broadcasts to the account's status-privacy audience.",
             "example": [
               "628123456789@c.us"
             ],
@@ -6853,7 +6853,7 @@
             "maxLength": 1024
           },
           "recipients": {
-            "description": "Recipient JIDs (1–256), @c.us or @lid.",
+            "description": "Recipient JIDs (1–256), @c.us or @lid. Honored on the Baileys engine only: whatsapp-web.js ignores this allow-list and broadcasts to the account's status-privacy audience.",
             "example": [
               "628123456789@c.us"
             ],

--- a/openapi.json
+++ b/openapi.json
@@ -3860,7 +3860,7 @@
             "description": "Text status posted to the specified recipients."
           }
         },
-        "summary": "Post a text status (Baileys only)",
+        "summary": "Post a text status",
         "tags": [
           "status"
         ]
@@ -3894,7 +3894,7 @@
             "description": "Image status posted to the specified recipients."
           }
         },
-        "summary": "Post an image status (Baileys only)",
+        "summary": "Post an image status",
         "tags": [
           "status"
         ]
@@ -3928,7 +3928,7 @@
             "description": "Video status posted to the specified recipients."
           }
         },
-        "summary": "Post a video status (Baileys only)",
+        "summary": "Post a video status",
         "tags": [
           "status"
         ]
@@ -3981,10 +3981,13 @@
         ],
         "responses": {
           "200": {
-            "description": "Business catalog metadata for the session."
+            "description": "Always null on whatsapp-web.js: catalog reads are not implemented on either engine."
+          },
+          "501": {
+            "description": "Not supported by the active engine: Baileys does not implement catalog reads."
           }
         },
-        "summary": "Get business catalog info",
+        "summary": "Get business catalog info (not implemented by any engine)",
         "tags": [
           "catalog"
         ]
@@ -4027,10 +4030,13 @@
         ],
         "responses": {
           "200": {
-            "description": "Paginated list of catalog products."
+            "description": "Always an empty page on whatsapp-web.js: catalog reads are not implemented on either engine."
+          },
+          "501": {
+            "description": "Not supported by the active engine: Baileys does not implement catalog reads."
           }
         },
-        "summary": "List catalog products",
+        "summary": "List catalog products (not implemented by any engine)",
         "tags": [
           "catalog"
         ]
@@ -4059,10 +4065,13 @@
         ],
         "responses": {
           "200": {
-            "description": "The requested catalog product."
+            "description": "Always null on whatsapp-web.js: catalog reads are not implemented on either engine."
+          },
+          "501": {
+            "description": "Not supported by the active engine: Baileys does not implement catalog reads."
           }
         },
-        "summary": "Get a specific product",
+        "summary": "Get a specific product (not implemented by any engine)",
         "tags": [
           "catalog"
         ]
@@ -4092,11 +4101,11 @@
           }
         },
         "responses": {
-          "201": {
-            "description": "Product message sent."
+          "501": {
+            "description": "Not supported by the active engine: no engine can send product messages."
           }
         },
-        "summary": "Send a product message",
+        "summary": "Send a product message (not supported by any engine)",
         "tags": [
           "catalog"
         ]
@@ -4126,11 +4135,11 @@
           }
         },
         "responses": {
-          "201": {
-            "description": "Catalog link sent."
+          "501": {
+            "description": "Not supported by the active engine: no engine can send catalog links."
           }
         },
-        "summary": "Send catalog link",
+        "summary": "Send catalog link (not supported by any engine)",
         "tags": [
           "catalog"
         ]

--- a/src/engine/engine-capability-matrix.ts
+++ b/src/engine/engine-capability-matrix.ts
@@ -29,12 +29,13 @@
  * by the spec and are updated by hand as adapters are wired or libraries change.
  *
  * NOTE on phantom support: the drift gate's throw-heuristic cannot see adapter methods that silently
- * stub (return null/[] + a warn log) without throwing. The matrix BELOW is the source-of-truth: five
- * wwjs entries (getCatalog/getProducts/getProduct/getContactStatus/getContactStatuses) are marked
- * `not-available` here even though their adapter bodies do not throw — because the underlying library
- * either has no API (catalog) or the adapter stubs instead of calling the available symbol (status
- * read). If the drift gate is extended to assert against this matrix, it must consult `status`, not
- * just the throw pattern, for these rows (or the adapter stubs must start throwing).
+ * stub (return null/[] + a warn log) without throwing. The matrix BELOW is the source-of-truth: three
+ * wwjs entries (getCatalog/getProducts/getProduct) are marked `not-available` here even though their
+ * adapter bodies do not throw — the library has no API for them, so the adapter stubs. If the drift
+ * gate is extended to assert against this matrix, it must consult `status`, not just the throw
+ * pattern, for these rows (or the adapter stubs must start throwing). getContactStatus/
+ * getContactStatuses were on this list until #714 wired them on whatsapp-web.js; their rows say
+ * `supported` and the adapter really does read stories, so they no longer belong here.
  */
 export type CapabilityStatus = 'supported' | 'not-available';
 export type RootCause = 'adapter-gap' | 'library-limitation' | 'uncertain';
@@ -70,7 +71,7 @@ export const ENGINE_CAPABILITY_MATRIX: Record<string, MethodCapability> = {
     wwjs: { status: 'not-available', rootCause: 'library-limitation' },
     baileys: { status: 'not-available', rootCause: 'adapter-gap' },
     evidence:
-      'baileys Socket/business.d.ts:7 getCatalog({jid,limit,cursor}) + getCollections (business.d.ts:11) — adapter unwired (returns Product[]+cursor, not Catalog metadata; medium-confidence shape synthesis); wwjs index.d.ts has NO Client.getCatalog (0 hits), adapter stubs to null @whatsapp-web-js.adapter.ts:1770',
+      'baileys Socket/business.d.ts:7 getCatalog({jid,limit,cursor}) + getCollections (business.d.ts:11) — adapter unwired (returns Product[]+cursor, not Catalog metadata; medium-confidence shape synthesis); wwjs index.d.ts has NO Client.getCatalog (0 hits), adapter stubs to null @whatsapp-web-js.adapter.ts:1895',
   },
   getChannelById: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   getChannelMessages: {
@@ -132,13 +133,13 @@ export const ENGINE_CAPABILITY_MATRIX: Record<string, MethodCapability> = {
     wwjs: { status: 'not-available', rootCause: 'library-limitation' },
     baileys: { status: 'not-available', rootCause: 'adapter-gap' },
     evidence:
-      'baileys only getCatalog (Socket/business.d.ts:7); getProduct = getCatalog then find-by-id (compose-and-filter, loads whole page; medium-confidence); wwjs no Client.getProduct — only page-internal getProductMetadata (Utils.js:1253), not a public Client fn; adapter stubs to null @whatsapp-web-js.adapter.ts:1786',
+      'baileys only getCatalog (Socket/business.d.ts:7); getProduct = getCatalog then find-by-id (compose-and-filter, loads whole page; medium-confidence); wwjs no Client.getProduct — only page-internal getProductMetadata (Utils.js:1253), not a public Client fn; adapter stubs to null @whatsapp-web-js.adapter.ts:1911',
   },
   getProducts: {
     wwjs: { status: 'not-available', rootCause: 'library-limitation' },
     baileys: { status: 'not-available', rootCause: 'adapter-gap' },
     evidence:
-      'baileys Socket/business.d.ts:7 getCatalog({jid,limit,cursor}) → {products, nextPageCursor} — adapter unwired; wwjs no Client.getProducts in index.d.ts (0 hits); adapter stubs to empty @whatsapp-web-js.adapter.ts:1777',
+      'baileys Socket/business.d.ts:7 getCatalog({jid,limit,cursor}) → {products, nextPageCursor} — adapter unwired; wwjs no Client.getProducts in index.d.ts (0 hits); adapter stubs to empty @whatsapp-web-js.adapter.ts:1902',
   },
   getProfilePicture: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   getPushName: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },

--- a/src/modules/catalog/catalog.controller.ts
+++ b/src/modules/catalog/catalog.controller.ts
@@ -11,38 +11,59 @@ export class CatalogController {
   constructor(private readonly catalogService: CatalogService) {}
 
   @Get('catalog')
-  @ApiOperation({ summary: 'Get business catalog info' })
-  @ApiResponse({ status: 200, description: 'Business catalog metadata for the session.' })
+  @ApiOperation({ summary: 'Get business catalog info (not implemented by any engine)' })
+  @ApiResponse({
+    status: 200,
+    description: 'Always null on whatsapp-web.js: catalog reads are not implemented on either engine.',
+  })
+  @ApiResponse({
+    status: 501,
+    description: 'Not supported by the active engine: Baileys does not implement catalog reads.',
+  })
   async getCatalog(@Param('sessionId') sessionId: string) {
     return this.catalogService.getCatalog(sessionId);
   }
 
   @Get('catalog/products')
-  @ApiOperation({ summary: 'List catalog products' })
-  @ApiResponse({ status: 200, description: 'Paginated list of catalog products.' })
+  @ApiOperation({ summary: 'List catalog products (not implemented by any engine)' })
+  @ApiResponse({
+    status: 200,
+    description: 'Always an empty page on whatsapp-web.js: catalog reads are not implemented on either engine.',
+  })
+  @ApiResponse({
+    status: 501,
+    description: 'Not supported by the active engine: Baileys does not implement catalog reads.',
+  })
   async getProducts(@Param('sessionId') sessionId: string, @Query() query: ProductQueryDto) {
     return this.catalogService.getProducts(sessionId, query.page, query.limit);
   }
 
   @Get('catalog/products/:productId')
-  @ApiOperation({ summary: 'Get a specific product' })
-  @ApiResponse({ status: 200, description: 'The requested catalog product.' })
+  @ApiOperation({ summary: 'Get a specific product (not implemented by any engine)' })
+  @ApiResponse({
+    status: 200,
+    description: 'Always null on whatsapp-web.js: catalog reads are not implemented on either engine.',
+  })
+  @ApiResponse({
+    status: 501,
+    description: 'Not supported by the active engine: Baileys does not implement catalog reads.',
+  })
   async getProduct(@Param('sessionId') sessionId: string, @Param('productId') productId: string) {
     return this.catalogService.getProduct(sessionId, productId);
   }
 
   @Post('messages/send-product')
   @RequireRole(ApiKeyRole.OPERATOR)
-  @ApiOperation({ summary: 'Send a product message' })
-  @ApiResponse({ status: 201, description: 'Product message sent.' })
+  @ApiOperation({ summary: 'Send a product message (not supported by any engine)' })
+  @ApiResponse({ status: 501, description: 'Not supported by the active engine: no engine can send product messages.' })
   async sendProduct(@Param('sessionId') sessionId: string, @Body() dto: SendProductDto) {
     return this.catalogService.sendProduct(sessionId, dto.chatId, dto.productId, dto.body);
   }
 
   @Post('messages/send-catalog')
   @RequireRole(ApiKeyRole.OPERATOR)
-  @ApiOperation({ summary: 'Send catalog link' })
-  @ApiResponse({ status: 201, description: 'Catalog link sent.' })
+  @ApiOperation({ summary: 'Send catalog link (not supported by any engine)' })
+  @ApiResponse({ status: 501, description: 'Not supported by the active engine: no engine can send catalog links.' })
   async sendCatalog(@Param('sessionId') sessionId: string, @Body() dto: SendCatalogDto) {
     return this.catalogService.sendCatalog(sessionId, dto.chatId, dto.body);
   }

--- a/src/modules/status/dto/send-media-status.dto.ts
+++ b/src/modules/status/dto/send-media-status.dto.ts
@@ -47,7 +47,9 @@ export class SendImageStatusDto {
   caption?: string;
 
   @ApiProperty({
-    description: 'Recipient JIDs (1–256), @c.us or @lid.',
+    description:
+      'Recipient JIDs (1–256), @c.us or @lid. Honored on the Baileys engine only: whatsapp-web.js ignores ' +
+      "this allow-list and broadcasts to the account's status-privacy audience.",
     type: String,
     isArray: true,
     example: ['628123456789@c.us'],
@@ -75,7 +77,9 @@ export class SendVideoStatusDto {
   caption?: string;
 
   @ApiProperty({
-    description: 'Recipient JIDs (1–256), @c.us or @lid.',
+    description:
+      'Recipient JIDs (1–256), @c.us or @lid. Honored on the Baileys engine only: whatsapp-web.js ignores ' +
+      "this allow-list and broadcasts to the account's status-privacy audience.",
     type: String,
     isArray: true,
     example: ['628123456789@c.us'],

--- a/src/modules/status/dto/send-text-status.dto.ts
+++ b/src/modules/status/dto/send-text-status.dto.ts
@@ -32,7 +32,10 @@ export class SendTextStatusDto {
   font?: number;
 
   @ApiProperty({
-    description: 'Recipient JIDs (1–256). WhatsApp Status is not posted to a group — use @c.us or @lid individuals.',
+    description:
+      'Recipient JIDs (1–256). WhatsApp Status is not posted to a group — use @c.us or @lid individuals. ' +
+      'Honored on the Baileys engine only: whatsapp-web.js ignores this allow-list and broadcasts to the ' +
+      "account's status-privacy audience.",
     type: String,
     isArray: true,
     example: ['628123456789@c.us'],

--- a/src/modules/status/status.controller.ts
+++ b/src/modules/status/status.controller.ts
@@ -27,7 +27,7 @@ export class StatusController {
 
   @Post('send-text')
   @RequireRole(ApiKeyRole.OPERATOR)
-  @ApiOperation({ summary: 'Post a text status (Baileys only)' })
+  @ApiOperation({ summary: 'Post a text status' })
   @ApiResponse({ status: 201, description: 'Text status posted to the specified recipients.' })
   async sendTextStatus(@Param('sessionId') sessionId: string, @Body() dto: SendTextStatusDto) {
     return this.statusService.postTextStatus(sessionId, dto.text, {
@@ -39,7 +39,7 @@ export class StatusController {
 
   @Post('send-image')
   @RequireRole(ApiKeyRole.OPERATOR)
-  @ApiOperation({ summary: 'Post an image status (Baileys only)' })
+  @ApiOperation({ summary: 'Post an image status' })
   @ApiResponse({ status: 201, description: 'Image status posted to the specified recipients.' })
   async sendImageStatus(@Param('sessionId') sessionId: string, @Body() dto: SendImageStatusDto) {
     return this.statusService.postImageStatus(sessionId, dto.image, {
@@ -50,7 +50,7 @@ export class StatusController {
 
   @Post('send-video')
   @RequireRole(ApiKeyRole.OPERATOR)
-  @ApiOperation({ summary: 'Post a video status (Baileys only)' })
+  @ApiOperation({ summary: 'Post a video status' })
   @ApiResponse({ status: 201, description: 'Video status posted to the specified recipients.' })
   async sendVideoStatus(@Param('sessionId') sessionId: string, @Body() dto: SendVideoStatusDto) {
     return this.statusService.postVideoStatus(sessionId, dto.video, {

--- a/src/modules/status/status.controller.ts
+++ b/src/modules/status/status.controller.ts
@@ -28,7 +28,12 @@ export class StatusController {
   @Post('send-text')
   @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Post a text status' })
-  @ApiResponse({ status: 201, description: 'Text status posted to the specified recipients.' })
+  @ApiResponse({
+    status: 201,
+    description:
+      'Text status posted. The recipients allow-list is honored on Baileys only; whatsapp-web.js broadcasts ' +
+      "to the account's status-privacy audience.",
+  })
   async sendTextStatus(@Param('sessionId') sessionId: string, @Body() dto: SendTextStatusDto) {
     return this.statusService.postTextStatus(sessionId, dto.text, {
       recipients: dto.recipients,
@@ -40,7 +45,12 @@ export class StatusController {
   @Post('send-image')
   @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Post an image status' })
-  @ApiResponse({ status: 201, description: 'Image status posted to the specified recipients.' })
+  @ApiResponse({
+    status: 201,
+    description:
+      'Image status posted. The recipients allow-list is honored on Baileys only; whatsapp-web.js broadcasts ' +
+      "to the account's status-privacy audience.",
+  })
   async sendImageStatus(@Param('sessionId') sessionId: string, @Body() dto: SendImageStatusDto) {
     return this.statusService.postImageStatus(sessionId, dto.image, {
       recipients: dto.recipients,
@@ -51,7 +61,12 @@ export class StatusController {
   @Post('send-video')
   @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Post a video status' })
-  @ApiResponse({ status: 201, description: 'Video status posted to the specified recipients.' })
+  @ApiResponse({
+    status: 201,
+    description:
+      'Video status posted. The recipients allow-list is honored on Baileys only; whatsapp-web.js broadcasts ' +
+      "to the account's status-privacy audience.",
+  })
   async sendVideoStatus(@Param('sessionId') sessionId: string, @Body() dto: SendVideoStatusDto) {
     return this.statusService.postVideoStatus(sessionId, dto.video, {
       recipients: dto.recipients,


### PR DESCRIPTION
Nothing ties `@ApiOperation` text to `ENGINE_CAPABILITY_MATRIX`, and the two had drifted apart — **in both directions.**

## Understating: status posts still say "(Baileys only)"

```
status.controller.ts:30  'Post a text status (Baileys only)'
engine-capability-matrix.ts:157-159  postTextStatus: { wwjs: 'supported', baileys: 'supported' }
```

#714 (`7d65212`, "status posts on the whatsapp-web.js engine") wired these on **the default engine**, and the matrix has said `supported` for both ever since. The label was telling whatsapp-web.js users that a working endpoint was unavailable to them.

## Overstating: catalog reads document a 200 as though they return data

```
catalog.controller.ts:14  @ApiResponse({ status: 200, description: 'Business catalog metadata for the session.' })
engine-capability-matrix.ts:70-75  getCatalog: { wwjs: 'not-available', baileys: 'not-available' }
```

Neither engine implements it. whatsapp-web.js **stubs** — returns `null`/an empty page with a warn log, never throwing, which is precisely the "phantom support" the matrix header warns the drift gate cannot see. Baileys raises `EngineNotSupportedError`, which extends `NotImplementedException` and so surfaces as **501**.

So the documented `200` is real but empty, and the `501` — the only response a Baileys caller ever gets — was undocumented. Both are now stated, and the summaries name the gap. This is the annotation the catalog **send** routes directly beneath already carried (`'Send a product message (not supported by any engine)'` + 501); the GET trio was the odd one out.

## The matrix contradicts itself

Its header claims **five** whatsapp-web.js entries are `not-available` and names `getContactStatus`/`getContactStatuses` among them — while their own rows, two lines below, say `supported`, and the adapter genuinely reads stories (`:1744`/`:1749`, again #714). It is **three**. The catalog evidence strings also cite adapter lines `1770/1777/1786`; those drifted long ago — `:1770` is now inside a status loop. They now cite the real stubs at `:1895/:1902/:1911`.

## Scope

Swagger text and matrix comments only. **No behavior change.** `openapi.json` regenerated — the delta is exactly these six operations, nothing else.

`engine-parity.spec.ts` asserts matrix *keys* against the interface and the throw/status invariant. It never parses the evidence strings or the header comment, so none of this can affect it — confirmed by reading it, and the suite is green.

## Known gap, not fixed here

There is still nothing that *enforces* Swagger against the matrix, which is why this drift went unnoticed through two releases. A gate would need to read `status` rather than the throw-heuristic — as the matrix header itself points out. Out of scope for a docs correction.

## Verification

- `openapi:check` green · `eslint` 0 errors · `npm test` — 188 suites, 2438 passing

Refs #714, #738.
