### PR TITLE
chore(release): v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-07-20
+
 ### Added
 - Design draft `docs/28-multitenancy.md`: the enterprise multitenancy proposal — tenant entity,
   named users with per-tenant roles, TOTP two-factor auth, per-tenant branding/isolation/quotas,

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboard",
   "private": true,
-  "version": "0.10.0",
+  "version": "0.10.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/openapi.json
+++ b/openapi.json
@@ -5373,7 +5373,7 @@
   "info": {
     "title": "OpenWA API",
     "description": "Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API",
-    "version": "0.10.0",
+    "version": "0.10.1",
     "contact": {
       "name": "OpenWA",
       "url": "https://github.com/rmyndharis/OpenWA",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwa",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API for WhatsApp",
   "author": "Yudhi Armyndharis & OpenWA Contributors",
   "private": true,


### PR DESCRIPTION
## Summary

Cuts the 0.10.1 patch release: dates the post-0.10.0 work in the changelog and bumps both `package.json` files.

## Highlights

- **Chats**: LID privacy ids no longer format as fake phone numbers — the header resolves and shows the real number; chat-list rows render profile pictures through the batched profile-picture endpoint (single request, per-id deadline, top-50 list order — no more throttle bursts or stalls on long sidebars).
- **Branding**: the linked-device name is brandable via the optional `BAILEYS_BROWSER_NAME` env var (default unchanged).
- **Docs**: the multitenancy design draft (docs/28) ships, plus changelog structure/accuracy fixes.

## Release mechanics

- `openapi.json` regenerated alongside the version bump (the gate failure from the previous release is preempted).
- `npm run check:versions` passes; full gates green: lint, format, backend tests (2,580), dashboard tests (134), both builds.
- After merge, tagging `v0.10.1` fires the release workflow.
