### PR TITLE
fix(wwjs): close the last three id-rename sites, and align the docs with the code

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -312,7 +312,6 @@ SEARCH_LIMIT_MAX=100                # hard cap on the `limit` query param
 # =============================================================================
 # PLUGINS
 # =============================================================================
-PLUGINS_ENABLED=true                # Enable plugin system
 PLUGINS_DIR=./data/plugins          # Plugin directory
 
 # =============================================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   empty page with a warn log) and Baileys raises `501`; the sends are `501` on both. Every real response
   is now documented and the summaries name the gap. The matrix's own header claimed five whatsapp-web.js
   entries were `not-available` while two of the five it named said `supported` two lines below; it is
-  three, and the stale adapter line references in the catalog evidence now point at the real stubs. No
+  three, and the stale adapter line references in the catalog evidence now cite the symbols instead, so they cannot drift again. No
   behavior change; `openapi.json` regenerated.
 
 - **The send-response Swagger text now matches the prose it was corrected alongside (docs only).** The
@@ -110,6 +110,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   — that signal existed all along and is now written down. No behavior change. Refs #738.
 
 ### Fixed
+
+- **A deleted message is cleared again on a WhatsApp Web build that renamed the id field.** The rename
+  sweep reached the send, ack, status and inbound paths but not `message_revoke_everyone`, which read
+  both ids unguarded. `revokedId` needed the fallback even on a patched install: whatsapp-web.js
+  overwrites the normalized id with a raw spread of the revocation's `protocolMessageKey`, and that key
+  is normalized by neither the structure constructor nor the injected serializer — so it is the one
+  place a fully patched build still hands back a raw key. Without it the id arrived undefined, the
+  update fell back to the notification's own id, matched no row, and the deleted message's text stayed
+  in the database and on the dashboard while WhatsApp showed it as deleted. The status listing
+  (`collectStatuses`) and channel-message reads had the same gap: a status whose id was lost could not
+  be revoked by `deleteStatus`, and a channel message reported the literal string `"undefined"` as its
+  id rather than the empty sentinel. The channel-message type declared the id in a shape that made the
+  renamed field unreadable without a cast, the same defect corrected on the inbound path.
+
+- **Documentation corrected where it contradicted the code.** `docs/06` told whatsapp-web.js operators —
+  the default engine — that posting a status returns `501`, which has been untrue since #714 wired it;
+  the shipped OpenAPI schema and the adapter both say otherwise. In the other direction it promised that
+  the `recipients` allow-list restricts who sees a status, which holds on Baileys but not on
+  whatsapp-web.js, where the list is ignored and the status reaches the account's whole status-privacy
+  audience with no error — the one drift here that could surprise someone about who read their status.
+  The catalog routes documented success bodies no engine can return (both sends always `501`; the reads
+  are stubs that return `null`/empty unconditionally). `docs/03` marked Phone Link unavailable on
+  whatsapp-web.js though the adapter has implemented it since #552. `docs/18` and `sdk/README.md` still
+  described three or four SDKs, listed three of five in their tables, omitted Maven Central entirely, and
+  pinned a gateway version last true at 0.7.3. The capability-matrix summary counts were stale
+  (recomputed from the matrix itself: 123 supported, 19 not-available across 14 methods), and its catalog
+  evidence now cites symbols rather than line numbers, which had drifted twice in two releases.
+
+- **`PLUGINS_ENABLED` removed from `.env.example` and the compose file.** It was documented, plumbed into
+  the container, and read by nothing — an operator setting it to `false` still got the full plugin
+  surface. The flag is gone rather than wired: the plugins module is `@Global()` and eight non-plugin
+  files inject its providers, so a genuine opt-out is a change of its own, not a release-eve edit. All
+  plugin routes remain ADMIN-only.
 
 - **Inbound messages keep their id on a WhatsApp Web build that renamed the field.** The id-rename
   sweep (#762/#765/#773) taught the send, ack and status paths to read `$1` when `_serialized` is

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,7 +162,6 @@ services:
       - RATE_LIMIT_TTL=${RATE_LIMIT_TTL:-60}
       - RATE_LIMIT_MAX=${RATE_LIMIT_MAX:-100}
       # Plugins
-      - PLUGINS_ENABLED=${PLUGINS_ENABLED:-true}
       - PLUGINS_DIR=${PLUGINS_DIR:-/app/data/plugins}
       # Security
       - API_MASTER_KEY=${API_MASTER_KEY:-}

--- a/docs/03-system-architecture.md
+++ b/docs/03-system-architecture.md
@@ -1184,7 +1184,7 @@ flowchart TB
 | **Community** | Large | Large |
 | **Multi-device** | ✅ | ✅ |
 | **QR Code** | ✅ | ✅ |
-| **Phone Link** | ❌ | ✅ |
+| **Phone Link** | ✅ | ✅ |
 | **Maintenance** | Active | Active |
 
 ### Benefits of Abstraction

--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -2235,7 +2235,7 @@ Get business catalog info for the session's WhatsApp Business account.
 }
 ```
 
-Returns `null` when the account has no catalog (catalog is a WhatsApp Business-only feature; non-business accounts may yield `null`). The response is the raw `engine.getCatalog()` return — no envelope.
+**Not implemented on any engine.** whatsapp-web.js returns `null` unconditionally (it has no native Catalog API and the adapter stubs without calling the client); Baileys raises `501`. The shape below documents the contract, not a response you can obtain today. The response is the raw `engine.getCatalog()` return — no envelope.
 
 **Errors:** `401` missing/invalid API key · `404` `Session <sessionId> not found or not connected` · `500` engine error
 
@@ -2346,13 +2346,18 @@ Send a product message (catalog product card) to a chat. Note: this route lives 
 }
 ```
 
