### PR TITLE
fix(engine): log the no-LID send retry so a possible duplicate is visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A message send that is retried after a recipient-address change is now recorded in the log.** When
+  whatsapp-web.js reports that a contact's cached address is stale, the gateway re-resolves the address
+  and sends again. That retry was silent, so in the case where the engine reports a failure for a
+  message it had in fact already delivered, the resulting second copy appeared nowhere in the logs and
+  could only be noticed on the recipient's phone. The retry now logs a warning naming the chat and both
+  addresses. Sending behaviour is unchanged.
+
 - **The login screen shows the gateway's actual version again.** The dashboard resolved its version
   from whichever `package.json` sat in the working directory the build ran from, which meant
   `dashboard/package.json` — a file a release never touches — rather than the root `package.json` that

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -1456,6 +1456,13 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
       if (fresh === to) {
         throw err;
       }
+      // The first send threw, but wwjs can throw after the message is already on the wire — so this
+      // retry may produce a duplicate. Log it: without this the second copy is invisible.
+      this.logger.warn('Send retried against a re-resolved id after "No LID for user"; may duplicate', {
+        chatId,
+        staleId: to,
+        freshId: fresh,
+      });
       return send(fresh);
     }
   }


### PR DESCRIPTION
## Summary

`sendResolved` self-heals a stale recipient mapping: when whatsapp-web.js reports `No LID for user`, it drops the cached id, re-resolves, and retries the send against the fresh id. That retry had **no logging at all**.

If whatsapp-web.js ever throws *after* the message has already reached the wire, the retry puts a second copy in front of the recipient — and nothing in the logs would say so. It is the kind of duplicate that is otherwise only observable from the recipient's device, which makes it expensive to diagnose.

## Change

A `logger.warn` before the retry, recording the chat, the stale id and the fresh one.

The path is narrow — it needs an `@c.us` target, a `No LID for user` error, *and* a freshly resolved id that actually differs — so there is no log-spam risk, and `warn` is the right level: every line printed is a candidate duplicate worth investigating. Logging the stale and fresh ids as a pair is what makes it actionable; `chatId` alone cannot distinguish a real `@c.us` → `@lid` migration from resolver churn.

Behaviour is unchanged — this is observability only. It does not make the retry idempotent; if the logs later show this firing against real duplicates, that is a separate fix.

## Verification

Backend lint + build + jest (2833 passed, 203 suites) clean.
