### PR TITLE
fix(dashboard): stop rendering a literal "0" where a chat's time belongs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The chat list no longer shows a stray `0` next to every conversation.** Each row in the Chats
+  sidebar rendered a literal `0` where the last message's time belongs, on every chat. A conversation
+  with no messages reports a timestamp of zero, and the check that was meant to hide the time in that
+  case ended up displaying the zero itself. The time is now simply omitted when there is no last
+  message, as intended. The unread-count badge was unaffected.
+
 - **A message send that is retried after a recipient-address change is now recorded in the log.** When
   whatsapp-web.js reports that a contact's cached address is stale, the gateway re-resolves the address
   and sends again. That retry was silent, so in the case where the engine reports a failure for a

--- a/dashboard/src/pages/Chats.tsx
+++ b/dashboard/src/pages/Chats.tsx
@@ -953,7 +953,12 @@ export function Chats() {
                           <span className="chat-item-name" title={chat.name || chat.id}>
                             {chat.name || chat.id.split('@')[0]}
                           </span>
-                          {chat.timestamp && <span className="chat-item-time">{formatChatTime(chat.timestamp)}</span>}
+                          {/* Ternary, not `&&`: a chat with no messages carries timestamp 0, and React
+                              renders the number 0 as text — so `0 && <span/>` painted a literal "0"
+                              where the time belongs, on every such row. */}
+                          {chat.timestamp ? (
+                            <span className="chat-item-time">{formatChatTime(chat.timestamp)}</span>
+                          ) : null}
                         </div>
                         <div className="chat-item-bottom">
                           <span className="chat-item-snippet" title={formatLastMessageSnippet(chat)}>


### PR DESCRIPTION
## Summary

Every row in the Chats sidebar showed a stray `0` in its top-right corner, where the last message's time should be.

## Cause

The row guarded the timestamp with a logical `&&`:

```jsx
{chat.timestamp && <span className="chat-item-time">{formatChatTime(chat.timestamp)}</span>}
```

A chat with no messages carries `timestamp: 0`. Zero is falsy, so the span is correctly skipped — but the expression then evaluates to `0`, and React renders the *number* zero as text. The guard intended to hide the time ended up printing it instead.

This is not an edge case in practice: every chat the engine currently returns reports `timestamp: 0`, so the sidebar showed the zero on every row.

```
total chats: 13
timestamp == 0    : 13
timestamp missing : 0
```

Had the field been absent rather than zero, `undefined && …` would have rendered nothing and the bug would never have appeared — which is why it shows up only for a list where nothing has a last message yet.

## Fix

A ternary that yields `null`, so nothing is rendered when there is no timestamp.

The unread badge two lines below is unaffected: it already compares explicitly with `chat.unreadCount > 0`, which produces a boolean rather than a number. That is the shape to prefer for numeric guards in JSX.

I swept the rest of the dashboard for the same numeric-`&&` pattern (`.length`, `.count`, `.total`, `.size`, `.duration`, `.timestamp`); this was the only occurrence.

## Testing

No render test: the dashboard's unit tests run under Node's built-in runner over `*.test.ts` with no DOM or JSX support, so covering this would mean adding a browser-test stack for a one-line change. Extracting a helper would not have helped either — the defect is in the JSX operator, not in any logic a helper could hold, so a test around it would pass just as happily with the bug present.

Verified against a live instance whose chats all report `timestamp: 0` (the exact condition that triggered it), plus dashboard build, lint, and unit suite (135 pass).
