### PR TITLE
chore(deps): stop dependabot re-proposing TypeScript 7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,10 +17,18 @@ updates:
     labels:
       - dependencies
     ignore:
-      # Ignore major bumps for packages that need manual migration
-      # Uncomment specific packages below if you want to skip them entirely
-      # - dependency-name: "typescript"
-      #   update-types: ["version-update:semver-major"]
+      # TypeScript 7 is the native port: `require('typescript')` no longer exposes the classic
+      # compiler API from its main entry, so @typescript-eslint/typescript-estree throws at load
+      # reading `ts.Extension` ("Cannot read properties of undefined (reading 'Cjs')"). ts-jest@29
+      # independently caps typescript at ">=4.3 <7". Proven by #727/#729.
+      #
+      # Pinned on the version, not update-types: the 6.x line is healthy (6.0.3 runs fine today) and
+      # this must not silently block it. Lift when typescript-eslint and ts-jest support TypeScript 7.
+      #
+      # NB: typescript-eslint's peer is "<6.1.0", so a future 6.1 bump WILL fail resolution — that is
+      # a separate matter from this ignore; pin with ~ rather than ^ when a 6.0.x bump lands.
+      - dependency-name: "typescript"
+        versions: [">=7.0.0"]
 
   - package-ecosystem: npm
     directory: /dashboard
@@ -39,6 +47,19 @@ updates:
     labels:
       - dependencies
       - dashboard
+    ignore:
+      # TypeScript 7 is the native port: `require('typescript')` no longer exposes the classic
+      # compiler API from its main entry, so @typescript-eslint/typescript-estree throws at load
+      # reading `ts.Extension` ("Cannot read properties of undefined (reading 'Cjs')"). ts-jest@29
+      # independently caps typescript at ">=4.3 <7". Proven by #727/#729.
+      #
+      # Pinned on the version, not update-types: the 6.x line is healthy (6.0.3 runs fine today) and
+      # this must not silently block it. Lift when typescript-eslint and ts-jest support TypeScript 7.
+      #
+      # NB: typescript-eslint's peer is "<6.1.0", so a future 6.1 bump WILL fail resolution — that is
+      # a separate matter from this ignore; pin with ~ rather than ^ when a 6.0.x bump lands.
+      - dependency-name: "typescript"
+        versions: [">=7.0.0"]
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Follow-up to closing #729 and #727. Without this they get recreated on every 7.x release.

## Why TypeScript 7 can't land

Two blockers, and only the second matters.

**Peer ranges.** `ts-jest@29.4.11` → `typescript: ">=4.3 <7"`. `typescript-eslint@8.63.0` → `">=4.8.4 <6.1.0"`.

**The real one.** TypeScript 7 is the native port: its main entry no longer exposes the classic compiler API, and `@typescript-eslint/typescript-estree` reads `ts.Extension` at module load. **#727 proves the peer range is not the blocker** — the dashboard workspace sets `legacy-peer-deps=true`, installs 7.0.2 without complaint, then dies on the first lint run:

```
TypeError: Cannot read properties of undefined (reading 'Cjs')
    at @typescript-eslint/typescript-estree/dist/create-program/shared.js:59:18
```

Relaxing the range just moves the failure from install time to lint time.

## Why `versions: [">=7.0.0"]` and not `update-types: semver-major`

The commented-out stub in the root block suggested `update-types: ["version-update:semver-major"]`. That's the wrong tool here, and so is pinning at `>=6.1.0`:

- **The 6.x line is healthy.** The dashboard runs **6.0.3 today** — `ts.Extension` present, 2248 symbols exported. An ignore keyed on `>=6.1.0` would silently block 6.1/6.2 under a lift-trigger ("when TS 7 is supported") that has nothing to do with them.
- typescript-eslint's `<6.1.0` peer is its **routine next-unvalidated-minor policy**, set roughly six weeks *before* TypeScript 7 shipped. It does not encode the TS 7 break, and I've deliberately not written it into the config as though it does.

`>=7.0.0` blocks exactly the proven-broken major and absorbs the 7.x churn.

## Scope

Both npm blocks. The `/dashboard` block had no `ignore:` key at all. The `github-actions` and `docker` blocks are untouched; `labels` on both npm blocks are unchanged (verified by parsing the YAML, after an earlier edit of mine orphaned the `dashboard` label into the ignore list).

## Known follow-up, not handled here

A root `5.9.3 → 6.0.3` bump is now the ceiling under either range and will likely land next Monday. Dependabot writes `^6.0.3`, which re-admits 6.1.0 and would trip typescript-eslint's `<6.1.0` peer. Retighten to `~6.0.3` before merging that one, mirroring the dashboard's deliberate tilde.

Refs #727, #729.
