### PR TITLE
fix(plugins): stop a hook's chain-stop from erasing the message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Messages handled by a plugin are no longer missing from your history.** When an auto-reply plugin
+  answered a message, it told the gateway to stop passing that message to the remaining plugins — and
+  the gateway took that as a cue to forget the message entirely. It was never saved, never sent to your
+  webhooks, and never appeared in the dashboard. A chat handled by a bot therefore read as a series of
+  replies answering nothing, and any integration downstream never learned the customer had written. The
+  same applied to outgoing messages. Stopping the plugin chain now does exactly that and nothing more:
+  the message is recorded and delivered to webhooks as usual. Plugin authors: this is a behaviour change
+  if you relied on it to hide messages — see [19 — Plugin Architecture](docs/19-plugin-architecture.md).
+- **A plugin configuration that fails to save no longer reports success.** The dashboard showed "Saved"
+  and closed the dialog even when the gateway had rejected the change, so the edit appeared to have been
+  applied and was silently gone the next time the dialog was opened. The failure and its reason are now
+  shown. The same fix applies to a plugin that fails to disable, which previously reported nothing at
+  all.
+
+### Fixed
+
 - **A plugin that ships its own settings editor no longer shows two editors at once.** When a plugin
   provided a custom editor, the dashboard rendered the generated form underneath it as well — so every
   field appeared twice, followed by a second Save button that behaved differently from the editor's own.

--- a/dashboard/src/i18n/locales/ar.json
+++ b/dashboard/src/i18n/locales/ar.json
@@ -768,7 +768,11 @@
       "installed": "تم تثبيت الإضافة",
       "installFailed": "فشل التثبيت",
       "uninstalled": "تمت إزالة الإضافة",
