### PR TITLE
fix(dashboard): restore h2 as a real heading, make the eyebrow opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Dashboard theming is simplified to a single light/dark toggle button; the accent-palette picker
-  was removed for maintainability. The stored theme is applied before first paint, so standalone
+  was removed for maintainability. The global `h2` is a real heading
+  again instead of a forced small uppercase eyebrow (section/card titles were smaller than body
+  text); the eyebrow look survives as an opt-in `.eyebrow` class.
+ The stored theme is applied before first paint, so standalone
   routes no longer flash the OS default, and the message-analytics chart now defaults to 24h.
 - The dev compose defaults `AUTO_START_SESSIONS=true`, so previously authenticated sessions come
   back by themselves after a container restart (the application-level default stays off).

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -46,7 +46,17 @@ h1 {
   letter-spacing: -0.025em;
 }
 
+/* h2 is a real heading again — the old global made EVERY h2 a small uppercase eyebrow, which
+   forced pages to keep resetting it (and left section titles smaller than body text). The eyebrow
+   look is now opt-in via .eyebrow for the section/card labels that actually want it. */
 h2 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.eyebrow {
   font-size: 0.8125rem;
   font-weight: 600;
   color: var(--text-secondary);

--- a/dashboard/src/pages/MessageTester.tsx
+++ b/dashboard/src/pages/MessageTester.tsx
@@ -195,7 +195,7 @@ export function MessageTester() {
 
       <div className="tester-panels">
         <div className="compose-panel">
-          <h2>{t('messageTester.compose')}</h2>
+          <h2 className="eyebrow">{t('messageTester.compose')}</h2>
 
           <div className="form-group">
             <label>{t('messageTester.session')}</label>
@@ -352,7 +352,7 @@ export function MessageTester() {
         </div>
 
         <div className="response-panel">
-          <h2>{t('messageTester.responseTitle')}</h2>
+          <h2 className="eyebrow">{t('messageTester.responseTitle')}</h2>
 
           {response ? (
             <>


### PR DESCRIPTION
## Summary

The global `h2` rule forced every heading into a small uppercase eyebrow style (0.8125rem, uppercase, letterspaced). Section and card titles rendered smaller than body text, and pages kept re-resetting it rule by rule.

## What changed

- `h2` is a real heading by default again (1.25rem, bold, primary color, no forced case).
- The eyebrow look survives as the opt-in `.eyebrow` class — applied to the two panel labels that intentionally inherited it (Message Tester compose and response panels).
- Unaffected by design: modal headers (`.modal-header h2` was already a full title style), card headers, and page-level h2 rules.
- Side effect fixed: the Message Analytics chart title loses its leftover forced uppercase.

Verified per element: 26 `h2` usages across the app — 6 section/card titles get the intended real-title default, 2 keep the eyebrow look via the new class, 18 were already fully styled.

## Testing

- Dashboard build, unit tests, typecheck, and lint all green.
