### PR TITLE
fix(wwjs): read a renamed id on the inbound path too, and credit #748

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `500 Internal server error` on every load while the rest of the dashboard kept working from stored data.
   Operators on v0.8.17 hitting that symptom found nothing in the release notes matching it and so had no
   reason to upgrade. No behavior change, and no change to which release carries the fix — it is still
-  v0.8.18. Refs #753, #757.
+  v0.8.18. The chat-list site was first reported here by @SkywardLab in #748.
+  Refs #748, #753, #757.
 
 - **Typed SDK response models now match the status, label, and channel payloads the server actually
   returns.** The status, label, and channel routes hand back the engine-neutral shape from
@@ -109,6 +110,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   — that signal existed all along and is now written down. No behavior change. Refs #738.
 
 ### Fixed
+
+- **Inbound messages keep their id on a WhatsApp Web build that renamed the field.** The id-rename
+  sweep (#762/#765/#773) taught the send, ack and status paths to read `$1` when `_serialized` is
+  absent, but missed the busiest path of all: `buildIncomingMessageBase`, which runs on every message
+  that arrives (`onMessage`) and every message the account sends from a linked phone
+  (`onMessage_create`). It read `msg.id._serialized` unguarded — and its parameter type declared the
+  id as `{ _serialized: string }`, so the renamed field was not merely unread but *unreachable*
+  without a cast, and the `id: string` it produced was `undefined` at runtime. On an affected build
+  without the build-time backport applied, every inbound message reached the webhook, the WebSocket
+  and the database with no id: nothing to dedup on, nothing to quote in a reply, nothing for an ack
+  to match. The id now falls back to `$1`, and an id readable by neither name reports the same empty
+  sentinel the send path uses — normalized to NULL at the persist chokepoint, mirroring
+  `saveOutgoingMessage`, because the non-partial `(sessionId, waMessageId)` unique index exempts NULL
+  but would collide the second `''`.
 - **Logs CSV export truncated at 200 rows.** The export loop requested 500-row pages and treated any
   short page as the last one, but `GET /audit` clamps `limit` to `MAX_AUDIT_PAGE_SIZE` (200) — so the
   first page always looked short and every export stopped at 200 rows regardless of how much history

--- a/src/engine/adapters/message-mapper.spec.ts
+++ b/src/engine/adapters/message-mapper.spec.ts
@@ -29,6 +29,20 @@ describe('buildIncomingMessageBase', () => {
     expect(r.isLidSender).toBeUndefined(); // a normal @c.us sender is not flagged
   });
 
+  it('reads a renamed `$1` id when the dependency has not normalized it (#747)', () => {
+    // The live inbound path. Without this, every arriving message on a renamed build carries
+    // `id: undefined` — no dedup key, no reply target, nothing to match an ack against.
+    const r = buildIncomingMessageBase({ ...base, id: { $1: 'MSG_RENAMED' } });
+    expect(r.id).toBe('MSG_RENAMED');
+  });
+
+  it('reports an unreadable id as the empty sentinel rather than undefined', () => {
+    // `''` means "received, id unreadable" and is normalized to NULL at the persist chokepoint.
+    // `undefined` would type-lie about `IncomingMessage.id: string`.
+    const r = buildIncomingMessageBase({ ...base, id: {} });
+    expect(r.id).toBe('');
+  });
+
   it('flags a 1:1 sender identified by an @lid privacy id (#263)', () => {
     const r = buildIncomingMessageBase({ ...base, from: '111@lid' });
     expect(r.isLidSender).toBe(true);

--- a/src/engine/adapters/message-mapper.ts
+++ b/src/engine/adapters/message-mapper.ts
@@ -1,4 +1,5 @@
 import { IncomingMessage, MessageContact, MessageType } from '../interfaces/whatsapp-engine.interface';
+import type { SerializedWid } from '../types/whatsapp-web-js.types';
 
 /**
  * Map a whatsapp-web.js `MessageTypes` token to the engine-neutral {@link MessageType}, so no
@@ -44,7 +45,13 @@ export function mapWwebjsMessageType(raw: string): MessageType {
  * unit-testable without constructing a full wwebjs `Message`.
  */
 export interface RawMessageFields {
-  id: { _serialized: string };
+  /**
+   * Typed as the raw wid rather than `{ _serialized: string }`: a WA Web build that renamed the field
+   * to `$1` (#747) leaves `_serialized` undefined, and the old type made that state unrepresentable —
+   * so `$1` could not even be read without a cast, and the unsound `id: string` it fed was `undefined`
+   * at runtime on every inbound message.
+   */
+  id: SerializedWid;
   from: string;
   to: string;
   body: string;
@@ -69,7 +76,12 @@ export function buildIncomingMessageBase(msg: RawMessageFields): IncomingMessage
   // for an incoming message it's the reverse. So the chat is `to` when fromMe, else `from`.
   const chatId = msg.fromMe ? msg.to : msg.from;
   const incoming: IncomingMessage = {
-    id: msg.id._serialized,
+    // Read `$1` before giving up, as the send/ack/status paths do (#762/#765/#773). This runs on the
+    // LIVE inbound path (`onMessage`/`onMessageCreate`), so on a renamed build without the build-time
+    // backport every arriving message otherwise carries `id: undefined`. The empty sentinel means
+    // "received, id unreadable" and is normalized to NULL where it is persisted — never to `''`, which
+    // the non-partial (sessionId, waMessageId) unique index would collide the second such message on.
+    id: msg.id._serialized ?? msg.id.$1 ?? '',
     from: msg.from,
     to: msg.to,
     chatId,

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -829,7 +829,11 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
 
             const dbMessage = this.messageRepository.create({
               sessionId: id,
-              waMessageId: incoming.id,
+              // Mirror saveOutgoingMessage's chokepoint: an engine that received a message but could
+              // not read its id back reports the empty sentinel, and NULL is what the non-partial
+              // (sessionId, waMessageId) unique index exempts — `''` would collide the second such
+              // message and lose the row.
+              waMessageId: incoming.id || undefined,
               chatId: incoming.chatId,
               chatName,
               from: incoming.from,


### PR DESCRIPTION
The id-rename sweep taught the send (#762), ack and status (#773) paths to read `$1` when `_serialized` is absent. It missed the busiest path in the product.

## The gap

`buildIncomingMessageBase` runs on **every arriving message** (`adapter:517` `onMessage`) and every message sent from a linked phone (`:593` `onMessage_create`):

```ts
id: msg.id._serialized,
```

Unguarded. And `RawMessageFields` declared the id as:

```ts
id: { _serialized: string };
```

So on a renamed build `$1` was not merely unread — it was **unrepresentable**. The fallback couldn't be written without a cast, and the `id: string` the mapper produced was `undefined` at runtime for every inbound message.

Downstream that means no dedup key, no reply target, and nothing for an ack to match — on the highest-volume path in the product, with no defence in depth. The build-time backport (#772) normally makes it moot, which is exactly why it survived the sweep: the one path where the patcher failing is worst is the one path that assumed it never would.

## The sentinel needed care

`?? ''` alone would have been a **new** bug. `saveOutgoingMessage` normalizes an empty id to NULL at its chokepoint and documents why:

> Store NULL rather than `''`: the `(sessionId, waMessageId)` unique index is not partial, so a second id-less send in the same session collides on `''` while NULLs stay exempt — and in the bulk path that violation is swallowed into a warning, losing the row silently.

The **inbound** persist had no such normalization — `session.service.ts:832` passed `incoming.id` straight through. So an `''` sentinel there would have made the *second* id-less inbound message violate the unique index. The same normalization is now applied where inbound messages are stored, and only then is `''` safe to mean "received, id unreadable".

## Tests

Two cases, **both failing against the previous mapper** (2 failed / 34 passed): `$1` recovered, and an id readable by neither name reporting the empty sentinel rather than `undefined`.

## Also: credit for #748

@SkywardLab reported the `chat.lastReceivedKey._serialized` chat-list site in #748 — independently, and it was the first report of that site in this tracker. The shipped fix came via the upstream backport instead, so the changelog entry for the chat-list repair now says so. A changelog entry outlasts a PR thread.

## Verification

- `eslint` 0 errors · `prettier` clean
- `npm test` — 188 suites, **2452** passing (was 2450; +2)

Refs #747, #762, #773, #748.
