### PR TITLE
fix(dashboard): resolve ghost CSS tokens and foreign fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Audit log rows now carry the resolved API key and client IP for every call site: the values are
   stamped into the per-request async context by the auth guard and auto-filled on write (explicit
   context still wins).
+- Dashboard CSS no longer references undefined custom properties or fallbacks from a foreign
+  design system: every danger/danger-color usage now resolves to the single `--error` token, wrong
+  `--primary`/`--text-secondary`/`--border`/`--warning` fallbacks are dropped, and the plugin
+  instances "off" badge shows its background again (it referenced an undefined `--bg-secondary`).
 - Dashboard readability and behavior: the send button stays readable when disabled, API Keys badges
   render on desktop (rules were stranded in a mobile-only media query), the Templates page gets real
   primary/secondary button styles, fourteen dark-mode selectors are corrected so dark mode applies,

--- a/dashboard/src/components/GlobalSearch.css
+++ b/dashboard/src/components/GlobalSearch.css
@@ -101,7 +101,7 @@
 }
 
 .global-search-hit-snippet mark {
-  background: var(--warning, #fde68a);
+  background: var(--warning);
   color: inherit;
   border-radius: 2px;
   padding: 0 1px;

--- a/dashboard/src/components/PluginInstances.css
+++ b/dashboard/src/components/PluginInstances.css
@@ -68,11 +68,11 @@
   white-space: nowrap;
 }
 .plugin-instances .pi-badge.on {
-  background: var(--success-bg, #dcfce7);
-  color: var(--success, #16a34a);
+  background: var(--primary-soft);
+  color: var(--success);
 }
 .plugin-instances .pi-badge.off {
-  background: var(--bg-secondary);
+  background: var(--bg-light);
   color: var(--text-muted);
 }
 .plugin-instances .pi-actions {
@@ -94,19 +94,19 @@
 .plugin-instances .pi-secret code {
   flex: 1;
   padding: 0.75rem;
-  background: var(--bg-secondary);
+  background: var(--bg-light);
   border-radius: 6px;
   word-break: break-all;
 }
 .plugin-instances .pi-error {
-  color: var(--danger, #e5484d);
+  color: var(--error);
   font-size: 0.85rem;
   margin-top: 0.5rem;
 }
 .plugin-instances .pi-confirm-icon {
   display: flex;
   justify-content: center;
-  color: var(--danger, #e5484d);
+  color: var(--error);
   margin-bottom: 0.75rem;
 }
 .plugin-instances textarea {

--- a/dashboard/src/pages/Infrastructure.css
+++ b/dashboard/src/pages/Infrastructure.css
@@ -498,7 +498,7 @@
 }
 .infrastructure-page .engine-web-version code {
   font-size: 0.8125rem;
-  background: var(--bg-subtle, rgba(127, 127, 127, 0.1));
+  background: rgba(127, 127, 127, 0.1);
   padding: 0.05rem 0.35rem;
   border-radius: 4px;
 }
@@ -512,7 +512,7 @@
   gap: 0.4rem;
   margin: 0 0 1rem;
   font-size: 0.8125rem;
-  color: var(--warning, #b45309);
+  color: var(--warning);
 }
 .infrastructure-page .env-pin-note svg {
   flex-shrink: 0;
@@ -531,7 +531,7 @@
 }
 .infrastructure-page .migration-warning svg {
   flex-shrink: 0;
-  color: var(--warning, #d97706);
+  color: var(--warning);
   margin-top: 0.1rem;
 }
 .infrastructure-page .migration-warning p {

--- a/dashboard/src/pages/Plugins.css
+++ b/dashboard/src/pages/Plugins.css
@@ -392,15 +392,15 @@
   border: 1px solid var(--border);
   border-radius: 8px;
   background: var(--bg-light);
-  color: var(--danger, #e5484d);
+  color: var(--error);
   cursor: pointer;
   transition: all 0.2s;
 }
 
 .plugins-page .config-form .config-array-remove:hover {
-  background: var(--danger, #e5484d);
+  background: var(--error);
   color: #fff;
-  border-color: var(--danger, #e5484d);
+  border-color: var(--error);
 }
 
 .plugins-page .config-form .config-array-add {
@@ -443,7 +443,7 @@
 .plugins-page .config-ui-error {
   padding: 1rem;
   text-align: center;
-  color: var(--danger, #e5484d);
+  color: var(--error);
 }
 
 .plugins-page .config-form .form-group small {
@@ -455,7 +455,7 @@
 }
 
 .plugins-page .config-form .form-group .required-mark {
-  color: var(--danger, #e5484d);
+  color: var(--error);
 }
 
 .plugins-page .toggle-group {
@@ -522,7 +522,7 @@
 }
 
 .plugins-page .toggle-switch input:checked + .toggle-slider {
-  background-color: var(--primary, #22c55e);
+  background-color: var(--primary);
 }
 
 .plugins-page .toggle-switch input:checked + .toggle-slider:before {
@@ -710,7 +710,7 @@
   padding: 0;
   background: none;
   border: none;
-  color: var(--primary, #22c55e);
+  color: var(--primary);
   font: inherit;
   font-weight: 600;
   cursor: pointer;
@@ -845,11 +845,11 @@
    and the transition on background/color/box-shadow/transform above animates the swap smoothly. */
 .plugins-page .install-tab.active,
 .plugins-page .config-modal .modal-tab.active {
-  background: var(--primary, #22c55e);
+  background: var(--primary);
   color: #fff;
   box-shadow:
     0 1px 2px rgba(0, 0, 0, 0.08),
-    0 4px 12px color-mix(in srgb, var(--primary, #22c55e) 35%, transparent);
+    0 4px 12px color-mix(in srgb, var(--primary) 35%, transparent);
   transform: translateY(-1px);
 }
 
@@ -857,7 +857,7 @@
    it's obvious they're clickable before the active treatment snaps in. */
 .plugins-page .install-tab:not(.active):hover,
 .plugins-page .config-modal .modal-tab:not(.active):hover {
-  background: color-mix(in srgb, var(--primary, #22c55e) 12%, transparent);
+  background: color-mix(in srgb, var(--primary) 12%, transparent);
   color: var(--text-primary);
 }
 
@@ -940,13 +940,13 @@
   justify-content: center;
   gap: 10px;
   padding: 28px 12px;
-  color: var(--text-secondary, #6b7280);
+  color: var(--text-secondary);
   font-size: 0.875rem;
 }
 
 .plugins-page .catalog-error {
   flex-wrap: wrap;
-  color: var(--danger, #dc2626);
+  color: var(--error);
 }
 
 .plugins-page .catalog-search {
@@ -983,7 +983,7 @@
   justify-content: space-between;
   gap: 12px;
   padding: 12px;
-  border: 1px solid var(--border, #e5e7eb);
+  border: 1px solid var(--border);
   border-radius: 8px;
 }
 
@@ -996,13 +996,13 @@
 }
 
 .plugins-page .catalog-row-version {
-  color: var(--text-secondary, #6b7280);
+  color: var(--text-secondary);
   font-weight: 400;
   font-size: 0.85em;
 }
 
 .plugins-page .catalog-row-desc {
-  color: var(--text-secondary, #6b7280);
+  color: var(--text-secondary);
   font-size: 0.85rem;
   margin-top: 2px;
 }
@@ -1013,7 +1013,7 @@
   gap: 8px;
   margin-top: 4px;
   font-size: 0.8rem;
-  color: var(--text-secondary, #6b7280);
+  color: var(--text-secondary);
 }
 
 .plugins-page .catalog-badge.update {
@@ -1028,6 +1028,6 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  color: var(--text-secondary, #6b7280);
+  color: var(--text-secondary);
   font-size: 0.85rem;
 }

--- a/dashboard/src/pages/Sessions.css
+++ b/dashboard/src/pages/Sessions.css
@@ -151,7 +151,7 @@
 }
 
 .sessions-page .info-value.error-text {
-  color: var(--color-danger, #dc2626);
+  color: var(--error);
   font-weight: 500;
   max-width: 60%;
   text-align: right;


### PR DESCRIPTION
## Summary

Fixes CSS that referenced custom properties which are never defined, or carried fallback values from a different design system — so colors quietly depended on the wrong palette.

## What changed

- Ghost tokens removed: `--danger` (×8), `--color-danger`, `--bg-secondary`, `--bg-subtle`, `--success-bg` — none of these are defined anywhere, so usages either fell back to off-palette colors or rendered nothing.
- All danger styling now resolves to the single `--error` token; success/badge styling uses `--success` and `--primary-soft`.
- Wrong fallbacks on real tokens dropped: `var(--primary, #22c55e)`, `var(--text-secondary, #6b7280)`, `var(--border, #e5e7eb)`, `var(--warning, …)` now resolve to the actual design tokens.
- **Visible fix**: the plugin-instances "off" badge shows its background again — it referenced an undefined `--bg-secondary` with no fallback, so it rendered transparent.

## Testing

- Dashboard build, unit tests, and typecheck all green.
- Repo-wide sweep confirms zero remaining references to undefined custom properties.
