### PR TITLE
fix(engine): stop sharing the puppeteer args array across sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Running more than one session no longer corrupts the Chromium launch flags of every
+  session started after the first. The whatsapp-web.js adapter appended its per-session
+  arguments (`--proxy-server`, and the `--openwa-session=<id>` process marker) directly
+  to the array returned by `engine.puppeteer.args` — but `ConfigService` hands back a
+  live reference into the cached configuration tree, so every session shared one array
+  and each start mutated it permanently. Three symptoms followed: the argument list grew
+  without bound across starts and reconnects until Chromium refused to launch; a session
+  configured without a proxy inherited the previous session's `--proxy-server` and routed
+  its traffic through it; and because the orphaned-Chromium sweep identifies processes by
+  substring-matching the session marker, a restart of one session could `SIGKILL` another
+  session's healthy browser. The adapter now copies the array before appending, so the
+  shared configuration is never mutated. Fixed in #840 — thanks @szmazhr.
+
 - Typing a session name in the dashboard's **Create New Session** dialog no longer
   stalls after the first character. The shared `Modal` component ran its initial-focus
   step inside a `useEffect` whose dependency array included `onClose`, and callers pass

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -2657,6 +2657,34 @@ describe('WhatsAppWebJsAdapter orphaned Chromium sweep (pre-launch)', () => {
     expect(client.options.puppeteer?.args).toContain(`--openwa-session=${SESSION_ID}`);
   });
 
+  it('does not mutate the caller-owned puppeteer args array shared across sessions', async () => {
+    // Every adapter receives the SAME array instance — ConfigService.get() returns a live reference
+    // into the cached config tree, via the plugin path (plugins/engines/whatsapp-web-js) and the
+    // factory fallback alike. Appending in place therefore rewrites global config for the rest of
+    // the process lifetime, leaking one session's flags (proxy, session marker) into every later
+    // launch. Without the defensive copy this assertion sees both session markers accumulate.
+    const sharedArgs = ['--no-sandbox'];
+    const argsFor = async (sessionId: string): Promise<string[] | undefined> => {
+      const adapter = new WhatsAppWebJsAdapter({
+        sessionId,
+        sessionDataPath: './data/sessions',
+        puppeteer: { args: sharedArgs },
+      });
+      await adapter.initialize({});
+      return (adapter as unknown as { client: { options: { puppeteer?: { args?: string[] } } } }).client.options
+        .puppeteer?.args;
+    };
+
+    await argsFor('sess-a');
+    const argsB = await argsFor('sess-b');
+
+    expect(sharedArgs).toEqual(['--no-sandbox']);
+    expect(argsB).toContain('--openwa-session=sess-b');
+    // The cross-session leak that let a restart of sess-a SIGKILL sess-b's live browser: the sweep
+    // substring-matches this marker against the full `ps` command line.
+    expect(argsB).not.toContain('--openwa-session=sess-a');
+  });
+
   it('SIGKILLs a Chromium process carrying this session marker and logs the sweep', async () => {
     mockPsResult({
       stdout: psTable([

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -378,15 +378,17 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
 
     try {
       // Build puppeteer args, including proxy if configured
-      const puppeteerArgs = this.config.puppeteer?.args || [
-        '--no-sandbox',
-        '--disable-setuid-sandbox',
-        '--disable-dev-shm-usage',
-        '--disable-accelerated-2d-canvas',
-        '--no-first-run',
-        '--no-zygote',
-        '--disable-gpu',
-      ];
+      const puppeteerArgs = this.config.puppeteer?.args
+        ? [...this.config.puppeteer.args]
+        : [
+            '--no-sandbox',
+            '--disable-setuid-sandbox',
+            '--disable-dev-shm-usage',
+            '--disable-accelerated-2d-canvas',
+            '--no-first-run',
+            '--no-zygote',
+            '--disable-gpu',
+          ];
 
       // Add proxy configuration if provided — but only when the URL parses to a supported scheme, so
       // a malformed/stored proxy value can't break the Chromium launch or smuggle a non-proxy scheme.


### PR DESCRIPTION
Carries @szmazhr's fix from #840, with a regression test and a changelog entry added on top. Their original commit is preserved as-is, authorship intact.

## The problem

`WhatsAppWebJsAdapter.initialize()` appended its per-session Chromium flags — `--proxy-server` and the `--openwa-session=<id>` process marker — directly onto the array it received as `config.puppeteer.args`:

```ts
const puppeteerArgs = this.config.puppeteer?.args || [ /* defaults */ ];
// ...
puppeteerArgs.push(`--proxy-server=${proxyLaunch.serverArg}`);
puppeteerArgs.push(`--openwa-session=${this.config.sessionId}`);
```

That array is not per-session. `ConfigService.get()` returns a live reference into the configuration tree built once at load, and both construction paths pass it straight through — the plugin path at `src/plugins/engines/whatsapp-web-js/index.ts` and the fallback at `src/engine/engine.factory.ts`. Every session therefore mutated one shared array, permanently, for the lifetime of the process.

The marker push is unconditional, so this affects every deployment running more than one session, not only those using proxies.

## Consequences

Three distinct failure modes, all resolved by the same fix:

1. **Unbounded argument growth.** Each start and each auto-reconnect appended another marker that was never removed. Over a long-running gateway the list grows until Chromium refuses to launch — the crash originally reported.

2. **Proxy inheritance across sessions.** A session configured without a proxy still launched carrying the previous session's `--proxy-server`. As the only proxy flag on the command line, it took effect, so that session's traffic was routed through a proxy it was never configured to use.

3. **Cross-session browser kills.** `killOrphanedChromiumProcesses()` runs on every `initialize()` and identifies targets by substring-matching `--openwa-session=<id>` against the full `ps` command line. Because later sessions carried earlier sessions' markers, restarting one session could `SIGKILL` another session's healthy browser. The comment at `whatsapp-web-js.adapter.ts:468` states the sweep "cannot kill a live browser" — this restores that invariant.

## The fix

Copy the array before appending, so the adapter's mutations stay local to the instance. Applying the copy in the adapter — the only component that mutates — covers both construction paths with one change, rather than guarding each producer separately.

Behaviour is otherwise identical: an unset `args` still falls through to the defaults, and an empty array is still respected.

## Test coverage

The existing suite could not have caught this. Every helper builds its adapter with `puppeteer: {}`, which falls through to a fresh default literal — exactly the case that was never broken. The new test hands two adapters a single shared array and asserts it survives untouched. Against the unfixed adapter it fails with both session markers accumulated:

```
  Array [
    "--no-sandbox",
+   "--openwa-session=sess-a",
+   "--openwa-session=sess-b",
```

## Verification

Full backend gate run locally: `lint` clean, `build` clean, `tsc --noEmit` clean, Prettier clean, and the complete Jest suite at 2581 passed / 5 skipped / 0 failed.

Please merge with **rebase** rather than squash, so @szmazhr's commit keeps its authorship in the history.

Closes #840.
