### PR TITLE
chore(release): v0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.2] - 2026-07-20
+
+### Added
+
+- The README gains an end-user-facing **"Before you connect a number"** section that consolidates
+  the recurring ban-risk / safe-sending questions: it states plainly that OpenWA is unofficial (it
+  uses `whatsapp-web.js` and `@whiskeysockets/baileys`, not Meta's Cloud API), includes a per-engine
+  ban-risk vs. resource-cost trade-off table, six practical safe-sending guardrails (warm-up,
+  no cold-blast, rate-limit, opt-in recipients, keep a fallback, mind the hosting IP), calls out the
+  known cold-contact first-send silent drop (tracked in #830) as server-side WhatsApp policy rather
+  than an OpenWA bug, and points regulated deployments to the official Cloud API. Responds to the
+  ban-risk questions raised in discussions #87, #154, #436, #687, and #694.
+
 ### Fixed
+
+- `BODY_SIZE_LIMIT` now actually takes effect under Docker Compose. The variable was documented in
+  `.env.example` and read correctly by the app (`src/main.ts` → `resolveBodyLimit()`), but neither
+  `docker-compose.yml` nor `docker-compose.dev.yml` forwarded it into the container, so a value set
+  in `.env` stayed on the host and the app fell back to its default — large base64 media sends
+  returned `413 Payload Too Large`. Both compose files now pass `BODY_SIZE_LIMIT` through, matching
+  the existing `${VAR:-}` convention; blank/unset keeps the 25 MB app default. Reported in #540,
+  tracked in #831, fixed in #832.
 - The dashboard's integration-instance create form now offers an optional **ingress secret** field,
   so providers that fix their own webhook signing secret (e.g. Chatwoot's per-webhook secret, which
   cannot be replaced with a custom value) can be integrated without resorting to the REST API.
@@ -18,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.10.1] - 2026-07-20
 
 ### Added
+
 - Design draft `docs/28-multitenancy.md`: the enterprise multitenancy proposal — tenant entity,
   named users with per-tenant roles, TOTP two-factor auth, per-tenant branding/isolation/quotas,
   and the migration path from single-operator deployments (nothing implemented yet).

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboard",
   "private": true,
-  "version": "0.10.1",
+  "version": "0.10.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/openapi.json
+++ b/openapi.json
@@ -5373,7 +5373,7 @@
   "info": {
     "title": "OpenWA API",
     "description": "Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API",
-    "version": "0.10.1",
+    "version": "0.10.2",
     "contact": {
       "name": "OpenWA",
       "url": "https://github.com/rmyndharis/OpenWA",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwa",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API for WhatsApp",
   "author": "Yudhi Armyndharis & OpenWA Contributors",
   "private": true,


### PR DESCRIPTION
## Patch release

Cut `v0.10.2`. Three unreleased commits land in this version:

### Added
- **README — "Before you connect a number" risk & safe-sending section.** End-user-facing guidance consolidating the recurring ban-risk questions: states plainly that OpenWA is unofficial, includes a per-engine ban-risk vs. resource-cost trade-off table, six practical safe-sending guardrails, calls out the cold-contact first-send silent drop (#830) as server-side WhatsApp policy, and points regulated deployments to the official Cloud API. Responds to discussions #87, #154, #436, #687, #694.

### Fixed
- **`BODY_SIZE_LIMIT` now takes effect under Docker Compose.** Neither `docker-compose.yml` nor `docker-compose.dev.yml` forwarded it into the container, so values set in `.env` stayed on the host and large base64 media sends 413'd under the app default. Both compose files now pass it through. Reported in #540, tracked in #831, fixed in #832.
- **Dashboard integration-instance create form gains an optional ingress secret field** for providers that fix their own webhook signing secret (e.g. Chatwoot). Previously the form auto-generated a secret that could never match, so every webhook delivery failed HMAC verification with 401 (#829, fixes #821).

## Bump scope

- `package.json` 0.10.1 → 0.10.2
- `dashboard/package.json` 0.10.1 → 0.10.2 (lockstep)
- `openapi.json` `info.version` regenerated (0.10.2, 119 paths unchanged)
- `CHANGELOG.md` `[Unreleased]` → `[0.10.2] - 2026-07-20`

## Local pre-flight (mirrors `release.yml` gates)

- `npm run lint` — clean
- `npx tsc --noEmit -p tsconfig.json` (full program, incl specs) — clean
- `npm run format:check` — clean
- `npm run check:versions` — ✓ (`package.json = 0.10.2`)
- `npm run openapi:check` — ✓ (snapshot matches, 119 paths)
- `npm test -- --coverage` — 191 suites passed, 2580 tests passed, 0 failed
- `npm run test:e2e` — 9 suites passed, 53 tests passed, 0 failed

## After merge

I will tag `v0.10.2` on the squash-merge commit and push the tag. The `release.yml` workflow will then build and publish the multi-arch Docker image (`linux/amd64`, `linux/arm64`) and create the GitHub Release with these notes.