### PR TITLE
fix(dashboard): render one settings editor per plugin, and tell it the theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A plugin that ships its own settings editor no longer shows two editors at once.** When a plugin
+  provided a custom editor, the dashboard rendered the generated form underneath it as well — so every
+  field appeared twice, followed by a second Save button that behaved differently from the editor's own.
+  The Chat Flow settings dialog was the visible case. A plugin's own editor now replaces the generated
+  form and owns saving; plugins without one are unchanged, form and Save button included.
+- **A plugin's own settings editor follows the dashboard theme.** The editor runs in a sandboxed frame
+  that cannot see the dashboard's theme, so it had no way to match it and stayed light — a bright panel
+  in the middle of a dark dialog. The dashboard now tells the editor which theme is in use. Plugin
+  authors: the theme arrives with the existing settings handshake and can be ignored safely; see
+  [19 — Plugin Architecture](docs/19-plugin-architecture.md) for the contract.
+
+### Fixed
+
 - **Plugins you enabled stay enabled across a restart.** Every restart of the gateway — an upgrade, a
   host reboot, a container restart policy — silently switched off every extension plugin, with nothing
   written to the log and nothing shown in the dashboard. An integration such as the Chatwoot adapter

--- a/dashboard/src/pages/Plugins.tsx
+++ b/dashboard/src/pages/Plugins.tsx
@@ -28,6 +28,7 @@ import {
 import { pluginsApi } from '../services/api';
 import type { Plugin, CatalogPlugin, PluginConfigField } from '../services/api';
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
+import { useTheme } from '../hooks/useTheme';
 import { usePluginsQuery, useSessionsQuery, queryKeys } from '../hooks/queries';
 import { PageHeader } from '../components/PageHeader';
 import { useToast } from '../components/Toast';
@@ -248,15 +249,24 @@ function ConfigField({
  * Renders a plugin's sandboxed-iframe config editor. The entry HTML is fetched WITH the API key
  * (which never enters the iframe) and injected as `srcdoc` into a `sandbox="allow-scripts"` iframe
  * (opaque origin — no access to the parent). The editor talks to the host over a postMessage bridge:
- *   iframe → host  { type: 'config:get' }          → host → iframe { type: 'config:value', config, schema }
+ *   iframe → host  { type: 'config:get' }          → host → iframe { type: 'config:value', config, schema, theme }
  *   iframe → host  { type: 'config:save', config }  → host → iframe { type: 'config:saved' } | { type: 'config:error', message }
  * The host makes the authenticated PUT (secret redact/restore applies); the iframe only ever sees the
  * already-redacted config.
+ *
+ * `theme` is 'light' | 'dark', already resolved (so 'system' arrives as one of the two). The iframe has
+ * an opaque origin and cannot read the parent's theme itself, so without this an editor can only guess —
+ * which is how the Chat Flow editor ended up a glaring white panel inside a dark modal. Additive: an
+ * editor that ignores the field renders exactly as it did before.
+ *
+ * Sending it once, with the handshake, is sufficient: the theme control sits behind the modal overlay,
+ * so the theme cannot change while an editor is open, and reopening re-runs the handshake.
  */
 function PluginConfigUi({ plugin, sessionId }: { plugin: Plugin; sessionId?: string }) {
   const { t } = useTranslation();
   const toast = useToast();
   const queryClient = useQueryClient();
+  const { resolvedTheme } = useTheme();
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [html, setHtml] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -322,7 +332,7 @@ function PluginConfigUi({ plugin, sessionId }: { plugin: Plugin; sessionId?: str
               }),
             )
           : {};
-        post({ type: 'config:value', config: safeConfig, schema: plugin.configSchema });
+        post({ type: 'config:value', config: safeConfig, schema: plugin.configSchema, theme: resolvedTheme });
       } else if (msg?.type === 'config:save') {
         void (async () => {
           try {
@@ -346,7 +356,7 @@ function PluginConfigUi({ plugin, sessionId }: { plugin: Plugin; sessionId?: str
     };
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
-  }, [plugin, sessionId, queryClient, t, toast]);
+  }, [plugin, sessionId, queryClient, t, toast, resolvedTheme]);
 
   if (error) return <div className="config-ui-status config-ui-error">{error}</div>;
   if (html === null)
@@ -1203,24 +1213,23 @@ export default function Plugins() {
                     <PluginInstances pluginId={configPlugin.id} />
                   ) : showTabs && configTab === 'sessions' && configPlugin.sessionScoped !== false ? (
                     <SessionsTab plugin={configPlugin} />
-                  ) : configPlugin.configUi ||
-                    (lz.configSchema && Object.keys(lz.configSchema.properties).length > 0) ? (
-                    <>
-                      {configPlugin.configUi && <PluginConfigUi plugin={configPlugin} />}
-                      {lz.configSchema && Object.keys(lz.configSchema.properties).length > 0 && (
-                        <form ref={schemaFormRef} className="config-form" onSubmit={e => e.preventDefault()}>
-                          {Object.entries(lz.configSchema.properties).map(([key, field]) => (
-                            <ConfigField
-                              key={key}
-                              field={field}
-                              label={field.title || key}
-                              value={schemaConfig[key]}
-                              onChange={v => setSchemaConfig({ ...schemaConfig, [key]: v })}
-                            />
-                          ))}
-                        </form>
-                      )}
-                    </>
+                  ) : /* A plugin that ships its own editor owns the whole config: rendering the generic
+                         form underneath it too produced a second copy of every field and a second Save
+                         button with different semantics, which is what the Chat Flow modal looked like. */
+                  configPlugin.configUi ? (
+                    <PluginConfigUi plugin={configPlugin} />
+                  ) : lz.configSchema && Object.keys(lz.configSchema.properties).length > 0 ? (
+                    <form ref={schemaFormRef} className="config-form" onSubmit={e => e.preventDefault()}>
+                      {Object.entries(lz.configSchema.properties).map(([key, field]) => (
+                        <ConfigField
+                          key={key}
+                          field={field}
+                          label={field.title || key}
+                          value={schemaConfig[key]}
+                          onChange={v => setSchemaConfig({ ...schemaConfig, [key]: v })}
+                        />
+                      ))}
+                    </form>
                   ) : (
                     <div className="no-config">
                       <Settings size={48} style={{ opacity: 0.3 }} />
@@ -1233,8 +1242,11 @@ export default function Plugins() {
                   <button className="btn-secondary" onClick={() => setShowConfigModal(false)}>
                     {t('common.close')}
                   </button>
-                  {/* The Sessions and Instances tabs have their own actions; the footer Save is config-tab only. */}
-                  {showTabs && (configTab === 'sessions' || configTab === 'instances') ? null : lz.configSchema &&
+                  {/* The Sessions and Instances tabs have their own actions; the footer Save is config-tab
+                      only. A plugin with its own editor saves through that editor, so the footer Save is
+                      omitted rather than left to save a form the operator cannot see. */}
+                  {showTabs && (configTab === 'sessions' || configTab === 'instances') ||
+                  configPlugin.configUi ? null : lz.configSchema &&
                     Object.keys(lz.configSchema.properties).length > 0 ? (
                     <button className="btn-primary" onClick={handleSaveSchemaConfig} disabled={savingConfig}>
                       {savingConfig ? <Loader2 size={16} className="animate-spin" /> : t('plugins.config.save')}

--- a/docs/19-plugin-architecture.md
+++ b/docs/19-plugin-architecture.md
@@ -163,11 +163,27 @@ a host version. The config schema is the top-level `configSchema` (note: not nes
 | `sessions` | — | Session ids this plugin may act on, or `['*']`. Absent = `['*']`. Static — editing config can't widen it |
 | `sessionScoped` | — | Default `true`. A scoped plugin only sees events for the sessions it's activated for; `false` = always runs |
 | `net.allow` | — | Outbound-HTTP host allowlist for `ctx.net.fetch` (`host`, `host:port`, or `'*'`). Absent = deny all |
-| `configSchema` | — | Declarative config schema the dashboard renders as an always-available form fallback |
-| `configUi` | — | Optional self-contained HTML config editor served into a sandboxed iframe alongside `configSchema` when both exist |
+| `configSchema` | — | Declarative config schema the dashboard renders as a form when there is no `configUi`. Still required with one: it defines the fields, their types and which are `secret` |
+| `configUi` | — | Optional self-contained HTML config editor served into a sandboxed iframe. When present it **replaces** the generated form and owns saving — the dashboard renders neither the form nor its Save button |
 | `hooks` | — | Hook events this plugin listens to (informational) |
 | `provides` / `requires` | — | Features this plugin provides / depends on |
 | `i18n` | — | Localized dashboard text per locale (dashboard-only) |
+
+**The `configUi` bridge.** The editor is injected as `srcdoc` into a `sandbox="allow-scripts"` iframe, so
+it has an opaque origin and no access to the dashboard. It talks to the host by `postMessage`:
+
+| Direction | Message | Notes |
+| --- | --- | --- |
+| iframe → host | `{ type: 'config:get' }` | Sent on load; the host answers with the current values |
+| host → iframe | `{ type: 'config:value', config, schema, theme }` | `config` is already secret-redacted. `theme` is `'light'` or `'dark'`, resolved by the host |
+| iframe → host | `{ type: 'config:save', config }` | The host makes the authenticated write |
+| host → iframe | `{ type: 'config:saved' }` / `{ type: 'config:error', message }` | Outcome of that write |
+
+`theme` matters because an opaque-origin iframe cannot read the dashboard's theme for itself; without it
+an editor can only guess, and a light-only editor becomes a glaring white panel inside a dark modal. It is
+sent once, with the handshake — the theme control sits behind the modal overlay, so the theme cannot
+change while an editor is open. Treat it as optional: an editor that ignores it still works, and one that
+uses it should fall back to `prefers-color-scheme` so it stays readable on an older host.
 
 A `configSchema` field may set `secret: true` (e.g. an API key): the value is masked on read and
 preserved on an unchanged write.


### PR DESCRIPTION
Follow-up to the plugin settings dialog reported in #853.

## What was wrong

A plugin that ships its own settings editor was rendered **alongside** the generated schema form rather than instead of it. Every field appeared twice — once in the plugin's editor, once again in a form below it — followed by a footer **Save Configuration** button whose behaviour differed from the editor's own **Save**. The Chat Flow dialog was the visible case: two Save buttons and a stray duplicate "Trigger word" hanging below the editor.

I initially suspected this could also destroy configuration, since two editors wrote the same keys. That turned out to be wrong, and worth stating plainly: saving through the editor and then pressing the footer button left `trigger`, `greeting` and `options` all intact, because the host re-syncs after the editor saves. It is a clarity defect, not a data one.

## Changes

**One editor.** A custom `configUi` now replaces the generated form and owns saving. The footer Save is omitted rather than left to submit a form the operator cannot see. Plugins *without* a custom editor are untouched — form and footer Save both remain.

**The editor is told the theme.** It runs in an opaque-origin `sandbox="allow-scripts"` iframe, so it cannot read the dashboard's theme; a light-only editor therefore became a bright panel inside a dark dialog with no way to know better. The resolved theme (`'light' | 'dark'`, so `'system'` arrives already resolved) now rides along with the existing `config:value` handshake. Additive — an editor that ignores it renders exactly as before.

One thing I removed before pushing: I first added a `config:theme` message to push theme changes to an open editor, then found it could never fire, because the theme control sits behind the modal overlay and the theme cannot change while an editor is open. Rather than ship a documented message nothing sends — which would invite plugin authors to handle an event they will never receive — I dropped it and documented why the handshake alone is sufficient.

Contract and manifest table updated in [19 — Plugin Architecture](docs/19-plugin-architecture.md); the old text described `configUi` as rendering "alongside `configSchema` when both exist", which this changes.

## Verification

Against a running dashboard with all ten first-party plugins installed, in both themes:

| Check | Result |
|---|---|
| Chat Flow: generic form also rendered | no |
| Chat Flow: footer buttons | `Close` only |
| Chat Flow: editor matches light and dark | yes |
| FAQ Bot (no custom editor): form + fields | yes, 4 fields |
| FAQ Bot: footer buttons | `Close`, `Save Configuration` |

The FAQ Bot row is the regression that mattered: the change must not remove Save from the nine plugins that rely on the generated form.

Full gate: backend lint + build + jest (2840 pass, 204 suites), dashboard build + lint.

Needs [OpenWA-plugins#43](https://github.com/rmyndharis/OpenWA-plugins/pull/43) for Chat Flow to actually use the theme; the two are independent and safe to merge in either order.
