### PR TITLE
chore(release): v0.8.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.8.19] - 2026-07-17
 
 ### Added
 - **Official Go SDK (`sdk/go`).** Hand-written, stdlib-only (no third-party dependencies) Go client

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashboard",
-  "version": "0.8.18",
+  "version": "0.8.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashboard",
-      "version": "0.8.18",
+      "version": "0.8.19",
       "dependencies": {
         "@tanstack/react-query": "^5.101.2",
         "@tanstack/react-table": "^8.21.3",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboard",
   "private": true,
-  "version": "0.8.18",
+  "version": "0.8.19",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/openapi.json
+++ b/openapi.json
@@ -5312,7 +5312,7 @@
   "info": {
     "title": "OpenWA API",
     "description": "Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API",
-    "version": "0.8.18",
+    "version": "0.8.19",
     "contact": {
       "name": "OpenWA",
       "url": "https://github.com/rmyndharis/OpenWA",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openwa",
-  "version": "0.8.18",
+  "version": "0.8.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openwa",
-      "version": "0.8.18",
+      "version": "0.8.19",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwa",
-  "version": "0.8.18",
+  "version": "0.8.19",
   "description": "Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API for WhatsApp",
   "author": "Yudhi Armyndharis & OpenWA Contributors",
   "private": true,


### PR DESCRIPTION
Cuts **v0.8.19** — 22 commits since v0.8.18.

## Why 0.8.19 and not 0.9.0

`[Unreleased]` carries a ⚠️ breaking marker, so a minor looked right at first glance. It isn't, by the repo's own written policy:

- **#777 touches zero `src/` or `dashboard/` files** — only CHANGELOG, docs, sdk. The gateway's payloads are byte-identical; it corrected the *SDKs' type declarations* to match what the server already sent.
- `docs/15:125-126` scopes **MINOR** to "removed/renamed fields, **changed payload semantics**, deployment-topology changes" — gateway concerns. **PATCH** is "bug fixes **and** backward-compatible additions… The default for ongoing work."
- The ⚠️ is audience-scoped: "Breaking (**typed SDK consumers**)".
- #777's own commit says "breaking → minor **at the next SDK cut**", and `docs/18` states the SDKs are versioned independently of the gateway.

So: fixes + one backward-compatible addition (the Go SDK) = **PATCH**. `docs/18`'s independence claim stays true and needs no amendment.

## What's in it

The `$1` id-rename saga closes out. WA Web 2.3000.x renamed `MsgKey._serialized` → `$1`; this release finishes the sweep across every path — send, ack, status, **live inbound** (#779), and **revocation** (#789). The last one bites even a fully patched install: `Client.js:680` overwrites the normalized id with a raw spread of `protocolMessageKey`, so without the fallback a deleted message's text stayed in the database while WhatsApp showed it deleted.

Also: the patcher can no longer latch a half-patched dependency (#772); status posts fail honestly instead of fabricating a 201 (#773); the Message Tester stopped inventing HTTP status codes (#771, closing #750); typed SDK records match the wire (#777, closing #754); and four dashboard fixes (#766–#769).

Plus a documentation pass that removed eleven verified-false sentences — most importantly that `docs/06` told whatsapp-web.js operators status posting returns `501` (untrue since #714) while promising a `recipients` allow-list the wwjs path silently ignores.

## Verification

Full gate on this exact tree:

- `check:versions` — OK (package.json = 0.8.19)
- `openapi:check` — green; the snapshot delta is the version line only
- `eslint` 0 errors (backend + dashboard) · `npm run build` clean (both)
- `npm test` — 188 suites, **2453** passing
- `npm run test:e2e` — 52 passing
- dashboard `test:unit` — **109** passing · `i18n:check` — parity passed

The diff is exactly the six files the v0.8.18 cut touched (`f71127b`), and both lockfile diffs are version-only — no dependency churn.

## Not in this release, deliberately

The seven open dependabot PRs are held for post-tag triage. Two are red for real reasons worth recording: **#788** fails because TypeScript 6.0.3 itself demands an explicit `rootDir` and rejects `node10` resolution (a tsconfig migration, not a bump) — and it bundles `typeorm 0.3.30 → 1.1.0` and `sqlite3 5 → 6` behind a routine-looking title. **#783** fails the Docker build because `node:26-slim` moves the base to Debian trixie and the Chromium install doesn't survive it.
