### PR TITLE
feat(baileys): make the linked-device name brandable via BAILEYS_BROWSER_NAME

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -118,6 +118,10 @@ BAILEYS_AUTH_DIR=./data/baileys
 # Pull the FULL message-history archive on connect (large). Off by default: the engine still enables the
 # initial sync (contacts, chats, recent messages, lid mappings) without downloading the entire history.
 BAILEYS_SYNC_FULL_HISTORY=false
+# Device name shown in WhatsApp Settings → Linked Devices for NEW pairings (existing sessions keep
+# the name they were paired with until re-linked). Default: OpenWA.
+# BAILEYS_BROWSER_NAME=
+
 # Surface the Baileys library's own logs for debugging (trace|debug|info|warn|error). Silent by default.
 # `trace` dumps the decoded WhatsApp wire frames to stdout (context "baileys-wire").
 # BAILEYS_LOG_LEVEL=debug

--- a/src/engine/adapters/baileys.adapter.ts
+++ b/src/engine/adapters/baileys.adapter.ts
@@ -57,8 +57,13 @@ import {
 } from './inbound-media-cap';
 import { ConcurrencyLimiter } from '../../common/utils/concurrency-limiter';
 
-/** Linked-device identity shown in WhatsApp (Settings → Linked Devices). */
-const BAILEYS_BROWSER: [string, string, string] = ['OpenWA', 'Chrome', '120.0.0'];
+/** Linked-device identity shown in WhatsApp (Settings → Linked Devices). The display name is
+ * operator-brandable via BAILEYS_BROWSER_NAME; it only applies to pairings made after the change. */
+const BAILEYS_BROWSER: [string, string, string] = [
+  process.env.BAILEYS_BROWSER_NAME?.trim() || 'OpenWA',
+  'Chrome',
+  '120.0.0',
+];
 
 /** Fully silent logger so Baileys does not spam stdout; diagnostics flow via connection.update. */
 function createSilentLogger(): BaileysLogger {


### PR DESCRIPTION
Operators white-labeling the stack need their own brand in WhatsApp's **Settings → Linked Devices** entry, which is currently hardcoded to `OpenWA`.

This makes the first element of `BAILEYS_BROWSER` configurable through a new optional env var, `BAILEYS_BROWSER_NAME` (default unchanged: `OpenWA`). Documented in `.env.example`.

Note: the name is fixed at pairing time — it applies to new QR pairings; existing sessions keep the identity they were linked with until re-paired.

## How to test
1. Set `BAILEYS_BROWSER_NAME=mybrand` on the container and start a session (`ENGINE_TYPE=baileys`).
2. Pair via QR and check the phone's Linked Devices list: the entry shows **mybrand (Chrome)**.
3. Unset the var and re-pair: entry shows **OpenWA (Chrome)** as before.