-**Response** `201`
+**Response** `501` — always (not implemented)
 
 ```json
-{ "id": "true_6281234567890@c.us_3EB0...", "timestamp": 1719331200 }
+{
+  "statusCode": 501,
+  "message": "Operation not supported by the active engine: sendProduct",
+  "error": "Not Implemented"
+}
 ```
 
-`timestamp` is an epoch number (seconds).
+No engine implements this. whatsapp-web.js and Baileys both raise `EngineNotSupportedError`, so the
+route cannot return a success body on any deployment; it is documented here because it is mounted.
 
 **Errors:** `400` missing `chatId`/`productId`, wrong types, or any field not on the DTO · `401` missing/invalid API key · `403` API-key role below OPERATOR · `404` `Session <sessionId> not found or not connected` · `500` engine error
 
@@ -2382,13 +2387,18 @@ Send the business catalog link to a chat. Note: this route lives under the `/mes
 }
 ```
 
-**Response** `201`
+**Response** `501` — always (not implemented)
 
 ```json
-{ "id": "true_6281234567890@c.us_3EB0...", "timestamp": 1719331200 }
+{
+  "statusCode": 501,
+  "message": "Operation not supported by the active engine: sendCatalog",
+  "error": "Not Implemented"
+}
 ```
 
-`timestamp` is an epoch number (seconds).
+No engine implements this. whatsapp-web.js and Baileys both raise `EngineNotSupportedError`, so the
+route cannot return a success body on any deployment; it is documented here because it is mounted.
 
 **Errors:** `400` missing/invalid `chatId` or any non-DTO field · `401` missing/invalid API key · `403` API-key role below OPERATOR · `404` `Session <sessionId> not found or not connected` · `500` engine error
 
@@ -2762,7 +2772,7 @@ Same `{ statuses }` wrapper and `Status` shape as the list-all route.
 
 #### POST /api/sessions/:sessionId/status/send-text
 
-Post a text status (story) to the session's status feed. **Baileys engine only** — a whatsapp-web.js session returns `501` (see Errors).
+Post a text status (story) to the session's status feed. The recipients allow-list is honored on Baileys only; whatsapp-web.js broadcasts to the account's status-privacy audience.
 
 **Auth:** API key (OPERATOR)
 
@@ -2777,7 +2787,7 @@ Post a text status (story) to the session's status feed. **Baileys engine only**
 | Field | Type | Required | Constraints | Description |
 | --- | --- | --- | --- | --- |
 | text | string | yes | — | Status text body |
