### PR TITLE
fix(compose): forward BODY_SIZE_LIMIT into both containers

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -91,6 +91,9 @@ services:
       - RATE_LIMIT_MEDIUM_LIMIT=${RATE_LIMIT_MEDIUM_LIMIT:-}
       - RATE_LIMIT_LONG_TTL=${RATE_LIMIT_LONG_TTL:-}
       - RATE_LIMIT_LONG_LIMIT=${RATE_LIMIT_LONG_LIMIT:-}
+      # Max request body size. Base64 media sends ride in the JSON body, so the default is generous;
+      # raise this for large documents (e.g. BODY_SIZE_LIMIT=50mb). Blank keeps the app default of 25mb.
+      - BODY_SIZE_LIMIT=${BODY_SIZE_LIMIT:-}
       - TRUSTED_PROXIES=${TRUSTED_PROXIES:-}
       - QUEUE_ENABLED=${QUEUE_ENABLED:-false}
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,6 +166,9 @@ services:
       - RATE_LIMIT_MEDIUM_LIMIT=${RATE_LIMIT_MEDIUM_LIMIT:-}
       - RATE_LIMIT_LONG_TTL=${RATE_LIMIT_LONG_TTL:-}
       - RATE_LIMIT_LONG_LIMIT=${RATE_LIMIT_LONG_LIMIT:-}
+      # Max request body size. Base64 media sends ride in the JSON body, so the default is generous;
+      # raise this for large documents (e.g. BODY_SIZE_LIMIT=50mb). Blank keeps the app default of 25mb.
+      - BODY_SIZE_LIMIT=${BODY_SIZE_LIMIT:-}
       # Plugins
       - PLUGINS_DIR=${PLUGINS_DIR:-/app/data/plugins}
       # Security


### PR DESCRIPTION
## What & why

`BODY_SIZE_LIMIT` is documented in `.env.example` and read correctly by the app (`src/main.ts` → `resolveBodyLimit()` → `json({ limit })`). **But neither compose file forwarded it into the container.** An operator who sets `BODY_SIZE_LIMIT=50mb` in `.env` (as the docs imply) saw no effect — base64 media sends returned `413 Payload Too Large`.

`.env` values are only used by Compose for *${VAR}* interpolation, not auto-injected into the container's environment. Both compose files enumerate tunable runtime envs explicitly and simply missed this one.

Reported in discussion #540, tracked in #831.

## Change

Add one line to each file's `environment:` list, matching the existing `- VAR=${VAR:-}` convention:

```diff
+      - BODY_SIZE_LIMIT=${BODY_SIZE_LIMIT:-}
```

Blank/unset on the host keeps the app default (`25mb`).

## Verification

- Diff is 6 insertions, 0 deletions across two files.
- Placement chosen next to the rate-limit / operator-tunable settings, not near container-internal values.
- No code path change — `resolveBodyLimit` in `src/config/bootstrap-security.ts` was already correct; the only missing link was the compose passthrough.

## After merge

Operators with a non-default `BODY_SIZE_LIMIT` in `.env` need to `docker compose up -d` once to pick up the new env line. No data migration, no breaking change.

Closes #831.