### PR TITLE
chore: regenerate the OpenAPI snapshot for the profile-pictures batch endpoint

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2713,6 +2713,41 @@
         ]
       }
     },
+    "/api/sessions/{sessionId}/contacts/profile-pictures": {
+      "get": {
+        "description": "One request for a whole chat sidebar — avoids the burst of parallel single fetches that would exhaust the per-IP throttle. Engine lookups run 3 at a time; per-id failures return null.",
+        "operationId": "ContactController_getProfilePictures",
+        "parameters": [
+          {
+            "name": "sessionId",
+            "required": true,
+            "in": "path",
+            "description": "Session ID",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "ids",
+            "required": true,
+            "in": "query",
+            "description": "Comma-separated contact ids (max 50 used)",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "Batch-resolve profile picture URLs for up to 50 contacts",
+        "tags": [
+          "contacts"
+        ]
+      }
+    },
     "/api/sessions/{sessionId}/contacts/{contactId}": {
       "get": {
         "operationId": "ContactController_findOne",


### PR DESCRIPTION
## Summary

Fixes the red lint job on main: the new `GET …/contacts/profile-pictures` batch endpoint changed the API surface, so the checked-in `openapi.json` snapshot went stale and the `openapi:check` gate failed.

Regenerated via `npm run openapi:export` (118 → 119 paths); `npm run openapi:check` diffs clean. Snapshot-only change.
