### PR TITLE
fix(dashboard): stop Modal from stealing focus on each keystroke

### DIFF
--- a/dashboard/src/components/Modal.tsx
+++ b/dashboard/src/components/Modal.tsx
@@ -33,6 +33,18 @@ export function Modal({ open, onClose, title, children, footer, className, close
   const titleId = useId();
   const cardRef = useRef<HTMLDivElement>(null);
 
+  // Keep the latest onClose in a ref so the open/close effect below can depend on `[open]` only.
+  // Callers commonly pass an inline arrow (`onClose={() => setShow(false)}`), which is a fresh
+  // reference on every parent render. If `onClose` were a useEffect dependency, the effect would
+  // re-run on every keystroke that re-renders the parent — and because that effect performs the
+  // initial-focus step, focus would be yanked back to the first focusable (the header close button)
+  // after every character, making text inputs inside the modal unusable (issue #837). Reading via
+  // the ref breaks that coupling without holding a stale handler.
+  const onCloseRef = useRef(onClose);
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  });
+
   useEffect(() => {
     if (!open) return undefined;
 
@@ -41,7 +53,7 @@ export function Modal({ open, onClose, title, children, footer, className, close
         // Capture phase: nested widgets (selects, menus) may also listen for Escape — the dialog
         // owns dismissal while it is open.
         event.stopPropagation();
-        onClose();
+        onCloseRef.current();
         return;
       }
       if (event.key === 'Tab') {
@@ -68,6 +80,7 @@ export function Modal({ open, onClose, title, children, footer, className, close
     document.body.style.overflow = 'hidden';
 
     // Initial focus: the first visible focusable in the dialog, else the dialog card itself.
+    // Runs only when `open` flips true (not on parent re-renders) thanks to the `[open]` dep above.
     const card = cardRef.current;
     const initial =
       card && (Array.from(card.querySelectorAll<HTMLElement>(FOCUSABLE)).find(el => el.offsetParent !== null) ?? null);
@@ -77,7 +90,7 @@ export function Modal({ open, onClose, title, children, footer, className, close
       document.removeEventListener('keydown', onKeyDown, true);
       document.body.style.overflow = previousOverflow;
     };
-  }, [open, onClose]);
+  }, [open]);
 
   if (!open) return null;
 


### PR DESCRIPTION
## Problem

When creating a session from the dashboard, the name input in the **Create New Session** dialog accepted only one character before losing focus (issue #837). The user had to click back into the field after every keystroke, making it effectively impossible to type a session name.

## Root cause

The shared `Modal` component (`dashboard/src/components/Modal.tsx`) keeps all its open/close behavior — Escape/overlay dismissal, the focus trap, body scroll lock, and the **initial-focus** step — inside a single `useEffect` whose dependency array was `[open, onClose]`.

Callers routinely pass an inline arrow for `onClose`, e.g. in `Sessions.tsx`:

```tsx
<Modal open onClose={() => setShowCreateModal(false)} ... />
```

That arrow is a fresh function reference on every render of the parent. Typing into the name input updates `newSessionName`, which re-renders `Sessions`, which produces a new `onClose`, which re-runs the Modal effect — and the effect's initial-focus step re-runs too, yanking focus back to the first focusable element in the dialog (the header close button). The result is exactly the reported symptom: input is interrupted after a single character.

This affects **every** modal that renders a text input and whose parent re-renders on each keystroke, but the Create Session dialog is the most visible victim.

## Fix

Hold the latest `onClose` in a ref (kept up to date by a dedicated effect) and drop `onClose` from the open/close effect's dependency array:

```tsx
const onCloseRef = useRef(onClose);
useEffect(() => {
  onCloseRef.current = onClose;
});

useEffect(() => {
  // ... keydown handler reads onCloseRef.current() ...
  // ... initial focus runs once when `open` flips true ...
}, [open]);
```

Consequences:
- Initial focus is applied **once** when the dialog opens and is stable across parent re-renders — inputs inside the modal stay focused while typing.
- The `keydown` listener and body scroll lock now (re-)subscribe only on open/close transitions instead of on every keystroke.
- `onClose` is never stale inside the Escape handler, because the ref is refreshed on every commit.

## Validation

- `tsc --noEmit -p tsconfig.test.json` — clean
- `eslint dashboard/src/components/Modal.tsx` — clean (incl. `react-hooks/refs`)
- `npm run test:unit` (dashboard) — 135 tests pass
- `npm run build` (dashboard) — succeeds

Closes #837