### PR TITLE
fix(dashboard): show the gateway version on the login screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The login screen shows the gateway's actual version again.** The dashboard resolved its version
+  from whichever `package.json` sat in the working directory the build ran from, which meant
+  `dashboard/package.json` — a file a release never touches — rather than the root `package.json` that
+  a release bumps. The two had drifted, so the login screen advertised an older version than the
+  gateway was running. Everywhere else in the dashboard hid this, because the sidebar replaces the
+  build-time value with the live version from the API once you are signed in; the login screen has no
+  session yet and shows the constant as-is. The version is now resolved relative to the build config
+  itself, so it no longer depends on where the build was started from.
+
 ### Changed
 
 - **A release image is only tagged after it has been proven to start.** The release workflow

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -1,13 +1,18 @@
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-// Single source of truth for the version shown in the dashboard: read it from
-// package.json at build time so the Login screen always reflects the actual
-// release (bumped via `npm version`), instead of a hard-coded literal that
-// silently drifts. APP_VERSION env still overrides if explicitly provided.
-const { version: pkgVersion } = JSON.parse(readFileSync(resolve(process.cwd(), 'package.json'), 'utf-8')) as {
+// Single source of truth for the version shown in the dashboard: the ROOT package.json, which is
+// what a release bumps and what `npm run check:versions` gates. Resolved relative to this config
+// file (not process.cwd()), because the dashboard is normally built from inside `dashboard/` — where
+// cwd-relative resolution picks up `dashboard/package.json` instead. That file is not touched by a
+// release, so the Login screen kept rendering whatever version it happened to be pinned at while the
+// gateway moved on. The sidebar hid the drift by replacing the build-time value with the live
+// version from the API (see Layout.tsx); the Login screen has no session yet, so it shows this
+// constant verbatim. APP_VERSION env still overrides if explicitly provided.
+const { version: pkgVersion } = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf-8'),
+) as {
   version: string;
 };
 


### PR DESCRIPTION
## Summary

The Login screen rendered a stale version. It is the one place in the dashboard that shows a build-time constant with no chance to correct it, so the drift was visible to anyone who reached the login page.

`vite.config.ts` resolved `package.json` relative to `process.cwd()`. The dashboard is normally built from inside `dashboard/`, so that picked up `dashboard/package.json` — a file a release never touches — instead of the root `package.json` that a release bumps and that `npm run check:versions` gates. The two had drifted apart: the root is currently `0.10.4` while `dashboard/package.json` sits at `0.10.2`.

The sidebar hid the problem, because `Layout.tsx` replaces the build-time value with the live version from the API once a session exists. The Login screen has no session yet, so it shows the constant verbatim.

## Fix

Resolve the root `package.json` relative to the config file itself (`new URL('../package.json', import.meta.url)`) rather than the working directory, so the value no longer depends on where the build was invoked from. The `APP_VERSION` env override is unchanged.

## Verification

Built from `dashboard/` (the normal path, and the one that was broken):

| | Version |
|---|---|
| Root `package.json` | `0.10.4` |
| `dashboard/package.json` | `0.10.2` (stale — untouched by a release) |
| Value baked into the bundle, after this change | **`0.10.4`** |

Full gate: backend lint + build + jest (2833 passed, 203 suites) and dashboard build + lint, all clean.