-| recipients | string[] | yes | 1–256 items, each matching `^\d+@(c\.us\|lid)$` | JIDs of the contacts permitted to view the status (passed as `statusJidList` to the engine). Empty array → `400` |
+| recipients | string[] | yes | 1–256 items, each matching `^\d+@(c\.us\|lid)$` | JIDs of the contacts permitted to view the status. **Honored on Baileys only** (passed as `statusJidList`); whatsapp-web.js ignores the allow-list and broadcasts to the account's status-privacy audience. Empty array → `400` |
 | backgroundColor | string | no | 6-digit hex color matching `^#[0-9A-Fa-f]{6}$` | e.g. `#25D366`; bad value → `backgroundColor must be a hex color (e.g., #25D366)` |
 | font | integer | no | integer `0`–`5` | Font index |
 
@@ -2801,11 +2811,11 @@ Returns the engine `StatusResult` directly (no wrapper). POST default status is 
 
 **Sender-side caveat:** the posting account's own phone may display a "waiting for this status update" notice in its status feed; this is cosmetic — recipients view the status normally.
 
-**Errors:** `400` validation failure (unknown body field, missing/empty `recipients`, a JID not matching `@c.us`/`@lid`, or more than 256 recipients, bad `backgroundColor`/`font`), or session is not started · `401` missing/invalid API key · `403` key lacks `OPERATOR` role · `404` session not found / not connected · `501` the session is on the whatsapp-web.js engine (status posting is Baileys-only; WA Web removed `WAWebStatusGatingUtils.canCheckStatusRankingPosterGating` around 2026-04-30, so the wwebjs path is upstream-blocked — see #455)
+**Errors:** `400` validation failure (unknown body field, missing/empty `recipients`, a JID not matching `@c.us`/`@lid`, or more than 256 recipients, bad `backgroundColor`/`font`), or session is not started · `401` missing/invalid API key · `403` key lacks `OPERATOR` role · `404` session not found / not connected
 
 #### POST /api/sessions/:sessionId/status/send-image
 
-Post an image status (story) from a URL or base64 payload. **Baileys engine only** — a whatsapp-web.js session returns `501` (see Errors).
+Post an image status (story) from a URL or base64 payload. The recipients allow-list is honored on Baileys only; whatsapp-web.js broadcasts to the account's status-privacy audience.
 
 **Auth:** API key (OPERATOR)
 
@@ -2846,11 +2856,11 @@ Returns the engine `StatusResult` directly. POST default status is `201`.
 
 **Recipient JIDs:** `@c.us` (regular phone) recipients are reliable. `@lid` (privacy-id) recipients are best-effort and unverified — prefer `@c.us` where the phone number is known. **Sender-side caveat:** the posting account's own phone may show a "waiting for this status update" notice; recipients view it normally.
 
-**Errors:** `400` validation failure (unknown body field, missing/empty `recipients`, a JID not matching `@c.us`/`@lid`, or more than 256 recipients), or session is not started · `401` missing/invalid API key · `403` key lacks `OPERATOR` role · `404` session not found / not connected · `501` the session is on the whatsapp-web.js engine (status posting is Baileys-only; see `send-text` and #455)
+**Errors:** `400` validation failure (unknown body field, missing/empty `recipients`, a JID not matching `@c.us`/`@lid`, or more than 256 recipients), or session is not started · `401` missing/invalid API key · `403` key lacks `OPERATOR` role · `404` session not found / not connected
 
 #### POST /api/sessions/:sessionId/status/send-video
 
-Post a video status (story) from a URL or base64 payload. **Baileys engine only** — a whatsapp-web.js session returns `501` (see Errors).
+Post a video status (story) from a URL or base64 payload. The recipients allow-list is honored on Baileys only; whatsapp-web.js broadcasts to the account's status-privacy audience.
 
 **Auth:** API key (OPERATOR)
 
@@ -2891,7 +2901,7 @@ Returns the engine `StatusResult` directly. POST default status is `201`.
 
 **Recipient JIDs:** `@c.us` (regular phone) recipients are reliable. `@lid` (privacy-id) recipients are best-effort and unverified — prefer `@c.us` where the phone number is known. **Sender-side caveat:** the posting account's own phone may show a "waiting for this status update" notice; recipients view it normally.
 
-**Errors:** `400` validation failure (unknown body field, missing/empty `recipients`, a JID not matching `@c.us`/`@lid`, or more than 256 recipients), or session is not started · `401` missing/invalid API key · `403` key lacks `OPERATOR` role · `404` session not found / not connected · `501` the session is on the whatsapp-web.js engine (status posting is Baileys-only; see `send-text` and #455)
+**Errors:** `400` validation failure (unknown body field, missing/empty `recipients`, a JID not matching `@c.us`/`@lid`, or more than 256 recipients), or session is not started · `401` missing/invalid API key · `403` key lacks `OPERATOR` role · `404` session not found / not connected
 
 #### DELETE /api/sessions/:sessionId/status/:statusId
 

--- a/docs/18-sdk-design.md
+++ b/docs/18-sdk-design.md
@@ -9,12 +9,14 @@ OpenWA ships five official, hand-written client libraries for the REST API. They
 | JavaScript / TypeScript | [`@rmyndharis/openwa`](https://www.npmjs.com/package/@rmyndharis/openwa) | `npm install @rmyndharis/openwa` | Dual ESM + CJS, bundled `.d.ts` types, Node 18+ |
 | Python | [`rmyndharis-openwa`](https://pypi.org/project/rmyndharis-openwa/) | `pip install rmyndharis-openwa` | Synchronous (httpx), PEP 561 typed, Python 3.9+ |
 | PHP | [`rmyndharis/openwa`](https://packagist.org/packages/rmyndharis/openwa) | `composer require rmyndharis/openwa` | Synchronous (Guzzle 7), PSR-4, PHP 8.1+ |
+| Java | [`com.rmyndharis:openwa`](https://central.sonatype.com/artifact/com.rmyndharis/openwa) | Maven Central | Sync, `java.net.http`. See [`sdk/java/README.md`](../sdk/java/README.md). |
+| Go | [`github.com/rmyndharis/OpenWA/sdk/go`](../sdk/go) | `go get` | Stdlib-only, no third-party deps. See [`sdk/go/README.md`](../sdk/go/README.md). |
 
 > The import names differ from the dist names where the ecosystem requires it. Python installs `rmyndharis-openwa` but imports `openwa`; the client class is `OpenWAClient` in JS/Python and `OpenWA\Client` in PHP.
 
 ### Design Principles
 
-- **One client, fluent resources.** A single client object (`OpenWAClient` / `OpenWA\Client`) exposes every resource as a property — `client.messages.sendText(...)`, `client.sessions.start(...)`. All three SDKs expose the **same** resource surface; only the language idioms differ (camelCase methods + objects in JS/PHP, snake_case methods + dicts in Python).
+- **One client, fluent resources.** A single client object (`OpenWAClient` / `OpenWA\Client`) exposes every resource as a property — `client.messages.sendText(...)`, `client.sessions.start(...)`. All five SDKs expose the **same** resource surface; only the language idioms differ (camelCase methods + objects in JS/PHP/Java, snake_case methods + dicts in Python, exported fields + structs in Go).
 - **It is a request/response client, not an event SDK.** There is no WebSocket, EventEmitter, or `client.on(...)`. To receive inbound messages and acks, register a webhook (the `webhooks` resource) and host your own receiver, or connect to the real-time Socket.IO API directly (see [API Specification §6.5](./06-api-specification.md)).
 - **Typed errors.** Non-2xx responses raise/throw a typed error mapped from the HTTP status (`401/403/404/409/429/501`), plus a timeout error — all `instanceof`/`catch`-checkable. See each language's Error Handling subsection.
 - **Injectable transport.** The HTTP layer is replaceable (`fetch` in JS, an `httpx` transport in Python, a Guzzle client in PHP) — the extension point for retry/observability middleware and for testing without the network.
@@ -22,7 +24,7 @@ OpenWA ships five official, hand-written client libraries for the REST API. They
 
 ### Resource Coverage
 
-All three SDKs expose the same fluent surface:
+All five SDKs expose the same fluent surface:
 
 | Resource | Methods |
 | --- | --- |
@@ -898,13 +900,15 @@ For installation and node-by-node configuration, see the dedicated [n8n Integrat
 
 ### Versioning
 
-The three SDKs are versioned **independently of the gateway** and of each other, each following SemVer. They are currently published at `0.1.0` while the gateway is at `0.7.3`; an SDK version does **not** track the gateway version. Pin the SDK version your code is tested against and treat a major SDK bump as potentially breaking.
+The five SDKs are versioned **independently of the gateway** and of each other, each following SemVer. An SDK version does **not** track the gateway version — check the registry for the current one rather than inferring it from the gateway's. Pin the SDK version your code is tested against and treat a major SDK bump as potentially breaking.
 
 | SDK | Registry | Package |
 | --- | --- | --- |
 | JavaScript/TypeScript | npm | `@rmyndharis/openwa` |
 | Python | PyPI | `rmyndharis-openwa` |
 | PHP | Packagist | `rmyndharis/openwa` |
+| Java | Maven Central | `com.rmyndharis:openwa` |
+| Go | (none — module path) | `github.com/rmyndharis/OpenWA/sdk/go` |
 
 ### Contract-drift protection
 
@@ -925,4 +929,4 @@ cd sdk/python && python -m pytest -q
 cd sdk/php && composer install && ./vendor/bin/phpunit
 ```
 
-CI runs all three suites (path-filtered to `sdk/**`). The PHP package is mirrored to its own Packagist repository via a `git subtree split`, and that mirror publish is gated on the PHP tests passing, so a broken SDK cannot auto-publish. Bump the version, update the SDK's CHANGELOG, run the suite above, then tag/publish to the relevant registry.
+CI runs all five suites (`sdk-ci.yml`), path-filtered to `sdk/**` plus the server-side contract surfaces the SDKs are written against — `src/**/dto/**`, `src/**/*.controller.ts`, `src/**/*.service.ts` and `whatsapp-engine.interface.ts` — so a change to the wire contract re-runs them. The PHP package is mirrored to its own Packagist repository via a `git subtree split`, and that mirror publish is gated on the PHP tests passing, so a broken SDK cannot auto-publish. Bump the version, update the SDK's CHANGELOG, run the suite above, then tag/publish to the relevant registry.

--- a/docs/engine-capability-matrix.md
+++ b/docs/engine-capability-matrix.md
@@ -22,7 +22,7 @@ The `rootCause`/`evidence` fields are hand-curated from source traces of the ins
 
 ## Unwired-capability inventory
 
-24 of the 71 interface methods are `not-available` on at least one adapter (31 not-available adapter-cells total). Grouped by cluster below. Each entry shows: status today → rootCause → evidence → wiring note.
+14 of the 71 interface methods are `not-available` on at least one adapter (19 not-available adapter-cells total). Grouped by cluster below. Each entry shows: status today → rootCause → evidence → wiring note.
 
 ### Channels / Newsletter
 
@@ -147,6 +147,6 @@ These are honestly out of reach of a clean adapter wiring because the installed 
 ## Snapshot summary
 
 - **71** interface methods, **142** adapter-cells (71 × 2 engines).
-- **111** supported cells; **31** not-available cells across **24** methods.
-- Of the 31 not-available cells: **17 adapter-gaps** (fixable) + **14 library-limitations** + **0 uncertain**.
-- **5 phantom-support corrections** in this re-frame (wwjs catalog + status-read methods that stubbed without throwing are now honestly `not-available`).
+- **123** supported cells; **19** not-available cells across **14** methods.
+- Of the 19 not-available cells: **5 adapter-gaps** (fixable) + **14 library-limitations** + **0 uncertain**.
+- **3 phantom-support rows** (wwjs `getCatalog`/`getProducts`/`getProduct` — they stub without throwing, so the drift gate's throw-heuristic cannot see them; the matrix is the source of truth for these).

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -3,7 +3,7 @@
 Official client libraries for the [OpenWA](https://github.com/rmyndharis/OpenWA)
 WhatsApp API Gateway.
 
-All four SDKs are **hand-written** against the exact API surface (paths, DTOs,
+All five SDKs are **hand-written** against the exact API surface (paths, DTOs,
 response shapes) and **unit-tested with mocked HTTP transports** that assert on
 the precise request URL, method, and body — so drift is caught at test time.
 The wire types live in a dedicated module (`types.ts` / `types.py` / `model/`)
@@ -20,7 +20,7 @@ hand-written resource methods.
 
 ## Coverage
 
-All three SDKs expose the same fluent resource surface:
+All five SDKs expose the same fluent resource surface:
 
 | Resource   | Methods                                                                                                                                                                                |
 | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -1605,6 +1605,24 @@ describe('WhatsAppWebJsAdapter message_revoke_everyone (forwards the original de
     expect(revoked.id).toBe('REVOKE_NOTIF_2');
     expect(revoked.revokedId).toBeUndefined();
   });
+
+  it('reads renamed `$1` ids on both sides (#747)', () => {
+    // `revokedId` needs this even on a patched tree: Client.js overwrites the normalized id with a raw
+    // spread of `protocolMessageKey`, which neither normalization layer touches. Losing it strands the
+    // revocation — the UPDATE matches no row and the deleted body stays in the DB.
+    const { onMessageRevoked, client } = wireRevokeHandler();
+
+    client.emit(
+      'message_revoke_everyone',
+      { id: { $1: 'REVOKE_NOTIF_RENAMED' }, from: 'peer@c.us', to: 'me@c.us', timestamp: 1700000072 },
+      { id: { $1: 'ORIGINAL_RENAMED' } },
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const revoked = onMessageRevoked.mock.calls[0][0] as { id: string; revokedId?: string };
+    expect(revoked.id).toBe('REVOKE_NOTIF_RENAMED');
+    expect(revoked.revokedId).toBe('ORIGINAL_RENAMED');
+  });
 });
 
 describe('outbound mentions (#530)', () => {

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -627,9 +627,17 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
         // ORIGINAL deleted message (when whatsapp-web.js has it in the local store).
         // We forward `before.id` as `revokedId` so consumers can reconcile the
         // deleted message in their own storage.
+        // Both ids read `$1` before giving up (#747). `revokedId` needs it even on a patched tree:
+        // `Client.js` overwrites the normalized id with a raw spread of `protocolMessageKey`
+        // (`revoked_msg.id = { ...message.protocolMessageKey }`), and that key is normalized by
+        // neither the structure constructor nor the injected serializer — so this is the one place a
+        // patched build still hands us a raw MsgKey. Losing it strands the revocation: the UPDATE
+        // falls back to the notification's own id, matches no row, and the deleted body stays put.
+        const afterId = after.id as unknown as SerializedWid | undefined;
+        const beforeId = before?.id as unknown as SerializedWid | undefined;
         const payload: RevokedMessage = {
-          id: after.id._serialized,
-          revokedId: before?.id?._serialized,
+          id: afterId?._serialized ?? afterId?.$1 ?? '',
+          revokedId: beforeId?._serialized ?? beforeId?.$1,
           chatId: after.from === selfWid ? after.to : after.from,
           from: after.from,
           to: after.to,
@@ -1616,7 +1624,11 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     }
     const messages = await channel.fetchMessages({ limit });
     return (messages ?? []).map(msg => ({
-      id: String(typeof msg.id === 'object' ? msg.id._serialized : msg.id),
+      // Read `$1` before the sentinel (#747), and don't `String()` the object branch: that turned an
+      // unreadable id into the literal "undefined" rather than the empty sentinel every other path
+      // uses. Read-only endpoint — never persisted, never ack-matched — so `''` carries no collision
+      // risk here; it just means "id unreadable".
+      id: (typeof msg.id === 'object' ? (msg.id?._serialized ?? msg.id?.$1) : msg.id) || '',
       body: String(msg.body || ''),
       timestamp: Number(msg.timestamp),
       hasMedia: Boolean(msg.hasMedia),
@@ -1789,7 +1801,9 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
       for (const msg of broadcast.msgs) {
         const ts = new Date(msg.timestamp * 1000);
         statuses.push({
-          id: msg.id._serialized,
+          // `deleteStatus` takes this id as its revoke handle, so losing it to the rename makes a
+          // listed status unactionable (#747). The contact id above is a Wid and is unaffected.
+          id: ((msg.id as unknown as SerializedWid)?._serialized ?? (msg.id as unknown as SerializedWid)?.$1) || '',
           contact: contactSummary,
           type: msg.type === MessageTypes.IMAGE ? 'image' : msg.type === MessageTypes.VIDEO ? 'video' : 'text',
           ...(msg.body ? { caption: msg.body } : {}),

--- a/src/engine/engine-capability-matrix.ts
+++ b/src/engine/engine-capability-matrix.ts
@@ -71,7 +71,7 @@ export const ENGINE_CAPABILITY_MATRIX: Record<string, MethodCapability> = {
     wwjs: { status: 'not-available', rootCause: 'library-limitation' },
     baileys: { status: 'not-available', rootCause: 'adapter-gap' },
     evidence:
-      'baileys Socket/business.d.ts:7 getCatalog({jid,limit,cursor}) + getCollections (business.d.ts:11) — adapter unwired (returns Product[]+cursor, not Catalog metadata; medium-confidence shape synthesis); wwjs index.d.ts has NO Client.getCatalog (0 hits), adapter stubs to null @whatsapp-web-js.adapter.ts:1895',
+      'baileys Socket/business.d.ts:7 getCatalog({jid,limit,cursor}) + getCollections (business.d.ts:11) — adapter unwired (returns Product[]+cursor, not Catalog metadata; medium-confidence shape synthesis); wwjs index.d.ts has NO Client.getCatalog (0 hits), adapter stubs to null @WhatsAppWebJsAdapter.getCatalog',
   },
   getChannelById: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   getChannelMessages: {
@@ -133,13 +133,13 @@ export const ENGINE_CAPABILITY_MATRIX: Record<string, MethodCapability> = {
     wwjs: { status: 'not-available', rootCause: 'library-limitation' },
     baileys: { status: 'not-available', rootCause: 'adapter-gap' },
     evidence:
-      'baileys only getCatalog (Socket/business.d.ts:7); getProduct = getCatalog then find-by-id (compose-and-filter, loads whole page; medium-confidence); wwjs no Client.getProduct — only page-internal getProductMetadata (Utils.js:1253), not a public Client fn; adapter stubs to null @whatsapp-web-js.adapter.ts:1911',
+      'baileys only getCatalog (Socket/business.d.ts:7); getProduct = getCatalog then find-by-id (compose-and-filter, loads whole page; medium-confidence); wwjs no Client.getProduct — only page-internal getProductMetadata (Utils.js:1253), not a public Client fn; adapter stubs to null @WhatsAppWebJsAdapter.getProduct',
   },
   getProducts: {
     wwjs: { status: 'not-available', rootCause: 'library-limitation' },
     baileys: { status: 'not-available', rootCause: 'adapter-gap' },
     evidence:
-      'baileys Socket/business.d.ts:7 getCatalog({jid,limit,cursor}) → {products, nextPageCursor} — adapter unwired; wwjs no Client.getProducts in index.d.ts (0 hits); adapter stubs to empty @whatsapp-web-js.adapter.ts:1902',
+      'baileys Socket/business.d.ts:7 getCatalog({jid,limit,cursor}) → {products, nextPageCursor} — adapter unwired; wwjs no Client.getProducts in index.d.ts (0 hits); adapter stubs to empty @WhatsAppWebJsAdapter.getProducts',
   },
   getProfilePicture: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   getPushName: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },

--- a/src/engine/types/whatsapp-web-js.types.ts
+++ b/src/engine/types/whatsapp-web-js.types.ts
@@ -105,7 +105,8 @@ export interface WwjsChannelData {
  * Channel message data.
  */
 export interface WwjsChannelMessage {
-  id: { _serialized: string } | string;
+  /** `SerializedWid`, not `{ _serialized: string }`: the latter makes the `$1` rename unreadable. */
+  id: SerializedWid | string;
   body?: string;
   type?: string;
   timestamp?: number;


### PR DESCRIPTION
Pre-release audit of the whole tree, ahead of the v0.8.19 cut. Three code sites, eleven false sentences.

## Code — three MsgKey reads the sweep missed

**`message_revoke_everyone` is the one that matters, because it bites a *patched* install.**

```js
// node_modules/whatsapp-web.js/src/Client.js:680
if (message.protocolMessageKey)
    revoked_msg.id = { ...message.protocolMessageKey };
```

That **overwrites** the constructor-normalized id with a raw spread, and `protocolMessageKey` is normalized by neither layer. So it's the one place a fully patched build still hands back a raw key. With `revokedId` undefined, the UPDATE falls back to the notification's own id, matches no row (`AFFECTED = 0`), and **the deleted message's text stays in the database and on the dashboard** while WhatsApp shows it deleted. The adapter already documented this exact hazard twelve lines away and didn't apply it here.

Also: **`collectStatuses`** lost the id `deleteStatus` needs as its revoke handle, and **`getChannelMessages`** fabricated the literal string `"undefined"` — its type declared `id: { _serialized: string } | string`, making the renamed field unreadable without a cast, the same structural defect #779 fixed inbound.

The contact id beside `collectStatuses` is deliberately untouched — it's a **Wid**, and #747's rename hit MsgKey only.

## Docs — every sentence verified false against source

**The blocker.** `docs/06` told whatsapp-web.js operators — *the default engine* — that status posting returns `501`. Untrue since #714: the adapter implements it and `openapi.json` declares `201` only. #774 fixed this exact copy in `status.controller.ts` **this release** and left `docs/06` stale, so the correct sentence is **ported verbatim** rather than rewritten — that's what stops the two surfaces drifting a third time.

**The inverse, and the one that could actually surprise someone:** `docs/06` promised `recipients` restricts who sees a status. True on Baileys. On whatsapp-web.js the list is **ignored** and the status reaches the account's entire status-privacy audience, silently — the adapter only logs it.

Also corrected: catalog routes documenting success bodies no engine can return (both sends always `501`; the reads stub to `null`/empty unconditionally); `docs/03` marking Phone Link ❌ on wwjs though `adapter:925` calls `requestPairingCode` and #552 ships the UI; `docs/18` + `sdk/README` describing three or four SDKs, tabling three of five, omitting Maven Central, and pinning the gateway at `0.7.3`.

**Matrix counts recomputed by executing the matrix**, not grepping it: 123 supported / 19 not-available across 14 methods / 5 adapter-gap. `library-limitations=14` and `uncertain=0` were already correct and are left alone.

**The evidence refs now cite symbols.** They drifted twice in two releases — #773 shifted them 17 minutes after #774 landed them, and this very commit shifts them again. A line number can't survive that.

## Dead code

`PLUGINS_ENABLED` shipped in `.env.example` and `docker-compose.yml`, plumbed into the container, **read by nothing** — an operator setting it `false` still got the full plugin surface. Removed rather than wired: `plugins.module` is `@Global()` with eight non-plugin injectors, so a real opt-out is its own change. All plugin routes remain ADMIN-only.

## What the audit got wrong, and I didn't act on

- **"`gid?.$1` is dead code"** — false, and deleting it would have **reintroduced #747 for `createGroup`**. `Client.js:2439` returns a raw POJO normalization never touches; on 2.3000.x `$1` is the only readable group id.
- **"the catalog field should be `messageId`"** — false. `catalog.service` returns `MessageResult` verbatim; only `message.service` remaps. The `201` was the only false part.
- **"rewrite the matrix summary"** — three of its numbers were already right.

## Verification

- `eslint` 0 errors · `prettier` clean · `openapi:check` green (no controller/DTO touched) · `check:versions` green
- `npm test` — 188 suites, **2453** passing (+1)
- The new revoke test **fails against the previous adapter**
- Zero residue: greps for every corrected phrase return 0 across `docs/` and `sdk/README.md`

Refs #747, #714, #762, #773, #779.
