### PR TITLE
docs(wwjs): stop calling Reaction the one structure normalization misses

### DIFF
--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -645,9 +645,11 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
 
     this.client.on('message_reaction', reaction => {
       try {
-        // `Reaction` assigns its keys straight through (`this.msgId = data.parentMsgKey`), so it is the
-        // one structure upstream's id normalization doesn't reach — on a WA Web build that renamed
-        // `_serialized` to `$1` (#747), `msgId._serialized` is undefined even with the backport applied.
+        // `Reaction` assigns its keys straight through (`this.msgId = data.parentMsgKey`), which
+        // upstream's id normalization doesn't reach: it covers structure constructors and `msg.id`,
+        // not keys assigned straight through (`Message.protocolMessageKey` and `Reaction.id` are the
+        // same pattern). On a WA Web build that renamed `_serialized` to `$1` (#747),
+        // `msgId._serialized` is undefined even with the backport applied.
         // Read `$1` as a fallback, and fall back again to `''` (the same no-id sentinel Baileys uses)
         // rather than pass undefined on: `applyReaction` looks the message up by this id, and TypeORM
         // DROPS an undefined condition from the where-clause — which would match an arbitrary row and


### PR DESCRIPTION
Comment-only. No behavior change.

## What was wrong

The `message_reaction` guard's comment claimed `Reaction` "is **the one** structure upstream's id normalization doesn't reach."

It isn't the one — it's an instance of a pattern. The normalization covers structure constructors and `msg.id`; what it misses is any key **assigned straight through**. whatsapp-web.js has at least three:

```
Reaction.js:21   this.id    = data.msgKey;
Reaction.js:51   this.msgId = data.parentMsgKey;
Message.js:300   this.protocolMessageKey = data.protocolMessageKey;
PollVote.js:72   this.parentMsgKey = data.parentMsgKey;
```

A count that says "one" invites the next reader to treat `Reaction` as a special case and stop looking. The comment now states the rule instead.

## Scope

The guard itself is unchanged and still correct. `PollVote` has no handler in this adapter, so nothing new is owed for it — this is a wording fix, not a hunt for more guards.

Split out of the #754 SDK work (#777) deliberately: it shares no subject with those record types, `main` has since moved this file (#773), and folding it in would drag full backend CI into an SDK-only PR.

## Verification

- Confirmed comment-only: no non-comment line changed
- `eslint` 0 errors · `prettier` clean · `npm run build` clean
- Every claim above checked against `node_modules/whatsapp-web.js` source

Refs #747, #765.
