### PR TITLE
fix(dashboard): flatten decorative hover and selection effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   danger buttons use the single `--error` red.
 - The Infrastructure page's inline-styled elements (including the restart/migration progress modal) are
   moved to scoped CSS classes, so all surfaces stay on the design-token system.
+- Decorative hover/selection effects are flattened for a more professional look: the install/config
+  tab active state no longer lifts or glows, the restart progress bar is a flat primary fill instead
+  of a gradient, and the emoji-picker button no longer scales on hover.
 
 ### Removed
 

--- a/dashboard/src/pages/Chats.css
+++ b/dashboard/src/pages/Chats.css
@@ -685,7 +685,6 @@
 
 .chats-page .emoji-btn:hover {
   background: var(--bg-light);
-  transform: scale(1.15);
 }
 
 .chats-page .message-bubble.media-type {

--- a/dashboard/src/pages/Infrastructure.css
+++ b/dashboard/src/pages/Infrastructure.css
@@ -723,7 +723,7 @@
 
 .infrastructure-page .restart-progress-fill {
   height: 100%;
-  background: linear-gradient(90deg, #22c55e, #10b981);
+  background: var(--primary);
   transition: width 1s linear;
 }
 

--- a/dashboard/src/pages/Plugins.css
+++ b/dashboard/src/pages/Plugins.css
@@ -840,17 +840,11 @@
     transform 0.18s ease;
 }
 
-/* Active tab: a clear, primary-tinted treatment instead of the near-invisible white-on-light it had
-   before. The tint + colored text + lifted shadow + tiny scale make the selected tab read at a glance,
-   and the transition on background/color/box-shadow/transform above animates the swap smoothly. */
+/* Active tab: a clear primary treatment that reads at a glance — flat, no lift or glow. */
 .plugins-page .install-tab.active,
 .plugins-page .config-modal .modal-tab.active {
   background: var(--primary);
   color: #fff;
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.08),
-    0 4px 12px color-mix(in srgb, var(--primary) 35%, transparent);
-  transform: translateY(-1px);
 }
 
 /* Keep the inactive tabs legible against the pill's light track and give them a hover affordance so


### PR DESCRIPTION
## Summary

Flattens the remaining consumer-style decorative effects so the dashboard reads as a professional admin console.

## What changed

- Install/config modal tab active state: keeps its clear primary treatment but no longer lifts (`translateY`) or glows (colored shadow).
- Restart progress bar: flat `--primary` fill instead of a two-tone green gradient.
- Emoji picker button: hover keeps only the background affordance, no more `scale(1.15)` zoom.

## Testing

- Dashboard build, unit tests, and typecheck all green.
