### PR TITLE
fix(plugins): prune registry ghosts of legacy removed built-ins at boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Boot no longer warns about (and the plugin list no longer shows) ghost entries for the legacy
+  bundled extensions removed in v0.7 (`auto-reply`, `translation`): when their code directory has no
+  manifest, the stale registry entry is pruned at startup. The guard is scoped to those known ids so
+  a temporarily unreadable plugin directory never loses its persisted config.
+
+
 - Long-lived sessions no longer die permanently after hours of uptime. A dead whatsapp-web.js
   Chromium (browser process exit, renderer crash, or closed page) is now detected through the
   puppeteer lifecycle handles and driven through the standard disconnect → reconnect pipeline, and

--- a/src/core/plugins/plugin-loader.service.spec.ts
+++ b/src/core/plugins/plugin-loader.service.spec.ts
@@ -410,6 +410,60 @@ describe('PluginLoaderService — skips dot-prefixed directories on load (crash-
   });
 });
 
+describe('PluginLoaderService — prunes registry ghosts of removed built-ins', () => {
+  let tmpDir: string;
+  let pluginsDir: string;
+  let loader: PluginLoaderService;
+  let storage: PluginStorageService;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'owa-ghosts-'));
+    pluginsDir = path.join(tmpDir, 'plugins');
+    fs.mkdirSync(pluginsDir, { recursive: true });
+    const config = {
+      get: (k: string) => (k === 'plugins.dir' ? pluginsDir : k === 'dataDir' ? tmpDir : undefined),
+    } as unknown as ConfigService;
+    storage = new PluginStorageService(config);
+    loader = new PluginLoaderService(config, new HookManager(), storage, {} as unknown as ModuleRef);
+  });
+  afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+  const seedGhost = (id: string): void => {
+    // A leftover directory with no manifest (code deleted) + a stale registry entry still claiming
+    // the plugin is installed — the ghost state upgrades from <=0.6 are in.
+    fs.mkdirSync(path.join(pluginsDir, id), { recursive: true });
+    storage.setPluginEntry({
+      id,
+      type: 'extension',
+      name: id,
+      version: '1.0.0',
+      status: 'installed',
+      config: {},
+      builtIn: true,
+      installedAt: new Date(),
+      updatedAt: new Date(),
+    } as never);
+  };
+
+  it('prunes registry entries of legacy removed built-ins (auto-reply, translation) with no manifest', () => {
+    seedGhost('auto-reply');
+    seedGhost('translation');
+
+    loader.onModuleInit();
+
+    expect(storage.getPluginEntry('auto-reply')).toBeUndefined();
+    expect(storage.getPluginEntry('translation')).toBeUndefined();
+  });
+
+  it('keeps a manifest-less NON-legacy plugin entry (config survives an unreadable dir)', () => {
+    seedGhost('some-other-plugin');
+
+    loader.onModuleInit();
+
+    expect(storage.getPluginEntry('some-other-plugin')).toBeDefined();
+  });
+});
+
 describe('PluginLoaderService — enable concurrency', () => {
   let tmpDir: string;
   let loader: PluginLoaderService;

--- a/src/core/plugins/plugin-loader.service.ts
+++ b/src/core/plugins/plugin-loader.service.ts
@@ -132,6 +132,13 @@ export function dispatchConversationMedia(
   }
 }
 
+// Plugin ids whose bundled-extension code was permanently removed (v0.7 — superseded by the
+// marketplace chat-flow / group-translate; also reserved in plugin-installer). A leftover
+// directory without a manifest marks them as deleted on disk, so the stale registry entry (which
+// still reports them installed/enabled) is pruned on boot. Scoped to these known ids so a
+// temporarily-unreadable plugin dir (e.g. an unmounted volume) never loses its persisted config.
+const LEGACY_REMOVED_PLUGIN_IDS = new Set(['auto-reply', 'translation']);
+
 @Injectable()
 export class PluginLoaderService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = createLogger('PluginLoaderService');
@@ -221,6 +228,12 @@ export class PluginLoaderService implements OnModuleInit, OnModuleDestroy {
           pluginPath,
           action: 'manifest_missing',
         });
+        if (LEGACY_REMOVED_PLUGIN_IDS.has(entry.name)) {
+          this.pluginStorage.deletePluginEntry(entry.name);
+          this.logger.log(`Pruned stale registry entry for removed built-in plugin: ${entry.name}`, {
+            action: 'registry_ghost_pruned',
+          });
+        }
         continue;
       }
 


### PR DESCRIPTION
## Summary

Installations upgraded from ≤0.6 carry stale plugin registry entries for the bundled extensions removed in v0.7 (`auto-reply`, `translation`). Their code is gone, so every boot logs a `manifest_missing` warning and the entries keep reporting those plugins as installed/enabled indefinitely.

## What changed

- During the plugin directory scan, a directory with no manifest for one of the known legacy ids now has its persisted registry entry pruned — the warning and the ghost listing stop after one boot.
- The prune is deliberately scoped to those two ids, so a temporarily unreadable plugin directory (e.g. an unmounted volume) never loses its persisted configuration.
- Tests cover both directions: legacy ghosts are pruned, a manifest-less non-legacy entry is preserved.

## Testing

- Backend: full suite green (36 loader specs incl. the 2 new ones).
- Verified on a real data directory: ghost entries and empty directories removed; next boot is warning-free.
