### PR TITLE
fix(database): replace the unmaintained sqlite3 driver with better-sqlite3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The SQLite driver is now `better-sqlite3`.** The `sqlite3` package that previously drove both the
+  always-SQLite main database (auth and audit) and the default data database is unmaintained upstream —
+  its repository was archived in July 2026 — and its final release still bundles an outdated SQLite
+  library. The gateway now uses the actively maintained `better-sqlite3` driver, which carries a current
+  SQLite (3.53.x) including the recent FTS5 fixes the old line will never receive. Nothing changes in
+  how you configure or run OpenWA: `DATABASE_TYPE` keeps its `sqlite`/`postgres` values, existing
+  database files are opened as-is, and all migrations apply unchanged. PostgreSQL deployments are
+  affected only in the main (auth/audit) database, which has always been SQLite. Prebuilt binaries
+  cover the same platforms as before, including Alpine/musl and arm64
+  ([#848](https://github.com/rmyndharis/OpenWA/issues/848)).
+
 ### Fixed
 
 - **The Sessions overview on the dashboard labels its last column correctly instead of printing `DASHBOARD.COLUMNS.ACTIONS`.** The header above the View and Disconnect buttons rendered the uppercased translation key verbatim, in every language, because the table referenced a `dashboard.columns.actions` key that no locale file defined. The missing key has been added to every supported locale, so the column now reads "Actions" (or its equivalent) as the other columns do.

--- a/docs/14-migration-guide.md
+++ b/docs/14-migration-guide.md
@@ -251,6 +251,10 @@ docker compose up -d
 
 ### Migration Script (Legacy)
 
+> **Note:** This example uses the standalone `sqlite3` npm package, which is no longer part of
+> OpenWA's dependencies (the app itself uses `better-sqlite3`). Install it ad hoc before running:
+> `npm install --no-save sqlite3`.
+
 ```typescript
 // scripts/migrate-sqlite-to-postgres.ts
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@whiskeysockets/baileys": "7.0.0-rc13",
         "adm-zip": "^0.6.0",
         "archiver": "^8.0.0",
+        "better-sqlite3": "^12.11.1",
         "bullmq": "^5.80.10",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.15.1",
@@ -41,7 +42,6 @@
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "socket.io": "^4.8.3",
-        "sqlite3": "^5.1.7",
         "tar-stream": "^3.2.0",
         "typeorm": "^0.3.31",
         "undici": "^8.8.0",
@@ -2663,18 +2663,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -5554,16 +5542,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/abbrev": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
-      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -6325,6 +6303,20 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "node_modules/better-sqlite3": {
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+      }
+    },
     "node_modules/bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -6781,15 +6773,6 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/chownr": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/chrome-trace-event": {
@@ -8555,13 +8538,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/exponential-backoff": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
-      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
-      "license": "Apache-2.0",
-      "optional": true
-    },
     "node_modules/express": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
@@ -8736,7 +8712,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -11096,18 +11072,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/minizlib": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
@@ -11365,12 +11329,6 @@
       "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
       "license": "MIT"
     },
-    "node_modules/node-addon-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "license": "MIT"
-    },
     "node_modules/node-emoji": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
@@ -11401,31 +11359,6 @@
         }
       }
     },
-    "node_modules/node-gyp": {
-      "version": "12.4.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz",
-      "integrity": "sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "env-paths": "^2.2.0",
-        "exponential-backoff": "^3.1.1",
-        "graceful-fs": "^4.2.6",
-        "nopt": "^9.0.0",
-        "proc-log": "^6.0.0",
-        "semver": "^7.3.5",
-        "tar": "^7.5.4",
-        "tinyglobby": "^0.2.12",
-        "undici": "^6.25.0",
-        "which": "^6.0.0"
-      },
-      "bin": {
-        "node-gyp": "bin/node-gyp.js"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/node-gyp-build-optional-packages": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
@@ -11439,42 +11372,6 @@
         "node-gyp-build-optional-packages": "bin.js",
         "node-gyp-build-optional-packages-optional": "optional.js",
         "node-gyp-build-optional-packages-test": "build-test.js"
-      }
-    },
-    "node_modules/node-gyp/node_modules/isexe": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
-      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
-      "license": "BlueOak-1.0.0",
-      "optional": true,
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/node-gyp/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
-    "node_modules/node-gyp/node_modules/which": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
-      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "isexe": "^4.0.0"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/node-int64": {
@@ -11496,22 +11393,6 @@
       "resolved": "https://registry.npmjs.org/node-webpmux/-/node-webpmux-3.2.1.tgz",
       "integrity": "sha512-MKgpq9nFgo44pIVNx/umD3nkqb2E8oqQTfmstVsfNdx9uV4cX7a4LqA+d8AZd3v5tgJXwENKUFsXNP3bRLP8nQ==",
       "license": "LGPL-3.0-or-later"
-    },
-    "node_modules/nopt": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
-      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "abbrev": "^4.0.0"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -12028,7 +11909,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -12322,16 +12203,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/proc-log": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
-      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/process": {
@@ -13644,30 +13515,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/sqlite3": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.7.tgz",
-      "integrity": "sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "node-addon-api": "^7.0.0",
-        "prebuild-install": "^7.1.1",
-        "tar": "^6.1.11"
-      },
-      "optionalDependencies": {
-        "node-gyp": "8.x"
-      },
-      "peerDependencies": {
-        "node-gyp": "8.x"
-      },
-      "peerDependenciesMeta": {
-        "node-gyp": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/ssh2": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
@@ -13966,22 +13813,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/tar": {
-      "version": "7.5.20",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
-      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.1.0",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -14040,15 +13871,6 @@
         "bare-fs": "^4.5.5",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
-      }
-    },
-    "node_modules/tar/node_modules/yallist": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/teex": {
@@ -14285,7 +14107,7 @@
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@whiskeysockets/baileys": "7.0.0-rc13",
     "adm-zip": "^0.6.0",
     "archiver": "^8.0.0",
+    "better-sqlite3": "^12.11.1",
     "bullmq": "^5.80.10",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",
@@ -88,7 +89,6 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "socket.io": "^4.8.3",
-    "sqlite3": "^5.1.7",
     "tar-stream": "^3.2.0",
     "typeorm": "^0.3.31",
     "undici": "^8.8.0",
@@ -213,8 +213,6 @@
     "testEnvironment": "node"
   },
   "overrides": {
-    "shell-quote": "^1.10.0",
-    "node-gyp": "^12.4.0",
-    "tar": "^7.5.20"
+    "shell-quote": "^1.10.0"
   }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -116,7 +116,7 @@ if (dashboardServingEnabled && dashboardBuildPresent) {
         const synchronize = configService.get<boolean>('database.synchronize', true);
         return {
           name: 'main',
-          type: 'sqlite' as const,
+          type: 'better-sqlite3' as const,
           database: configService.get<string>('database.database', './data/main.sqlite'),
           entities: [
             __dirname + '/modules/auth/**/*.entity{.ts,.js}',
@@ -207,7 +207,7 @@ if (dashboardServingEnabled && dashboardBuildPresent) {
         return {
           ...baseConfig,
           name: 'data',
-          type: 'sqlite' as const,
+          type: 'better-sqlite3' as const,
           database: configService.get<string>('dataDatabase.database', './data/openwa.sqlite'),
           synchronize,
           migrationsRun: !synchronize,

--- a/src/common/utils/column-types.ts
+++ b/src/common/utils/column-types.ts
@@ -9,7 +9,7 @@
  *
  * DATA CONNECTION ONLY. These resolve the dialect of the *data* connection from the global
  * `DATABASE_TYPE` env var. Use them only on entities bound to the data connection. Entities on the
- * MAIN connection (auth, audit) are ALWAYS SQLite — it is hardcoded `type: 'sqlite'` in
+ * MAIN connection (auth, audit) are ALWAYS SQLite — it is hardcoded `type: 'better-sqlite3'` in
  * app.module.ts regardless of DATABASE_TYPE — so they must hardcode `simple-json` / `datetime`
  * (see audit-log.entity.ts) and must NOT call these helpers, or a Postgres deployment would emit a
  * `jsonb`/`timestamp` column on the always-SQLite main DB.

--- a/src/common/utils/db-errors.spec.ts
+++ b/src/common/utils/db-errors.spec.ts
@@ -1,8 +1,10 @@
 import { QueryFailedError } from 'typeorm';
 import { isUniqueViolation, isMissingTableError } from './db-errors';
 
-// Realistic driver errors: sqlite3 / pg both throw an Error carrying a `code` property, which TypeORM
-// wraps in QueryFailedError (message copied from the driver error).
+// Realistic driver errors: better-sqlite3 / pg both throw an Error carrying a `code` property, which
+// TypeORM wraps in QueryFailedError (message copied from the driver error). better-sqlite3 messages are
+// UNPREFIXED ('no such table: x'); the legacy sqlite3 driver prefixed them ('SQLITE_ERROR: no such
+// table: x') — the classifiers must keep matching both shapes.
 const driverErr = (message: string, code: string): Error => Object.assign(new Error(message), { code });
 const qfe = (message: string, code: string): QueryFailedError =>
   new QueryFailedError('DELETE FROM x', [], driverErr(message, code));
@@ -14,6 +16,19 @@ describe('isMissingTableError', () => {
 
   it('recognizes a SQLite missing table by MESSAGE, not by its generic code', () => {
     expect(isMissingTableError(qfe('SQLITE_ERROR: no such table: templates', 'SQLITE_ERROR'))).toBe(true);
+  });
+
+  it("recognizes better-sqlite3's unprefixed shapes (missing table and unique violation)", () => {
+    expect(isMissingTableError(qfe('no such table: templates', 'SQLITE_ERROR'))).toBe(true);
+    expect(isUniqueViolation(qfe('UNIQUE constraint failed: templates.name', 'SQLITE_CONSTRAINT_UNIQUE'))).toBe(true);
+  });
+
+  it('recognizes the RAW SqliteError better-sqlite3 throws at prepare() time (never wrapped by TypeORM)', () => {
+    // TypeORM's BetterSqlite3QueryRunner prepares the statement outside its try/catch, so a DELETE on a
+    // missing table escapes as the raw driver error — QueryFailedError never enters the picture.
+    const raw = Object.assign(new Error('no such table: plugin_instances'), { code: 'SQLITE_ERROR' });
+    raw.name = 'SqliteError';
+    expect(isMissingTableError(raw)).toBe(true);
   });
 
   it('does NOT treat a genuine SQLite failure as missing-table (it must surface)', () => {

--- a/src/common/utils/db-errors.ts
+++ b/src/common/utils/db-errors.ts
@@ -23,9 +23,15 @@ export function isUniqueViolation(err: unknown): boolean {
  * QueryFailedError so a future TypeORM change to the nesting fails toward the regex still matching.
  */
 export function isMissingTableError(err: unknown): boolean {
-  if (!(err instanceof QueryFailedError)) return false;
-  const driver = err.driverError as { code?: string; message?: string } | undefined;
-  if (driver?.code === '42P01') return true; // postgres undefined_table
-  const message = `${driver?.message ?? ''} ${err.message ?? ''}`;
-  return /no such table/i.test(message);
+  if (err instanceof QueryFailedError) {
+    const driver = err.driverError as { code?: string; message?: string } | undefined;
+    if (driver?.code === '42P01') return true; // postgres undefined_table
+    const message = `${driver?.message ?? ''} ${err.message ?? ''}`;
+    return /no such table/i.test(message);
+  }
+  // better-sqlite3 validates SQL at prepare() time, and TypeORM's BetterSqlite3QueryRunner creates the
+  // statement OUTSIDE its try/catch — so a missing-table error surfaces as the RAW SqliteError, never
+  // wrapped in QueryFailedError. Recognize that exact shape (class name + message); a plain Error whose
+  // text happens to mention a missing table must still NOT classify.
+  return err instanceof Error && err.name === 'SqliteError' && /no such table/i.test(err.message);
 }

--- a/src/database/add-integration-fabric.spec.ts
+++ b/src/database/add-integration-fabric.spec.ts
@@ -4,7 +4,7 @@ import { AddIntegrationFabric1781900000000 } from './migrations/1781900000000-Ad
 describe('AddIntegrationFabric migration (sqlite)', () => {
   let ds: DataSource;
   beforeEach(async () => {
-    ds = new DataSource({ type: 'sqlite', database: ':memory:', entities: [], migrations: [] });
+    ds = new DataSource({ type: 'better-sqlite3', database: ':memory:', entities: [], migrations: [] });
     await ds.initialize();
   });
   afterEach(async () => {

--- a/src/database/data-source-main.spec.ts
+++ b/src/database/data-source-main.spec.ts
@@ -5,7 +5,7 @@ import mainDataSource from './data-source-main';
 // DataSource exists so the CLI can run/generate the main-owned migrations too.
 describe('main CLI DataSource', () => {
   it('targets the always-SQLite main connection', () => {
-    expect(mainDataSource.options.type).toBe('sqlite');
+    expect(mainDataSource.options.type).toBe('better-sqlite3');
   });
 
   it('uses the main-owned migrations dir, not the data migrations dir', () => {

--- a/src/database/data-source-main.ts
+++ b/src/database/data-source-main.ts
@@ -19,7 +19,7 @@ loadCliEnv();
  * Usage: `npm run migration:run:main` (dev) / `migration:run:main:prod` (compiled).
  */
 const mainDataSource = new DataSource({
-  type: 'sqlite',
+  type: 'better-sqlite3',
   // Mirrors the runtime main path (configuration.ts) — MAIN_DATABASE_NAME overrides the default
   // ./data/main.sqlite (e.g. e2e points it at a temp file), so the CLI and the app never target
   // different main databases.

--- a/src/database/data-source.ts
+++ b/src/database/data-source.ts
@@ -25,7 +25,7 @@ const dataMigrations = [sourceGlob('migrations', '*{.ts,.js}')];
 
 // SQLite configuration
 const sqliteDataSourceOptions: DataSourceOptions = {
-  type: 'sqlite',
+  type: 'better-sqlite3',
   database: process.env.DATABASE_NAME || './data/openwa.sqlite',
   entities: dataEntities,
   migrations: dataMigrations,

--- a/src/database/migrations-main/__tests__/1779900000000-CreateAuthAuditTables.spec.ts
+++ b/src/database/migrations-main/__tests__/1779900000000-CreateAuthAuditTables.spec.ts
@@ -10,7 +10,7 @@ describe('CreateAuthAuditTables migration', () => {
   let ds: DataSource;
 
   beforeEach(async () => {
-    ds = new DataSource({ type: 'sqlite', database: ':memory:', entities: [], synchronize: false });
+    ds = new DataSource({ type: 'better-sqlite3', database: ':memory:', entities: [], synchronize: false });
     await ds.initialize();
   });
 

--- a/src/database/migrations/__tests__/1770108659848-AddMessageStatus.spec.ts
+++ b/src/database/migrations/__tests__/1770108659848-AddMessageStatus.spec.ts
@@ -5,7 +5,7 @@ describe('AddMessageStatus baseline migration', () => {
   let ds: DataSource;
 
   beforeEach(async () => {
-    ds = new DataSource({ type: 'sqlite', database: ':memory:' });
+    ds = new DataSource({ type: 'better-sqlite3', database: ':memory:' });
     await ds.initialize();
   });
 

--- a/src/database/migrations/__tests__/1770200000000-NormalizeSynchronizeUuidColumns.spec.ts
+++ b/src/database/migrations/__tests__/1770200000000-NormalizeSynchronizeUuidColumns.spec.ts
@@ -86,7 +86,7 @@ describe('NormalizeSynchronizeUuidColumns migration', () => {
 
   // ---- SQLite: absolute no-op ----
   it('is a no-op on SQLite — issues no query and never probes tables', async () => {
-    const qr = makeQueryRunner({ type: 'sqlite', uuidColumns: new Set(['sessions.id']) });
+    const qr = makeQueryRunner({ type: 'better-sqlite3', uuidColumns: new Set(['sessions.id']) });
     await migration.up(qr as unknown as QueryRunner);
     expect(qr.query).not.toHaveBeenCalled();
     expect(qr.hasTable).not.toHaveBeenCalled();
@@ -256,7 +256,7 @@ describe('NormalizeSynchronizeUuidColumns migration', () => {
   });
 
   it('down() is a no-op on SQLite', async () => {
-    const qr = makeQueryRunner({ type: 'sqlite' });
+    const qr = makeQueryRunner({ type: 'better-sqlite3' });
     await migration.down(qr as unknown as QueryRunner);
     expect(qr.query).not.toHaveBeenCalled();
   });

--- a/src/database/migrations/__tests__/1779840000000-AddTemplates.spec.ts
+++ b/src/database/migrations/__tests__/1779840000000-AddTemplates.spec.ts
@@ -5,7 +5,7 @@ describe('AddTemplates migration', () => {
   let ds: DataSource;
 
   beforeEach(async () => {
-    ds = new DataSource({ type: 'sqlite', database: ':memory:' });
+    ds = new DataSource({ type: 'better-sqlite3', database: ':memory:' });
     await ds.initialize();
     // up() declares a CASCADE FK to sessions; create a minimal stand-in (mirrors the sibling specs).
     await ds.query(`CREATE TABLE "sessions" ("id" varchar PRIMARY KEY NOT NULL)`);

--- a/src/database/migrations/__tests__/1781000000000-AddBaileysStoredMessages.spec.ts
+++ b/src/database/migrations/__tests__/1781000000000-AddBaileysStoredMessages.spec.ts
@@ -6,7 +6,7 @@ describe('AddBaileysStoredMessages migration', () => {
 
   beforeEach(async () => {
     // A `sessions` table must exist for the FK; create a minimal stand-in.
-    ds = new DataSource({ type: 'sqlite', database: ':memory:' });
+    ds = new DataSource({ type: 'better-sqlite3', database: ':memory:' });
     await ds.initialize();
     await ds.query(`CREATE TABLE "sessions" ("id" varchar PRIMARY KEY NOT NULL)`);
   });

--- a/src/database/migrations/__tests__/1781100000000-AddTemplateNameUnique.spec.ts
+++ b/src/database/migrations/__tests__/1781100000000-AddTemplateNameUnique.spec.ts
@@ -5,7 +5,7 @@ describe('AddTemplateNameUnique migration', () => {
   let ds: DataSource;
 
   beforeEach(async () => {
-    ds = new DataSource({ type: 'sqlite', database: ':memory:' });
+    ds = new DataSource({ type: 'better-sqlite3', database: ':memory:' });
     await ds.initialize();
     // Minimal templates table mirroring the AddTemplates sqlite schema.
     await ds.query(

--- a/src/database/migrations/__tests__/1781200000000-AddLidMappings.spec.ts
+++ b/src/database/migrations/__tests__/1781200000000-AddLidMappings.spec.ts
@@ -5,7 +5,7 @@ describe('AddLidMappings migration', () => {
   let ds: DataSource;
 
   beforeEach(async () => {
-    ds = new DataSource({ type: 'sqlite', database: ':memory:' });
+    ds = new DataSource({ type: 'better-sqlite3', database: ':memory:' });
     await ds.initialize();
   });
 

--- a/src/database/migrations/__tests__/1781300000000-AddMessagesWaMessageIdUnique.spec.ts
+++ b/src/database/migrations/__tests__/1781300000000-AddMessagesWaMessageIdUnique.spec.ts
@@ -5,7 +5,7 @@ describe('AddMessagesWaMessageIdUnique migration', () => {
   let ds: DataSource;
 
   beforeEach(async () => {
-    ds = new DataSource({ type: 'sqlite', database: ':memory:' });
+    ds = new DataSource({ type: 'better-sqlite3', database: ':memory:' });
     await ds.initialize();
     await ds.query(
       `CREATE TABLE "messages" ("id" varchar PRIMARY KEY NOT NULL, "sessionId" varchar NOT NULL, ` +

--- a/src/database/migrations/__tests__/1781600000000-DropRedundantMessagesSessionIdIndex.spec.ts
+++ b/src/database/migrations/__tests__/1781600000000-DropRedundantMessagesSessionIdIndex.spec.ts
@@ -5,7 +5,7 @@ describe('DropRedundantMessagesSessionIdIndex migration', () => {
   let ds: DataSource;
 
   beforeEach(async () => {
-    ds = new DataSource({ type: 'sqlite', database: ':memory:' });
+    ds = new DataSource({ type: 'better-sqlite3', database: ':memory:' });
     await ds.initialize();
     await ds.query(
       `CREATE TABLE "messages" ("id" varchar PRIMARY KEY NOT NULL, "sessionId" varchar NOT NULL, ` +

--- a/src/database/migrations/__tests__/1781700000000-AddWebhookDeliveryFailures.spec.ts
+++ b/src/database/migrations/__tests__/1781700000000-AddWebhookDeliveryFailures.spec.ts
@@ -5,7 +5,7 @@ describe('AddWebhookDeliveryFailures migration', () => {
   let ds: DataSource;
 
   beforeEach(async () => {
-    ds = new DataSource({ type: 'sqlite', database: ':memory:' });
+    ds = new DataSource({ type: 'better-sqlite3', database: ':memory:' });
     await ds.initialize();
   });
 

--- a/src/database/migrations/__tests__/1781800000000-ScopeBatchIdUniqueToSession.spec.ts
+++ b/src/database/migrations/__tests__/1781800000000-ScopeBatchIdUniqueToSession.spec.ts
@@ -27,7 +27,7 @@ describe('ScopeBatchIdUniqueToSession migration', () => {
     ]);
 
   beforeEach(async () => {
-    ds = new DataSource({ type: 'sqlite', database: ':memory:' });
+    ds = new DataSource({ type: 'better-sqlite3', database: ':memory:' });
     await ds.initialize();
     await ds.query(BASELINE_DDL);
   });

--- a/src/database/migrations/__tests__/1782400000000-AddMessagesFts.spec.ts
+++ b/src/database/migrations/__tests__/1782400000000-AddMessagesFts.spec.ts
@@ -19,7 +19,7 @@ describe('AddMessagesFts migration (sqlite)', () => {
 
   beforeEach(async () => {
     ds = new DataSource({
-      type: 'sqlite',
+      type: 'better-sqlite3',
       database: ':memory:',
       entities: [Session, Message],
       synchronize: true,
@@ -115,7 +115,7 @@ describe('AddMessagesFts migration (sqlite)', () => {
     // return early (no CREATE VIRTUAL TABLE) so a non-FTS5 build doesn't crash boot.
     const calls: string[] = [];
     const stub = {
-      connection: { options: { type: 'sqlite' as const } },
+      connection: { options: { type: 'better-sqlite3' as const } },
       query: jest.fn((stmt: string) => {
         calls.push(stmt);
         if (stmt.includes("sqlite_compileoption_used('ENABLE_FTS5')")) {
@@ -143,7 +143,7 @@ describe('AddMessagesFts — dual-DB safety', () => {
 
   beforeEach(async () => {
     ds = new DataSource({
-      type: 'sqlite',
+      type: 'better-sqlite3',
       database: ':memory:',
       entities: [Session, Message],
       synchronize: true,

--- a/src/engine/adapters/baileys-message-store.service.spec.ts
+++ b/src/engine/adapters/baileys-message-store.service.spec.ts
@@ -28,7 +28,7 @@ describe('BaileysMessageStoreService', () => {
 
   beforeEach(async () => {
     ds = new DataSource({
-      type: 'sqlite',
+      type: 'better-sqlite3',
       database: ':memory:',
       // Session must be present so the @ManyToOne relation metadata resolves and synchronize
       // can emit the CASCADE FK on the baileys_stored_messages table.

--- a/src/modules/infra/infra.controller.spec.ts
+++ b/src/modules/infra/infra.controller.spec.ts
@@ -502,7 +502,7 @@ describe('InfraController.importData round-trips export-data (no silent message/
 
   beforeEach(async () => {
     ds = new DataSource({
-      type: 'sqlite',
+      type: 'better-sqlite3',
       database: ':memory:',
       entities: [
         Session,
@@ -784,7 +784,7 @@ describe('InfraController.import/export preserves every data-DB table', () => {
 
   beforeEach(async () => {
     ds = new DataSource({
-      type: 'sqlite',
+      type: 'better-sqlite3',
       database: ':memory:',
       entities: [Session, Webhook, Message, MessageBatch, Template, BaileysStoredMessage, LidMapping],
       synchronize: true,

--- a/src/modules/infra/infra.controller.ts
+++ b/src/modules/infra/infra.controller.ts
@@ -1256,6 +1256,18 @@ export class InfraController {
           this.logger.debug('Skipped clearing a table that does not exist during import', { table });
         }
       };
+      // The INSERTs below are written once, in Postgres' `$N` placeholder form. better-sqlite3 differs
+      // from the legacy sqlite3 driver on raw queries in two ways: SQLite parses `$N` as a NAMED
+      // parameter, which cannot be bound from the positional array TypeORM passes through (RangeError),
+      // and strict binding rejects booleans/undefined — which a Postgres-made backup carries (real
+      // booleans survive the JSON round-trip). Postgres needs `$N` and binds booleans natively, so both
+      // rewrites apply only on the SQLite path. Safe: every `$N` below occurs once, in ascending order.
+      const isPostgres = this.dataDataSource.options.type === 'postgres';
+      const insert = (text: string, params: unknown[]): Promise<unknown> =>
+        queryRunner.query(
+          isPostgres ? text : text.replace(/\$\d+/g, '?'),
+          isPostgres ? params : params.map(v => (typeof v === 'boolean' ? Number(v) : (v ?? null))),
+        );
       await queryRunner.query('DELETE FROM webhooks');
       await clearTable('messages');
       await clearTable('message_batches');
@@ -1285,7 +1297,7 @@ export class InfraController {
             continue;
           }
           try {
-            await queryRunner.query(
+            await insert(
               `INSERT INTO sessions (id, name, status, phone, "pushName", config, "proxyUrl", "proxyType", "connectedAt", "lastActiveAt", "createdAt", "updatedAt") 
                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
               [
@@ -1315,7 +1327,7 @@ export class InfraController {
       if (data.tables.webhooks?.length) {
         for (const webhook of data.tables.webhooks) {
           try {
-            await queryRunner.query(
+            await insert(
               `INSERT INTO webhooks (id, "sessionId", url, events, secret, headers, filters, active, "retryCount", "lastTriggeredAt", "createdAt", "updatedAt")
                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
               [
@@ -1349,7 +1361,7 @@ export class InfraController {
       if (data.tables.messages?.length) {
         for (const msg of data.tables.messages) {
           try {
-            await queryRunner.query(
+            await insert(
               `INSERT INTO messages (id, "sessionId", "waMessageId", "chatId", "chatName", "from", "to", body, type, direction, "timestamp", metadata, status, "createdAt")
                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
               [
@@ -1385,7 +1397,7 @@ export class InfraController {
       if (data.tables.messageBatches?.length) {
         for (const batch of data.tables.messageBatches) {
           try {
-            await queryRunner.query(
+            await insert(
               `INSERT INTO message_batches (id, batch_id, session_id, status, messages, options, progress, results, current_index, created_at, updated_at, started_at, completed_at)
                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`,
               [
@@ -1428,7 +1440,7 @@ export class InfraController {
       if (data.tables.templates?.length) {
         for (const tpl of data.tables.templates) {
           try {
-            await queryRunner.query(
+            await insert(
               `INSERT INTO templates (id, "sessionId", name, body, header, footer, "createdAt", "updatedAt")
                VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
               [
@@ -1454,7 +1466,7 @@ export class InfraController {
       if (data.tables.baileysStoredMessages?.length) {
         for (const bsm of data.tables.baileysStoredMessages) {
           try {
-            await queryRunner.query(
+            await insert(
               `INSERT INTO baileys_stored_messages (id, "sessionId", "waMessageId", "serializedMessage", "createdAt")
                VALUES ($1, $2, $3, $4, $5)`,
               [bsm.id, bsm.sessionId, bsm.waMessageId, bsm.serializedMessage, bsm.createdAt],
@@ -1471,10 +1483,12 @@ export class InfraController {
       if (data.tables.lidMappings?.length) {
         for (const lm of data.tables.lidMappings) {
           try {
-            await queryRunner.query(
-              `INSERT INTO lid_mappings (lid, phone, "sessionId", "updatedAt") VALUES ($1, $2, $3, $4)`,
-              [lm.lid, lm.phone ?? null, lm.sessionId ?? null, lm.updatedAt],
-            );
+            await insert(`INSERT INTO lid_mappings (lid, phone, "sessionId", "updatedAt") VALUES ($1, $2, $3, $4)`, [
+              lm.lid,
+              lm.phone ?? null,
+              lm.sessionId ?? null,
+              lm.updatedAt,
+            ]);
             lidMappingsCount++;
           } catch (err) {
             warnings.push(`Failed to import lid mapping ${lm.lid}: ${err}`);
@@ -1487,7 +1501,7 @@ export class InfraController {
       if (data.tables.pluginInstances?.length) {
         for (const pi of data.tables.pluginInstances) {
           try {
-            await queryRunner.query(
+            await insert(
               `INSERT INTO plugin_instances (id, "pluginId", "instanceId", "sessionScope", secret, "verifyToken", config, enabled, "createdAt", "updatedAt")
                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
               [
@@ -1515,7 +1529,7 @@ export class InfraController {
       if (data.tables.conversationMappings?.length) {
         for (const cm of data.tables.conversationMappings) {
           try {
-            await queryRunner.query(
+            await insert(
               `INSERT INTO conversation_mappings (id, "sessionId", "chatId", "pluginId", "instanceId", "providerConversationId", "handoverState", metadata, "updatedAt")
                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
               [
@@ -1546,7 +1560,7 @@ export class InfraController {
       if (data.tables.ingressEvents?.length) {
         for (const ie of data.tables.ingressEvents) {
           try {
-            await queryRunner.query(
+            await insert(
               `INSERT INTO ingress_events (id, "instanceId", "pluginId", "providerDeliveryId", route, payload, "sessionId", "createdAt")
                VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
               [
@@ -1572,7 +1586,7 @@ export class InfraController {
       if (data.tables.webhookDeliveryFailures?.length) {
         for (const wf of data.tables.webhookDeliveryFailures) {
           try {
-            await queryRunner.query(
+            await insert(
               `INSERT INTO webhook_delivery_failures (id, "webhookId", "sessionId", event, url, "idempotencyKey", "deliveryId", attempts, "lastStatusCode", "lastError", "createdAt")
                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
               [
@@ -1601,7 +1615,7 @@ export class InfraController {
       if (data.tables.integrationDeliveryFailures?.length) {
         for (const df of data.tables.integrationDeliveryFailures) {
           try {
-            await queryRunner.query(
+            await insert(
               `INSERT INTO integration_delivery_failures (id, direction, "pluginId", "instanceId", "sessionId", "deliveryId", attempts, "lastError", payload, redriven, "createdAt")
                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
               [

--- a/src/modules/integration/conversation-mapping.service.spec.ts
+++ b/src/modules/integration/conversation-mapping.service.spec.ts
@@ -7,7 +7,12 @@ describe('ConversationMappingService', () => {
   let ds: DataSource;
   let service: ConversationMappingService;
   beforeEach(async () => {
-    ds = new DataSource({ type: 'sqlite', database: ':memory:', entities: [ConversationMapping], migrations: [] });
+    ds = new DataSource({
+      type: 'better-sqlite3',
+      database: ':memory:',
+      entities: [ConversationMapping],
+      migrations: [],
+    });
     await ds.initialize();
     const runner = ds.createQueryRunner();
     await new AddIntegrationFabric1781900000000().up(runner);

--- a/src/modules/integration/ingress-event.service.spec.ts
+++ b/src/modules/integration/ingress-event.service.spec.ts
@@ -8,7 +8,7 @@ describe('IngressEventService.recordOrSkip', () => {
   let ds: DataSource;
   let service: IngressEventService;
   beforeEach(async () => {
-    ds = new DataSource({ type: 'sqlite', database: ':memory:', entities: [IngressEvent], migrations: [] });
+    ds = new DataSource({ type: 'better-sqlite3', database: ':memory:', entities: [IngressEvent], migrations: [] });
     await ds.initialize();
     const runner = ds.createQueryRunner();
     await new AddIntegrationFabric1781900000000().up(runner);

--- a/src/modules/integration/integration-retention.service.spec.ts
+++ b/src/modules/integration/integration-retention.service.spec.ts
@@ -15,7 +15,7 @@ describe('IntegrationRetentionService.pruneOlderThan', () => {
 
   beforeEach(async () => {
     ds = new DataSource({
-      type: 'sqlite',
+      type: 'better-sqlite3',
       database: ':memory:',
       entities: [IngressEvent, IntegrationDeliveryFailure],
       synchronize: true,

--- a/src/modules/integration/plugin-instance.service.spec.ts
+++ b/src/modules/integration/plugin-instance.service.spec.ts
@@ -8,7 +8,7 @@ describe('PluginInstanceService', () => {
   let ds: DataSource;
   let service: PluginInstanceService;
   beforeEach(async () => {
-    ds = new DataSource({ type: 'sqlite', database: ':memory:', entities: [PluginInstance], migrations: [] });
+    ds = new DataSource({ type: 'better-sqlite3', database: ':memory:', entities: [PluginInstance], migrations: [] });
     await ds.initialize();
     const runner = ds.createQueryRunner();
     await new AddIntegrationFabric1781900000000().up(runner);
@@ -111,7 +111,7 @@ describe('PluginInstanceService provisioning', () => {
   let ds: DataSource;
   let service: PluginInstanceService;
   beforeEach(async () => {
-    ds = new DataSource({ type: 'sqlite', database: ':memory:', entities: [PluginInstance], migrations: [] });
+    ds = new DataSource({ type: 'better-sqlite3', database: ':memory:', entities: [PluginInstance], migrations: [] });
     await ds.initialize();
     const runner = ds.createQueryRunner();
     await new AddIntegrationFabric1781900000000().up(runner);

--- a/src/modules/search/providers/builtin-fts.provider.spec.ts
+++ b/src/modules/search/providers/builtin-fts.provider.spec.ts
@@ -10,7 +10,12 @@ describe('BuiltInFtsProvider (sqlite)', () => {
   let provider: BuiltInFtsProvider;
 
   beforeEach(async () => {
-    ds = new DataSource({ type: 'sqlite', database: ':memory:', entities: [Session, Message], synchronize: true });
+    ds = new DataSource({
+      type: 'better-sqlite3',
+      database: ':memory:',
+      entities: [Session, Message],
+      synchronize: true,
+    });
     await ds.initialize();
     await new AddMessagesFts1782400000000().up(ds.createQueryRunner());
     provider = new BuiltInFtsProvider(ds);

--- a/src/modules/search/providers/search-dual-db.spec.ts
+++ b/src/modules/search/providers/search-dual-db.spec.ts
@@ -18,7 +18,7 @@ import { BuiltInFtsProvider } from './builtin-fts.provider';
  */
 async function boot(): Promise<{ ds: DataSource; provider: BuiltInFtsProvider }> {
   const ds = new DataSource({
-    type: 'sqlite',
+    type: 'better-sqlite3',
     database: ':memory:',
     entities: [Session, Message],
     synchronize: true,
@@ -66,7 +66,7 @@ describe('search dual-DB + import/export round-trip safety (sqlite)', () => {
     // Boot a DataSource WITHOUT running AddMessagesFts → messages_fts is absent. The provider must
     // detect this and throw NotImplementedException (→ HTTP 501), not crash on a missing table.
     const ds = new DataSource({
-      type: 'sqlite',
+      type: 'better-sqlite3',
       database: ':memory:',
       entities: [Session, Message],
       synchronize: true,
@@ -82,7 +82,7 @@ describe('search dual-DB + import/export round-trip safety (sqlite)', () => {
     // end-to-end above (and in builtin-fts.provider.spec.ts); the PG branch lives in the PG-gated
     // spec. This pins the branch decision so a future refactor can't silently drop the dialect read.
     const sqlite = await boot();
-    expect((sqlite.provider as unknown as { dataSource: DataSource }).dataSource.options.type).toBe('sqlite');
+    expect((sqlite.provider as unknown as { dataSource: DataSource }).dataSource.options.type).toBe('better-sqlite3');
     await sqlite.ds.destroy();
   });
 });

--- a/src/modules/search/search-provider.contract.spec.ts
+++ b/src/modules/search/search-provider.contract.spec.ts
@@ -85,7 +85,7 @@ describe('BuiltInFtsProvider satisfies the SearchProvider contract', () => {
 
   runProviderContract(async () => {
     ds = new DataSource({
-      type: 'sqlite',
+      type: 'better-sqlite3',
       database: ':memory:',
       entities: [Session, Message],
       synchronize: true,

--- a/src/modules/stats/stats.service.spec.ts
+++ b/src/modules/stats/stats.service.spec.ts
@@ -35,7 +35,7 @@ describe('StatsService time-series + hourly activity on SQLite (end-to-end regre
 
   beforeEach(async () => {
     ds = new DataSource({
-      type: 'sqlite',
+      type: 'better-sqlite3',
       database: ':memory:',
       entities: [Session, Message],
       synchronize: true,

--- a/src/modules/webhook/webhook-session-scope.spec.ts
+++ b/src/modules/webhook/webhook-session-scope.spec.ts
@@ -17,7 +17,7 @@ describe('WebhookService session-scoped access', () => {
 
   beforeEach(async () => {
     ds = new DataSource({
-      type: 'sqlite',
+      type: 'better-sqlite3',
       database: ':memory:',
       entities: [Session, Webhook],
       synchronize: true,


### PR DESCRIPTION
## Summary

Replaces the `sqlite3` driver with `better-sqlite3@^12` for both database connections: the always-SQLite main connection (auth/audit, every deployment) and the default data connection. Tracking discussion: #848.

**Why now.** node-sqlite3 is unmaintained and its GitHub repository was archived on 2026-07-01, so no release will ever ship a newer bundled SQLite: staying put means SQLite 3.44.2 (Nov 2023) indefinitely, without the post-3.44.2 FTS5 fixes (notably the 3.53.2 corruption fix), while our message search runs on FTS5. better-sqlite3 is actively maintained, is TypeORM's default SQLite driver going forward (TypeORM 1.x dropped `sqlite3` entirely), bundles a current SQLite 3.53.x with FTS5 enabled, and its 12.x Linux prebuilds require only glibc 2.29 — comfortably inside the `node:22-slim` (glibc 2.36) runtime image on both amd64 and arm64.

**Contract is frozen.** `DATABASE_TYPE` keeps its `sqlite`/`postgres` values everywhere they are visible (env validation, OpenAPI enum, dashboard Infrastructure page, `.env.generated` round-trip). The driver is mapped internally at the four TypeORM `type:` literals only. Existing database files open as-is; all data and main migrations apply unchanged (they branch on postgres-vs-not, never on the literal `sqlite`). PostgreSQL deployments are affected only in the main connection, which has always been SQLite. `scripts/backup.sh` uses the `sqlite3` CLI binary and is unaffected.

## Behavioral differences handled

Two raw-query behaviors differ from the legacy driver; both were caught by the existing test suite and are fixed here:

1. **Missing-table errors surface at prepare() time.** better-sqlite3 validates SQL when the statement is prepared, and TypeORM (0.3.x) creates the statement outside its try/catch — so the raw `SqliteError` escapes without ever becoming a `QueryFailedError`. `isMissingTableError` now also recognizes that shape (class name + message), keeping the import path tolerant of genuinely-absent tables while still surfacing every other failure. Covered by new fixtures in `db-errors.spec.ts` that mirror the real error shapes.
2. **`$N` placeholders and strict binding in `importData`.** The import INSERTs are written once in Postgres' `$N` form; SQLite parses `$N` as a *named* parameter, which better-sqlite3 refuses to bind from the positional array TypeORM passes through, and its strict binding also rejects booleans/`undefined` — which a Postgres-made backup legitimately carries (real booleans survive the JSON round-trip). A local `insert()` helper rewrites `$N` → `?` and normalizes boolean → 0/1 and `undefined` → `null`, on the SQLite path only; the Postgres path is byte-identical to before.

Also removes the `node-gyp`/`tar` entries from `overrides`: they existed solely to keep sqlite3's install chain audit-clean, and neither package remains in the dependency tree.

## Verification

- Backend: lint, build, full unit suite (204 suites / 2845 tests), and e2e — all green.
- Dashboard: build and lint — green.
- Driver runtime check: `better-sqlite3` 12.11.1 resolves within TypeORM 0.3.31's peer range (13.x cannot resolve), loads SQLite 3.53.2, and reports `ENABLE_FTS5` compiled in; the FTS migration probe, triggers, and search queries run unchanged.
- Restore path: the import/export round-trip specs cover both regressions above (they fail on the naive swap and pass with the fixes).
- Staging boot smoke (amd64): the production Docker image was built from this branch and booted on a staging host — the toolchain-less production stage installed the prebuilt binary successfully, all 19 data migrations applied on a fresh volume, `/api/health/live` returned ok, and an end-to-end FTS check (row insert → FTS trigger → `GET /api/search`) returned the expected hit with a `<mark>` snippet on SQLite 3.53.2.
