### PR TITLE
feat(dashboard): shared accessible modal component, Sessions modals migrated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The whatsapp-web.js own-send echo now downloads media through the same capped inbound path as
   inbound messages (declared-size pre-gate, timeout, concurrency limiter), so phone-composed images
   persist and render with their real payload.
+- The dashboard gains a shared accessible modal dialog — Escape and overlay dismissal, a focus
+  trap with initial focus, background scroll lock, and `role="dialog"` semantics. The Sessions page
+  modals are the first to use it, gaining those behaviors plus a pinned header/footer with a
+  scrolling body on long content.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   routes no longer flash the OS default, and the message-analytics chart now defaults to 24h.
 - The dev compose defaults `AUTO_START_SESSIONS=true`, so previously authenticated sessions come
   back by themselves after a container restart (the application-level default stays off).
+- Dashboard action buttons are consolidated into shared global `.btn-primary`/`.btn-secondary`/
+  `.btn-danger` classes (28 page-scoped copies removed), so padding, radius, hover, and disabled
+  states are consistent across pages; the Plugins hover now uses the `--primary-hover` token and
+  danger buttons use the single `--error` red.
 
 ### Removed
 

--- a/dashboard/src/components/Modal.tsx
+++ b/dashboard/src/components/Modal.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useId, useRef, type ReactNode } from 'react';
+import { X } from 'lucide-react';
+
+export interface ModalProps {
+  /** Whether the dialog is shown. When false, renders nothing. */
+  open: boolean;
+  /** Called on Escape, overlay click, and the header close button. */
+  onClose: () => void;
+  /** Dialog title — rendered in the pinned header and referenced by aria-labelledby. */
+  title: ReactNode;
+  children: ReactNode;
+  /** Optional pinned footer (action buttons), kept visible while the body scrolls. */
+  footer?: ReactNode;
+  /** Extra class(es) on the .modal card (e.g. 'confirm-modal', 'install-modal'). */
+  className?: string;
+  /** aria-label for the header close button. */
+  closeLabel?: string;
+}
+
+const FOCUSABLE =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+/**
+ * Shared accessible modal dialog: role="dialog", aria-modal, Escape/overlay close, body scroll
+ * lock, initial focus, and a minimal focus trap. Markup uses the GLOBAL modal styles
+ * (.modal-overlay/.modal/.modal-header/.modal-body/.modal-footer from index.css), so the card
+ * gets the 90vh cap with pinned header/footer and a scrolling body for free.
+ *
+ * Every page previously hand-rolled the overlay+dialog without any dialog semantics; new modals
+ * must use this component, and existing ones are being migrated to it.
+ */
+export function Modal({ open, onClose, title, children, footer, className, closeLabel = 'Close' }: ModalProps) {
+  const titleId = useId();
+  const cardRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return undefined;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        // Capture phase: nested widgets (selects, menus) may also listen for Escape — the dialog
+        // owns dismissal while it is open.
+        event.stopPropagation();
+        onClose();
+        return;
+      }
+      if (event.key === 'Tab') {
+        const card = cardRef.current;
+        if (!card) return;
+        const focusables = Array.from(card.querySelectorAll<HTMLElement>(FOCUSABLE)).filter(
+          el => el.offsetParent !== null,
+        );
+        if (focusables.length === 0) return;
+        const first = focusables[0];
+        const last = focusables[focusables.length - 1];
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown, true);
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    // Initial focus: the first visible focusable in the dialog, else the dialog card itself.
+    const card = cardRef.current;
+    const initial =
+      card && (Array.from(card.querySelectorAll<HTMLElement>(FOCUSABLE)).find(el => el.offsetParent !== null) ?? null);
+    (initial ?? card)?.focus();
+
+    return () => {
+      document.removeEventListener('keydown', onKeyDown, true);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="modal-overlay"
+      onMouseDown={event => {
+        // Close only on a press that STARTS on the overlay itself — a drag that begins inside the
+        // dialog and ends outside must not dismiss it (e.g. selecting text outwards).
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <div
+        ref={cardRef}
+        className={className ? `modal ${className}` : 'modal'}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
+      >
+        <div className="modal-header">
+          <h2 id={titleId}>{title}</h2>
+          <button type="button" className="btn-icon" onClick={onClose} aria-label={closeLabel}>
+            <X size={20} />
+          </button>
+        </div>
+        <div className="modal-body">{children}</div>
+        {footer ? <div className="modal-footer">{footer}</div> : null}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/pages/Sessions.tsx
+++ b/dashboard/src/pages/Sessions.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { Trans, useTranslation } from 'react-i18next';
-import { Plus, QrCode, RefreshCw, Trash2, Eye, Loader2, Play, Square, X, Search, Filter, Skull } from 'lucide-react';
+import { Plus, QrCode, RefreshCw, Trash2, Eye, Loader2, Play, Square, Search, Filter, Skull } from 'lucide-react';
 import { sessionApi, type Session } from '../services/api';
 import { queryKeys } from '../hooks/queries';
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
@@ -10,6 +10,7 @@ import { useWebSocket } from '../hooks/useWebSocket';
 import { useRole } from '../hooks/useRole';
 import { PageHeader } from '../components/PageHeader';
 import { CustomSelect } from '../components/CustomSelect';
+import { Modal } from '../components/Modal';
 import './Sessions.css';
 
 export function Sessions() {
@@ -396,43 +397,13 @@ export function Sessions() {
       )}
 
       {showCreateModal && (
-        <div className="modal-overlay" onClick={() => setShowCreateModal(false)}>
-          <div className="modal" onClick={e => e.stopPropagation()}>
-            <div className="modal-header">
-              <h2>{t('sessions.create.title')}</h2>
-              <button className="btn-icon" onClick={() => setShowCreateModal(false)}>
-                <X size={20} />
-              </button>
-            </div>
-            <div className="modal-body">
-              <label>{t('sessions.create.label')}</label>
-              <input
-                type="text"
-                placeholder={t('sessions.create.placeholder')}
-                value={newSessionName}
-                onChange={e => {
-                  const value = e.target.value.toLowerCase().replace(/\s+/g, '-');
-                  setNewSessionName(value);
-                }}
-                onKeyDown={e => e.key === 'Enter' && handleCreate()}
-              />
-              <p className="input-hint">
-                <Trans i18nKey="sessions.create.hint" components={{ code: <code /> }} />
-              </p>
-              {newSessionName && !/^[a-z0-9-]+$/.test(newSessionName) && (
-                <p className="input-error">{t('sessions.create.invalidChars')}</p>
-              )}
-              {newSessionName && newSessionName.length > 50 && (
-                <p className="input-error">{t('sessions.create.tooLong', { length: newSessionName.length })}</p>
-              )}
-              {newSessionName &&
-                /^[a-z0-9-]+$/.test(newSessionName) &&
-                newSessionName.length <= 50 &&
-                sessions.some(s => s.name === newSessionName) && (
-                  <p className="input-error">{t('sessions.create.duplicate')}</p>
-                )}
-            </div>
-            <div className="modal-footer">
+        <Modal
+          open
+          onClose={() => setShowCreateModal(false)}
+          title={t('sessions.create.title')}
+          closeLabel={t('common.close')}
+          footer={
+            <>
               <button className="btn-secondary" onClick={() => setShowCreateModal(false)}>
                 {t('common.cancel')}
               </button>
@@ -449,279 +420,293 @@ export function Sessions() {
               >
                 {creating ? <Loader2 className="animate-spin" size={16} /> : t('common.create')}
               </button>
-            </div>
-          </div>
-        </div>
+            </>
+          }
+        >
+          <label>{t('sessions.create.label')}</label>
+          <input
+            type="text"
+            placeholder={t('sessions.create.placeholder')}
+            value={newSessionName}
+            onChange={e => {
+              const value = e.target.value.toLowerCase().replace(/\s+/g, '-');
+              setNewSessionName(value);
+            }}
+            onKeyDown={e => e.key === 'Enter' && handleCreate()}
+          />
+          <p className="input-hint">
+            <Trans i18nKey="sessions.create.hint" components={{ code: <code /> }} />
+          </p>
+          {newSessionName && !/^[a-z0-9-]+$/.test(newSessionName) && (
+            <p className="input-error">{t('sessions.create.invalidChars')}</p>
+          )}
+          {newSessionName && newSessionName.length > 50 && (
+            <p className="input-error">{t('sessions.create.tooLong', { length: newSessionName.length })}</p>
+          )}
+          {newSessionName &&
+            /^[a-z0-9-]+$/.test(newSessionName) &&
+            newSessionName.length <= 50 &&
+            sessions.some(s => s.name === newSessionName) && (
+              <p className="input-error">{t('sessions.create.duplicate')}</p>
+            )}
+        </Modal>
       )}
 
       {qrData && (
-        <div className="modal-overlay" onClick={handleCloseQRModal}>
-          <div className="modal qr-modal" onClick={e => e.stopPropagation()}>
-            <div className="modal-header">
-              <div className="modal-title">
-                <h2>{pairingMode ? t('sessions.pairing.tabPhone') : t('sessions.qr.title')}</h2>
-                <span className="session-name">{qrData.sessionName}</span>
+        <Modal
+          open
+          onClose={handleCloseQRModal}
+          className="qr-modal"
+          closeLabel={t('common.close')}
+          title={
+            <span className="modal-title">
+              {pairingMode ? t('sessions.pairing.tabPhone') : t('sessions.qr.title')}
+              <span className="session-name">{qrData.sessionName}</span>
+            </span>
+          }
+        >
+          <div style={{ textAlign: 'center' }}>
+            {!pairingCode && (
+              <div className="pairing-tabs" role="tablist">
+                <button
+                  role="tab"
+                  aria-selected={!pairingMode}
+                  className={`pairing-tab-btn ${!pairingMode ? 'active' : ''}`}
+                  onClick={() => {
+                    setPairingMode(false);
+                    setPairingError(null);
+                  }}
+                >
+                  {t('sessions.pairing.tabQr')}
+                </button>
+                <button
+                  role="tab"
+                  aria-selected={pairingMode}
+                  className={`pairing-tab-btn ${pairingMode ? 'active' : ''}`}
+                  onClick={() => {
+                    setPairingMode(true);
+                    setPairingError(null);
+                  }}
+                >
+                  {t('sessions.pairing.tabPhone')}
+                </button>
               </div>
-              <button className="btn-close" onClick={handleCloseQRModal} aria-label={t('common.close')}>
-                <X size={20} style={{ color: 'var(--text-muted)' }} />
-              </button>
-            </div>
-            <div className="modal-body" style={{ textAlign: 'center' }}>
-              {!pairingCode && (
-                <div className="pairing-tabs" role="tablist">
-                  <button
-                    role="tab"
-                    aria-selected={!pairingMode}
-                    className={`pairing-tab-btn ${!pairingMode ? 'active' : ''}`}
-                    onClick={() => {
-                      setPairingMode(false);
-                      setPairingError(null);
-                    }}
-                  >
-                    {t('sessions.pairing.tabQr')}
-                  </button>
-                  <button
-                    role="tab"
-                    aria-selected={pairingMode}
-                    className={`pairing-tab-btn ${pairingMode ? 'active' : ''}`}
-                    onClick={() => {
-                      setPairingMode(true);
-                      setPairingError(null);
-                    }}
-                  >
-                    {t('sessions.pairing.tabPhone')}
-                  </button>
-                </div>
-              )}
+            )}
 
-              {!pairingMode ? (
-                // QR Code Content
-                qrData.qrCode ? (
+            {!pairingMode ? (
+              // QR Code Content
+              qrData.qrCode ? (
+                <>
+                  <img src={qrData.qrCode} alt="QR" style={{ maxWidth: '280px', borderRadius: '12px' }} />
+                  <div className="qr-instructions">
+                    <p className="qr-step">
+                      <Trans i18nKey="sessions.qr.step1" components={{ strong: <strong /> }} />
+                    </p>
+                    <p className="qr-step">
+                      <Trans i18nKey="sessions.qr.step2" components={{ strong: <strong /> }} />
+                    </p>
+                    <p className="qr-step">
+                      <Trans i18nKey="sessions.qr.step3" components={{ strong: <strong /> }} />
+                    </p>
+                  </div>
+                  <p className="qr-auto-refresh">
+                    <RefreshCw size={14} className="spin-slow" /> {t('sessions.qr.autoRefresh')}
+                  </p>
+                </>
+              ) : (
+                <div style={{ padding: '2rem' }}>
+                  <Loader2 className="animate-spin" size={48} />
+                  <p>{t('sessions.qr.generating')}</p>
+                </div>
+              )
+            ) : (
+              // Pairing Code Content
+              <div className="pairing-container" role="tabpanel">
+                {pairingError && <div className="pairing-error">{pairingError}</div>}
+
+                {!pairingCode ? (
+                  <div className="pairing-form">
+                    <label htmlFor="pairing-phone" className="pairing-label">
+                      {t('sessions.pairing.phoneLabel')}
+                    </label>
+                    <input
+                      id="pairing-phone"
+                      className="pairing-input"
+                      type="tel"
+                      inputMode="numeric"
+                      maxLength={15}
+                      placeholder={t('sessions.pairing.phonePlaceholder')}
+                      value={phoneNumber}
+                      onChange={e => setPhoneNumber(e.target.value.replace(/\D/g, ''))}
+                      onKeyDown={e => e.key === 'Enter' && handleGeneratePairingCode()}
+                    />
+                    <p className="input-hint" style={{ marginBottom: '1.5rem' }}>
+                      {t('sessions.pairing.phoneHint')}
+                    </p>
+                    <button
+                      className="btn-primary"
+                      onClick={handleGeneratePairingCode}
+                      disabled={requestingPairing || !/^[0-9]{6,15}$/.test(phoneNumber.trim())}
+                      style={{ width: '100%', justifyContent: 'center' }}
+                    >
+                      {requestingPairing ? (
+                        <>
+                          <Loader2 className="animate-spin" size={16} />
+                          <span style={{ marginLeft: '0.5rem' }}>{t('sessions.pairing.generating')}</span>
+                        </>
+                      ) : (
+                        t('sessions.pairing.generateButton')
+                      )}
+                    </button>
+                  </div>
+                ) : (
                   <>
-                    <img src={qrData.qrCode} alt="QR" style={{ maxWidth: '280px', borderRadius: '12px' }} />
+                    <label style={{ display: 'block', fontWeight: 600, color: 'var(--text-secondary)' }}>
+                      {t('sessions.pairing.codeLabel')}
+                    </label>
+                    <div className="pairing-code-display">
+                      {pairingCode.substring(0, 4)} - {pairingCode.substring(4)}
+                    </div>
+
                     <div className="qr-instructions">
+                      <p className="pairing-instructions-title">{t('sessions.pairing.instructions')}</p>
                       <p className="qr-step">
-                        <Trans i18nKey="sessions.qr.step1" components={{ strong: <strong /> }} />
+                        <Trans i18nKey="sessions.pairing.step1" components={{ strong: <strong /> }} />
                       </p>
                       <p className="qr-step">
-                        <Trans i18nKey="sessions.qr.step2" components={{ strong: <strong /> }} />
+                        <Trans i18nKey="sessions.pairing.step2" components={{ strong: <strong /> }} />
                       </p>
                       <p className="qr-step">
-                        <Trans i18nKey="sessions.qr.step3" components={{ strong: <strong /> }} />
+                        <Trans i18nKey="sessions.pairing.step3" components={{ strong: <strong /> }} />
+                      </p>
+                      <p className="qr-step">
+                        <Trans i18nKey="sessions.pairing.step4" components={{ strong: <strong /> }} />
                       </p>
                     </div>
-                    <p className="qr-auto-refresh">
-                      <RefreshCw size={14} className="spin-slow" /> {t('sessions.qr.autoRefresh')}
-                    </p>
-                  </>
-                ) : (
-                  <div style={{ padding: '2rem' }}>
-                    <Loader2 className="animate-spin" size={48} />
-                    <p>{t('sessions.qr.generating')}</p>
-                  </div>
-                )
-              ) : (
-                // Pairing Code Content
-                <div className="pairing-container" role="tabpanel">
-                  {pairingError && <div className="pairing-error">{pairingError}</div>}
 
-                  {!pairingCode ? (
-                    <div className="pairing-form">
-                      <label htmlFor="pairing-phone" className="pairing-label">
-                        {t('sessions.pairing.phoneLabel')}
-                      </label>
-                      <input
-                        id="pairing-phone"
-                        className="pairing-input"
-                        type="tel"
-                        inputMode="numeric"
-                        maxLength={15}
-                        placeholder={t('sessions.pairing.phonePlaceholder')}
-                        value={phoneNumber}
-                        onChange={e => setPhoneNumber(e.target.value.replace(/\D/g, ''))}
-                        onKeyDown={e => e.key === 'Enter' && handleGeneratePairingCode()}
-                      />
-                      <p className="input-hint" style={{ marginBottom: '1.5rem' }}>
-                        {t('sessions.pairing.phoneHint')}
-                      </p>
+                    <div style={{ marginTop: '1.5rem' }}>
                       <button
-                        className="btn-primary"
-                        onClick={handleGeneratePairingCode}
-                        disabled={requestingPairing || !/^[0-9]{6,15}$/.test(phoneNumber.trim())}
-                        style={{ width: '100%', justifyContent: 'center' }}
+                        className="btn-secondary"
+                        onClick={() => {
+                          setPairingCode(null);
+                          setPhoneNumber('');
+                        }}
+                        style={{ width: '100%' }}
                       >
-                        {requestingPairing ? (
-                          <>
-                            <Loader2 className="animate-spin" size={16} />
-                            <span style={{ marginLeft: '0.5rem' }}>{t('sessions.pairing.generating')}</span>
-                          </>
-                        ) : (
-                          t('sessions.pairing.generateButton')
-                        )}
+                        {t('sessions.pairing.changeNumber')}
                       </button>
                     </div>
-                  ) : (
-                    <>
-                      <label style={{ display: 'block', fontWeight: 600, color: 'var(--text-secondary)' }}>
-                        {t('sessions.pairing.codeLabel')}
-                      </label>
-                      <div className="pairing-code-display">
-                        {pairingCode.substring(0, 4)} - {pairingCode.substring(4)}
-                      </div>
 
-                      <div className="qr-instructions">
-                        <p className="pairing-instructions-title">{t('sessions.pairing.instructions')}</p>
-                        <p className="qr-step">
-                          <Trans i18nKey="sessions.pairing.step1" components={{ strong: <strong /> }} />
-                        </p>
-                        <p className="qr-step">
-                          <Trans i18nKey="sessions.pairing.step2" components={{ strong: <strong /> }} />
-                        </p>
-                        <p className="qr-step">
-                          <Trans i18nKey="sessions.pairing.step3" components={{ strong: <strong /> }} />
-                        </p>
-                        <p className="qr-step">
-                          <Trans i18nKey="sessions.pairing.step4" components={{ strong: <strong /> }} />
-                        </p>
-                      </div>
-
-                      <div style={{ marginTop: '1.5rem' }}>
-                        <button
-                          className="btn-secondary"
-                          onClick={() => {
-                            setPairingCode(null);
-                            setPhoneNumber('');
-                          }}
-                          style={{ width: '100%' }}
-                        >
-                          {t('sessions.pairing.changeNumber')}
-                        </button>
-                      </div>
-
-                      <p className="qr-auto-refresh">
-                        <RefreshCw size={14} className="spin-slow" /> {t('sessions.pairing.waitingConnection')}
-                      </p>
-                    </>
-                  )}
-                </div>
-              )}
-            </div>
+                    <p className="qr-auto-refresh">
+                      <RefreshCw size={14} className="spin-slow" /> {t('sessions.pairing.waitingConnection')}
+                    </p>
+                  </>
+                )}
+              </div>
+            )}
           </div>
-        </div>
+        </Modal>
       )}
 
       {selectedSession && (
-        <div className="modal-overlay" onClick={() => setSelectedSession(null)}>
-          <div className="modal" onClick={e => e.stopPropagation()}>
-            <div className="modal-header">
-              <h2>{t('sessions.details.title')}</h2>
-              <button className="btn-icon" onClick={() => setSelectedSession(null)}>
-                <X size={20} />
-              </button>
+        <Modal
+          open
+          onClose={() => setSelectedSession(null)}
+          title={t('sessions.details.title')}
+          closeLabel={t('common.close')}
+          footer={
+            <button className="btn-secondary" onClick={() => setSelectedSession(null)}>
+              {t('common.close')}
+            </button>
+          }
+        >
+          <div className="detail-grid">
+            <div className="detail-item">
+              <span className="detail-label">{t('sessions.details.name')}</span>
+              <span className="detail-value">{selectedSession.name}</span>
             </div>
-            <div className="modal-body">
-              <div className="detail-grid">
-                <div className="detail-item">
-                  <span className="detail-label">{t('sessions.details.name')}</span>
-                  <span className="detail-value">{selectedSession.name}</span>
-                </div>
-                <div className="detail-item">
-                  <span className="detail-label">{t('sessions.details.status')}</span>
-                  <span className={`status-badge ${selectedSession.status}`}>
-                    {formatStatus(selectedSession.status)}
-                  </span>
-                </div>
-                <div className="detail-item">
-                  <span className="detail-label">{t('sessions.details.sessionId')}</span>
-                  <span className="detail-value mono">{selectedSession.id}</span>
-                </div>
-                <div className="detail-item">
-                  <span className="detail-label">{t('sessions.details.phone')}</span>
-                  <span className="detail-value">{selectedSession.phone || t('sessions.details.phoneNone')}</span>
-                </div>
-                <div className="detail-item">
-                  <span className="detail-label">{t('sessions.details.created')}</span>
-                  <span className="detail-value">{new Date(selectedSession.createdAt).toLocaleString()}</span>
-                </div>
-                <div className="detail-item">
-                  <span className="detail-label">{t('sessions.details.lastActive')}</span>
-                  <span className="detail-value">
-                    {selectedSession.lastActive
-                      ? new Date(selectedSession.lastActive).toLocaleString()
-                      : t('common.never')}
-                  </span>
-                </div>
-              </div>
+            <div className="detail-item">
+              <span className="detail-label">{t('sessions.details.status')}</span>
+              <span className={`status-badge ${selectedSession.status}`}>{formatStatus(selectedSession.status)}</span>
             </div>
-            <div className="modal-footer">
-              <button className="btn-secondary" onClick={() => setSelectedSession(null)}>
-                {t('common.close')}
-              </button>
+            <div className="detail-item">
+              <span className="detail-label">{t('sessions.details.sessionId')}</span>
+              <span className="detail-value mono">{selectedSession.id}</span>
+            </div>
+            <div className="detail-item">
+              <span className="detail-label">{t('sessions.details.phone')}</span>
+              <span className="detail-value">{selectedSession.phone || t('sessions.details.phoneNone')}</span>
+            </div>
+            <div className="detail-item">
+              <span className="detail-label">{t('sessions.details.created')}</span>
+              <span className="detail-value">{new Date(selectedSession.createdAt).toLocaleString()}</span>
+            </div>
+            <div className="detail-item">
+              <span className="detail-label">{t('sessions.details.lastActive')}</span>
+              <span className="detail-value">
+                {selectedSession.lastActive ? new Date(selectedSession.lastActive).toLocaleString() : t('common.never')}
+              </span>
             </div>
           </div>
-        </div>
+        </Modal>
       )}
 
       {deleteConfirmId && (
-        <div className="modal-overlay" onClick={() => setDeleteConfirmId(null)}>
-          <div className="modal confirm-modal" onClick={e => e.stopPropagation()}>
-            <div className="modal-header">
-              <h2>{t('sessions.delete.title')}</h2>
-              <button className="btn-icon" onClick={() => setDeleteConfirmId(null)}>
-                <X size={20} />
-              </button>
-            </div>
-            <div className="modal-body">
-              <p>
-                <Trans
-                  i18nKey="sessions.delete.message"
-                  values={{ name: sessions.find(s => s.id === deleteConfirmId)?.name }}
-                  components={{ strong: <strong /> }}
-                />
-              </p>
-              <p className="text-muted">{t('sessions.delete.warning')}</p>
-            </div>
-            <div className="modal-footer">
+        <Modal
+          open
+          onClose={() => setDeleteConfirmId(null)}
+          title={t('sessions.delete.title')}
+          className="confirm-modal"
+          closeLabel={t('common.close')}
+          footer={
+            <>
               <button className="btn-secondary" onClick={() => setDeleteConfirmId(null)}>
                 {t('common.cancel')}
               </button>
               <button className="btn-danger" onClick={() => handleDelete(deleteConfirmId)}>
                 {t('common.delete')}
               </button>
-            </div>
-          </div>
-        </div>
+            </>
+          }
+        >
+          <p>
+            <Trans
+              i18nKey="sessions.delete.message"
+              values={{ name: sessions.find(s => s.id === deleteConfirmId)?.name }}
+              components={{ strong: <strong /> }}
+            />
+          </p>
+          <p className="text-muted">{t('sessions.delete.warning')}</p>
+        </Modal>
       )}
 
       {killConfirmId && (
-        <div className="modal-overlay" onClick={() => setKillConfirmId(null)}>
-          <div className="modal confirm-modal" onClick={e => e.stopPropagation()}>
-            <div className="modal-header">
-              <h2>{t('sessions.forceKill.title')}</h2>
-              <button className="btn-icon" onClick={() => setKillConfirmId(null)}>
-                <X size={20} />
-              </button>
-            </div>
-            <div className="modal-body">
-              <p>
-                <Trans
-                  i18nKey="sessions.forceKill.message"
-                  values={{ name: sessions.find(s => s.id === killConfirmId)?.name }}
-                  components={{ strong: <strong /> }}
-                />
-              </p>
-              <p className="text-muted">{t('sessions.forceKill.warning')}</p>
-            </div>
-            <div className="modal-footer">
+        <Modal
+          open
+          onClose={() => setKillConfirmId(null)}
+          title={t('sessions.forceKill.title')}
+          className="confirm-modal"
+          closeLabel={t('common.close')}
+          footer={
+            <>
               <button className="btn-secondary" onClick={() => setKillConfirmId(null)}>
                 {t('common.cancel')}
               </button>
               <button className="btn-danger" onClick={() => handleForceKill(killConfirmId)}>
                 {t('sessions.forceKill.confirm')}
               </button>
-            </div>
-          </div>
-        </div>
+            </>
+          }
+        >
+          <p>
+            <Trans
+              i18nKey="sessions.forceKill.message"
+              values={{ name: sessions.find(s => s.id === killConfirmId)?.name }}
+              components={{ strong: <strong /> }}
+            />
+          </p>
+          <p className="text-muted">{t('sessions.forceKill.warning')}</p>
+        </Modal>
       )}
 
       <div className="sessions-grid">


### PR DESCRIPTION
## Summary

Introduces a shared accessible modal dialog component and migrates the Sessions page to it. Previously every page hand-rolled its own overlay + dialog with no dialog semantics at all.

## What changed

- **New `Modal` component** (`dashboard/src/components/Modal.tsx`): `role="dialog"` with `aria-modal`/`aria-labelledby`, Escape and overlay dismissal (a drag that starts inside the dialog no longer dismisses it), a minimal focus trap with initial focus, background scroll lock, and the global 90vh cap with pinned header/footer and a scrolling body.
- **All five Sessions modals migrated** (create session, QR/pairing, session details, delete confirm, force-kill confirm) — 5 → 0 hand-rolled overlays. Content, handlers, i18n, and page-scoped styling (`qr-modal`, `confirm-modal`) are preserved; the QR modal's custom header (title + session name) is pixel-identical.
- **Changelog**: entries for this change and for the button-style consolidation (#803), which was missed in that PR.

Every modal additionally gains keyboard accessibility: Escape to close, Tab/Shift+Tab cycling within the dialog, and automatic initial focus.

## Testing

- Dashboard typecheck, lint, 115 unit tests, and production build all green.
- Verified manually: all five modals render and behave as before, plus the new dismissal and focus behaviors work.
