### PR TITLE
chore: regenerate the OpenAPI snapshot for v0.10.0

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5338,7 +5338,7 @@
   "info": {
     "title": "OpenWA API",
     "description": "Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API",
-    "version": "0.9.0",
+    "version": "0.10.0",
     "contact": {
       "name": "OpenWA",
       "url": "https://github.com/rmyndharis/OpenWA",


### PR DESCRIPTION
## Summary

Follow-up to the v0.10.0 release PR: the version bump made the checked-in `openapi.json` snapshot stale (the spec embeds the version), which failed the lint job's `openapi:check` gate on #814. This regenerates the snapshot via `npm run openapi:export`; `npm run openapi:check` now diffs clean.

No code changes — one-line version update inside the generated spec.
