### PR TITLE
docs(changelog): drop the stale concurrency figure from the avatar-batch entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,8 +83,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 - Chat-list avatars no longer burst into HTTP 429s: profile pictures for the whole sidebar are
-  batch-resolved in ONE request (`GET .../contacts/profile-pictures?ids=…`, up to 50 ids, 3 engine
-  lookups at a time) instead of one parallel fetch per row, which exhausted the per-IP throttle.
+  batch-resolved in ONE request (`GET .../contacts/profile-pictures?ids=…`, up to 50 ids) instead
+  of one parallel fetch per row, which exhausted the per-IP throttle.
 
 
 - The chat header no longer formats a LID privacy id as a fake phone number (e.g. "+26 281 346


### PR DESCRIPTION
One-line accuracy fix: the #818 changelog entry quoted the intermediate 3-way concurrency; the shipped implementation (#823) uses a per-id deadline with 5-way chunking. The figure is dropped so the notes describe only what is true regardless of tuning.