### PR TITLE
chore(release): v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.0] - 2026-07-18
 
 ### Added
 
@@ -16,8 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `GET /api/settings` no longer returns the incorrect, always-zero `general.sessionTimeout` field. Clients
-  reading that admin-only field should remove the read; no equivalent session timeout exists.
+- ⚠️ **Breaking:** `GET /api/settings` no longer returns the incorrect, always-zero
+  `general.sessionTimeout` field. Migration: remove reads, destructuring, or schema requirements for that
+  admin-only field; there is no replacement because OpenWA has no equivalent session-timeout setting.
 - Java SDK callers sending audio/voice notes now pass `SendAudioRequest` to `sendAudio`; other media sends
   continue to use `SendMediaRequest`. Bulk media uses the nested `BulkMediaRequest` type.
 - The PHP SDK's configured `timeout` now applies to every request, including calls made through an injected

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashboard",
-  "version": "0.8.19",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashboard",
-      "version": "0.8.19",
+      "version": "0.9.0",
       "dependencies": {
         "@tanstack/react-query": "^5.101.2",
         "@tanstack/react-table": "^8.21.3",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboard",
   "private": true,
-  "version": "0.8.19",
+  "version": "0.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/openapi.json
+++ b/openapi.json
@@ -5338,7 +5338,7 @@
   "info": {
     "title": "OpenWA API",
     "description": "Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API",
-    "version": "0.8.19",
+    "version": "0.9.0",
     "contact": {
       "name": "OpenWA",
       "url": "https://github.com/rmyndharis/OpenWA",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openwa",
-  "version": "0.8.19",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openwa",
-      "version": "0.8.19",
+      "version": "0.9.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwa",
-  "version": "0.8.19",
+  "version": "0.9.0",
   "description": "Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API for WhatsApp",
   "author": "Yudhi Armyndharis & OpenWA Contributors",
   "private": true,


### PR DESCRIPTION
## Summary

- Stamp the gateway and bundled dashboard version as `0.9.0` in both manifests and lockfiles.
- Promote the current changelog entries to the `0.9.0` release dated 2026-07-18.
- Update the OpenAPI document version while leaving independently versioned SDK packages unchanged.
- Add an explicit migration note for the removed `general.sessionTimeout` settings field.

## Release classification

This is a pre-1.0 MINOR release under the repository versioning policy. The release removes the documented `general.sessionTimeout` field from `GET /api/settings`; although the value was incorrect and had no real setting behind it, consumers requiring that response field must update. Backward-compatible additions, fixes, and dependency updates are included in the same release notes.

## Verification

- `npm run check:versions`
- `npm run openapi:check`
- JSON parsing for both manifests, both lockfiles, and `openapi.json`
- `git diff --check`
- Release-prep diff is limited to the six version/changelog artifacts used by previous cuts