-      "uninstallFailed": "فشلت الإزالة"
+      "uninstallFailed": "فشلت الإزالة",
+      "enableFailedTitle": "فشل التفعيل",
+      "disableFailedTitle": "فشل التعطيل",
+      "configRequiredTitle": "الإعداد مطلوب",
+      "configRequiredDesc": "املأ الحقول المطلوبة قبل التفعيل: {{fields}}"
     },
     "sessions": {
       "activationTitle": "التشغيل لـ",

--- a/dashboard/src/i18n/locales/en.json
+++ b/dashboard/src/i18n/locales/en.json
@@ -764,7 +764,11 @@
       "installed": "Plugin installed",
       "installFailed": "Install failed",
       "uninstalled": "Plugin uninstalled",
-      "uninstallFailed": "Uninstall failed"
+      "uninstallFailed": "Uninstall failed",
+      "enableFailedTitle": "Enable failed",
+      "disableFailedTitle": "Disable failed",
+      "configRequiredTitle": "Configuration required",
+      "configRequiredDesc": "Fill in the required field(s) before enabling: {{fields}}"
     },
     "sessions": {
       "activationTitle": "Run for",

--- a/dashboard/src/i18n/locales/es.json
+++ b/dashboard/src/i18n/locales/es.json
@@ -764,7 +764,11 @@
       "installed": "Plugin instalado",
       "installFailed": "Error en la instalación",
       "uninstalled": "Plugin desinstalado",
-      "uninstallFailed": "Error al desinstalar"
+      "uninstallFailed": "Error al desinstalar",
+      "enableFailedTitle": "Error al activar",
+      "disableFailedTitle": "Error al desactivar",
+      "configRequiredTitle": "Configuración requerida",
+      "configRequiredDesc": "Completa los campos obligatorios antes de activar: {{fields}}"
     },
     "sessions": {
       "activationTitle": "Ejecutar para",

--- a/dashboard/src/i18n/locales/fr.json
+++ b/dashboard/src/i18n/locales/fr.json
@@ -764,7 +764,11 @@
       "installed": "Plugin installé",
       "installFailed": "Échec de l'installation",
       "uninstalled": "Plugin désinstallé",
-      "uninstallFailed": "Échec de la désinstallation"
+      "uninstallFailed": "Échec de la désinstallation",
+      "enableFailedTitle": "Échec de l'activation",
+      "disableFailedTitle": "Échec de la désactivation",
+      "configRequiredTitle": "Configuration requise",
+      "configRequiredDesc": "Renseignez les champs obligatoires avant l'activation : {{fields}}"
     },
     "sessions": {
       "activationTitle": "Exécuter pour",

--- a/dashboard/src/i18n/locales/he.json
+++ b/dashboard/src/i18n/locales/he.json
@@ -765,7 +765,11 @@
       "installed": "התוסף הותקן",
       "installFailed": "ההתקנה נכשלה",
       "uninstalled": "התוסף הוסר",
-      "uninstallFailed": "ההסרה נכשלה"
+      "uninstallFailed": "ההסרה נכשלה",
+      "enableFailedTitle": "ההפעלה נכשלה",
+      "disableFailedTitle": "ההשבתה נכשלה",
+      "configRequiredTitle": "נדרשת הגדרה",
+      "configRequiredDesc": "מלא את שדות החובה לפני ההפעלה: {{fields}}"
     },
     "sessions": {
       "activationTitle": "הפעלה עבור",

--- a/dashboard/src/i18n/locales/it.json
+++ b/dashboard/src/i18n/locales/it.json
@@ -764,7 +764,11 @@
       "installed": "Plugin installato",
       "installFailed": "Installazione non riuscita",
       "uninstalled": "Plugin disinstallato",
-      "uninstallFailed": "Disinstallazione non riuscita"
+      "uninstallFailed": "Disinstallazione non riuscita",
+      "enableFailedTitle": "Attivazione non riuscita",
+      "disableFailedTitle": "Disattivazione non riuscita",
+      "configRequiredTitle": "Configurazione richiesta",
+      "configRequiredDesc": "Compila i campi obbligatori prima di attivare: {{fields}}"
     },
     "sessions": {
       "activationTitle": "Esegui per",

--- a/dashboard/src/i18n/locales/ko.json
+++ b/dashboard/src/i18n/locales/ko.json
@@ -764,7 +764,11 @@
       "installed": "플러그인이 설치되었습니다",
       "installFailed": "설치 실패",
       "uninstalled": "플러그인이 제거되었습니다",
-      "uninstallFailed": "제거 실패"
+      "uninstallFailed": "제거 실패",
+      "enableFailedTitle": "활성화 실패",
+      "disableFailedTitle": "비활성화 실패",
+      "configRequiredTitle": "설정 필요",
+      "configRequiredDesc": "활성화하기 전에 필수 항목을 입력하세요: {{fields}}"
     },
     "sessions": {
       "activationTitle": "실행 대상",

--- a/dashboard/src/i18n/locales/pt-BR.json
+++ b/dashboard/src/i18n/locales/pt-BR.json
@@ -764,7 +764,11 @@
       "installed": "Plugin instalado",
       "installFailed": "Erro na instalação",
       "uninstalled": "Plugin desinstalado",
-      "uninstallFailed": "Erro ao desinstalar"
+      "uninstallFailed": "Erro ao desinstalar",
+      "enableFailedTitle": "Falha ao ativar",
+      "disableFailedTitle": "Falha ao desativar",
+      "configRequiredTitle": "Configuração necessária",
+      "configRequiredDesc": "Preencha os campos obrigatórios antes de ativar: {{fields}}"
     },
     "sessions": {
       "activationTitle": "Executar para",

--- a/dashboard/src/i18n/locales/te.json
+++ b/dashboard/src/i18n/locales/te.json
@@ -764,7 +764,11 @@
       "installed": "ప్లగిన్ ఇన్‌స్టాల్ చేయబడింది",
       "installFailed": "ఇన్‌స్టాల్ విఫలమైంది",
       "uninstalled": "ప్లగిన్ అన్‌ఇన్‌స్టాల్ చేయబడింది",
-      "uninstallFailed": "అన్‌ఇన్‌స్టాల్ విఫలమైంది"
+      "uninstallFailed": "అన్‌ఇన్‌స్టాల్ విఫలమైంది",
+      "enableFailedTitle": "ప్రారంభించడం విఫలమైంది",
+      "disableFailedTitle": "నిలిపివేయడం విఫలమైంది",
+      "configRequiredTitle": "కాన్ఫిగరేషన్ అవసరం",
+      "configRequiredDesc": "ప్రారంభించే ముందు అవసరమైన ఫీల్డ్‌లను పూరించండి: {{fields}}"
     },
     "sessions": {
       "activationTitle": "దీని కోసం రన్ చేయండి",

--- a/dashboard/src/i18n/locales/zh-CN.json
+++ b/dashboard/src/i18n/locales/zh-CN.json
@@ -764,7 +764,11 @@
       "installed": "插件已安装",
       "installFailed": "安装失败",
       "uninstalled": "插件已卸载",
-      "uninstallFailed": "卸载失败"
+      "uninstallFailed": "卸载失败",
+      "enableFailedTitle": "启用失败",
+      "disableFailedTitle": "停用失败",
+      "configRequiredTitle": "需要配置",
+      "configRequiredDesc": "启用前请填写必填项：{{fields}}"
     },
     "sessions": {
       "activationTitle": "运行范围",

--- a/dashboard/src/i18n/locales/zh-HK.json
+++ b/dashboard/src/i18n/locales/zh-HK.json
@@ -764,7 +764,11 @@
       "installed": "外掛已安裝",
       "installFailed": "安裝失敗",
       "uninstalled": "外掛已解除安裝",
-      "uninstallFailed": "解除安裝失敗"
+      "uninstallFailed": "解除安裝失敗",
+      "enableFailedTitle": "啟用失敗",
+      "disableFailedTitle": "停用失敗",
+      "configRequiredTitle": "需要設定",
+      "configRequiredDesc": "啟用前請填寫必填項：{{fields}}"
     },
     "sessions": {
       "activationTitle": "執行對象",

--- a/dashboard/src/pages/Plugins.tsx
+++ b/dashboard/src/pages/Plugins.tsx
@@ -336,13 +336,17 @@ function PluginConfigUi({ plugin, sessionId }: { plugin: Plugin; sessionId?: str
       } else if (msg?.type === 'config:save') {
         void (async () => {
           try {
-            if (sessionId)
-              await pluginsApi.updateSessionConfig(
-                plugin.id,
-                sessionId,
-                sparseSessionOverride(msg.config ?? {}, plugin),
-              );
-            else await pluginsApi.updateConfig(plugin.id, msg.config ?? {});
+            // These endpoints report a failure as 200 + {success:false}, so the result has to be read.
+            // Taking the absence of a throw as success told the operator "Saved!" — and told the editor
+            // its values were stored — for a save the server had rejected.
+            const res = sessionId
+              ? await pluginsApi.updateSessionConfig(
+                  plugin.id,
+                  sessionId,
+                  sparseSessionOverride(msg.config ?? {}, plugin),
+                )
+              : await pluginsApi.updateConfig(plugin.id, msg.config ?? {});
+            if (!res.success) throw new Error(res.message);
             void queryClient.invalidateQueries({ queryKey: queryKeys.plugins });
             post({ type: 'config:saved' });
             toast.success(t('plugins.toasts.savedTitle'), t('plugins.toasts.savedDesc'));
@@ -605,12 +609,11 @@ export default function Plugins() {
     if (plugin.status !== 'enabled') {
       const missing = missingRequiredConfig(plugin);
       if (missing.length > 0) {
+        // Interpolation, not a template literal: with the field list baked into the default string the
+        // key could never be translated without silently dropping it.
         toast.warning(
-          t('plugins.toasts.configRequiredTitle', 'Configuration required'),
-          t(
-            'plugins.toasts.configRequiredDesc',
-            `Fill in the required field(s) before enabling: ${missing.join(', ')}`,
-          ),
+          t('plugins.toasts.configRequiredTitle'),
+          t('plugins.toasts.configRequiredDesc', { fields: missing.join(', ') }),
         );
         handleOpenConfig(plugin);
         return;
@@ -618,15 +621,18 @@ export default function Plugins() {
     }
     setActionLoading(plugin.id);
     try {
-      if (plugin.status === 'enabled') {
-        await pluginsApi.disable(plugin.id);
-      } else {
-        const res = await pluginsApi.enable(plugin.id);
-        // The endpoint reports lifecycle failures as 200 + {success:false} — surface them instead
-        // of silently refetching (the user would otherwise think the click did nothing).
-        if (!res.success) {
-          toast.warning(t('plugins.toasts.enableFailedTitle', 'Enable failed'), res.message);
-        }
+      // Both endpoints report lifecycle failures as 200 + {success:false} — surface them instead of
+      // silently refetching. The card flips to ERROR either way, but without the message the operator
+      // has to go to the logs to learn why.
+      const res =
+        plugin.status === 'enabled' ? await pluginsApi.disable(plugin.id) : await pluginsApi.enable(plugin.id);
+      if (!res.success) {
+        toast.warning(
+          plugin.status === 'enabled'
+            ? t('plugins.toasts.disableFailedTitle')
+            : t('plugins.toasts.enableFailedTitle'),
+          res.message,
+        );
       }
       refetchAll();
     } catch (err) {
@@ -675,7 +681,10 @@ export default function Plugins() {
     if (schemaFormRef.current && !schemaFormRef.current.reportValidity()) return;
     setSavingConfig(true);
     try {
-      await pluginsApi.updateConfig(configPlugin.id, schemaConfig);
+      // 200 + {success:false} is how a rejected save arrives; without this the modal closed on a
+      // "Saved!" toast and the operator's edit was silently gone on the next open.
+      const res = await pluginsApi.updateConfig(configPlugin.id, schemaConfig);
+      if (!res.success) throw new Error(res.message);
       void queryClient.invalidateQueries({ queryKey: queryKeys.plugins });
       toast.success(t('plugins.toasts.savedTitle'), t('plugins.toasts.savedDesc'));
       setShowConfigModal(false);

--- a/docs/19-plugin-architecture.md
+++ b/docs/19-plugin-architecture.md
@@ -360,7 +360,25 @@ sequenceDiagram
 
 A handler returns `{ continue: false }` to stop the chain. To transform the event it returns
 `{ continue: true, data: <new value> }`; the next handler (and the host) sees that `data`. (There is
-no `modified` field — the result type uses `data`.)
+no `modified` field — the result type uses `data`.) A handler that both transforms and stops the chain
+still has its `data` applied.
+
+**What `continue: false` does and does not do.** On a **notification** event — `message:received`,
+`message:sent` — it stops the remaining handlers and nothing else. The message has already arrived at,
+or left, WhatsApp, so the gateway still persists it and still dispatches `message.received` /
+`message.sent` to webhooks and the websocket. This is the flag an auto-reply plugin uses to claim a
+message ("I answered this, don't let another bot answer it too"); it is not a way to hide a message from
+the operator's own history.
+
+On a **pre-action** event it is a veto, because the action has not been taken yet: `false` on
+`message:sending` blocks the send (the caller gets a `400`), and on `webhook:before` it cancels that one
+delivery.
+
+> Until 0.10.5, `continue: false` on the two notification events also skipped persistence, the webhook
+> and the websocket emit. An auto-reply plugin returning it for its ordinary purpose therefore erased
+> the triggering message from the dashboard's chat history and from every integration downstream. If you
+> wrote a plugin that relied on that to hide messages, it no longer does — filter on the consumer side
+> instead.
 
 ### Hook events
 

--- a/src/common/security/ssrf-undici-pin.spec.ts
+++ b/src/common/security/ssrf-undici-pin.spec.ts
@@ -40,6 +40,14 @@ describe('undici honors the SSRF connect.lookup pin (real connection)', () => {
 
   it('control: the same host is genuinely unresolvable without the pin', async () => {
     // Proves the test above succeeds because of the pin, not because the host happens to resolve.
-    await expect(fetch(`http://pinned.invalid:${port}/`)).rejects.toThrow();
+    //
+    // Bounded by our own signal rather than left to the resolver: a `.invalid` lookup returns NXDOMAIN
+    // instantly on most machines, but a resolver that black-holes unknown TLDs instead makes the OS
+    // retry through its own multi-second schedule, which blew past Jest's 5s default and failed this
+    // suite in CI while passing everywhere else. The claim under test is "without the pin this request
+    // does not reach the server", and an abort satisfies it exactly as a DNS failure does. It does not
+    // weaken the control: had the host resolved, the connection is to 127.0.0.1 and would have
+    // succeeded well inside the budget, resolving the promise and failing this assertion.
+    await expect(fetch(`http://pinned.invalid:${port}/`, { signal: AbortSignal.timeout(2000) })).rejects.toThrow();
   });
 });

--- a/src/core/hooks/hook.interfaces.ts
+++ b/src/core/hooks/hook.interfaces.ts
@@ -70,7 +70,19 @@ export interface HookContext<T = unknown> {
 }
 
 export interface HookResult<T = unknown> {
-  continue: boolean; // false = stop processing chain
+  /**
+   * `false` stops the handler chain: the handlers registered after this one do not run.
+   *
+   * That is its whole meaning on a notification event (`message:received`, `message:sent`, …). The
+   * message has already arrived at, or left, WhatsApp — a handler can keep other plugins from acting on
+   * it, but the gateway still records it and still dispatches it to webhooks and the websocket. Use it
+   * to claim an event ("I answered this, don't let another bot answer too"), not to hide one.
+   *
+   * On a pre-action event it is a veto, because the action has not happened yet: `false` on
+   * `message:sending` blocks the send (core/hooks/sending-gate.ts), and on `webhook:before` it cancels
+   * that delivery.
+   */
+  continue: boolean;
   data?: T; // Modified data (optional)
   error?: Error; // Error to propagate
 }

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -1635,6 +1635,54 @@ describe('SessionService', () => {
       ...overrides,
     });
 
+    // A plugin returning `continue: false` means "stop the handler chain" — the plugins after it do not
+    // run. It must NOT also delete the message from the operator's records. Honouring it here used to
+    // skip the insert, the webhook and the websocket emit, so an auto-reply plugin doing the ordinary
+    // thing (keeping other bots off a message it answered) silently erased the customer's message from
+    // history, leaving bot replies answering nothing. Both branches had no coverage at all.
+    it('still persists and dispatches an inbound message when a plugin stops the hook chain', async () => {
+      (hookManager.execute as jest.Mock).mockImplementation((event: string, data: unknown) =>
+        Promise.resolve({ continue: event !== 'message:received', data }),
+      );
+      const callbacks = await startAndCaptureCallbacks();
+
+      callbacks.onMessage?.(makeMessage({ id: 'wa-swallowed-in' }));
+      await flush();
+
+      expect(messageRepository.insert).toHaveBeenCalled();
+      expect(dispatchedEvents('message.received')).toHaveLength(1);
+      expect(eventsGateway.emitMessage).toHaveBeenCalled();
+    });
+
+    it('still persists and dispatches an outgoing message when a plugin stops the hook chain', async () => {
+      (hookManager.execute as jest.Mock).mockImplementation((event: string, data: unknown) =>
+        Promise.resolve({ continue: event !== 'message:sent', data }),
+      );
+      const callbacks = await startAndCaptureCallbacks();
+
+      callbacks.onMessageCreate!(makeMessage({ id: 'wa-swallowed-out', from: 'me@c.us', fromMe: true }));
+      await flush();
+
+      expect(messageRepository.insert).toHaveBeenCalled();
+      expect(dispatchedEvents('message.sent')).toHaveLength(1);
+    });
+
+    // The transform half of the contract must survive: a plugin that rewrites the payload and stops the
+    // chain still has its edit persisted, rather than the original being written back.
+    it('persists the plugin-modified payload even when that plugin stops the chain', async () => {
+      (hookManager.execute as jest.Mock).mockImplementation((event: string, data: unknown) =>
+        event === 'message:received'
+          ? Promise.resolve({ continue: false, data: { ...(data as object), body: 'rewritten by plugin' } })
+          : Promise.resolve({ continue: true, data }),
+      );
+      const callbacks = await startAndCaptureCallbacks();
+
+      callbacks.onMessage?.(makeMessage({ id: 'wa-rewritten', body: 'original' }));
+      await flush();
+
+      expect(messageRepository.create).toHaveBeenCalledWith(expect.objectContaining({ body: 'rewritten by plugin' }));
+    });
+
     it('dispatches message.sent exactly once for an outgoing (message_create) event', async () => {
       const callbacks = await startAndCaptureCallbacks();
       expect(typeof callbacks.onMessageCreate).toBe('function');

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -868,11 +868,23 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
             sessionId: id,
             source: 'Engine',
           })
-          .then(async ({ continue: shouldContinue, data: finalMessage }) => {
-            if (!shouldContinue) {
-              // A plugin handled the event and asked to stop the chain (continue: false).
-              return;
-            }
+          .then(async ({ data: finalMessage }) => {
+            // `continue: false` is deliberately NOT read here. It means "stop the handler chain", which
+            // HookManager has already done — the plugins after the one that returned it never ran. It
+            // does not mean "this message never happened".
+            //
+            // Honouring it here used to skip everything below: the message was never written to the
+            // messages table, never dispatched to webhooks, and never emitted over the websocket. An
+            // auto-reply plugin returning `false` for its ordinary purpose — keeping other bots from
+            // answering the same message — silently erased the customer's message from the operator's
+            // own history, leaving a thread of bot replies answering nothing. Nothing in the hook
+            // contract (`HookResult.continue`, docs/19) or the webhook contract (`message.received`
+            // fires when "an inbound message arrives", docs/06) hinted at that, and a sandboxed
+            // marketplace plugin could swallow a session's entire inbound traffic with no audit trail.
+            //
+            // The message has already arrived at WhatsApp. A plugin can stop other plugins from acting
+            // on it; it cannot make the gateway forget it. Pre-action hooks are where a veto belongs —
+            // `message:sending` blocks a send that has not happened yet (core/hooks/sending-gate.ts).
 
             // Persist the incoming message so the dashboard chats view can render history.
             const incoming: IncomingMessage = finalMessage;
@@ -1017,10 +1029,11 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
             sessionId: id,
             source: 'Engine',
           })
-          .then(async ({ continue: shouldContinue, data: finalMessage }) => {
-            if (!shouldContinue) {
-              return;
-            }
+          .then(async ({ data: finalMessage }) => {
+            // `continue: false` is not read here, for the same reason as the message:received path
+            // above: the send has already happened, so a plugin can stop the handler chain but cannot
+            // un-send it. Skipping the persist below dropped the operator's own outgoing message from
+            // history and from `message.sent` webhooks.
 
             // Persist the outgoing message so local history reflects sends composed on a linked phone
             // (message_create is the ONLY event those produce). It also fires for API-originated sends,


### PR DESCRIPTION
## What was wrong

An auto-reply plugin returning `continue: false` — the documented way to claim a message so other plugins leave it alone — made the gateway drop that message entirely: no row in `messages`, no `message.received` webhook, no websocket emit.

A chat handled by a bot therefore rendered as a series of replies answering nothing, and any downstream integration never learned the customer had written at all.

Found while exercising a Chat Flow menu end to end against a live session. The pattern is exact — being *handled* is what deleted them:

| Inbound | Plugin | In `messages`? |
|---|---|---|
| `halo` | ignored | ✅ |
| `menu`, `1`, `99`, `11` | replied | ❌ |
| `11` (flow already closed) | ignored | ✅ |

## Why this is the right layer to fix

`continue: false` means "stop the handler chain", and `HookManager` has already done that by the time the host sees the result. Nothing promised more:

- `HookResult.continue` — *"false = stop processing chain"*
- `docs/19` — *"A handler returns `{ continue: false }` to stop the chain."*
- The webhook contract — `message.received` fires when *"an inbound message arrives"*, with no plugin caveat

The message had already arrived at WhatsApp. A plugin can stop other plugins from acting on it; it cannot make the gateway forget it. A veto belongs on a **pre-action** hook, and still works there — `message:sending` blocks a send that has not happened yet.

`message:sent` carried the identical branch, so a plugin could also erase the operator's own **outgoing** messages from history. Both are fixed.

## Blast radius

Only two first-party plugins ever return false: `chat-flow` when it replies, and `group-translate` for a `/tr` command. Both mean "don't let another bot act on this", not "delete this" — neither changes behaviour beyond keeping its record. A plugin that relied on the old behaviour to hide messages no longer can; that is called out in the changelog and in `docs/19`.

Worth noting the branches had **no test coverage at all**, which is how the semantics drifted from the contract unnoticed.

## Also fixed, from tracing the same dialog

- **A config save the gateway rejected reported "Saved" and closed the dialog.** The endpoint reports failure as `200 + {success:false}` and the caller treated "did not throw" as success — an affirmative false positive, with the operator's edit silently gone on the next open. Both save paths now read the result.
- A failed **disable** reported nothing at all; it now surfaces the reason, as enable already did.
- `configRequiredDesc` built its field list with a template literal and passed no interpolation values, so translating that key would have silently dropped the list.
- Four toast keys were missing from **all 11** locales and rendered as untranslated inline English. `check-i18n-parity.mjs` compares locales against `en.json` and never scans source, so a key absent from `en.json` too is structurally invisible to it — worth a follow-up on the checker itself.

One suspicion I had did **not** survive checking: a failed *enable* is already surfaced correctly. No change there.

## Verification

Three regression tests, confirmed red against the previous commit before being called passing. They cover inbound, outgoing, and that a plugin's payload edit still survives when it stops the chain.

Live, on a build of this branch running against a real WhatsApp session — the same messages that vanished before:

```
04:21:41 | incoming | halo          ← ignored, recorded (unchanged)
04:21:46 | incoming | menu          ← HANDLED, now recorded
04:21:46 | outgoing | Halo! 👋 …    ← reply still sent
04:21:52 | incoming | 1             ← HANDLED, now recorded
04:21:52 | outgoing | Paket Hosting …
```

The webhook and websocket halves are covered by the tests only — the test session has no webhook registered, so that path was not exercised live.

Full gate: backend lint + build + jest (2843 pass, 204 suites), dashboard build + lint, i18n parity.
