### PR TITLE
chore(release): v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-07-19
+
 ### Added
 
 - Reconnect-loop observability: every scheduled reconnect attempt is counted in the new

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboard",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.10.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwa",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API for WhatsApp",
   "author": "Yudhi Armyndharis & OpenWA Contributors",
   "private": true,


### PR DESCRIPTION
## Summary

Cuts the 0.10.0 release. The `[Unreleased]` section had accumulated a full release's worth of changes; this PR dates them as `## [0.10.0] - 2026-07-19` and bumps both `package.json` files to `0.10.0`.

Highlights shipping in this release:

- **Messaging reliability**: outgoing messages composed on a linked phone are persisted (atomic dedup vs the REST send path), the own-send media echo carries real payloads, sent media renders immediately and survives reloads, and full-text search self-heals its schema and sanitizes queries.
- **Session resilience**: liveness watchdog, unlimited reconnect backoff, orphaned-browser sweep, terminal-error detection, and boot-time auto-start for previously authenticated sessions.
- **Dashboard**: accessible shared modal, consolidated global button styles, real `h2` headings with opt-in eyebrow, ghost-token cleanup, simplified light/dark theming, chat scroll correctness on every path, and a Message Tester covering 11 send types including bulk with live batch progress.
- **Plugins**: config-schema defaults seeded at load, registry ghosts of removed built-ins pruned at boot.
- Substantial verified dead-code removal across CSS, client methods, assets, and i18n keys.

## Release mechanics

- `npm run check:versions` passes (CHANGELOG carries the `## [0.10.0]` entry).
- Full gates green: lint, format, backend tests (2,576), dashboard tests (121), both builds.
- After merge, tagging `v0.10.0` fires the release workflow (CI-strength gate, Docker image publish, GitHub Release).
