### PR TITLE
docs(changelog): credit v0.8.18 with restoring the Chats page (#753)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **v0.8.18's whatsapp-web.js id-rename fix also restored the Chats page (docs only).** The v0.8.18 entry
+  credits that fix with repairing inbound media downloads, message ids, acks, reply quoting, and reactions,
+  but never mentions `GET /sessions/{id}/chats` — which the same patch repaired as well. The rename broke the
+  injected read of each chat's last-received message key, and because every chat resolves through a single
+  `Promise.all`, one unreadable key rejected the entire request, so the dashboard's Chats page returned
+  `500 Internal server error` on every load while the rest of the dashboard kept working from stored data.
+  Operators on v0.8.17 hitting that symptom found nothing in the release notes matching it and so had no
+  reason to upgrade. No behavior change, and no change to which release carries the fix — it is still
+  v0.8.18. Refs #753, #757.
+
 - **Swagger now agrees with the engine capability matrix on status and catalog (docs only).** Eight
   operations were describing something other than what they do, and the drift ran in both directions.
   The three status-post routes were labelled "(Baileys only)" — stale since #714 wired them on


### PR DESCRIPTION
Closes a public commitment made on #753.

## Why

The v0.8.18 entry describes the whatsapp-web.js id-rename backport in terms of media downloads, message ids, acks, reply quoting, and reactions. It never mentions `GET /sessions/{id}/chats` — which the same patch repaired.

The rename broke the injected read of each chat's last-received message key, and because every chat resolves through a single `Promise.all`, one unreadable key rejected the whole request. So the Chats page returned `500 Internal server error` on every load while the rest of the dashboard kept working from stored data — a distinctive symptom with nothing in the release notes matching it.

An operator on v0.8.17 hitting that had no reason to upgrade. That is exactly what happened on #753, and I said so there:

> the v0.8.18 entry describes this fix in terms of media downloads, message ids, acks, and reply quoting, and doesn't call out the Chats page explicitly — but the same patch covers it. That omission is on me; I'll get the changelog amended so it's findable.

This is that amendment.

## Scope

Documentation only. **No change to which release carries the fix** — it is still v0.8.18. The entry lands under `[Unreleased]` rather than rewriting the released `[0.8.18]` section: `[Unreleased]` is the first thing in the file, so anyone searching the changelog for their symptom finds it, and the released section stays as it shipped.

## Verification

- `check:versions` green (package.json = 0.8.18)
- "Chats page" is now greppable in `CHANGELOG.md` — the one thing the commitment was about
- All 13 `[Unreleased]` entries intact after rebasing onto current main

Refs #753, #757.
