### PR TITLE
fix(dashboard): stop formatting LIDs as fake phones, resolve real numbers, show chat list avatars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The chat header no longer formats a LID privacy id as a fake phone number (e.g. "+26 281 346
+  125 0071"): digit-only LIDs and group ids are rejected by the phone formatter, and personal @lid
+  chats now resolve and display the real number through the engine (cached a day). Chat list rows
+  also render profile pictures now, sharing the room header's 1-hour cache instead of static icons.
+
+
 - Boot no longer warns about (and the plugin list no longer shows) ghost entries for the legacy
   bundled extensions removed in v0.7 (`auto-reply`, `translation`): when their code directory has no
   manifest, the stale registry entry is pruned at startup. The guard is scoped to those known ids so

--- a/dashboard/src/hooks/useResolvedPhone.ts
+++ b/dashboard/src/hooks/useResolvedPhone.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
+import { contactApi } from '../services/api';
+
+/**
+ * Lazily resolve a contact id (e.g. an @lid privacy id) to its phone number (MSISDN digits) for
+ * one (sessionId, contactId). Returns null when the engine can't map it — the caller keeps its
+ * fallback label in that case. An @lid ↔ phone mapping is stable, so the result is cached for a
+ * day; `retry: false` keeps an unmappable id from spamming the server.
+ *
+ * Call it with `enabled` inputs only when the cheap local formatting already failed
+ * (formatPhoneForDisplay returned null) — normal @c.us chats never need the engine round-trip.
+ */
+export function useResolvedPhone(sessionId: string | undefined, contactId: string | undefined) {
+  return useQuery<string | null, Error>({
+    queryKey: ['resolvedPhone', sessionId, contactId] as const,
+    queryFn: () => contactApi.resolvePhone(sessionId!, contactId!).then(r => r.phone),
+    enabled: Boolean(sessionId && contactId),
+    staleTime: 24 * 60 * 60 * 1000, // 1 day — lid→phone mappings don't churn
+    gcTime: 60 * 60 * 1000,
+    retry: false,
+  });
+}

--- a/dashboard/src/pages/Chats.tsx
+++ b/dashboard/src/pages/Chats.tsx
@@ -19,6 +19,7 @@ import {
   ChevronDown,
 } from 'lucide-react';
 import { useProfilePicture } from '../hooks/useProfilePicture';
+import { useResolvedPhone } from '../hooks/useResolvedPhone';
 import { formatPhoneForDisplay } from '../utils/formatPhone';
 import {
   sessionApi,
@@ -87,6 +88,21 @@ const getMediaSrc = (media?: MessageMedia): string => {
   return `data:${media.mimetype};base64,${media.data}`;
 };
 
+// Chat list avatar: the same 1h-cached profile picture as the room header (shared TanStack Query
+// cache keyed by (sessionId, contactId), so the row and the header never fetch twice), falling
+// back to the generic person/group icon while it loads or when the picture is hidden/unavailable.
+function ChatAvatar({ sessionId, chat }: { sessionId: string; chat: Chat }) {
+  const pp = useProfilePicture(sessionId, chat.id);
+  if (pp.data) {
+    return (
+      <div className="chat-avatar">
+        <img src={pp.data} alt="" onError={() => pp.refetch()} />
+      </div>
+    );
+  }
+  return <div className="chat-avatar">{chat.isGroup ? <Users size={20} /> : <User size={20} />}</div>;
+}
+
 export function Chats() {
   const { t } = useTranslation();
   useDocumentTitle(t('nav.chats'));
@@ -146,6 +162,18 @@ export function Chats() {
   // Profile-picture fetch for the active room (cached 1h by useProfilePicture; TanStack Query
   // dedupes, so other components querying the same key share this slice).
   const activePp = useProfilePicture(selectedSessionId || undefined, activeChat?.id);
+
+  // Header phone line. Local formatting handles @c.us ids offline; for anything else personal
+  // (notably @lid privacy ids, which are NOT phones and must never be formatted as one) resolve
+  // the real number through the engine — cached a day, and only fired when local formatting failed.
+  const activePhoneDisplay = activeChat ? formatPhoneForDisplay(activeChat.id) : null;
+  const needsPhoneResolution = Boolean(activeChat && !activeChat.isGroup && !activePhoneDisplay);
+  const resolvedPhoneQ = useResolvedPhone(
+    needsPhoneResolution ? selectedSessionId || undefined : undefined,
+    needsPhoneResolution ? activeChat?.id : undefined,
+  );
+  const activePhoneText =
+    activePhoneDisplay ?? (resolvedPhoneQ.data ? formatPhoneForDisplay(resolvedPhoneQ.data) : null);
 
   // Scroll-to-bottom button visibility. The main scroll-position memory is owned by
   // useChatScrollPosition, which doesn't expose its pin state (intentionally — that would re-render
@@ -912,7 +940,7 @@ export function Chats() {
                       className={`chat-item-card ${isActive ? 'active' : ''}`}
                       onClick={() => setActiveChat(chat)}
                     >
-                      <div className="chat-avatar">{chat.isGroup ? <Users size={20} /> : <User size={20} />}</div>
+                      <ChatAvatar sessionId={selectedSessionId} chat={chat} />
 
                       <div className="chat-item-info">
                         <div className="chat-item-top">
@@ -962,11 +990,12 @@ export function Chats() {
                   </div>
                   <div className="room-contact-info">
                     <h3>{activeChat.name || activeChat.id.split('@')[0]}</h3>
-                    {/* For personal chats, show the prettified phone number (most common ask). For
-                        groups/LID, show a stable semantic label instead — the raw JID follows below
-                        for the technical case (lid debugging, group id lookups). */}
+                    {/* Personal chats show the prettified phone number — local formatting for
+                        @c.us ids, engine-resolved for @lid privacy ids (which are NOT phones and
+                        must never be formatted as one). Groups fall back to a semantic label;
+                        the raw JID follows below for the technical case. */}
                     <span className="room-contact-phone">
-                      {formatPhoneForDisplay(activeChat.id) ??
+                      {activePhoneText ??
                         (activeChat.isGroup ? t('chats.groupSubtitle') : t('chats.privateContactSubtitle'))}
                     </span>
                     {/* Raw JID preserved for the technical case (the gateway speaks JIDs everywhere:

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -656,6 +656,12 @@ export const contactApi = {
   // dashboard caches it for an hour (see useProfilePicture) and re-fetches on expiry.
   profilePicture: (sessionId: string, contactId: string) =>
     request<ProfilePictureResponse>(`/sessions/${sessionId}/contacts/${encodeURIComponent(contactId)}/profile-picture`),
+  // Best-effort resolution of a contact id (e.g. an @lid privacy id) to its phone number (MSISDN
+  // digits), or null when the engine can't map it. Cached a day by useResolvedPhone.
+  resolvePhone: (sessionId: string, contactId: string) =>
+    request<{ contactId: string; phone: string | null }>(
+      `/sessions/${sessionId}/contacts/${encodeURIComponent(contactId)}/phone`,
+    ),
 };
 
 // =============================================================================

--- a/dashboard/src/utils/formatPhone.test.ts
+++ b/dashboard/src/utils/formatPhone.test.ts
@@ -18,6 +18,16 @@ test('parsePhoneFromJid returns null for LID privacy ids', () => {
   assert.equal(parsePhoneFromJid('abcdef@lid'), null);
 });
 
+test('parsePhoneFromJid returns null for a DIGITS-ONLY LID (privacy ids are not phones)', () => {
+  // The actual bug: a LID user part is all digits, so the digits check alone formatted it as a
+  // fake phone number ("+26 281 346 125 0071"). The domain guard rejects it first.
+  assert.equal(parsePhoneFromJid('262813461250071@lid'), null);
+});
+
+test('parsePhoneFromJid returns null for a digits-only GROUP id (not a phone either)', () => {
+  assert.equal(parsePhoneFromJid('120363404149049457@g.us'), null);
+});
+
 test('parsePhoneFromJid returns null for broadcast/newsletter/status JIDs', () => {
   assert.equal(parsePhoneFromJid('status@broadcast'), null);
   assert.equal(parsePhoneFromJid('abc@newsletter'), null);
@@ -34,6 +44,10 @@ test('formatPhoneForDisplay formats a US-style 11-digit number with 1-digit coun
 test('formatPhoneForDisplay returns null for non-phone JIDs (group/lid)', () => {
   assert.equal(formatPhoneForDisplay('120363abc@g.us'), null);
   assert.equal(formatPhoneForDisplay('xyz@lid'), null);
+});
+
+test('formatPhoneForDisplay returns null for a digits-only LID instead of inventing a phone', () => {
+  assert.equal(formatPhoneForDisplay('262813461250071@lid'), null);
 });
 
 test('formatPhoneForDisplay passes short codes through unchanged with a + prefix', () => {

--- a/dashboard/src/utils/formatPhone.ts
+++ b/dashboard/src/utils/formatPhone.ts
@@ -14,7 +14,12 @@
  */
 export function parsePhoneFromJid(jid: string): string | null {
   if (!jid) return null;
-  const local = jid.split('@')[0];
+  const [local, domain] = jid.split('@');
+  // Only personal-account domains carry a real phone number. LID privacy ids, groups, and
+  // status/broadcast/newsletter ids are digit-heavy too but are NOT phones — treating them as one
+  // formats a privacy/group id as a fake number (a LID like 262813461250071@lid displayed as
+  // "+26 281 346 125 0071").
+  if (domain && !domain.startsWith('c.us') && domain !== 's.whatsapp.net') return null;
   // Group participant ids include a colon + device, e.g. `628xxx@c.us:7`. Strip it for display.
   const user = local.split(':')[0];
   if (!/^\d+$/.test(user)) return null;


### PR DESCRIPTION
## Summary

Fixes two chat-display issues: LID privacy ids being formatted as fake phone numbers, and chat list rows showing only static icons instead of profile pictures.

## What changed

- **Phone formatter**: the digits-only test used to pass LID privacy ids (and numeric group ids), so a header could display nonsense like `+26 281 346 125 0071` for a contact whose real number is entirely different. The formatter now only accepts personal-account domains (`@c.us` / `@s.whatsapp.net`). Regression tests added for digits-only LID and group ids.
- **Real number for @lid chats**: the room header resolves the actual phone through the engine's contact phone endpoint when local formatting fails — cached for a day via a new `useResolvedPhone` hook (`contactApi.resolvePhone`), with the semantic label kept when the engine can't map the id.
- **Chat list avatars**: rows now render the contact/group profile picture via the same 1-hour-cached `useProfilePicture` the room header uses (shared TanStack Query cache — a row and its header never fetch twice), keeping the generic icon while loading or when the picture is hidden/unavailable.

## Testing

- Dashboard: 134/134 unit tests (incl. the new formatter cases), typecheck, lint, and production build all green.
- Verified the resolution endpoint maps the reported LID to the correct number.
