### PR TITLE
fix(engine): clone puppeteer args to prevent multi-session browser crash

### DIFF
--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -378,15 +378,17 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
 
     try {
       // Build puppeteer args, including proxy if configured
-      const puppeteerArgs = this.config.puppeteer?.args || [
-        '--no-sandbox',
-        '--disable-setuid-sandbox',
-        '--disable-dev-shm-usage',
-        '--disable-accelerated-2d-canvas',
-        '--no-first-run',
-        '--no-zygote',
-        '--disable-gpu',
-      ];
+      const puppeteerArgs = this.config.puppeteer?.args
+        ? [...this.config.puppeteer.args]
+        : [
+            '--no-sandbox',
+            '--disable-setuid-sandbox',
+            '--disable-dev-shm-usage',
+            '--disable-accelerated-2d-canvas',
+            '--no-first-run',
+            '--no-zygote',
+            '--disable-gpu',
+          ];
 
       // Add proxy configuration if provided — but only when the URL parses to a supported scheme, so
       // a malformed/stored proxy value can't break the Chromium launch or smuggle a non-proxy scheme.


### PR DESCRIPTION
### Description

This PR fixes a critical bug where starting multiple sessions simultaneously or sequentially with distinct configurations (e.g. session-specific proxy configurations) could lead to Chromium/Puppeteer crashes. 

### Cause of the Bug

In the original implementation, the array representing `puppeteerArgs` was initialized as:
```typescript
const puppeteerArgs = this.config.puppeteer?.args || [ ... ];
```
Since arrays in JavaScript/TypeScript are passed by reference, `this.config.puppeteer?.args` retrieved the direct reference to the shared, global configuration array. 

Later in the code, when session-specific parameters (such as proxy server credentials or other arguments) were configured, they were appended directly to `puppeteerArgs`. This mutated the global `this.config.puppeteer.args` array in memory. When subsequent sessions initialized, they inherited the mutated arguments from previous sessions, leading to duplicate or conflicting command-line options (e.g. multiple `--proxy-server` flags) and eventual browser launch failure/crashes.

### Solution

We cloned the arguments array using the spread operator (`[...this.config.puppeteer.args]`), ensuring that any mutations to `puppeteerArgs` remain local to the current session adapter instance:
```typescript
const puppeteerArgs = this.config.puppeteer?.args
  ? [...this.config.puppeteer.args]
  : [
      '--no-sandbox',
      '--disable-setuid-sandbox',
      '--disable-dev-shm-usage',
      '--disable-accelerated-2d-canvas',
      '--no-first-run',
      '--no-zygote',
      '--disable-gpu',
    ];
```

### Checklist
- [x] Tested starting multiple sessions.
- [x] Verified that global configuration is not mutated when session-specific arguments are appended.
