### PR TITLE
feat(annotations): add provider-neutral message annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Plugins can now store bounded, provider-neutral transcript annotations without changing normal message or webhook payloads.** The additive `message_annotations` store is scoped to a session and a persisted message, validates a small typed transcript record, and keeps transcript text outside `Message.metadata`. An opt-in plugin declares `message-annotations:write` to call the write-only `ctx.annotations.upsert` capability; it cannot list, search, or read annotations through this foundation. Eligible live media emits minimal annotation lifecycle hooks, while no transcription provider, external AI dependency, or annotation REST endpoint is enabled by default.
+
 ## [0.10.6] - 2026-07-22
 
 ### Changed

--- a/docs/19-plugin-architecture.md
+++ b/docs/19-plugin-architecture.md
@@ -124,7 +124,7 @@ a host version. The config schema is the top-level `configSchema` (note: not nes
 
   "main": "dist/index.js",
 
-  "permissions": ["messages:send", "engine:read", "net:fetch"],
+  "permissions": ["messages:send", "engine:read", "net:fetch", "message-annotations:write"],
 
   "sessionScoped": true,
   "sessions": ["*"],
@@ -279,6 +279,7 @@ export interface PluginContext {
   messages: PluginMessagingCapability; // requires 'messages:send'
   engine: PluginEngineReadCapability;  // requires 'engine:read' (read-only)
   net: PluginNetCapability;            // requires 'net:fetch' (SSRF-guarded, net.allow-scoped)
+  annotations: PluginMessageAnnotationsCapability; // requires 'message-annotations:write' (write-only)
 }
 
 export interface PluginLogger {
@@ -295,8 +296,8 @@ event emitter. Hook handlers use the host `HookContext` / `HookResult` shape (se
 
 ### Capability facade
 
-A plugin reaches WhatsApp, the engine, and the network **only** through these three namespaces. Each
-call is gated by the matching declared permission (and, for `messages`/`engine`, the session scope) —
+A plugin reaches host capabilities only through the documented namespaces. Each call is gated by the
+matching declared permission (and, where a session id is supplied, the session scope) —
 a missing grant throws a `PluginCapabilityError`.
 
 ```typescript
@@ -319,11 +320,38 @@ export interface PluginEngineReadCapability {
 export interface PluginNetCapability {
   fetch(url: string, init?: PluginNetRequestInit): Promise<PluginNetResponse>;
 }
+
+// ctx.annotations — requires 'message-annotations:write'. Session-scoped write only.
+export interface PluginMessageAnnotationsCapability {
+  upsert(sessionId: string, messageId: string, input: UpsertMessageAnnotationInput): Promise<{
+    messageId: string;
+    provider: string;
+    kind: 'transcript';
+    status: 'pending' | 'complete' | 'failed' | 'expired';
+    language?: string;
+    externalProcessing: boolean;
+  }>;
+}
 ```
 
 `ctx.net.fetch` returns a serializable response (`{ ok, status, statusText, headers, body }`, body as
 a string) — no streaming and no live `Response` object, because it must cross the worker boundary via
 structured clone. The request has a default 15 s / hard-cap 30 s timeout and a 10 MB response cap.
+
+### Derived-content annotations
+
+An annotation provider can register `message:annotation-requested` and then call
+`ctx.annotations.upsert(sessionId, messageId, input)`. The host binds `provider` to the manifest id,
+checks the manifest session scope and operator activation before looking up the message, and selects only
+the message id for that scoped parent check. The store accepts only `kind: 'transcript'` today; status,
+language, SHA-256 media fingerprint, processor version, external-processing flag, transcript text, expiry,
+and a small scalar-only metadata object are bounded and validated.
+
+The capability is intentionally write-only: it has no `get`, `list`, or search operation. Neither the
+`Message` entity nor normal message/webhook projections gain annotations or transcript text. The lifecycle
+events carry only a media request `{ messageId, kind, messageType }` or a text-free status projection.
+There is no annotation REST endpoint in this foundation; an explicit, separately authorized read contract
+is required before any transcript retrieval is added.
 
 ### Plugin Storage
 
@@ -400,6 +428,9 @@ export type HookEvent =
   | 'message:sent'
   | 'message:failed'
   | 'message:ack'
+  | 'message:persisted'
+  | 'message:annotation-requested'
+  | 'message:annotation-updated'
   // Webhook lifecycle
   | 'webhook:before'
   | 'webhook:queued'
@@ -586,8 +617,8 @@ URL / catalog), not an npm/github source descriptor.
 
 ### Permission model
 
-There are exactly **three** capability permissions, declared in the manifest `permissions` array and
-enforced at the capability boundary:
+Capability permissions are declared in the manifest `permissions` array and enforced at the capability
+boundary:
 
 ```typescript
 // src/core/plugins/plugin.interfaces.ts
@@ -599,6 +630,12 @@ export const PluginCapabilityPermission = {
   ENGINE_READ: 'engine:read',
   /** ctx.net.fetch — SSRF-guarded outbound HTTP, scoped to the manifest net.allow host list. */
   NET_FETCH: 'net:fetch',
+  /** ctx.registerWebhook — claim a validated inbound route. */
+  WEBHOOK_INGRESS: 'webhook:ingress',
+  /** ctx.conversations.send and conversation mappings/handover. */
+  CONVERSATION_SEND: 'conversation:send',
+  /** ctx.annotations.upsert — session-scoped derived-content write only. */
+  MESSAGE_ANNOTATIONS_WRITE: 'message-annotations:write',
 } as const;
 ```
 
@@ -621,7 +658,7 @@ private assertPermission(manifest: PluginManifest, permission: PluginCapabilityP
 
 Two further checks apply on top of the permission:
 
-- **Session scope.** `messages` and `engine` calls run `assertSessionAllowed(manifest, sessionId)` —
+- **Session scope.** `messages`, `engine`, and `annotations` calls run `assertSessionAllowed(manifest, sessionId)` —
   the plugin may only act on sessions in its manifest `sessions` list (`['*']` = all). The `sessionId`
   comes from the plugin, so this is the security boundary; it is static (editing config can't widen it).
 - **Network allowlist.** `ctx.net.fetch` additionally requires the target host to be in `manifest.net.allow`,

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,45 +30,46 @@
 
 **Full Index (by number)**
 
-| No  | Document                                                         | Description                                       |
-| --- | ---------------------------------------------------------------- | ------------------------------------------------- |
-| 01  | [Project Overview](./01-project-overview.md)                     | Vision, goals, scope, current status              |
-| 02  | [Requirements Specification](./02-requirements-specification.md) | Functional and non-functional requirements        |
-| 03  | [System Architecture](./03-system-architecture.md)               | Architecture, modules, and runtime flows          |
-| 04  | [Security Design](./04-security-design.md)                       | Auth, rate limiting, and security controls        |
-| 05  | [Database Design](./05-database-design.md)                       | Entities and storage considerations               |
-| 06  | [API Specification](./06-api-specification.md)                   | REST API and WebSocket protocol                   |
-| 07  | [API Collection](./07-api-collection.md)                         | Example requests and Postman import tips          |
-| 08  | [Development Guidelines](./08-development-guidelines.md)         | Coding standards and workflow                     |
-| 09  | [Testing Strategy](./09-testing-strategy.md)                     | Test types and tooling                            |
-| 10  | [DevOps & Infrastructure](./10-devops-infrastructure.md)         | Docker, deployment, and environment configuration |
-| 10-ID| [Panduan Docker (ID)](./DOCKER_ID.md)                            | Panduan deployment Docker dalam Bahasa Indonesia  |
-| 11  | [Operational Runbooks](./11-operational-runbooks.md)             | Incident, maintenance, and backup runbooks        |
-| 12  | [Troubleshooting FAQ](./12-troubleshooting-faq.md)               | Common issues and fixes                           |
-| 13  | [Horizontal Scaling](./13-horizontal-scaling.md)                 | Multi-node deployment guidance                    |
-| 14  | [Migration Guide](./14-migration-guide.md)                       | Upgrade and data migration guidance               |
-| 15  | [Project Roadmap](./15-project-roadmap.md)                       | Near-term and long-term roadmap                   |
-| 16  | [Risk Management](./16-risk-management.md)                       | Risks and mitigations                             |
-| 17  | [Dashboard Design](./17-dashboard-design.md)                     | Dashboard UX overview                             |
-| 18  | [SDK Design](./18-sdk-design.md)                                 | SDK plans and conventions                         |
-| 19  | [Plugin Architecture](./19-plugin-architecture.md)               | Extensibility concepts                            |
-| 20  | [Community Guidelines](./20-community-guidelines.md)             | Contribution and governance                       |
-| 21  | [Glossary](./21-glossary.md)                                     | Terms and definitions                             |
-| 22  | [n8n Integration](./22-n8n-integration.md)                       | n8n community nodes for OpenWA                    |
-| 23  | [Community Integrations](./23-community-integrations.md)         | Third-party adapters built on the OpenWA API      |
-| 23-S| [Plugin Sandboxing](./23-plugin-sandboxing.md)                   | Worker isolation, capabilities, and plugin limits |
-| 24  | [MCP Integration](./24-mcp-integration.md)                       | Model Context Protocol tools and auth model       |
-| 25  | [Integration Fabric](./25-integration-fabric.md)                | Inbound webhook substrate for plugin integrations |
-| 26  | [Global Search](./26-global-search.md)                          | Cross-session message search and the provider model |
+| No    | Document                                                         | Description                                                   |
+| ----- | ---------------------------------------------------------------- | ------------------------------------------------------------- |
+| 01    | [Project Overview](./01-project-overview.md)                     | Vision, goals, scope, current status                          |
+| 02    | [Requirements Specification](./02-requirements-specification.md) | Functional and non-functional requirements                    |
+| 03    | [System Architecture](./03-system-architecture.md)               | Architecture, modules, and runtime flows                      |
+| 04    | [Security Design](./04-security-design.md)                       | Auth, rate limiting, and security controls                    |
+| 05    | [Database Design](./05-database-design.md)                       | Entities and storage considerations                           |
+| 06    | [API Specification](./06-api-specification.md)                   | REST API and WebSocket protocol                               |
+| 07    | [API Collection](./07-api-collection.md)                         | Example requests and Postman import tips                      |
+| 08    | [Development Guidelines](./08-development-guidelines.md)         | Coding standards and workflow                                 |
+| 09    | [Testing Strategy](./09-testing-strategy.md)                     | Test types and tooling                                        |
+| 10    | [DevOps & Infrastructure](./10-devops-infrastructure.md)         | Docker, deployment, and environment configuration             |
+| 10-ID | [Panduan Docker (ID)](./DOCKER_ID.md)                            | Panduan deployment Docker dalam Bahasa Indonesia              |
+| 11    | [Operational Runbooks](./11-operational-runbooks.md)             | Incident, maintenance, and backup runbooks                    |
+| 12    | [Troubleshooting FAQ](./12-troubleshooting-faq.md)               | Common issues and fixes                                       |
+| 13    | [Horizontal Scaling](./13-horizontal-scaling.md)                 | Multi-node deployment guidance                                |
+| 14    | [Migration Guide](./14-migration-guide.md)                       | Upgrade and data migration guidance                           |
+| 15    | [Project Roadmap](./15-project-roadmap.md)                       | Near-term and long-term roadmap                               |
+| 16    | [Risk Management](./16-risk-management.md)                       | Risks and mitigations                                         |
+| 17    | [Dashboard Design](./17-dashboard-design.md)                     | Dashboard UX overview                                         |
+| 18    | [SDK Design](./18-sdk-design.md)                                 | SDK plans and conventions                                     |
+| 19    | [Plugin Architecture](./19-plugin-architecture.md)               | Extensibility concepts                                        |
+| 20    | [Community Guidelines](./20-community-guidelines.md)             | Contribution and governance                                   |
+| 21    | [Glossary](./21-glossary.md)                                     | Terms and definitions                                         |
+| 22    | [n8n Integration](./22-n8n-integration.md)                       | n8n community nodes for OpenWA                                |
+| 23    | [Community Integrations](./23-community-integrations.md)         | Third-party adapters built on the OpenWA API                  |
+| 23-S  | [Plugin Sandboxing](./23-plugin-sandboxing.md)                   | Worker isolation, capabilities, and plugin limits             |
+| 24    | [MCP Integration](./24-mcp-integration.md)                       | Model Context Protocol tools and auth model                   |
+| 25    | [Integration Fabric](./25-integration-fabric.md)                 | Inbound webhook substrate for plugin integrations             |
+| 26    | [Global Search](./26-global-search.md)                           | Cross-session message search and the provider model           |
+| BH    | [Bridge-Hybrid Design](./bridge-hybrid-design.md)                | Generic OpenWA/local-bridge boundaries and phased integration |
 
 **Examples**
 
-| Example | Description |
-| ------- | ----------- |
-| [Session Phone-Number Pairing](./examples/session-phone-number-pairing.md) | Link an existing WhatsApp account by phone number instead of scanning QR |
-| [Chat History Limits](./examples/chat-history-limits.md) | Understand local message history vs bounded live WhatsApp history |
-| [Webhook Signature Verification](./examples/webhook-signature-verification.md) | Verify signed OpenWA webhook deliveries in Node.js and Python |
-| [n8n Appointment Booking Workflow](./examples/n8n-appointment-booking.md) | Build an appointment-booking flow with OpenWA and n8n |
+| Example                                                                        | Description                                                              |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
+| [Session Phone-Number Pairing](./examples/session-phone-number-pairing.md)     | Link an existing WhatsApp account by phone number instead of scanning QR |
+| [Chat History Limits](./examples/chat-history-limits.md)                       | Understand local message history vs bounded live WhatsApp history        |
+| [Webhook Signature Verification](./examples/webhook-signature-verification.md) | Verify signed OpenWA webhook deliveries in Node.js and Python            |
+| [n8n Appointment Booking Workflow](./examples/n8n-appointment-booking.md)      | Build an appointment-booking flow with OpenWA and n8n                    |
 
 ## Quick Start
 
@@ -179,38 +180,38 @@ socket.on('message', msg => {
 
 ## Features (Current)
 
-| Feature                         | Status                        |
-| ------------------------------- | ----------------------------- |
-| REST API for WhatsApp           | Ready                         |
-| WebSocket Events (Socket.IO)    | Ready                         |
-| Multi-session Support           | Ready                         |
-| Web Dashboard                   | Ready                         |
-| Docker Deployment               | Ready                         |
-| Webhooks with HMAC Signature    | Ready                         |
-| SQLite / PostgreSQL Storage     | Ready                         |
-| API Key Authentication & Roles  | Ready                         |
-| CIDR IP Whitelisting            | Ready                         |
-| Rate Limiting                   | Ready                         |
-| Audit Logging                   | Ready                         |
-| Groups / Contacts / Labels API  | Ready                         |
-| Channels / Status / Catalog API | Experimental (engine-limited) |
-| Pluggable Engine (wwebjs / Baileys) | Ready (set `ENGINE_TYPE`)  |
-| Plugin Extension System         | Ready                         |
-| Queue-based Webhook Retries     | Optional (QUEUE_ENABLED=true) |
+| Feature                             | Status                        |
+| ----------------------------------- | ----------------------------- |
+| REST API for WhatsApp               | Ready                         |
+| WebSocket Events (Socket.IO)        | Ready                         |
+| Multi-session Support               | Ready                         |
+| Web Dashboard                       | Ready                         |
+| Docker Deployment                   | Ready                         |
+| Webhooks with HMAC Signature        | Ready                         |
+| SQLite / PostgreSQL Storage         | Ready                         |
+| API Key Authentication & Roles      | Ready                         |
+| CIDR IP Whitelisting                | Ready                         |
+| Rate Limiting                       | Ready                         |
+| Audit Logging                       | Ready                         |
+| Groups / Contacts / Labels API      | Ready                         |
+| Channels / Status / Catalog API     | Experimental (engine-limited) |
+| Pluggable Engine (wwebjs / Baileys) | Ready (set `ENGINE_TYPE`)     |
+| Plugin Extension System             | Ready                         |
+| Queue-based Webhook Retries         | Optional (QUEUE_ENABLED=true) |
 
 ## Tech Stack
 
-| Layer     | Technology                    |
-| --------- | ----------------------------- |
-| Runtime   | Node.js 22 LTS                |
-| Framework | NestJS 11.x                   |
-| Language  | TypeScript 5.x                |
+| Layer     | Technology                                                      |
+| --------- | --------------------------------------------------------------- |
+| Runtime   | Node.js 22 LTS                                                  |
+| Framework | NestJS 11.x                                                     |
+| Language  | TypeScript 5.x                                                  |
 | WA Engine | Pluggable (`ENGINE_TYPE`): whatsapp-web.js (default) or Baileys |
-| WebSocket | Socket.IO                     |
-| Database  | SQLite (default) / PostgreSQL |
-| ORM       | TypeORM                       |
-| Container | Docker + Docker Compose       |
-| Dashboard | React + Vite + TanStack Query |
+| WebSocket | Socket.IO                                                       |
+| Database  | SQLite (default) / PostgreSQL                                   |
+| ORM       | TypeORM                                                         |
+| Container | Docker + Docker Compose                                         |
+| Dashboard | React + Vite + TanStack Query                                   |
 
 ## Project Structure
 

--- a/docs/bridge-hybrid-design.md
+++ b/docs/bridge-hybrid-design.md
@@ -1,0 +1,315 @@
+# Bridge-hybrid design (Phase 1)
+
+## Status and decision
+
+This is a Phase 1 architecture decision, not an implementation change. It keeps OpenWA a general,
+self-hosted WhatsApp gateway and keeps deployment-specific agent behavior in a separate local bridge.
+The integration boundary is a versioned, deliberately small event/context contract; it is not a way
+to import local context stores, model prompts, calendars, or autonomous business actions into upstream
+OpenWA.
+
+```
+WhatsApp
+   |
+   v
+OpenWA core ---------------------------------------------------+
+  sessions, engines, canonical WhatsApp identity, messages     |
+  durable LID resolution, authenticated webhook delivery       | versioned event
+  optional generic message-annotation extension point          v
+                                                   local bridge
+                                                   local-context adapter
+                                                   transcription provider
+                                                   policy + approval ledger
+                                                             |
+                                                             v
+                                                    operator / local agent
+```
+
+The right hand side is deployment-local and is never packaged as a default OpenWA plugin. It may
+run on the same trusted machine only when the operator accepts that trust boundary; otherwise it
+must run in a separately contained process/service with a narrowly scoped OpenWA credential.
+
+## Evidence in the current code
+
+| Concern                 | Existing evidence                                                                                                                                                                                        | Design consequence                                                                                                                      |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Engine-neutral messages | `src/engine/adapters/baileys-message-mapper.ts` maps Baileys events into `IncomingMessage`; `src/engine/interfaces/whatsapp-engine.interface.ts` is the shared engine contract.                          | Upstream owns WhatsApp protocol and the neutral message model.                                                                          |
+| LID ownership           | `src/engine/identity/lid-mapping.entity.ts` and `lid-mapping-store.service.ts` persist a global, cross-session `lid -> phone` cache with negative results and provenance.                                | Do not duplicate or override LID resolution in the local bridge.                                                                        |
+| Message extensibility   | `src/modules/message/entities/message.entity.ts` already has a JSON `metadata` field.                                                                                                                    | A typed annotation contract can be introduced additively, but local-context data must not become an unbounded blob in generic metadata. |
+| Delivery boundary       | `src/modules/webhook/webhook.service.ts` creates idempotency/delivery ids, supports filters and hooks, and `src/modules/queue/processors/webhook.processor.ts` retries deliveries.                       | The bridge should consume a versioned OpenWA webhook rather than reach into the OpenWA database.                                        |
+| Plugin boundary         | `src/core/plugins/plugin.interfaces.ts` has manifest permissions, session scope, ingress routes, and `ctx.net.fetch`; `docs/23-plugin-sandboxing.md` documents that worker threads are not OS isolation. | Plugins are appropriate for generic extensions, not for untrusted code with access to private local context.                            |
+| Local bridge behavior   | A separate local bridge may own SQLite aliases, transcripts, and agent workflows.                                                                                                                        | Preserve these as local adapters while replacing only transport/identity duplication over time.                                         |
+
+## Ownership boundaries
+
+### Upstream OpenWA owns
+
+- Engine lifecycle, session authentication, message ingest/send, media acquisition, and the
+  canonical neutral JID representation.
+- LID-to-phone resolution, its cache invalidation/negative-result semantics, and mapping
+  provenance. Consumers receive the canonical identity plus resolution state; they do not write a
+  competing alias map.
+- Authenticated, scoped external delivery; retries; idempotency; webhook filtering; plugin
+  manifest validation; and generic audit/operational telemetry.
+- A generic transcription/derived-content annotation _contract_, but not an opinionated provider,
+  a deployment-specific transcript policy, or an AI prompt.
+
+### Local bridge owns
+
+- Which OpenWA session(s) are eligible for the configured deployment, local credentials, recipient
+  allow/block policy, model selection, style corpus, local-context retrieval, and all calendar/CRM/booking
+  integrations.
+- The meaning of a transcript for that operator, provider choice and consent, source-media
+  retention, prompt construction, action classification, approval records, and local audit data.
+- Its own LID compatibility read model only during migration. It treats OpenWA's canonical identity
+  as authoritative and must never infer a phone number from a LID.
+
+### Explicit non-goals
+
+- No local bridge-specific schema, vector store, calendar credential, contact list, or model key in
+  OpenWA configuration, database migrations, default plugins, SDKs, or webhook payloads.
+- No generic OpenWA auto-reply/booking agent in Phase 1.
+- No reverse dependency: OpenWA must start, send, receive, and operate normally if the local
+  bridge is absent, offline, rejected, or deleted.
+
+## LID identity and resolution
+
+OpenWA becomes the sole resolver once the hybrid is enabled. The bridge receives the following
+identity shape in each event/context result:
+
+```ts
+type PartyIdentityV1 = {
+  canonicalJid: string; // OpenWA neutral JID, never guessed by the bridge
+  sourceJid?: string; // raw/engine JID only when policy permits debugging exposure
+  kind: 'person' | 'group' | 'broadcast' | 'unknown';
+  resolution: 'phone-resolved' | 'lid-unresolved' | 'not-applicable';
+  phoneE164?: string; // present only for a resolved person and authorized consumer
+  mappingObservedAt?: string;
+};
+```
+
+Rules:
+
+1. The adapter normalizes before persistence and event construction. A raw `@lid` that cannot be
+   resolved remains a stable `@lid` canonical id with `lid-unresolved`; it is not dropped, replaced
+   by a guessed phone, or merged through name matching.
+2. OpenWA's `LidMappingStore` remains the read/write authority. A resolved mapping is included as
+   an observation, not a permanent identity claim; the existing last-write-wins behavior recognises
+   number recycling.
+3. The bridge keys local policy and approval records by `{openwaInstanceId, sessionId,
+canonicalJid}`. Existing `jid_aliases` are migration-only compatibility data, not a second
+   resolver.
+4. A LID mapping change emits a generic `identity.resolved`/`identity.changed` event with opaque
+   previous/current canonical identifiers. The bridge rekeys its local view transactionally and
+   retains an alias redirect. It must not re-send or re-run a request merely because identity changed.
+
+## Bounded agent-context surface
+
+The agent does not get a general database query, a shell, an OpenWA admin key, or the whole chat
+history. The bridge creates a short-lived `AgentContextV1` from an inbound delivery, and exposes it
+only to the configured local agent through a local authenticated IPC/API boundary.
+
+```ts
+type AgentContextV1 = {
+  schema: 'openwa.agent-context.v1';
+  delivery: { id: string; idempotencyKey: string; occurredAt: string };
+  session: { id: string; label?: string };
+  message: {
+    id: string;
+    canonicalChat: PartyIdentityV1;
+    sender: PartyIdentityV1;
+    direction: 'incoming';
+    type: string;
+    body?: string;
+    quotedMessage?: { id: string; body?: string; type: string };
+    annotationRefs: Array<{ provider: string; kind: 'transcript'; status: string; ref: string }>;
+  };
+  conversation: {
+    recent: Array<{ id: string; direction: string; body?: string; type: string; occurredAt: string }>;
+    maxItems: number;
+  };
+  localContext?: { items: Array<{ source: string; text: string; expiresAt?: string }>; maxChars: number };
+  permittedActions: Array<'draft.reply' | 'request.approval'>;
+  expiresAt: string;
+};
+```
+
+The bridge selects at most one inbound message, its quoted message, a fixed recent same-chat window,
+and a character-capped local-context result. It strips raw protocol JSON, arbitrary media bytes,
+contact lists, unrelated chats, access tokens, hidden prompt/configuration, and all historical
+messages outside that window. Transcript text is fetched by an opaque reference only after the local
+policy approves it. Context is single-delivery, tenant/session scoped, non-replayable after expiry,
+and logged as a digest/count rather than prompt text.
+
+`draft.reply` can create a proposed text only. It cannot call OpenWA send endpoints. Any agent tool
+that needs more data returns a structured `context_insufficient` result for an operator decision;
+it must not silently broaden its query.
+
+### Implemented Phase 2 boundary (generic, opt-in)
+
+The current upstream foundation is disabled unless `AGENT_CONTEXT_ENABLED=true` and exposes only
+`GET /api/sessions/:sessionId/agent-context/messages/:messageId`. It accepts an explicitly selected
+inbound message UUID; there is no list, search, pagination, send, or write endpoint. The response
+contains canonical chat/sender identities, a body capped at 1,000 characters, an aggregate persisted
+`receipt.status` (`pending`, `sent`, `delivered`, `read`, or `failed`), and at most six same-session
+messages from a bounded canonical-equivalent raw-chat bucket.
+
+The six-message conversation is an event-time window **anchored at and including the selected
+trigger**. It includes rows with an earlier WhatsApp `Message.timestamp` plus the exact trigger row.
+Because timestamps are second-granularity and persisted UUIDs are random rather than engine sequence
+keys, other same-second rows are deliberately omitted rather than risk including a later event. Rows
+with a later WhatsApp timestamp are excluded even if they arrived in the database earlier; `createdAt`
+is used only when a legacy row has no WhatsApp timestamp. `occurredAt` follows the same rule.
+
+Its raw-chat filter starts with the trigger JID and, only when the in-memory LID cache proves a phone
+mapping, adds both direct-user dialects (`phone@c.us` and `phone@s.whatsapp.net`) plus up to 30
+currently mapped LID aliases (32 IDs total). An unresolved LID remains an isolated one-ID bucket; the
+endpoint never guesses a phone, performs a network lookup, or reads a broad identity table. The
+message reads select only the fields that are projected or needed for this cutoff; `metadata`
+(including media/protocol JSON) is not read.
+
+Quote context is `{ messageId, body? }` from the additive typed `message_quotes` record, with the
+same body cap. Reactions are current state from additive typed `message_reactions`, capped at 16 per
+projected message and canonically identifying the reacting party. Existing `messages.metadata` quote
+and reaction shapes are still maintained for compatibility with current dashboard/webhook consumers,
+but the agent-context endpoint neither fetches nor falls back to them. Old rows therefore omit this
+optional enrichment rather than exposing raw metadata or inventing data.
+
+## Transcription metadata extension point
+
+OpenWA should expose a provider-neutral derived-content model rather than embed a particular speech
+API. Prefer a new additive `message_annotations` store and typed service over overloading the
+unvalidated `Message.metadata` object:
+
+```ts
+type MessageAnnotationV1 = {
+  messageId: string;
+  provider: string; // e.g. 'local-whisper' or deployment-specific id
+  kind: 'transcript';
+  status: 'pending' | 'complete' | 'failed' | 'expired';
+  language?: string;
+  text?: string; // access-controlled, never in default webhooks
+  mediaFingerprint?: string; // verify attachment, not a media path
+  createdAt: string;
+  expiresAt?: string;
+  provenance: { processorVersion: string; externalProcessing: boolean };
+};
+```
+
+The generic hook is `message:annotation-requested` for eligible media and
+`message:annotation-updated` after a provider writes a validated annotation. A provider is opt-in,
+session scoped, and needs future explicit permissions such as `media:read` and
+`message-annotations:write`. The normal message webhook carries only a status/ref by default;
+`includeAnnotations=transcript` is an authenticated, session-scoped opt-in. This prevents a large
+transcript from unexpectedly becoming part of every webhook or SDK response.
+
+The local bridge's current `src/transcribe.ts` can be adapted as one provider. Its current generic
+upload filename and 25 MiB bound are useful implementation evidence, but its OpenAI dependency is
+strictly local policy: an external processor requires operator consent and `externalProcessing:true`.
+`src/transcribe-backlog.ts` maps naturally to an annotation worker; it must not read OpenWA storage
+directly.
+
+## Webhook and plugin boundaries
+
+1. **Outbound OpenWA webhook → local bridge:** register a dedicated, session-scoped webhook with
+   only `message.received`, `identity.*`, and `message.annotation-updated`. Use OpenWA's delivery and
+   idempotency values. The bridge validates a secret/signature, stores a short dedup record, and ACKs
+   before doing slow transcription or model work. Its current `src/webhook.ts` retry code is replaced
+   by the upstream delivery/retry behavior, not duplicated.
+2. **Bridge → OpenWA:** use a dedicated bridge API key/client with read access to the bounded context
+   endpoint and a separate proposed-message submission endpoint. It receives no plugin-management,
+   raw database, arbitrary-session, or general administration rights.
+3. **Generic OpenWA plugins:** may implement a transcription provider or integration transport with
+   declared permissions and session activation. They must be general-purpose, configurable, and safe
+   without the local bridge.
+4. **Deployment-specific integration:** stays an external service or a built-in locally deployed adapter, never
+   an installable third-party plugin. OpenWA's documented worker-thread sandbox is not confidentiality
+   isolation, so it is insufficient for local-context data or calendar credentials on its own.
+5. **Ingress:** third-party systems (calendar/booking providers) terminate at the local bridge. They
+   do not claim an OpenWA plugin ingress route or receive WhatsApp data until the bridge authenticates
+   them and produces an approval request.
+
+## Approval-required actions
+
+The local bridge has a deny-by-default action classifier. The following intents always require an
+operator approval tied to an immutable preview and expiry: creating, accepting, declining, moving,
+or cancelling a **meeting**; recording or changing **interest**/lead state; revealing or committing
+**availability**; and any **booking**, payment-adjacent reservation, or external CRM/calendar write.
+
+An approval record contains the normalized action, target system, canonical chat identity, exact
+outbound message, structured parameters, source delivery id, policy version, content hash, creator,
+created/expiry timestamps, and final decision. Approval is single use; a changed parameter, recipient,
+or text invalidates it. The execution worker verifies the approval immediately before the external
+write and records the result/idempotency key. A conversational "yes" from the remote WhatsApp party
+is evidence for a _draft_, never the operator's approval.
+
+Ordinary reply drafts are also human-approved by default. If a later deployment permits narrowly
+scoped automatic replies, it may only send an already-created draft under a local policy and still
+must exclude all four intent classes. This preserves the useful guardrails in
+the local bridge's autoreply-safety module, whose scheduling/meeting pattern should fail safe.
+
+## Privacy and retention
+
+| Data                                                   | Location and default rule                                                                                                                                                              |
+| ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Raw WhatsApp messages/media and canonical LID mappings | OpenWA's existing data store; retention follows its operator configuration. Do not copy the raw store to the bridge.                                                                   |
+| Webhook event                                          | Bridge encrypted/local queue only; dedup and delivery metadata retained 30 days by default, payload deleted after successful context creation (or 24 hours on failure).                |
+| Agent context and prompt                               | Memory only where possible; otherwise encrypted local storage, 24-hour TTL. Store audit hashes, item counts, and policy ids rather than full prompt text.                              |
+| Transcript                                             | Annotation access controlled; default 30-day TTL after completion, with source-media path never exported. Delete/expire when the parent message/media is deleted or retention expires. |
+| Local-context retrieval                                | Query and selected snippets remain local; cap characters and results, do not persist prompts, and never send to a model/provider without explicit configured consent.                  |
+| Approval/audit ledger                                  | Minimal structured record (no unnecessary message bodies), 90-day default configurable retention, then delete or aggregate.                                                            |
+
+All bridge secrets belong in its private deployment environment. OpenWA webhook logs, failure records,
+and plugin diagnostics must redact body/transcript/phone values by default. Exporting a transcript,
+local-context snippet, or identifier to an external LLM, transcription service, calendar, CRM, or
+notification target is an explicit data-transfer policy decision, not an implied side effect of
+enabling the integration.
+
+## Migration and compatibility
+
+1. Add the generic contracts disabled by default. Existing message APIs, webhook payloads, SDKs,
+   plugins, engines, and `Message.metadata` remain byte-compatible; annotation fields are additive
+   and opt-in.
+2. Register an OpenWA webhook to the bridge in shadow mode. The bridge consumes and deduplicates
+   deliveries but makes no sends, external calls, or local-context queries. Compare counts and
+   canonical identities against its SQLite view.
+3. Enable OpenWA identity as the bridge read authority. Import only confirmed `jid_aliases` records
+   as migration hints; unresolved or conflicting aliases remain unresolved and are reviewed, never
+   force-merged. Preserve local alias redirects for historic lookup.
+4. Move transcription to the annotation contract in shadow mode. Compare status/text hashes; keep
+   the existing bridge `messages.transcript` only as a local compatibility cache until the configured
+   retention window passes.
+5. Switch event transport to the OpenWA webhook. Keep the bridge's existing inbound sender disabled
+   rather than running two live paths. Use delivery/idempotency keys to make cutover retry-safe.
+6. Enable bounded agent context and approvals with draft-only behavior. A rollback disables the
+   dedicated webhook/bridge credential and restores bridge-only reads; no core data migration is
+   destructive.
+
+## Implementation sequence and verification
+
+| Step                        | Planned source paths                                                                                                                                                                            | Tests / acceptance evidence                                                                                                                                                                                                                                                                        |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1. Freeze contracts         | Add `src/modules/message/annotations/*`, extend `src/modules/message/entities/message.entity.ts`, and add a migration under `src/database/migrations/`.                                         | New annotation DTO/service unit tests; migration smoke test; existing `src/modules/message/**/*.spec.ts` unchanged.                                                                                                                                                                                |
+| 2. Canonical identity event | Extend `src/engine/identity/lid-mapping-store.service.ts`, `src/engine/adapters/baileys-message-mapper.ts`, and webhook payload construction in `src/modules/webhook/webhook.service.ts`.       | Extend `src/engine/identity/lid-mapping-store.spec.ts` and `src/engine/adapters/baileys-message-mapper.spec.ts` for resolved, unresolved, remapped, and group identities; webhook idempotency/filter regressions in `src/modules/webhook/webhook.service.spec.ts` and `test/webhooks.e2e-spec.ts`. |
+| 3. Annotation extension     | Add typed hook/permission support in `src/core/hooks/*`, `src/core/plugins/plugin.interfaces.ts`, and `src/core/plugins/plugin-activation.ts`; create a disabled example provider fixture only. | Manifest permission-denial and session-scope tests in `src/core/plugins/*.spec.ts`; annotation lifecycle, TTL, and no-transcript-in-default-webhook tests.                                                                                                                                         |
+| 4. Bounded bridge client    | Add a dedicated read/proposal controller under `src/modules/agent-context/` and register it in the app/module graph. Keep it outside broad `src/core/agent-tools/tools/message.tools.ts`.       | E2E tests prove scope, TTL, max recent items/chars, body/media omission, no arbitrary-history route, and denial of send/admin endpoints.                                                                                                                                                           |
+| 5. Local adapter            | In a separate local bridge deployment, add an OpenWA client/consumer beside its webhook handler; adapt its transcription, context, and autoreply modules without changing local data semantics. | Add focused local-bridge tests for event dedup, LID rekey, context bounds, transcript-reference authorization, and no outbound action in shadow mode. Run that deployment's typecheck.                                                                                                             |
+| 6. Approval executor        | Add bridge-local `src/approvals.ts` and connector adapters; leave OpenWA send APIs unchanged.                                                                                                   | Tests for all required action classes, exact-preview hash mismatch, expiry, double-submit, connector failure/retry idempotency, and audit redaction.                                                                                                                                               |
+| 7. Cutover                  | Deployment/runbook documentation only after shadow metrics pass.                                                                                                                                | `npm run lint`, `npm test`, `npm run test:e2e`, and `npm run build` in OpenWA; bridge `npm run typecheck` plus its targeted tests; a manual rollback drill.                                                                                                                                        |
+
+## Risks and blockers
+
+- **Plugin isolation is not enough for sensitive local data.** The current OpenWA worker-thread
+  model runs under the same OS user and can access Node facilities; local adapters need explicit
+  process/OS containment or equivalent trusted deployment controls.
+- **There is no existing typed annotation capability or bounded agent-context API.** They are new
+  generic upstream work and must be designed/reviewed before a bridge can rely on them.
+- **LID mappings are observations, not proof of identity.** Migration must surface conflicts instead
+  of collapsing aliases automatically; this is especially important for old bridge data.
+- **OpenWA and the bridge currently have different storage/session models.** OpenWA is multi-session
+  and server-oriented; the bridge is intentionally one paired number with SQLite. The adapter must
+  explicitly select an allowed session.
+- **External transcription and local-context retrieval are data exports.** Provider consent,
+  retention configuration, and outage behavior must be settled before enabling them beyond local
+  shadow mode.
+- **No implementation or configuration changes are made by this Phase 1 document.**

--- a/docs/bridge-hybrid-design.md
+++ b/docs/bridge-hybrid-design.md
@@ -196,12 +196,17 @@ type MessageAnnotationV1 = {
 };
 ```
 
-The generic hook is `message:annotation-requested` for eligible media and
-`message:annotation-updated` after a provider writes a validated annotation. A provider is opt-in,
-session scoped, and needs future explicit permissions such as `media:read` and
-`message-annotations:write`. The normal message webhook carries only a status/ref by default;
-`includeAnnotations=transcript` is an authenticated, session-scoped opt-in. This prevents a large
-transcript from unexpectedly becoming part of every webhook or SDK response.
+Phase 3 implements the foundation: `message:annotation-requested` fires for an eligible persisted media
+row with only `{ messageId, kind, messageType }`; `message:annotation-updated` emits a text-free status
+projection after a provider writes a validated annotation. A provider is opt-in and session-scoped. Its
+only new capability is `message-annotations:write`, which binds the annotation provider to its manifest
+id and has no get/list/search operation. Media retrieval remains a future, separately permissioned
+`media:read` decision.
+
+This foundation intentionally does **not** change the default message or webhook projection and exposes
+no annotation HTTP API. A future authenticated, session-scoped annotation-read contract may add an
+explicit `includeAnnotations=transcript` opt-in; it must not make transcripts part of ordinary webhooks,
+SDK responses, or agent context by default.
 
 The local bridge's current `src/transcribe.ts` can be adapted as one provider. Its current generic
 upload filename and 25 MiB bound are useful implementation evidence, but its OpenAI dependency is

--- a/docs/testing/bridge-hybrid-annotations.tdd.md
+++ b/docs/testing/bridge-hybrid-annotations.tdd.md
@@ -1,0 +1,32 @@
+# Bridge-hybrid annotation foundation TDD evidence
+
+## Scope
+
+This Phase 3 slice implements only a generic, provider-neutral annotation store and plugin lifecycle
+contract. It has no transcription provider, external AI dependency, local bridge adapter, agent behavior,
+calendar/CRM integration, annotation HTTP endpoint, or annotation search/read capability.
+
+## Guarantees exercised
+
+- A provider writes only a validated, bounded transcript annotation for a message in its explicit session.
+  The scoped parent check selects `messages.id` only; it does not load message body, metadata, or media.
+- The provider identity comes from its plugin manifest, and `message-annotations:write` plus session
+  activation are enforced before the store is resolved.
+- The sandbox IPC router exposes only `annotations.upsert`; there is no annotation get/list/search verb.
+- Requested and updated lifecycle hooks are in the finite hook allowlist. Their payloads have only a
+  message reference/type or annotation status projection—never transcript text or arbitrary metadata.
+- Existing message and webhook projections stay unchanged. The live inbound persistence path invokes the
+  minimal lifecycle request only after a durable eligible-media row exists.
+- The additive migration has a composite session/message/provider/kind key, is idempotent, and is reversible.
+
+## RED and GREEN evidence
+
+The first focused run failed because the annotation service, migration, and hook names did not exist.
+After the implementation, the focused suite below passed with the validation, plugin-boundary, IPC, and
+live-persistence regressions in place.
+
+| Command                                                                                                                                                                                                                                                                                                                                                                                                        | Result           |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `npm test -- --runInBand modules/message/message-annotation.service.spec.ts modules/message/message.service.spec.ts modules/session/session.service.spec.ts core/hooks/hook.interfaces.spec.ts core/plugins/plugin-capability.spec.ts core/plugins/sandbox/capability-router.spec.ts core/plugins/sandbox/worker-capability.spec.ts database/migrations/__tests__/1782600000000-AddMessageAnnotations.spec.ts` | PASS — 315 tests |
+
+The final verification commands and their actual results are recorded with the Phase 3 handoff.

--- a/docs/testing/bridge-hybrid-foundation.tdd.md
+++ b/docs/testing/bridge-hybrid-foundation.tdd.md
@@ -1,0 +1,50 @@
+# Bridge-hybrid foundation TDD evidence
+
+## Source and scope
+
+Source design: [`docs/bridge-hybrid-design.md`](../bridge-hybrid-design.md). This Phase 2 slice adds
+only generic canonical-identity projection and an opt-in, read-only agent-context endpoint. It does
+not add annotations/transcription, local-agent behavior, outbound sends, or integrations.
+
+## User journeys
+
+- As a scoped API consumer, I can obtain a small context for one selected inbound message without
+  receiving raw metadata, media, an arbitrary message search, or send capability. The fixed history
+  window includes that trigger but excludes messages with a later WhatsApp event timestamp.
+- As a scoped API consumer, I receive only typed quote/current-reaction context and aggregate persisted
+  receipt status; legacy metadata is never fetched as a fallback.
+- As an operator, I can keep this surface absent unless `AGENT_CONTEXT_ENABLED=true` is explicitly
+  set.
+- As a consumer of WhatsApp identities, I receive a canonical phone JID when a persisted LID mapping
+  is known and an explicit unresolved-LID state when it is not.
+
+## RED and GREEN evidence
+
+The initial focused test run after adding tests failed because the new implementation modules did
+not exist. After implementation, a repository mock exposed a missing defensive context cap; the
+service now slices its result as well as requesting a database-level `take`.
+
+| Guarantee                                                                                                                                                        | Test                                                                                 | Result |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | ------ |
+| Phone, resolved LID, unresolved LID, and special JIDs project safely                                                                                             | `src/engine/identity/canonical-identity.spec.ts`                                     | PASS   |
+| Context is session/chat bounded, inbound-only, body capped, metadata unselected, and cross-session ids do not disclose existence                                 | `src/modules/agent-context/agent-context.service.spec.ts`                            | PASS   |
+| History includes the selected trigger, uses WhatsApp timestamp, excludes post-trigger/backfilled and ambiguous same-second events, and falls back only if absent | `src/modules/agent-context/agent-context.service.spec.ts`                            | PASS   |
+| Resolved phone/LID aliases and both direct-user JID dialects share a capped same-session bucket, while unresolved LIDs remain isolated                           | unit regression plus `test/agent-context.e2e-spec.ts`                                | PASS   |
+| Typed quote/current-reaction context is bounded and canonicalized; aggregate receipt status is projected                                                         | `src/modules/agent-context/agent-context.service.spec.ts`, endpoint E2E              | PASS   |
+| Live inbound quotes, API replies, and reaction upsert/delete write additive typed records while JSON payload compatibility remains                               | `src/modules/session/session.service.spec.ts`, `message.service.spec.ts`             | PASS   |
+| Additive quote/reaction migration is idempotent and reversible                                                                                                   | `src/database/migrations/__tests__/1782500000000-AddMessageContextRelations.spec.ts` | PASS   |
+| Feature defaults off and requires exact `true`                                                                                                                   | `src/config/feature-flags.spec.ts`                                                   | PASS   |
+| Enabled API is viewer-readable, session-scoped, six-entry bounded, GET-only, and feature-gated                                                                   | `test/agent-context.e2e-spec.ts`                                                     | PASS   |
+
+## Verification
+
+| Command                                                                                                                                                                                                                                                                                                              | Result                                                                                     |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `npx jest --runInBand --coverage --coverageThreshold='{}' --collectCoverageFrom='engine/identity/canonical-identity.ts' --collectCoverageFrom='modules/agent-context/agent-context.service.ts' engine/identity/canonical-identity.spec.ts modules/agent-context/agent-context.service.spec.ts`                       | PASS — 15 tests; 96.66% statements, 83.6% branches, 100% functions, 98.78% lines           |
+| `npm test -- --runInBand engine/identity/canonical-identity.spec.ts config/feature-flags.spec.ts modules/agent-context/agent-context.service.spec.ts modules/session/session.service.spec.ts modules/message/message.service.spec.ts database/migrations/__tests__/1782500000000-AddMessageContextRelations.spec.ts` | PASS — 287 tests                                                                           |
+| `npx jest --config test/jest-e2e.json --runInBand test/agent-context.e2e-spec.ts`                                                                                                                                                                                                                                    | PASS — 3 tests                                                                             |
+| `npm run lint`                                                                                                                                                                                                                                                                                                       | PASS with one unrelated existing warning in `src/common/utils/dto-strict-coercion.spec.ts` |
+| `npx tsc --noEmit`                                                                                                                                                                                                                                                                                                   | PASS                                                                                       |
+| `npm run build`                                                                                                                                                                                                                                                                                                      | PASS                                                                                       |
+
+This evidence covers only the generic Phase 2 foundation; local bridge adapters and deployment-specific integrations remain out of scope.

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,6 +11,7 @@ import configuration from './config/configuration';
 import { validateEnv } from './config/env.validation';
 import { SessionModule } from './modules/session/session.module';
 import { MessageModule } from './modules/message/message.module';
+import { MessageAnnotationsModule } from './modules/message/message-annotations.module';
 import { AgentContextModule } from './modules/agent-context/agent-context.module';
 import { TemplateModule } from './modules/template/template.module';
 import { WebhookModule } from './modules/webhook/webhook.module';
@@ -276,6 +277,7 @@ if (dashboardServingEnabled && dashboardBuildPresent) {
     ...queueModules,
     AuthModule,
     EngineModule,
+    MessageAnnotationsModule,
     SessionModule,
     MessageModule,
     ...agentContextModules,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,6 +11,7 @@ import configuration from './config/configuration';
 import { validateEnv } from './config/env.validation';
 import { SessionModule } from './modules/session/session.module';
 import { MessageModule } from './modules/message/message.module';
+import { AgentContextModule } from './modules/agent-context/agent-context.module';
 import { TemplateModule } from './modules/template/template.module';
 import { WebhookModule } from './modules/webhook/webhook.module';
 import { HealthModule } from './modules/health/health.module';
@@ -56,6 +57,13 @@ if (process.env.QUEUE_ENABLED === 'true') {
 const searchModules: Array<Type | DynamicModule> = [];
 if (process.env.SEARCH_ENABLED !== 'false') {
   searchModules.push(SearchModule);
+}
+
+// Opt-in by design: the agent-context surface is a narrow read-only boundary, but deployments that
+// do not explicitly need it must expose neither its route nor its providers.
+const agentContextModules: Array<Type | DynamicModule> = [];
+if (process.env.AGENT_CONTEXT_ENABLED === 'true') {
+  agentContextModules.push(AgentContextModule);
 }
 
 // Only mount the MCP server if explicitly enabled to avoid startup cost and
@@ -270,6 +278,7 @@ if (dashboardServingEnabled && dashboardBuildPresent) {
     EngineModule,
     SessionModule,
     MessageModule,
+    ...agentContextModules,
     TemplateModule,
     WebhookModule,
     HealthModule,

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -181,6 +181,7 @@ export function validateEnv(config: EnvConfig): EnvConfig {
     'AUTO_START_SESSIONS',
     'STORE_EPHEMERAL_MESSAGES',
     'RESOLVE_LID_TO_PHONE',
+    'AGENT_CONTEXT_ENABLED',
     'SIMULATE_TYPING',
     'SEARCH_ENABLED',
   ]) {

--- a/src/config/feature-flags.spec.ts
+++ b/src/config/feature-flags.spec.ts
@@ -8,18 +8,21 @@ describe('feature-flags', () => {
         autoStartSessions: false, // opt-in
         storeEphemeralMessages: true, // opt-out
         resolveLidToPhone: false, // opt-in
+        agentContext: false, // opt-in
         simulateTyping: true, // opt-out
         simulateTypingMaxMs: 5000,
       });
     });
 
-    it('treats opt-in flags (autoStart, resolveLid) as ON only for the exact string "true"', () => {
+    it('treats opt-in flags (autoStart, resolveLid, agentContext) as ON only for the exact string "true"', () => {
       expect(computeFeatureFlags({ AUTO_START_SESSIONS: 'true' }).autoStartSessions).toBe(true);
       expect(computeFeatureFlags({ RESOLVE_LID_TO_PHONE: 'true' }).resolveLidToPhone).toBe(true);
+      expect(computeFeatureFlags({ AGENT_CONTEXT_ENABLED: 'true' }).agentContext).toBe(true);
       // Anything else stays OFF.
       for (const v of ['false', 'TRUE', '1', 'yes', '']) {
         expect(computeFeatureFlags({ AUTO_START_SESSIONS: v }).autoStartSessions).toBe(false);
         expect(computeFeatureFlags({ RESOLVE_LID_TO_PHONE: v }).resolveLidToPhone).toBe(false);
+        expect(computeFeatureFlags({ AGENT_CONTEXT_ENABLED: v }).agentContext).toBe(false);
       }
     });
 

--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -13,6 +13,8 @@ export interface FeatureFlags {
   storeEphemeralMessages: boolean;
   /** Inline @lid -> phone resolution for inbound privacy-id senders. Opt-in — default OFF. */
   resolveLidToPhone: boolean;
+  /** Bounded GET-only context endpoint for one inbound message. Opt-in — default OFF. */
+  agentContext: boolean;
   /** Humanising typing indicator before single (non-bulk) sends. Default ON. */
   simulateTyping: boolean;
   /** Upper bound (ms) on the humanising typing pause. Default 5000. */
@@ -33,6 +35,7 @@ export function computeFeatureFlags(env: NodeJS.ProcessEnv = process.env): Featu
     autoStartSessions: env.AUTO_START_SESSIONS === 'true',
     storeEphemeralMessages: env.STORE_EPHEMERAL_MESSAGES !== 'false',
     resolveLidToPhone: env.RESOLVE_LID_TO_PHONE === 'true',
+    agentContext: env.AGENT_CONTEXT_ENABLED === 'true',
     simulateTyping: env.SIMULATE_TYPING !== 'false',
     simulateTypingMaxMs: Number(env.SIMULATE_TYPING_MAX_MS) || 5000,
   };

--- a/src/core/hooks/hook.interfaces.spec.ts
+++ b/src/core/hooks/hook.interfaces.spec.ts
@@ -6,3 +6,12 @@ describe('message:persisted hook event', () => {
     expect(KNOWN_HOOK_EVENTS.has('message:persisted')).toBe(true);
   });
 });
+
+describe('message annotation hook events', () => {
+  it('keeps the request and update lifecycle names in the finite sandbox allowlist', () => {
+    expect(isKnownHookEvent('message:annotation-requested')).toBe(true);
+    expect(isKnownHookEvent('message:annotation-updated')).toBe(true);
+    expect(KNOWN_HOOK_EVENTS.has('message:annotation-requested')).toBe(true);
+    expect(KNOWN_HOOK_EVENTS.has('message:annotation-updated')).toBe(true);
+  });
+});

--- a/src/core/hooks/hook.interfaces.ts
+++ b/src/core/hooks/hook.interfaces.ts
@@ -19,6 +19,8 @@ export type HookEvent =
   | 'message:failed'
   | 'message:ack'
   | 'message:persisted'
+  | 'message:annotation-requested'
+  | 'message:annotation-updated'
   // Webhook lifecycle
   | 'webhook:before'
   | 'webhook:queued' // After webhook job added to queue (queue mode only)
@@ -46,6 +48,8 @@ const HOOK_EVENT_REGISTRY: Record<HookEvent, true> = {
   'message:failed': true,
   'message:ack': true,
   'message:persisted': true,
+  'message:annotation-requested': true,
+  'message:annotation-updated': true,
   'webhook:before': true,
   'webhook:queued': true,
   'webhook:delivered': true,

--- a/src/core/plugins/plugin-capability.spec.ts
+++ b/src/core/plugins/plugin-capability.spec.ts
@@ -13,6 +13,7 @@ import {
 } from './plugin.interfaces';
 import { MessageService } from '../../modules/message/message.service';
 import { SessionService } from '../../modules/session/session.service';
+import { MessageAnnotationService } from '../../modules/message/message-annotation.service';
 
 function makePlugin(
   sessions?: string[],
@@ -280,5 +281,73 @@ describe('PluginLoaderService capability facade — ctx.net', () => {
   it('denies net.fetch when the host is not in the manifest net.allow list', async () => {
     const ctx = contextFor(loaderWith(), netPlugin(['net:fetch'], ['only.example.com:443']));
     await expect(ctx.net.fetch('https://api.example.com/x')).rejects.toBeInstanceOf(PluginCapabilityError);
+  });
+});
+
+describe('PluginLoaderService capability facade — ctx.annotations', () => {
+  let loader: PluginLoaderService;
+  let annotations: { upsert: jest.Mock };
+  let moduleRef: { get: jest.Mock };
+
+  beforeEach(() => {
+    annotations = { upsert: jest.fn().mockResolvedValue({ messageId: 'm1', kind: 'transcript', status: 'pending' }) };
+    moduleRef = {
+      get: jest.fn().mockImplementation((token: unknown) => {
+        if (token === MessageAnnotationService) return annotations;
+        return { getEngine: jest.fn() };
+      }),
+    };
+    loader = new PluginLoaderService(
+      { get: jest.fn().mockReturnValue(undefined) } as unknown as ConfigService,
+      new HookManager(),
+      { createPluginStorage: jest.fn().mockReturnValue({}) } as unknown as PluginStorageService,
+      moduleRef as unknown as ModuleRef,
+    );
+  });
+
+  function contextFor(plugin: PluginInstance): PluginContext {
+    return (loader as unknown as { createPluginContext: (p: PluginInstance) => PluginContext }).createPluginContext(
+      plugin,
+    );
+  }
+
+  it('writes only for the activated session and binds provider identity to the manifest', async () => {
+    const ctx = contextFor(makePlugin(['sess-1'], ['message-annotations:write'], ['sess-1']));
+    const input = {
+      kind: 'transcript' as const,
+      status: 'pending' as const,
+      processorVersion: '1',
+      externalProcessing: false,
+    };
+
+    await ctx.annotations.upsert('sess-1', 'message-1', input);
+
+    expect(annotations.upsert).toHaveBeenCalledWith('sess-1', 'message-1', 'test-ext', input);
+  });
+
+  it('denies annotation writes without the dedicated permission before resolving the store', async () => {
+    const ctx = contextFor(makePlugin(['sess-1'], [], ['sess-1']));
+    const input = {
+      kind: 'transcript' as const,
+      status: 'pending' as const,
+      processorVersion: '1',
+      externalProcessing: false,
+    };
+
+    await expect(ctx.annotations.upsert('sess-1', 'message-1', input)).rejects.toBeInstanceOf(PluginCapabilityError);
+    expect(moduleRef.get).not.toHaveBeenCalled();
+  });
+
+  it('denies annotation writes outside the active session before resolving the store', async () => {
+    const ctx = contextFor(makePlugin(['*'], ['message-annotations:write'], ['sess-1']));
+    const input = {
+      kind: 'transcript' as const,
+      status: 'pending' as const,
+      processorVersion: '1',
+      externalProcessing: false,
+    };
+
+    await expect(ctx.annotations.upsert('sess-2', 'message-1', input)).rejects.toBeInstanceOf(PluginCapabilityError);
+    expect(moduleRef.get).not.toHaveBeenCalled();
   });
 });

--- a/src/core/plugins/plugin-loader.service.ts
+++ b/src/core/plugins/plugin-loader.service.ts
@@ -24,6 +24,7 @@ import {
   IPlugin,
   PluginType,
   PluginLogger,
+  PluginMessageAnnotationsCapability,
   PluginConfigSchema,
   validateIngressManifest,
   warnUnauthenticatedIngressRoutes,
@@ -47,6 +48,7 @@ import type { ConversationMappingService } from '../../modules/integration/conve
 import type { PluginInstanceService } from '../../modules/integration/plugin-instance.service';
 import type { IngressJobData } from '../../modules/queue/processors/ingress.processor';
 import type { SearchProviderRegistry } from '../../modules/search/search-provider.registry';
+import type { MessageAnnotationService } from '../../modules/message/message-annotation.service';
 
 /** Default per-plugin heap cap for the sandbox worker; an OOM terminates the worker, not the host. */
 const SANDBOX_MAX_OLD_GEN_MB = 256;
@@ -770,6 +772,14 @@ export class PluginLoaderService implements OnModuleInit, OnApplicationBootstrap
     return this.moduleRef.get(mod.SessionService, { strict: false });
   }
 
+  /** Lazy like MessageService so annotation storage stays independent of the plugin module graph. */
+  private getMessageAnnotationService(): MessageAnnotationService {
+    const mod =
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require('../../modules/message/message-annotation.service') as typeof import('../../modules/message/message-annotation.service');
+    return this.moduleRef.get(mod.MessageAnnotationService, { strict: false });
+  }
+
   /**
    * Same lazy-require pattern as getMessageService/getSessionService: a static import of the
    * integration module would add a top-level edge back into plugin-loader's own module graph.
@@ -1330,6 +1340,13 @@ export class PluginLoaderService implements OnModuleInit, OnApplicationBootstrap
           return m ? { sessionId: m.sessionId, chatId: m.chatId, handoverState: m.handoverState } : null;
         },
       } satisfies PluginMappingsCapability,
+      annotations: {
+        upsert: async (sessionId, messageId, input) => {
+          this.assertPermission(plugin.manifest, PluginCapabilityPermission.MESSAGE_ANNOTATIONS_WRITE);
+          this.assertSessionActive(plugin, sessionId);
+          return this.getMessageAnnotationService().upsert(sessionId, messageId, plugin.manifest.id, input);
+        },
+      } satisfies PluginMessageAnnotationsCapability,
     };
   }
 

--- a/src/core/plugins/plugin.interfaces.ts
+++ b/src/core/plugins/plugin.interfaces.ts
@@ -9,6 +9,10 @@ import type { IWhatsAppEngine } from '../../engine/interfaces/whatsapp-engine.in
 import type { PluginNetRequestInit, PluginNetResponse } from './plugin-net';
 import type { HandoverState } from '../../modules/integration/entities/conversation-mapping.entity';
 import type { WebhookRequest, WebhookResponse, WebhookHandler } from './sandbox/worker-webhooks';
+import type {
+  MessageAnnotationLifecycle,
+  UpsertMessageAnnotationInput,
+} from '../../modules/message/message-annotation.service';
 
 // Re-export the ingress webhook types on the public SDK surface so plugin authors can type their
 // handler without importing from sandbox internals.
@@ -170,6 +174,8 @@ export const PluginCapabilityPermission = {
   WEBHOOK_INGRESS: 'webhook:ingress',
   /** `ctx.conversations.send` — normalized outbound send translated to MessageService. */
   CONVERSATION_SEND: 'conversation:send',
+  /** `ctx.annotations.upsert` — provider-owned derived-content write; no read/list capability. */
+  MESSAGE_ANNOTATIONS_WRITE: 'message-annotations:write',
 } as const;
 export type PluginCapabilityPermission = (typeof PluginCapabilityPermission)[keyof typeof PluginCapabilityPermission];
 
@@ -426,6 +432,15 @@ export interface PluginMappingsCapability {
   ): Promise<{ sessionId: string; chatId: string; handoverState: HandoverState } | null>;
 }
 
+/** Provider-owned derived-content write only. No list/get/search method is intentionally exposed. */
+export interface PluginMessageAnnotationsCapability {
+  upsert(
+    sessionId: string,
+    messageId: string,
+    input: UpsertMessageAnnotationInput,
+  ): Promise<MessageAnnotationLifecycle>;
+}
+
 // ============================================================================
 // Plugin Context (passed to plugin on initialization)
 // ============================================================================
@@ -471,6 +486,9 @@ export interface PluginContext {
 
   // Create/read the WA-chat <-> provider-conversation mapping. Requires `conversation:send`.
   mappings: PluginMappingsCapability;
+
+  // Bounded, session-scoped annotation write. It cannot read transcript text back or search messages.
+  annotations: PluginMessageAnnotationsCapability;
 }
 
 export interface PluginLogger {

--- a/src/core/plugins/sandbox/capability-router.spec.ts
+++ b/src/core/plugins/sandbox/capability-router.spec.ts
@@ -35,6 +35,9 @@ function makeContext() {
       get: jest.fn().mockResolvedValue(null),
       getByProvider: jest.fn().mockResolvedValue(null),
     },
+    annotations: {
+      upsert: jest.fn().mockResolvedValue({ messageId: 'm4', kind: 'transcript', status: 'complete' }),
+    },
   };
 }
 
@@ -111,6 +114,13 @@ describe('dispatchCapabilityVerb', () => {
       ['upsert', [{ sessionId: 's', chatId: 'c', instanceId: 'i' }, 'conv1']],
       ['getByProvider', ['i', 'conv1']],
     ]);
+  });
+
+  it('routes annotation writes only through the explicit allowlisted verb', async () => {
+    const ctx = makeContext();
+    const input = { kind: 'transcript', status: 'pending', processorVersion: '1', externalProcessing: false };
+    await dispatchCapabilityVerb(ctx, 'annotations.upsert', ['s', 'm4', input]);
+    expect(ctx.annotations.upsert).toHaveBeenCalledWith('s', 'm4', input);
   });
 
   it('rejects an unknown verb — only allowlisted capabilities are reachable', async () => {

--- a/src/core/plugins/sandbox/capability-router.ts
+++ b/src/core/plugins/sandbox/capability-router.ts
@@ -1,8 +1,9 @@
 import { ConversationSendEnvelope, PluginContext } from '../plugin.interfaces';
 import { HandoverState } from '../../../modules/integration/entities/conversation-mapping.entity';
+import { UpsertMessageAnnotationInput } from '../../../modules/message/message-annotation.service';
 
 /** The subset of the plugin context a sandboxed plugin reaches across the bridge. */
-export type CapabilityContext = Pick<PluginContext, 'messages' | 'engine' | 'storage' | 'net'> & {
+export type CapabilityContext = Pick<PluginContext, 'messages' | 'engine' | 'storage' | 'net' | 'annotations'> & {
   conversations: {
     send(env: ConversationSendEnvelope): Promise<unknown>;
   };
@@ -76,6 +77,8 @@ export async function dispatchCapabilityVerb(
       return context.mappings.get(args[0] as { sessionId: string; chatId: string; instanceId: string });
     case 'mappings.getByProvider':
       return context.mappings.getByProvider(s(0), s(1));
+    case 'annotations.upsert':
+      return context.annotations.upsert(s(0), s(1), args[2] as UpsertMessageAnnotationInput);
     default:
       throw new Error(`Unknown capability verb: ${verb}`);
   }

--- a/src/core/plugins/sandbox/worker-capability.spec.ts
+++ b/src/core/plugins/sandbox/worker-capability.spec.ts
@@ -60,5 +60,14 @@ describe('buildSandboxContext', () => {
 
     await ctx.storage.set('k', { a: 1 });
     expect(call).toHaveBeenCalledWith('storage.set', ['k', { a: 1 }]);
+
+    const annotation = {
+      kind: 'transcript' as const,
+      status: 'pending' as const,
+      processorVersion: '1',
+      externalProcessing: false,
+    };
+    await ctx.annotations.upsert('s', 'm', annotation);
+    expect(call).toHaveBeenCalledWith('annotations.upsert', ['s', 'm', annotation]);
   });
 });

--- a/src/core/plugins/sandbox/worker-capability.ts
+++ b/src/core/plugins/sandbox/worker-capability.ts
@@ -1,6 +1,10 @@
 import { WorkerToHostMessage, HostToWorkerMessage } from './protocol';
 import { ConversationSendEnvelope } from '../plugin.interfaces';
 import { HandoverState } from '../../../modules/integration/entities/conversation-mapping.entity';
+import type {
+  MessageAnnotationLifecycle,
+  UpsertMessageAnnotationInput,
+} from '../../../modules/message/message-annotation.service';
 
 /**
  * Worker-side correlation for capability calls. Each `call` posts a `cap` request and resolves when
@@ -67,6 +71,13 @@ export interface SandboxCapabilityContext {
     get(key: { sessionId: string; chatId: string; instanceId: string }): Promise<unknown>;
     getByProvider(instanceId: string, providerConversationId: string): Promise<unknown>;
   };
+  annotations: {
+    upsert(
+      sessionId: string,
+      messageId: string,
+      input: UpsertMessageAnnotationInput,
+    ): Promise<MessageAnnotationLifecycle>;
+  };
 }
 
 /** Build the proxy capability context handed to a sandboxed plugin in the worker. */
@@ -107,6 +118,10 @@ export function buildSandboxContext(client: WorkerCapabilityClient): SandboxCapa
       get: key => client.call('mappings.get', [key]),
       getByProvider: (instanceId, providerConversationId) =>
         client.call('mappings.getByProvider', [instanceId, providerConversationId]),
+    },
+    annotations: {
+      upsert: (sessionId, messageId, input) =>
+        client.call('annotations.upsert', [sessionId, messageId, input]) as Promise<MessageAnnotationLifecycle>,
     },
   };
 }

--- a/src/database/migrations/1782500000000-AddMessageContextRelations.ts
+++ b/src/database/migrations/1782500000000-AddMessageContextRelations.ts
@@ -1,0 +1,59 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+/**
+ * Adds typed quote and current-reaction records beside the long-standing `messages.metadata` JSON.
+ * The migration intentionally does not parse or backfill legacy JSON: doing so would make a privacy
+ * boundary depend on undocumented raw metadata shapes. Existing API payloads continue to use it.
+ */
+export class AddMessageContextRelations1782500000000 implements MigrationInterface {
+  name = 'AddMessageContextRelations1782500000000';
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    if (!(await queryRunner.hasTable('message_quotes'))) {
+      await queryRunner.createTable(
+        new Table({
+          name: 'message_quotes',
+          columns: [
+            { name: 'messageId', type: 'varchar', isPrimary: true },
+            { name: 'sessionId', type: 'varchar' },
+            { name: 'quotedWaMessageId', type: 'varchar' },
+            { name: 'body', type: 'text', isNullable: true },
+          ],
+        }),
+      );
+      await queryRunner.createIndex(
+        'message_quotes',
+        new TableIndex({
+          name: 'IDX_message_quotes_session_message',
+          columnNames: ['sessionId', 'messageId'],
+        }),
+      );
+    }
+
+    if (!(await queryRunner.hasTable('message_reactions'))) {
+      await queryRunner.createTable(
+        new Table({
+          name: 'message_reactions',
+          columns: [
+            { name: 'messageId', type: 'varchar', isPrimary: true },
+            { name: 'senderId', type: 'varchar', isPrimary: true },
+            { name: 'sessionId', type: 'varchar' },
+            { name: 'emoji', type: 'text' },
+          ],
+        }),
+      );
+      await queryRunner.createIndex(
+        'message_reactions',
+        new TableIndex({
+          name: 'IDX_message_reactions_session_message',
+          columnNames: ['sessionId', 'messageId'],
+        }),
+      );
+    }
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    if (await queryRunner.hasTable('message_reactions')) await queryRunner.dropTable('message_reactions');
+    if (await queryRunner.hasTable('message_quotes')) await queryRunner.dropTable('message_quotes');
+  }
+}

--- a/src/database/migrations/1782600000000-AddMessageAnnotations.ts
+++ b/src/database/migrations/1782600000000-AddMessageAnnotations.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+/** Adds provider-neutral derived content beside messages without parsing legacy metadata. */
+export class AddMessageAnnotations1782600000000 implements MigrationInterface {
+  name = 'AddMessageAnnotations1782600000000';
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    if (await queryRunner.hasTable('message_annotations')) return;
+    const dateType = queryRunner.connection.options.type === 'postgres' ? 'timestamp' : 'datetime';
+    await queryRunner.createTable(
+      new Table({
+        name: 'message_annotations',
+        columns: [
+          { name: 'sessionId', type: 'varchar', isPrimary: true },
+          { name: 'messageId', type: 'varchar', isPrimary: true },
+          { name: 'provider', type: 'varchar', length: '128', isPrimary: true },
+          { name: 'kind', type: 'varchar', length: '32', isPrimary: true },
+          { name: 'status', type: 'varchar', length: '32' },
+          { name: 'language', type: 'varchar', length: '35', isNullable: true },
+          { name: 'text', type: 'text', isNullable: true },
+          { name: 'mediaFingerprint', type: 'varchar', length: '64', isNullable: true },
+          { name: 'processorVersion', type: 'varchar', length: '128' },
+          { name: 'externalProcessing', type: 'boolean' },
+          { name: 'metadata', type: 'text', isNullable: true },
+          { name: 'createdAt', type: dateType, default: 'CURRENT_TIMESTAMP' },
+          { name: 'expiresAt', type: dateType, isNullable: true },
+        ],
+      }),
+    );
+    await queryRunner.createIndex(
+      'message_annotations',
+      new TableIndex({ name: 'IDX_message_annotations_session_message', columnNames: ['sessionId', 'messageId'] }),
+    );
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    if (await queryRunner.hasTable('message_annotations')) await queryRunner.dropTable('message_annotations');
+  }
+}

--- a/src/database/migrations/__tests__/1782500000000-AddMessageContextRelations.spec.ts
+++ b/src/database/migrations/__tests__/1782500000000-AddMessageContextRelations.spec.ts
@@ -1,0 +1,44 @@
+import 'reflect-metadata';
+import { DataSource } from 'typeorm';
+import { AddMessageContextRelations1782500000000 } from '../1782500000000-AddMessageContextRelations';
+
+describe('AddMessageContextRelations migration', () => {
+  let dataSource: DataSource;
+
+  beforeEach(async () => {
+    dataSource = new DataSource({ type: 'better-sqlite3', database: ':memory:', entities: [], synchronize: false });
+    await dataSource.initialize();
+  });
+
+  afterEach(async () => {
+    await dataSource.destroy();
+  });
+
+  it('creates idempotent typed quote/current-reaction tables and removes them on down', async () => {
+    const runner = dataSource.createQueryRunner();
+    const migration = new AddMessageContextRelations1782500000000();
+
+    await migration.up(runner);
+    await expect(migration.up(runner)).resolves.toBeUndefined();
+    const quotes = await runner.getTable('message_quotes');
+    const reactions = await runner.getTable('message_reactions');
+    expect(quotes?.columns.map(column => column.name)).toEqual(
+      expect.arrayContaining(['messageId', 'sessionId', 'quotedWaMessageId', 'body']),
+    );
+    expect(reactions?.primaryColumns.map(column => column.name)).toEqual(['messageId', 'senderId']);
+
+    await runner.query(
+      `INSERT INTO message_reactions (messageId, senderId, sessionId, emoji) VALUES ('m1', 'a@lid', 's1', '👍')`,
+    );
+    await expect(
+      runner.query(
+        `INSERT INTO message_reactions (messageId, senderId, sessionId, emoji) VALUES ('m1', 'a@lid', 's1', '🎉')`,
+      ),
+    ).rejects.toThrow();
+
+    await migration.down(runner);
+    expect(await runner.hasTable('message_quotes')).toBe(false);
+    expect(await runner.hasTable('message_reactions')).toBe(false);
+    await runner.release();
+  });
+});

--- a/src/database/migrations/__tests__/1782600000000-AddMessageAnnotations.spec.ts
+++ b/src/database/migrations/__tests__/1782600000000-AddMessageAnnotations.spec.ts
@@ -1,0 +1,59 @@
+import 'reflect-metadata';
+import { DataSource } from 'typeorm';
+import { AddMessageAnnotations1782600000000 } from '../1782600000000-AddMessageAnnotations';
+
+describe('AddMessageAnnotations migration', () => {
+  let dataSource: DataSource;
+
+  beforeEach(async () => {
+    dataSource = new DataSource({ type: 'better-sqlite3', database: ':memory:', entities: [], synchronize: false });
+    await dataSource.initialize();
+  });
+
+  afterEach(async () => {
+    await dataSource.destroy();
+  });
+
+  it('creates an idempotent, session-scoped typed annotation store and removes it on down', async () => {
+    const runner = dataSource.createQueryRunner();
+    const migration = new AddMessageAnnotations1782600000000();
+
+    await migration.up(runner);
+    await expect(migration.up(runner)).resolves.toBeUndefined();
+    const annotations = await runner.getTable('message_annotations');
+    expect(annotations?.primaryColumns.map(column => column.name)).toEqual([
+      'sessionId',
+      'messageId',
+      'provider',
+      'kind',
+    ]);
+    expect(annotations?.columns.map(column => column.name)).toEqual(
+      expect.arrayContaining([
+        'status',
+        'language',
+        'text',
+        'mediaFingerprint',
+        'processorVersion',
+        'externalProcessing',
+        'metadata',
+        'createdAt',
+        'expiresAt',
+      ]),
+    );
+
+    await runner.query(
+      `INSERT INTO message_annotations (sessionId, messageId, provider, kind, status, processorVersion, externalProcessing) ` +
+        `VALUES ('s1', 'm1', 'provider', 'transcript', 'pending', '1.0.0', 0)`,
+    );
+    await expect(
+      runner.query(
+        `INSERT INTO message_annotations (sessionId, messageId, provider, kind, status, processorVersion, externalProcessing) ` +
+          `VALUES ('s1', 'm1', 'provider', 'transcript', 'complete', '1.0.0', 0)`,
+      ),
+    ).rejects.toThrow();
+
+    await migration.down(runner);
+    expect(await runner.hasTable('message_annotations')).toBe(false);
+    await runner.release();
+  });
+});

--- a/src/engine/identity/canonical-identity.spec.ts
+++ b/src/engine/identity/canonical-identity.spec.ts
@@ -1,0 +1,58 @@
+import { canonicalIdentity } from './canonical-identity';
+import type { LidMappingStore } from './lid-mapping-store.service';
+
+function mappings(entries: Record<string, string | null> = {}): LidMappingStore {
+  return {
+    getCached: jest.fn((lid: string) => entries[lid]),
+    lidsForPhone: jest.fn(() => []),
+    remember: jest.fn(),
+  };
+}
+
+describe('canonicalIdentity', () => {
+  it('normalizes a phone-addressed JID without consulting LID state', () => {
+    const getCached = jest.fn();
+    const store: LidMappingStore = { getCached, lidsForPhone: jest.fn(() => []), remember: jest.fn() };
+
+    expect(canonicalIdentity('15551234567:12@s.whatsapp.net', store)).toEqual({
+      canonicalJid: '15551234567@c.us',
+      kind: 'person',
+      resolution: 'phone-resolved',
+    });
+    expect(getCached).not.toHaveBeenCalled();
+  });
+
+  it('uses the persisted mapping for a known LID', () => {
+    expect(canonicalIdentity('12345@lid', mappings({ '12345': '15551234567' }))).toEqual({
+      canonicalJid: '15551234567@c.us',
+      kind: 'person',
+      resolution: 'phone-resolved',
+    });
+  });
+
+  it('keeps an unknown LID as a first-class unresolved identity', () => {
+    expect(canonicalIdentity('12345:7@lid', mappings())).toEqual({
+      canonicalJid: '12345@lid',
+      kind: 'person',
+      resolution: 'lid-unresolved',
+    });
+  });
+
+  it('does not label groups, broadcasts, or unknown ids as phone-resolved people', () => {
+    expect(canonicalIdentity('group-1@g.us')).toEqual({
+      canonicalJid: 'group-1@g.us',
+      kind: 'group',
+      resolution: 'not-applicable',
+    });
+    expect(canonicalIdentity('status@broadcast')).toEqual({
+      canonicalJid: 'status@broadcast',
+      kind: 'broadcast',
+      resolution: 'not-applicable',
+    });
+    expect(canonicalIdentity('not-a-jid')).toEqual({
+      canonicalJid: 'not-a-jid',
+      kind: 'unknown',
+      resolution: 'not-applicable',
+    });
+  });
+});

--- a/src/engine/identity/canonical-identity.ts
+++ b/src/engine/identity/canonical-identity.ts
@@ -1,0 +1,53 @@
+import { parseWaId, toNeutralJid } from './wa-id';
+import type { LidMappingStore } from './lid-mapping-store.service';
+
+/**
+ * A compact, engine-neutral identity suitable for narrowly scoped consumers.
+ *
+ * This deliberately exposes only the resolved canonical JID and resolution state. It does not
+ * expose the raw engine JID, mapping provenance, contact data, or a write API for the LID cache.
+ */
+export interface CanonicalIdentity {
+  canonicalJid: string;
+  kind: 'person' | 'group' | 'broadcast' | 'unknown';
+  resolution: 'phone-resolved' | 'lid-unresolved' | 'not-applicable';
+}
+
+/**
+ * Resolve a JID using OpenWA's persisted LID mapping cache when it is available.
+ *
+ * The function is synchronous by design: it is safe to use on request/event hot paths and never
+ * triggers a network lookup. An unknown (or negatively cached) LID remains a first-class `@lid`
+ * identity rather than being guessed as a phone number.
+ */
+export function canonicalIdentity(jid: string, lidMappings?: Pick<LidMappingStore, 'getCached'>): CanonicalIdentity {
+  const parsed = parseWaId(jid);
+  if (parsed.kind === 'lid') {
+    const phone = lidMappings?.getCached(parsed.userPart);
+    if (phone) {
+      return {
+        canonicalJid: `${phone}@c.us`,
+        kind: 'person',
+        resolution: 'phone-resolved',
+      };
+    }
+    return {
+      canonicalJid: `${parsed.userPart}@lid`,
+      kind: 'person',
+      resolution: 'lid-unresolved',
+    };
+  }
+
+  switch (parsed.kind) {
+    case 'user':
+      return { canonicalJid: toNeutralJid(jid), kind: 'person', resolution: 'phone-resolved' };
+    case 'group':
+      return { canonicalJid: toNeutralJid(jid), kind: 'group', resolution: 'not-applicable' };
+    case 'status':
+    case 'newsletter':
+    case 'broadcast':
+      return { canonicalJid: toNeutralJid(jid), kind: 'broadcast', resolution: 'not-applicable' };
+    default:
+      return { canonicalJid: toNeutralJid(jid), kind: 'unknown', resolution: 'not-applicable' };
+  }
+}

--- a/src/modules/agent-context/agent-context.controller.ts
+++ b/src/modules/agent-context/agent-context.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Get, Param, ParseUUIDPipe } from '@nestjs/common';
+import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { AgentContextService, AgentContextV1 } from './agent-context.service';
+
+/**
+ * This controller is registered only when AGENT_CONTEXT_ENABLED=true. It has one GET operation and
+ * intentionally does not share MessageController/MessageService, which own broad history and sends.
+ * The global ApiKeyGuard scopes the `:sessionId` parameter against a key's allowedSessions list.
+ */
+@ApiTags('agent-context')
+@Controller('sessions/:sessionId/agent-context')
+export class AgentContextController {
+  constructor(private readonly agentContextService: AgentContextService) {}
+
+  @Get('messages/:messageId')
+  @ApiOperation({ summary: 'Get a bounded read-only context for one inbound message' })
+  @ApiParam({ name: 'sessionId', description: 'WhatsApp session ID; enforced against API-key session scope.' })
+  @ApiParam({ name: 'messageId', description: 'Persisted incoming message UUID.' })
+  @ApiResponse({ status: 200, description: 'Bounded v1 agent context.' })
+  @ApiResponse({ status: 400, description: 'The selected message is not incoming.' })
+  @ApiResponse({ status: 404, description: 'The message is absent from this session, or the feature is disabled.' })
+  getMessageContext(
+    @Param('sessionId') sessionId: string,
+    @Param('messageId', ParseUUIDPipe) messageId: string,
+  ): Promise<AgentContextV1> {
+    return this.agentContextService.getMessageContext(sessionId, messageId);
+  }
+}

--- a/src/modules/agent-context/agent-context.module.ts
+++ b/src/modules/agent-context/agent-context.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Message } from '../message/entities/message.entity';
+import { MessageQuote } from '../message/entities/message-quote.entity';
+import { MessageReaction } from '../message/entities/message-reaction.entity';
+import { AgentContextController } from './agent-context.controller';
+import { AgentContextService } from './agent-context.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Message, MessageQuote, MessageReaction], 'data')],
+  controllers: [AgentContextController],
+  providers: [AgentContextService],
+})
+export class AgentContextModule {}

--- a/src/modules/agent-context/agent-context.service.spec.ts
+++ b/src/modules/agent-context/agent-context.service.spec.ts
@@ -1,0 +1,313 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { AgentContextService } from './agent-context.service';
+import { Message, MessageDirection, MessageStatus } from '../message/entities/message.entity';
+import { MessageQuote } from '../message/entities/message-quote.entity';
+import { MessageReaction } from '../message/entities/message-reaction.entity';
+import { LidMappingStoreService, type LidMappingStore } from '../../engine/identity/lid-mapping-store.service';
+
+function message(overrides: Partial<Message> = {}): Message {
+  return {
+    id: '11111111-1111-4111-8111-111111111111',
+    sessionId: 'session-a',
+    waMessageId: 'wa-message-1',
+    chatId: '123@lid',
+    from: '123@lid',
+    to: 'self@c.us',
+    body: 'hello',
+    type: 'text',
+    direction: MessageDirection.INCOMING,
+    timestamp: 1700000000,
+    metadata: { raw: 'must never be exposed' },
+    status: MessageStatus.SENT,
+    createdAt: new Date('2026-01-01T12:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function lidStore(
+  entries: Record<string, string | null> = {},
+  aliases: Record<string, string[]> = {},
+): LidMappingStore {
+  return {
+    getCached: jest.fn((lid: string) => entries[lid]),
+    lidsForPhone: jest.fn((phone: string) => aliases[phone] ?? []),
+    remember: jest.fn(),
+  };
+}
+
+describe('AgentContextService', () => {
+  let repository: jest.Mocked<Pick<Repository<Message>, 'findOne' | 'createQueryBuilder'>>;
+  let quotes: jest.Mocked<Pick<Repository<MessageQuote>, 'find'>>;
+  let reactions: jest.Mocked<Pick<Repository<MessageReaction>, 'find'>>;
+  let recent: Message[];
+  let queryBuilder: Record<string, jest.Mock>;
+
+  beforeEach(() => {
+    recent = [];
+    queryBuilder = {
+      select: jest.fn(),
+      where: jest.fn(),
+      andWhere: jest.fn(),
+      orderBy: jest.fn(),
+      addOrderBy: jest.fn(),
+      take: jest.fn(),
+      getMany: jest.fn(() => Promise.resolve(recent)),
+    };
+    for (const method of ['select', 'where', 'andWhere', 'orderBy', 'addOrderBy', 'take']) {
+      queryBuilder[method].mockReturnValue(queryBuilder);
+    }
+    repository = {
+      findOne: jest.fn(),
+      createQueryBuilder: jest.fn(() => queryBuilder),
+      // The production data connection has this manager metadata; use SQLite semantics for this unit mock.
+      manager: { connection: { options: { type: 'better-sqlite3' } } },
+    } as unknown as jest.Mocked<Pick<Repository<Message>, 'findOne' | 'createQueryBuilder'>>;
+    quotes = { find: jest.fn().mockResolvedValue([]) };
+    reactions = { find: jest.fn().mockResolvedValue([]) };
+  });
+
+  const createService = (entries: Record<string, string | null> = {}, aliases: Record<string, string[]> = {}) =>
+    new AgentContextService(
+      repository as unknown as Repository<Message>,
+      lidStore(entries, aliases) as LidMappingStoreService,
+      quotes as unknown as Repository<MessageQuote>,
+      reactions as unknown as Repository<MessageReaction>,
+    );
+
+  it('returns a bounded, read-only context with canonical identities, receipt status, and no raw metadata', async () => {
+    const target = message({ body: 'x'.repeat(1200) });
+    recent = Array.from({ length: 8 }, (_, index) =>
+      message({ id: `00000000-0000-4000-8000-00000000000${index}`, body: `recent ${index}` }),
+    );
+    repository.findOne.mockResolvedValue(target);
+
+    const context = await createService({ '123': '15551234567' }).getMessageContext('session-a', target.id);
+
+    expect(context.message).toEqual({
+      id: target.id,
+      canonicalChat: { canonicalJid: '15551234567@c.us', kind: 'person', resolution: 'phone-resolved' },
+      sender: { canonicalJid: '15551234567@c.us', kind: 'person', resolution: 'phone-resolved' },
+      direction: 'incoming',
+      type: 'text',
+      body: 'x'.repeat(1000),
+      occurredAt: '2023-11-14T22:13:20.000Z',
+      receipt: { status: MessageStatus.SENT },
+    });
+    expect(context.conversation).toHaveLength(6);
+    expect(JSON.stringify(context)).not.toContain('must never be exposed');
+    expect(JSON.stringify(context)).not.toContain('wa-message-1');
+    expect(repository.findOne).toHaveBeenCalledWith({
+      where: { id: target.id, sessionId: 'session-a' },
+      select: ['id', 'sessionId', 'chatId', 'from', 'body', 'type', 'direction', 'timestamp', 'status', 'createdAt'],
+    });
+    expect(queryBuilder.select).toHaveBeenCalledWith([
+      'message.id',
+      'message.sessionId',
+      'message.chatId',
+      'message.from',
+      'message.body',
+      'message.type',
+      'message.direction',
+      'message.timestamp',
+      'message.status',
+      'message.createdAt',
+    ]);
+    expect(queryBuilder.take).toHaveBeenCalledWith(6);
+    expect(JSON.stringify(queryBuilder.select.mock.calls)).not.toContain('metadata');
+  });
+
+  it('anchors history at the trigger, includes it, and uses WhatsApp time rather than delayed DB arrival', async () => {
+    const target = message({
+      id: '00000000-0000-4000-8000-000000000010',
+      timestamp: 100,
+      createdAt: new Date('2026-01-10'),
+    });
+    const sameSecondButNotKnownEarlier = message({
+      id: '00000000-0000-4000-8000-000000000001',
+      timestamp: 100,
+      createdAt: new Date('2026-03-10'),
+    });
+    const older = message({
+      id: '00000000-0000-4000-8000-000000000009',
+      timestamp: 99,
+      createdAt: new Date('2026-02-10'),
+    });
+    // WhatsApp timestamps are only second-granularity. Until an engine sequence key exists, the
+    // conservative database query includes only the exact trigger at this second.
+    recent = [target, older];
+    repository.findOne.mockResolvedValue(target);
+
+    const context = await createService().getMessageContext('session-a', target.id);
+
+    expect(context.conversation.map(item => item.id)).toEqual([target.id, older.id]);
+    expect(context.conversation.map(item => item.occurredAt)).toEqual([
+      '1970-01-01T00:01:40.000Z',
+      '1970-01-01T00:01:39.000Z',
+    ]);
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      expect.stringContaining('message.id = :triggerId'),
+      expect.objectContaining({ triggerId: target.id }),
+    );
+    expect(JSON.stringify(queryBuilder.andWhere.mock.calls)).not.toContain('<= :triggerId');
+    expect(sameSecondButNotKnownEarlier.id).not.toBe(context.conversation[0]?.id);
+  });
+
+  it('excludes a later same-second message even when its random UUID sorts below the trigger UUID', async () => {
+    const target = message({ id: 'ffffffff-ffff-4fff-8fff-ffffffffffff', timestamp: 100 });
+    const laterSameSecond = message({ id: '00000000-0000-4000-8000-000000000001', timestamp: 100 });
+    // This is the exact SQL result the query must return: UUID sort is not a WhatsApp event sequence.
+    recent = [target];
+    repository.findOne.mockResolvedValue(target);
+
+    const context = await createService().getMessageContext('session-a', target.id);
+
+    expect(context.conversation.map(item => item.id)).toEqual([target.id]);
+    expect(laterSameSecond.id < target.id).toBe(true);
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      expect.stringContaining('message.id = :triggerId'),
+      expect.objectContaining({ triggerId: target.id }),
+    );
+  });
+
+  it('falls back to createdAt only when WhatsApp timestamp is absent', async () => {
+    const target = message({ timestamp: null as unknown as number, createdAt: new Date('2026-01-01T00:00:00.000Z') });
+    recent = [target];
+    repository.findOne.mockResolvedValue(target);
+
+    const context = await createService().getMessageContext('session-a', target.id);
+
+    expect(context.message.occurredAt).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  it('uses one same-session raw-chat bucket for a resolved LID, its phone JID, and mapped LID aliases', async () => {
+    const target = message({ id: '00000000-0000-4000-8000-000000000010', chatId: '123@lid', timestamp: 100 });
+    const phoneHistory = message({
+      id: '00000000-0000-4000-8000-000000000009',
+      chatId: '15551234567@c.us',
+      timestamp: 99,
+    });
+    const aliasHistory = message({
+      id: '00000000-0000-4000-8000-000000000008',
+      chatId: '456@lid',
+      timestamp: 98,
+    });
+    recent = [target, phoneHistory, aliasHistory];
+    repository.findOne.mockResolvedValue(target);
+
+    const context = await createService(
+      { '123': '15551234567', '456': '15551234567' },
+      { '15551234567': ['123', '456'] },
+    ).getMessageContext('session-a', target.id);
+
+    expect(context.conversation.map(item => item.id)).toEqual([target.id, phoneHistory.id, aliasHistory.id]);
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith('message.chatId IN (:...chatIds)', {
+      chatIds: ['123@lid', '15551234567@c.us', '15551234567@s.whatsapp.net', '456@lid'],
+    });
+  });
+
+  it('includes both direct-user JID dialects for a resolved phone trigger', async () => {
+    const target = message({ chatId: '15551234567@c.us', timestamp: 100 });
+    const protocolDialectHistory = message({
+      id: '00000000-0000-4000-8000-000000000009',
+      chatId: '15551234567@s.whatsapp.net',
+      timestamp: 99,
+    });
+    recent = [target, protocolDialectHistory];
+    repository.findOne.mockResolvedValue(target);
+
+    const context = await createService().getMessageContext('session-a', target.id);
+
+    expect(context.conversation.map(item => item.id)).toEqual([target.id, protocolDialectHistory.id]);
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith('message.chatId IN (:...chatIds)', {
+      chatIds: ['15551234567@c.us', '15551234567@s.whatsapp.net'],
+    });
+  });
+
+  it('keeps an unresolved LID isolated and does not guess a phone/alias bucket', async () => {
+    const target = message({ chatId: '999@lid', timestamp: 100 });
+    recent = [target];
+    repository.findOne.mockResolvedValue(target);
+    const mappedAliases = jest.fn(() => ['123', '456']);
+    const mappings: LidMappingStore = {
+      getCached: jest.fn(() => null),
+      lidsForPhone: mappedAliases,
+      remember: jest.fn(),
+    };
+    const service = new AgentContextService(
+      repository as unknown as Repository<Message>,
+      mappings as LidMappingStoreService,
+      quotes as unknown as Repository<MessageQuote>,
+      reactions as unknown as Repository<MessageReaction>,
+    );
+
+    await service.getMessageContext('session-a', target.id);
+
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith('message.chatId IN (:...chatIds)', { chatIds: ['999@lid'] });
+    expect(mappedAliases).not.toHaveBeenCalled();
+  });
+
+  it('projects only typed quote and bounded typed reactions', async () => {
+    const target = message({ status: MessageStatus.READ });
+    recent = [target];
+    repository.findOne.mockResolvedValue(target);
+    quotes.find.mockResolvedValue([
+      {
+        messageId: target.id,
+        sessionId: 'session-a',
+        quotedWaMessageId: 'quoted-id',
+        body: 'q'.repeat(1200),
+      },
+    ]);
+    reactions.find.mockResolvedValue([
+      { messageId: target.id, sessionId: 'session-a', senderId: '123@lid', emoji: '👍' },
+    ]);
+
+    const context = await createService({ '123': '15551234567' }).getMessageContext('session-a', target.id);
+
+    expect(context.message).toEqual(
+      expect.objectContaining({
+        receipt: { status: MessageStatus.READ },
+        quote: { messageId: 'quoted-id', body: 'q'.repeat(1000) },
+        reactions: [
+          { sender: { canonicalJid: '15551234567@c.us', kind: 'person', resolution: 'phone-resolved' }, emoji: '👍' },
+        ],
+      }),
+    );
+    expect(reactions.find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { sessionId: 'session-a', messageId: target.id },
+        take: 16,
+        select: ['messageId', 'senderId', 'emoji'],
+      }),
+    );
+  });
+
+  it('does not use the surface as a general message reader', async () => {
+    repository.findOne.mockResolvedValue(message({ direction: MessageDirection.OUTGOING }));
+    await expect(
+      createService().getMessageContext('session-a', '11111111-1111-4111-8111-111111111111'),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(repository.createQueryBuilder).not.toHaveBeenCalled();
+  });
+
+  it('does not reveal whether a message exists in another session', async () => {
+    repository.findOne.mockResolvedValue(null);
+    await expect(
+      createService().getMessageContext('session-a', '11111111-1111-4111-8111-111111111111'),
+    ).rejects.toBeInstanceOf(NotFoundException);
+    expect(repository.createQueryBuilder).not.toHaveBeenCalled();
+  });
+
+  it('omits an absent body instead of synthesizing content from metadata', async () => {
+    const target = message({
+      body: null as unknown as string,
+      metadata: { fallbackText: 'private metadata must not become body' },
+    });
+    recent = [target];
+    repository.findOne.mockResolvedValue(target);
+    const context = await createService().getMessageContext('session-a', target.id);
+    expect(context.message).not.toHaveProperty('body');
+    expect(JSON.stringify(context)).not.toContain('private metadata');
+  });
+});

--- a/src/modules/agent-context/agent-context.service.ts
+++ b/src/modules/agent-context/agent-context.service.ts
@@ -1,0 +1,231 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { canonicalIdentity, CanonicalIdentity } from '../../engine/identity/canonical-identity';
+import { LidMappingStoreService } from '../../engine/identity/lid-mapping-store.service';
+import { Message, MessageDirection, MessageStatus } from '../message/entities/message.entity';
+import { MessageQuote } from '../message/entities/message-quote.entity';
+import { MessageReaction } from '../message/entities/message-reaction.entity';
+
+/** Hard request/data cap; no caller-controlled pagination is accepted by this surface. */
+export const AGENT_CONTEXT_RECENT_LIMIT = 6;
+/** Per-message cap prevents a single long message from becoming an unbounded prompt input. */
+export const AGENT_CONTEXT_BODY_MAX_CHARS = 1000;
+/** Each projected message reads at most this many current reactions. */
+export const AGENT_CONTEXT_REACTIONS_PER_MESSAGE_LIMIT = 16;
+/** Raw JID aliases are cache-derived and capped so identity bridging cannot widen a context read. */
+export const AGENT_CONTEXT_CHAT_BUCKET_LIMIT = 32;
+
+const MESSAGE_PROJECTION_COLUMNS = [
+  'id',
+  'sessionId',
+  'chatId',
+  'from',
+  'body',
+  'type',
+  'direction',
+  'timestamp',
+  'status',
+  'createdAt',
+] as const;
+
+export interface AgentContextMessage {
+  id: string;
+  canonicalChat: CanonicalIdentity;
+  sender: CanonicalIdentity;
+  direction: MessageDirection;
+  type: string;
+  body?: string;
+  occurredAt: string;
+  /** Aggregate persisted status, never a fabricated per-recipient receipt. */
+  receipt: { status: MessageStatus };
+  quote?: { messageId: string; body?: string };
+  reactions?: Array<{ sender: CanonicalIdentity; emoji: string }>;
+}
+
+export interface AgentContextV1 {
+  schema: 'openwa.agent-context.v1';
+  session: { id: string };
+  message: AgentContextMessage;
+  /** The newest six persisted messages in the same session and canonical raw chat bucket. */
+  conversation: AgentContextMessage[];
+}
+
+function boundedBody(body: string | null | undefined): string | undefined {
+  if (body == null) return undefined;
+  return body.slice(0, AGENT_CONTEXT_BODY_MAX_CHARS);
+}
+
+function occurredAt(message: Pick<Message, 'timestamp' | 'createdAt'>): Date {
+  // WhatsApp time is the event time. createdAt is an arrival/persistence timestamp and is used only
+  // for old rows for which the engine did not provide a timestamp.
+  if (typeof message.timestamp === 'number' && Number.isFinite(message.timestamp)) {
+    return new Date(message.timestamp * 1000);
+  }
+  return message.createdAt;
+}
+
+/**
+ * Read-only, intentionally narrow context projection for an explicitly selected inbound message.
+ *
+ * It has no dependency on MessageService (which also owns send operations), no arbitrary list/search
+ * API, no metadata/media projection, and no caller-controlled history size. The feature module that
+ * mounts its controller is opt-in; this service only exists to make its narrow data boundary explicit.
+ */
+@Injectable()
+export class AgentContextService {
+  constructor(
+    @InjectRepository(Message, 'data')
+    private readonly messages: Repository<Message>,
+    private readonly lidMappings: LidMappingStoreService,
+    @InjectRepository(MessageQuote, 'data')
+    private readonly quotes: Repository<MessageQuote>,
+    @InjectRepository(MessageReaction, 'data')
+    private readonly reactions: Repository<MessageReaction>,
+  ) {}
+
+  async getMessageContext(sessionId: string, messageId: string): Promise<AgentContextV1> {
+    // Scope the primary lookup by session as well as id, so a valid id from another session has the
+    // same result as a missing id. The API key guard independently enforces allowedSessions.
+    const message = await this.messages.findOne({
+      where: { id: messageId, sessionId },
+      // Do not fetch `metadata`: it can contain raw media and adapter-specific fields. Every selected
+      // column below is either directly projected or needed only for the bounded event-time cutoff.
+      select: [...MESSAGE_PROJECTION_COLUMNS],
+    });
+    if (!message) {
+      throw new NotFoundException('Message not found');
+    }
+    // Requiring a selected inbound trigger keeps this from degrading into a generic historical message
+    // reader. It also makes the returned `message` an unambiguous agent input, not an outbound draft.
+    if (message.direction !== MessageDirection.INCOMING) {
+      throw new BadRequestException('Agent context is available only for incoming messages');
+    }
+
+    // This is the only message-history read. It is bounded at (and includes) the selected inbound
+    // trigger, so a late agent invocation never sees messages that happened afterward. `timestamp` is
+    // WhatsApp event time; createdAt is used only where timestamp is absent. WhatsApp timestamps have
+    // second granularity, so no UUID can safely establish same-second event order: include only the
+    // exact trigger at its second and prefer omitting ambiguous siblings over leaking a later event.
+    const triggerTime = occurredAt(message).getTime() / 1000;
+    const chatIds = this.historyChatBucket(message.chatId);
+    const eventTimeSql = this.eventTimeSql('message');
+    const recent = await this.messages
+      .createQueryBuilder('message')
+      .select(MESSAGE_PROJECTION_COLUMNS.map(column => `message.${column}`))
+      .where('message.sessionId = :sessionId', { sessionId })
+      .andWhere('message.chatId IN (:...chatIds)', { chatIds })
+      .andWhere(`(${eventTimeSql} < :triggerTime OR message.id = :triggerId)`, {
+        triggerTime,
+        triggerId: message.id,
+      })
+      .orderBy(eventTimeSql, 'DESC')
+      .addOrderBy('message.id', 'DESC')
+      .take(AGENT_CONTEXT_RECENT_LIMIT)
+      .getMany();
+
+    const projectionMessages = [message, ...recent.filter(item => item.id !== message.id)];
+    const quotesByMessage = await this.loadQuotes(
+      sessionId,
+      projectionMessages.map(item => item.id),
+    );
+    const reactionsByMessage = await this.loadReactions(
+      sessionId,
+      projectionMessages.map(item => item.id),
+    );
+
+    return {
+      schema: 'openwa.agent-context.v1',
+      session: { id: sessionId },
+      message: this.project(message, quotesByMessage.get(message.id), reactionsByMessage.get(message.id)),
+      // `take` bounds every supported TypeORM backend. Slice as well so this public projection
+      // remains bounded even if a future repository wrapper/mocked adapter ignores that hint.
+      conversation: recent
+        .slice(0, AGENT_CONTEXT_RECENT_LIMIT)
+        .map(item => this.project(item, quotesByMessage.get(item.id), reactionsByMessage.get(item.id))),
+    };
+  }
+
+  private eventTimeSql(alias: string): string {
+    // PostgreSQL and SQLite are the supported data stores. The query uses the same numeric epoch for
+    // both timestamp-bearing and legacy rows so ordering/cutoff cannot accidentally depend on DB arrival.
+    const type = this.messages.manager.connection.options.type;
+    if (type === 'postgres') {
+      return `COALESCE("${alias}"."timestamp", EXTRACT(EPOCH FROM "${alias}"."createdAt"))`;
+    }
+    return `COALESCE("${alias}"."timestamp", CAST(strftime('%s', "${alias}"."createdAt") AS INTEGER))`;
+  }
+
+  /**
+   * Return only the raw chat id plus aliases proven by the in-memory LID mapping cache. A LID without
+   * a cached phone mapping stays in a one-item bucket; no network/database lookup or guessed phone is
+   * permitted from this read path.
+   */
+  private historyChatBucket(chatId: string): string[] {
+    const bucket = new Set<string>([chatId]);
+    const identity = canonicalIdentity(chatId, this.lidMappings);
+    if (identity.kind !== 'person' || identity.resolution !== 'phone-resolved') {
+      return [...bucket];
+    }
+
+    const phone = identity.canonicalJid.slice(0, identity.canonicalJid.indexOf('@'));
+    // Persisted history can contain either adapter's direct-user dialect. Both identify the same
+    // resolved phone, while the original raw id remains present for exact backwards compatibility.
+    bucket.add(`${phone}@c.us`);
+    bucket.add(`${phone}@s.whatsapp.net`);
+    for (const lid of this.lidMappings.lidsForPhone(phone)) {
+      if (bucket.size >= AGENT_CONTEXT_CHAT_BUCKET_LIMIT) break;
+      if (lid) bucket.add(`${lid}@lid`);
+    }
+    return [...bucket];
+  }
+
+  private async loadQuotes(sessionId: string, messageIds: string[]): Promise<Map<string, MessageQuote>> {
+    if (messageIds.length === 0) return new Map();
+    const rows = await this.quotes.find({
+      where: messageIds.map(messageId => ({ sessionId, messageId })),
+      select: ['messageId', 'quotedWaMessageId', 'body'],
+    });
+    return new Map(rows.map(row => [row.messageId, row]));
+  }
+
+  private async loadReactions(sessionId: string, messageIds: string[]): Promise<Map<string, MessageReaction[]>> {
+    const entries = await Promise.all(
+      messageIds.map(async messageId => {
+        const rows = await this.reactions.find({
+          where: { sessionId, messageId },
+          select: ['messageId', 'senderId', 'emoji'],
+          order: { senderId: 'ASC' },
+          take: AGENT_CONTEXT_REACTIONS_PER_MESSAGE_LIMIT,
+        });
+        return [messageId, rows] as const;
+      }),
+    );
+    return new Map(entries);
+  }
+
+  private project(message: Message, quote?: MessageQuote, reactions: MessageReaction[] = []): AgentContextMessage {
+    const body = boundedBody(message.body);
+    const quoteBody = quote && boundedBody(quote.body);
+    const safeReactions = reactions
+      .filter(reaction => reaction.senderId.length > 0 && reaction.emoji.length > 0)
+      .map(reaction => ({
+        sender: canonicalIdentity(reaction.senderId, this.lidMappings),
+        emoji: reaction.emoji.slice(0, 64),
+      }));
+    return {
+      id: message.id,
+      canonicalChat: canonicalIdentity(message.chatId, this.lidMappings),
+      sender: canonicalIdentity(message.from, this.lidMappings),
+      direction: message.direction,
+      type: message.type,
+      ...(body !== undefined ? { body } : {}),
+      occurredAt: occurredAt(message).toISOString(),
+      receipt: { status: message.status },
+      ...(quote
+        ? { quote: { messageId: quote.quotedWaMessageId, ...(quoteBody !== undefined ? { body: quoteBody } : {}) } }
+        : {}),
+      ...(safeReactions.length > 0 ? { reactions: safeReactions } : {}),
+    };
+  }
+}

--- a/src/modules/message/entities/message-annotation.entity.ts
+++ b/src/modules/message/entities/message-annotation.entity.ts
@@ -1,0 +1,59 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryColumn } from 'typeorm';
+import { DateTransformer } from '../../../common/transformers/date.transformer';
+import { dateColumnType, jsonColumnType } from '../../../common/utils/column-types';
+
+export type MessageAnnotationKind = 'transcript';
+export type MessageAnnotationStatus = 'pending' | 'complete' | 'failed' | 'expired';
+export type MessageAnnotationMetadataValue = string | number | boolean | null;
+export type MessageAnnotationMetadata = Record<string, MessageAnnotationMetadataValue>;
+
+/** Provider-produced derived content kept beside, never inside, the raw message payload. */
+@Entity('message_annotations')
+@Index('IDX_message_annotations_session_message', ['sessionId', 'messageId'])
+export class MessageAnnotation {
+  @PrimaryColumn({ type: 'varchar' })
+  sessionId: string;
+
+  @PrimaryColumn({ type: 'varchar' })
+  messageId: string;
+
+  @PrimaryColumn({ type: 'varchar', length: 128 })
+  provider: string;
+
+  @PrimaryColumn({ type: 'varchar', length: 32 })
+  kind: MessageAnnotationKind;
+
+  @Column({ type: 'varchar', length: 32 })
+  status: MessageAnnotationStatus;
+
+  @Column({ type: 'varchar', length: 35, nullable: true })
+  language: string | null;
+
+  /** Sensitive derived text. It is intentionally absent from Message and webhook projections. */
+  @Column({ type: 'text', nullable: true })
+  text: string | null;
+
+  /** SHA-256 fingerprint only; never a media URL, path, or bytes. */
+  @Column({ type: 'varchar', length: 64, nullable: true })
+  mediaFingerprint: string | null;
+
+  @Column({ type: 'varchar', length: 128 })
+  processorVersion: string;
+
+  @Column({ type: 'boolean' })
+  externalProcessing: boolean;
+
+  /** Small scalar-only provider facts, bounded and validated by MessageAnnotationService. */
+  @Column({ type: jsonColumnType(), nullable: true })
+  metadata: MessageAnnotationMetadata | null;
+
+  // Bare, like every other @CreateDateColumn in the project (session/webhook/message-batch). Pairing
+  // a generated create-date with dateColumnType()+DateTransformer resolves to `text` on SQLite, which
+  // TypeORM does not treat as a date type — it then writes NULL and every insert trips the column's
+  // NOT NULL constraint.
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @Column({ type: dateColumnType(), nullable: true, transformer: DateTransformer })
+  expiresAt: Date | null;
+}

--- a/src/modules/message/entities/message-quote.entity.ts
+++ b/src/modules/message/entities/message-quote.entity.ts
@@ -1,0 +1,21 @@
+import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
+
+/**
+ * Typed, minimal reply context for a persisted message. This deliberately mirrors only the stable
+ * engine quote fields; the legacy JSON metadata remains untouched for existing API consumers.
+ */
+@Entity('message_quotes')
+@Index(['sessionId', 'messageId'])
+export class MessageQuote {
+  @PrimaryColumn()
+  messageId: string;
+
+  @Column()
+  sessionId: string;
+
+  @Column()
+  quotedWaMessageId: string;
+
+  @Column({ type: 'text', nullable: true })
+  body?: string;
+}

--- a/src/modules/message/entities/message-reaction.entity.ts
+++ b/src/modules/message/entities/message-reaction.entity.ts
@@ -1,0 +1,21 @@
+import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
+
+/**
+ * Current reaction state, keyed by the persisted message and the reacting WhatsApp identity.
+ * A cleared engine reaction deletes this row; no unbounded reaction event history is retained.
+ */
+@Entity('message_reactions')
+@Index(['sessionId', 'messageId'])
+export class MessageReaction {
+  @PrimaryColumn()
+  messageId: string;
+
+  @PrimaryColumn()
+  senderId: string;
+
+  @Column()
+  sessionId: string;
+
+  @Column({ type: 'text' })
+  emoji: string;
+}

--- a/src/modules/message/message-annotation.persistence.spec.ts
+++ b/src/modules/message/message-annotation.persistence.spec.ts
@@ -1,0 +1,81 @@
+import 'reflect-metadata';
+import { DataSource } from 'typeorm';
+import { MessageAnnotation } from './entities/message-annotation.entity';
+import { AddMessageAnnotations1782600000000 } from '../../database/migrations/1782600000000-AddMessageAnnotations';
+
+/**
+ * MessageAnnotationService's own spec mocks the repository, so it cannot catch a disagreement between
+ * the entity and the migration that creates its table. This drives a real better-sqlite3 DataSource
+ * through the migration and the entity to keep that contract honest — notably that `createdAt` stays a
+ * bare @CreateDateColumn (a dateColumnType()/DateTransformer pairing writes NULL into a NOT NULL column
+ * on SQLite and breaks every annotation write).
+ */
+describe('MessageAnnotation entity vs migration (real sqlite)', () => {
+  let dataSource: DataSource;
+
+  beforeEach(async () => {
+    dataSource = new DataSource({
+      type: 'better-sqlite3',
+      database: ':memory:',
+      entities: [MessageAnnotation],
+      migrations: [AddMessageAnnotations1782600000000],
+      synchronize: false,
+    });
+    await dataSource.initialize();
+    await dataSource.runMigrations();
+  });
+
+  afterEach(async () => {
+    await dataSource.destroy();
+  });
+
+  it('round-trips through the migrated schema and dedupes on the composite key', async () => {
+    const repo = dataSource.getRepository(MessageAnnotation);
+    const expires = new Date('2027-01-02T03:04:05.000Z');
+    const key = { sessionId: 's1', messageId: 'm1', provider: 'p1', kind: 'transcript' as const };
+
+    await repo.upsert(
+      {
+        ...key,
+        status: 'complete',
+        language: 'en',
+        text: 'hello world',
+        mediaFingerprint: null,
+        processorVersion: '1.0.0',
+        externalProcessing: false,
+        metadata: { confidence: 0.9, engine: 'x' },
+        expiresAt: expires,
+      },
+      { conflictPaths: ['sessionId', 'messageId', 'provider', 'kind'] },
+    );
+
+    const first = await repo.findOneByOrFail(key);
+    expect(first.createdAt instanceof Date && !Number.isNaN(first.createdAt.getTime())).toBe(true);
+    expect(first.expiresAt?.getTime()).toBe(expires.getTime());
+    expect(first.metadata).toEqual({ confidence: 0.9, engine: 'x' });
+    expect(first.externalProcessing).toBe(false);
+    expect(first.text).toBe('hello world');
+
+    await repo.upsert(
+      {
+        ...key,
+        status: 'failed',
+        language: null,
+        text: null,
+        mediaFingerprint: null,
+        processorVersion: '1.0.1',
+        externalProcessing: true,
+        metadata: null,
+        expiresAt: null,
+      },
+      { conflictPaths: ['sessionId', 'messageId', 'provider', 'kind'] },
+    );
+
+    const all = await repo.find();
+    expect(all).toHaveLength(1);
+    expect(all[0].status).toBe('failed');
+    expect(all[0].externalProcessing).toBe(true);
+    expect(all[0].expiresAt).toBeNull();
+    expect(all[0].metadata).toBeNull();
+  });
+});

--- a/src/modules/message/message-annotation.service.spec.ts
+++ b/src/modules/message/message-annotation.service.spec.ts
@@ -1,0 +1,165 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { HookManager } from '../../core/hooks';
+import { Message } from './entities/message.entity';
+import { MessageAnnotation } from './entities/message-annotation.entity';
+import {
+  ANNOTATION_ELIGIBLE_MESSAGE_TYPES,
+  MAX_ANNOTATION_METADATA_ENTRIES,
+  MAX_ANNOTATION_TEXT_LENGTH,
+  MessageAnnotationService,
+  UpsertMessageAnnotationInput,
+} from './message-annotation.service';
+
+describe('MessageAnnotationService', () => {
+  let service: MessageAnnotationService;
+  let messages: jest.Mocked<Pick<Repository<Message>, 'findOne'>>;
+  let annotations: jest.Mocked<Pick<Repository<MessageAnnotation>, 'upsert'>>;
+  let hooks: jest.Mocked<Pick<HookManager, 'execute'>>;
+
+  const input = {
+    kind: 'transcript' as const,
+    status: 'complete' as const,
+    language: 'en-US',
+    text: 'A short derived transcript.',
+    mediaFingerprint: 'a'.repeat(64),
+    processorVersion: '1.0.0',
+    externalProcessing: false,
+    metadata: { durationMs: 1250, confidence: 0.98 },
+  };
+
+  beforeEach(() => {
+    messages = { findOne: jest.fn().mockResolvedValue({ id: 'message-1' }) };
+    annotations = { upsert: jest.fn().mockResolvedValue(undefined) };
+    hooks = { execute: jest.fn().mockResolvedValue({ continue: true, data: {} }) };
+    service = new MessageAnnotationService(
+      messages as unknown as Repository<Message>,
+      annotations as unknown as Repository<MessageAnnotation>,
+      hooks as unknown as HookManager,
+    );
+  });
+
+  it('persists a bounded transcript annotation against an explicitly scoped message and emits a text-free lifecycle event', async () => {
+    const result = await service.upsert('session-1', 'message-1', 'example-transcriber', input);
+
+    expect(messages.findOne).toHaveBeenCalledWith({
+      select: { id: true },
+      where: { id: 'message-1', sessionId: 'session-1' },
+    });
+    expect(annotations.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'session-1',
+        messageId: 'message-1',
+        provider: 'example-transcriber',
+        text: input.text,
+        metadata: input.metadata,
+      }),
+      { conflictPaths: ['sessionId', 'messageId', 'provider', 'kind'] },
+    );
+    expect(result).toEqual({
+      messageId: 'message-1',
+      provider: 'example-transcriber',
+      kind: 'transcript',
+      status: 'complete',
+      language: 'en-US',
+      externalProcessing: false,
+    });
+    expect(result).not.toHaveProperty('text');
+    expect(result).not.toHaveProperty('metadata');
+    expect(hooks.execute).toHaveBeenCalledWith(
+      'message:annotation-updated',
+      { sessionId: 'session-1', annotation: result },
+      { sessionId: 'session-1', source: 'MessageAnnotationService' },
+    );
+  });
+
+  it('does not reveal or write across sessions when the message does not belong to the requested session', async () => {
+    messages.findOne.mockResolvedValue(null);
+
+    await expect(service.upsert('session-2', 'message-1', 'example-transcriber', input)).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+    expect(annotations.upsert).not.toHaveBeenCalled();
+    expect(hooks.execute).not.toHaveBeenCalled();
+  });
+
+  it('rejects overlong text and unbounded metadata before accessing storage', async () => {
+    await expect(
+      service.upsert('session-1', 'message-1', 'example-transcriber', {
+        ...input,
+        text: 'x'.repeat(MAX_ANNOTATION_TEXT_LENGTH + 1),
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    await expect(
+      service.upsert('session-1', 'message-1', 'example-transcriber', {
+        ...input,
+        metadata: Object.fromEntries(
+          Array.from({ length: MAX_ANNOTATION_METADATA_ENTRIES + 1 }, (_, index) => [`key${index}`, index]),
+        ),
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(messages.findOne).not.toHaveBeenCalled();
+    expect(annotations.upsert).not.toHaveBeenCalled();
+  });
+
+  it('requires transcript text for a completed transcript and rejects unknown provider identities', async () => {
+    await expect(
+      service.upsert('session-1', 'message-1', 'example-transcriber', { ...input, text: undefined }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    await expect(service.upsert('session-1', 'message-1', 'bad provider', input)).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+  });
+
+  it('accepts a serializable expiry but rejects invalid fingerprints, expiry values, and non-scalar metadata', async () => {
+    await service.upsert('session-1', 'message-1', 'example-transcriber', {
+      ...input,
+      expiresAt: '2026-08-01T12:00:00.000Z',
+    });
+    expect(annotations.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ expiresAt: new Date('2026-08-01T12:00:00.000Z') }),
+      expect.anything(),
+    );
+
+    await expect(
+      service.upsert('session-1', 'message-1', 'example-transcriber', { ...input, mediaFingerprint: 'not-a-hash' }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    await expect(
+      service.upsert('session-1', 'message-1', 'example-transcriber', { ...input, expiresAt: 'not-an-instant' }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    await expect(
+      service.upsert('session-1', 'message-1', 'example-transcriber', {
+        ...input,
+        metadata: { nested: { no: true } },
+      } as unknown as UpsertMessageAnnotationInput),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('contains lifecycle observer failures so a provider write remains durable', async () => {
+    hooks.execute.mockRejectedValueOnce(new Error('observer offline'));
+
+    await expect(service.upsert('session-1', 'message-1', 'example-transcriber', input)).resolves.toEqual(
+      expect.objectContaining({ messageId: 'message-1', status: 'complete' }),
+    );
+  });
+
+  it('announces only eligible media by id/type, never message body or metadata', async () => {
+    expect(ANNOTATION_ELIGIBLE_MESSAGE_TYPES.has('voice')).toBe(true);
+    await service.requestForMessage({ id: 'message-1', sessionId: 'session-1', type: 'voice' });
+
+    expect(hooks.execute).toHaveBeenCalledWith(
+      'message:annotation-requested',
+      {
+        sessionId: 'session-1',
+        annotation: { messageId: 'message-1', kind: 'transcript', messageType: 'voice' },
+      },
+      { sessionId: 'session-1', source: 'MessageAnnotationService' },
+    );
+
+    hooks.execute.mockClear();
+    await service.requestForMessage({ id: 'message-2', sessionId: 'session-1', type: 'text' });
+    expect(hooks.execute).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/message/message-annotation.service.ts
+++ b/src/modules/message/message-annotation.service.ts
@@ -1,0 +1,224 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { HookManager } from '../../core/hooks';
+import { Message } from './entities/message.entity';
+import {
+  MessageAnnotation,
+  MessageAnnotationKind,
+  MessageAnnotationMetadata,
+  MessageAnnotationStatus,
+} from './entities/message-annotation.entity';
+
+/** Kept deliberately small: providers can schedule derived work for these media-bearing message types only. */
+export const ANNOTATION_ELIGIBLE_MESSAGE_TYPES = new Set(['audio', 'voice', 'video', 'image', 'document', 'sticker']);
+export const MAX_ANNOTATION_TEXT_LENGTH = 20_000;
+export const MAX_ANNOTATION_METADATA_ENTRIES = 16;
+const MAX_ANNOTATION_METADATA_KEY_LENGTH = 64;
+const MAX_ANNOTATION_METADATA_STRING_LENGTH = 256;
+const MAX_ANNOTATION_METADATA_BYTES = 4_096;
+const MAX_PROCESSOR_VERSION_LENGTH = 128;
+const MAX_MESSAGE_ID_LENGTH = 255;
+const PROVIDER_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const LANGUAGE_TAG = /^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$/;
+const SHA256_HEX = /^[a-fA-F0-9]{64}$/;
+const ANNOTATION_STATUSES: ReadonlySet<MessageAnnotationStatus> = new Set(['pending', 'complete', 'failed', 'expired']);
+
+export interface UpsertMessageAnnotationInput {
+  kind: MessageAnnotationKind;
+  status: MessageAnnotationStatus;
+  language?: string;
+  text?: string;
+  mediaFingerprint?: string;
+  processorVersion: string;
+  externalProcessing: boolean;
+  metadata?: MessageAnnotationMetadata;
+  /** ISO-8601 instant; serializable across the sandbox worker boundary. */
+  expiresAt?: string;
+}
+
+/** Safe lifecycle projection: no transcript or arbitrary metadata crosses a hook by default. */
+export interface MessageAnnotationLifecycle {
+  messageId: string;
+  provider: string;
+  kind: MessageAnnotationKind;
+  status: MessageAnnotationStatus;
+  language?: string;
+  externalProcessing: boolean;
+}
+
+export interface MessageAnnotationRequest {
+  messageId: string;
+  kind: 'transcript';
+  messageType: string;
+}
+
+@Injectable()
+export class MessageAnnotationService {
+  constructor(
+    @InjectRepository(Message, 'data')
+    private readonly messageRepository: Repository<Message>,
+    @InjectRepository(MessageAnnotation, 'data')
+    private readonly annotationRepository: Repository<MessageAnnotation>,
+    private readonly hookManager: HookManager,
+  ) {}
+
+  /**
+   * Write one provider-owned annotation. The parent check selects only Message.id and always includes
+   * sessionId, so a plugin cannot turn this into a cross-session message read or metadata/media fetch.
+   */
+  async upsert(
+    sessionId: string,
+    messageId: string,
+    provider: string,
+    input: UpsertMessageAnnotationInput,
+  ): Promise<MessageAnnotationLifecycle> {
+    const annotation = this.validateInput(sessionId, messageId, provider, input);
+    const message = await this.messageRepository.findOne({
+      select: { id: true },
+      where: { id: messageId, sessionId },
+    });
+    if (!message) throw new NotFoundException('Message not found');
+
+    await this.annotationRepository.upsert(annotation, {
+      conflictPaths: ['sessionId', 'messageId', 'provider', 'kind'],
+    });
+
+    const lifecycle: MessageAnnotationLifecycle = {
+      messageId,
+      provider,
+      kind: annotation.kind,
+      status: annotation.status,
+      ...(annotation.language ? { language: annotation.language } : {}),
+      externalProcessing: annotation.externalProcessing,
+    };
+    void this.hookManager
+      .execute(
+        'message:annotation-updated',
+        { sessionId, annotation: lifecycle },
+        { sessionId, source: MessageAnnotationService.name },
+      )
+      .catch(() => undefined);
+    return lifecycle;
+  }
+
+  /** Emits a minimal scheduling notification after a live eligible media row has been persisted. */
+  requestForMessage(message: Pick<Message, 'id' | 'sessionId' | 'type'>): Promise<void> {
+    if (!message.id || !message.sessionId || !ANNOTATION_ELIGIBLE_MESSAGE_TYPES.has(message.type)) {
+      return Promise.resolve();
+    }
+    const annotation: MessageAnnotationRequest = {
+      messageId: message.id,
+      kind: 'transcript',
+      messageType: message.type,
+    };
+    void this.hookManager
+      .execute(
+        'message:annotation-requested',
+        { sessionId: message.sessionId, annotation },
+        { sessionId: message.sessionId, source: MessageAnnotationService.name },
+      )
+      .catch(() => undefined);
+    return Promise.resolve();
+  }
+
+  private validateInput(
+    sessionId: string,
+    messageId: string,
+    provider: string,
+    input: UpsertMessageAnnotationInput,
+  ): Omit<MessageAnnotation, 'createdAt'> {
+    if (!this.isBoundedIdentifier(sessionId) || !this.isBoundedIdentifier(messageId) || !PROVIDER_ID.test(provider)) {
+      throw new BadRequestException('Invalid annotation input');
+    }
+    if (input?.kind !== 'transcript' || !ANNOTATION_STATUSES.has(input.status)) {
+      throw new BadRequestException('Invalid annotation input');
+    }
+    if (
+      typeof input.processorVersion !== 'string' ||
+      !this.isBoundedText(input.processorVersion, MAX_PROCESSOR_VERSION_LENGTH)
+    ) {
+      throw new BadRequestException('Invalid annotation input');
+    }
+    if (typeof input.externalProcessing !== 'boolean') throw new BadRequestException('Invalid annotation input');
+    if (input.language !== undefined && (!LANGUAGE_TAG.test(input.language) || input.language.length > 35)) {
+      throw new BadRequestException('Invalid annotation input');
+    }
+    if (
+      input.text !== undefined &&
+      (typeof input.text !== 'string' || input.text.length > MAX_ANNOTATION_TEXT_LENGTH)
+    ) {
+      throw new BadRequestException('Invalid annotation input');
+    }
+    if (input.status === 'complete' && !input.text?.trim()) throw new BadRequestException('Invalid annotation input');
+    if (input.mediaFingerprint !== undefined && !SHA256_HEX.test(input.mediaFingerprint)) {
+      throw new BadRequestException('Invalid annotation input');
+    }
+    const expiresAt = input.expiresAt === undefined ? null : this.parseExpiration(input.expiresAt);
+    const metadata = this.validateMetadata(input.metadata);
+
+    return {
+      sessionId,
+      messageId,
+      provider,
+      kind: input.kind,
+      status: input.status,
+      language: input.language ?? null,
+      text: input.text ?? null,
+      mediaFingerprint: input.mediaFingerprint?.toLowerCase() ?? null,
+      processorVersion: input.processorVersion,
+      externalProcessing: input.externalProcessing,
+      metadata,
+      expiresAt,
+    };
+  }
+
+  private validateMetadata(metadata: MessageAnnotationMetadata | undefined): MessageAnnotationMetadata | null {
+    if (metadata === undefined) return null;
+    if (!this.isPlainObject(metadata)) throw new BadRequestException('Invalid annotation input');
+    const entries = Object.entries(metadata);
+    if (entries.length > MAX_ANNOTATION_METADATA_ENTRIES) throw new BadRequestException('Invalid annotation input');
+    for (const [key, value] of entries) {
+      if (!key || key.length > MAX_ANNOTATION_METADATA_KEY_LENGTH)
+        throw new BadRequestException('Invalid annotation input');
+      if (!(
+        value === null ||
+        typeof value === 'boolean' ||
+        (typeof value === 'number' && Number.isFinite(value)) ||
+        (typeof value === 'string' && value.length <= MAX_ANNOTATION_METADATA_STRING_LENGTH)
+      )) {
+        throw new BadRequestException('Invalid annotation input');
+      }
+    }
+    if (Buffer.byteLength(JSON.stringify(metadata), 'utf8') > MAX_ANNOTATION_METADATA_BYTES) {
+      throw new BadRequestException('Invalid annotation input');
+    }
+    return metadata;
+  }
+
+  private parseExpiration(value: string): Date {
+    if (typeof value !== 'string' || value.length > 40 || !/^\d{4}-\d{2}-\d{2}T/.test(value)) {
+      throw new BadRequestException('Invalid annotation input');
+    }
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) throw new BadRequestException('Invalid annotation input');
+    return parsed;
+  }
+
+  private isBoundedIdentifier(value: string): boolean {
+    return typeof value === 'string' && value.length > 0 && value.length <= MAX_MESSAGE_ID_LENGTH;
+  }
+
+  private isBoundedText(value: string, maximum: number): boolean {
+    return value.length > 0 && value.length <= maximum;
+  }
+
+  private isPlainObject(value: unknown): value is Record<string, unknown> {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      !Array.isArray(value) &&
+      Object.getPrototypeOf(value) === Object.prototype
+    );
+  }
+}

--- a/src/modules/message/message-annotations.module.ts
+++ b/src/modules/message/message-annotations.module.ts
@@ -1,0 +1,14 @@
+import { Global, Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Message } from './entities/message.entity';
+import { MessageAnnotation } from './entities/message-annotation.entity';
+import { MessageAnnotationService } from './message-annotation.service';
+
+/** A small global store service; it has no controller and exposes no default API/read surface. */
+@Global()
+@Module({
+  imports: [TypeOrmModule.forFeature([Message, MessageAnnotation], 'data')],
+  providers: [MessageAnnotationService],
+  exports: [MessageAnnotationService],
+})
+export class MessageAnnotationsModule {}

--- a/src/modules/message/message.module.ts
+++ b/src/modules/message/message.module.ts
@@ -8,9 +8,10 @@ import { SessionModule } from '../session/session.module';
 import { TemplateModule } from '../template/template.module';
 import { Message } from './entities/message.entity';
 import { MessageBatch } from './entities/message-batch.entity';
+import { MessageQuote } from './entities/message-quote.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Message, MessageBatch], 'data'), SessionModule, TemplateModule],
+  imports: [TypeOrmModule.forFeature([Message, MessageBatch, MessageQuote], 'data'), SessionModule, TemplateModule],
   controllers: [MessageController],
   providers: [MessageService, BulkMessageService, MessageTypeBackfillService],
   exports: [MessageService, BulkMessageService],

--- a/src/modules/message/message.service.spec.ts
+++ b/src/modules/message/message.service.spec.ts
@@ -11,6 +11,7 @@ import { TemplateService } from '../template/template.service';
 import { Template } from '../template/entities/template.entity';
 import { SsrfBlockedError } from '../../common/security/ssrf-guard';
 import { LidMappingStoreService } from '../../engine/identity/lid-mapping-store.service';
+import { MessageAnnotationService } from './message-annotation.service';
 
 const mockEngineResult = { id: 'wa-msg-1', timestamp: 1706868000 };
 
@@ -44,6 +45,7 @@ describe('MessageService', () => {
   let hookManager: jest.Mocked<Partial<HookManager>>;
   let templateService: jest.Mocked<Partial<TemplateService>>;
   let lidMappingStore: { lidsForPhone: jest.Mock };
+  let messageAnnotationService: { requestForMessage: jest.Mock };
   let mockEngine: ReturnType<typeof createMockEngine>;
 
   // Auto-typing is on by default; disable it for the unrelated send tests so they don't incur the
@@ -88,6 +90,7 @@ describe('MessageService', () => {
     };
 
     lidMappingStore = { lidsForPhone: jest.fn().mockReturnValue([]) };
+    messageAnnotationService = { requestForMessage: jest.fn().mockResolvedValue(undefined) };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -98,6 +101,7 @@ describe('MessageService', () => {
         { provide: HookManager, useValue: hookManager },
         { provide: TemplateService, useValue: templateService },
         { provide: LidMappingStoreService, useValue: lidMappingStore },
+        { provide: MessageAnnotationService, useValue: messageAnnotationService },
       ],
     }).compile();
 
@@ -860,6 +864,19 @@ describe('MessageService', () => {
           sessionId: 'sess-1',
           direction: MessageDirection.INCOMING,
         }),
+      );
+    });
+
+    it('announces an eligible persisted media row to the bounded annotation lifecycle', async () => {
+      await service.saveIncomingMessage('sess-1', {
+        waMessageId: 'wa-in-media-1',
+        chatId: 'sender@c.us',
+        type: 'voice',
+        metadata: { media: { data: 'must-not-cross-the-hook' } },
+      });
+
+      expect(messageAnnotationService.requestForMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'msg-uuid-1', sessionId: 'sess-1', type: 'voice' }),
       );
     });
   });

--- a/src/modules/message/message.service.spec.ts
+++ b/src/modules/message/message.service.spec.ts
@@ -4,6 +4,7 @@ import { Repository } from 'typeorm';
 import { BadRequestException, NotFoundException, PayloadTooLargeException } from '@nestjs/common';
 import { MessageService } from './message.service';
 import { Message, MessageDirection, MessageStatus } from './entities/message.entity';
+import { MessageQuote } from './entities/message-quote.entity';
 import { SessionService } from '../session/session.service';
 import { HookManager } from '../../core/hooks';
 import { TemplateService } from '../template/template.service';
@@ -38,6 +39,7 @@ function createMockEngine() {
 describe('MessageService', () => {
   let service: MessageService;
   let repository: jest.Mocked<Partial<Repository<Message>>>;
+  let quoteRepository: jest.Mocked<Partial<Repository<MessageQuote>>>;
   let sessionService: jest.Mocked<Partial<SessionService>>;
   let hookManager: jest.Mocked<Partial<HookManager>>;
   let templateService: jest.Mocked<Partial<TemplateService>>;
@@ -63,6 +65,7 @@ describe('MessageService', () => {
       delete: jest.fn().mockResolvedValue({ affected: 1 }),
       createQueryBuilder: jest.fn(),
     };
+    quoteRepository = { upsert: jest.fn().mockResolvedValue(undefined) };
 
     mockEngine = createMockEngine();
 
@@ -90,6 +93,7 @@ describe('MessageService', () => {
       providers: [
         MessageService,
         { provide: getRepositoryToken(Message, 'data'), useValue: repository },
+        { provide: getRepositoryToken(MessageQuote, 'data'), useValue: quoteRepository },
         { provide: SessionService, useValue: sessionService },
         { provide: HookManager, useValue: hookManager },
         { provide: TemplateService, useValue: templateService },
@@ -790,6 +794,25 @@ describe('MessageService', () => {
       });
 
       expect(mockEngine.replyToMessage).toHaveBeenCalledWith('test@c.us', 'wa-quoted-1', 'This is a reply');
+    });
+
+    it('persists the reply quote in the additive typed relation', async () => {
+      (repository.findOne as jest.Mock).mockResolvedValue({ body: 'quoted body' });
+      await service.reply('sess-1', {
+        chatId: 'test@c.us',
+        quotedMessageId: 'wa-quoted-1',
+        text: 'This is a reply',
+      });
+
+      expect(quoteRepository.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messageId: 'msg-uuid-1',
+          sessionId: 'sess-1',
+          quotedWaMessageId: 'wa-quoted-1',
+          body: 'quoted body',
+        }),
+        ['messageId'],
+      );
     });
   });
 

--- a/src/modules/message/message.service.ts
+++ b/src/modules/message/message.service.ts
@@ -19,6 +19,7 @@ import { userPart } from '../../engine/identity/wa-id';
 import { resolveFeatureFlags } from '../../config/feature-flags';
 import { LidMappingStoreService } from '../../engine/identity/lid-mapping-store.service';
 import { isUniqueConstraintError } from '../../common/utils/unique-constraint.util';
+import { MessageAnnotationService } from './message-annotation.service';
 
 export interface GetMessagesOptions {
   chatId?: string;
@@ -58,6 +59,8 @@ export class MessageService {
     private readonly lidMappingStore: LidMappingStoreService,
     @Optional()
     private readonly configService?: ConfigService,
+    @Optional()
+    private readonly messageAnnotationService?: MessageAnnotationService,
   ) {}
 
   async sendText(sessionId: string, dto: SendTextMessageDto): Promise<MessageResponseDto> {
@@ -512,7 +515,9 @@ export class MessageService {
       sessionId,
       direction: MessageDirection.INCOMING,
     });
-    return this.messageRepository.save(message);
+    const saved = await this.messageRepository.save(message);
+    void this.messageAnnotationService?.requestForMessage(saved).catch(() => undefined);
+    return saved;
   }
 
   /**
@@ -558,6 +563,7 @@ export class MessageService {
     void this.hookManager
       .execute('message:persisted', { sessionId, message: saved }, { sessionId, source: 'MessageService' })
       .catch(() => undefined);
+    void this.messageAnnotationService?.requestForMessage(saved).catch(() => undefined);
     return saved;
   }
 

--- a/src/modules/message/message.service.ts
+++ b/src/modules/message/message.service.ts
@@ -9,6 +9,7 @@ import { SendTemplateMessageDto } from './dto/send-template.dto';
 import { assertBase64WithinMediaCap, stripBase64DataUri } from './media-cap.util';
 import { MediaInput, IWhatsAppEngine, MessageResult } from '../../engine/interfaces/whatsapp-engine.interface';
 import { Message, MessageDirection, MessageStatus } from './entities/message.entity';
+import { MessageQuote } from './entities/message-quote.entity';
 import { HookManager, applySendingGate } from '../../core/hooks';
 import { TemplateService } from '../template/template.service';
 import { renderTemplate } from '../../common/utils/template-render';
@@ -49,6 +50,8 @@ export class MessageService {
   constructor(
     @InjectRepository(Message, 'data')
     private readonly messageRepository: Repository<Message>,
+    @InjectRepository(MessageQuote, 'data')
+    private readonly messageQuoteRepository: Repository<MessageQuote>,
     private readonly sessionService: SessionService,
     private readonly hookManager: HookManager,
     private readonly templateService: TemplateService,
@@ -171,7 +174,6 @@ export class MessageService {
         media: { mimetype: finalDto.mimetype, filename: finalDto.filename, data: media.data },
       },
     });
-
     let result: MessageResult;
     try {
       result = await engine.sendImageMessage(finalDto.chatId, media);
@@ -195,7 +197,6 @@ export class MessageService {
         media: { mimetype: finalDto.mimetype, filename: finalDto.filename, data: media.data },
       },
     });
-
     let result: MessageResult;
     try {
       result = await engine.sendVideoMessage(finalDto.chatId, media);
@@ -451,6 +452,22 @@ export class MessageService {
         quotedMessage: { id: finalDto.quotedMessageId, body: quotedBody },
       },
     });
+    // Keep the established metadata preview for existing clients, plus an additive typed relation for
+    // the opt-in agent context. A quote persistence fault cannot turn a valid WhatsApp reply into a
+    // failed send.
+    try {
+      await this.messageQuoteRepository.upsert(
+        {
+          messageId: message.id,
+          sessionId,
+          quotedWaMessageId: finalDto.quotedMessageId,
+          body: quotedBody || undefined,
+        },
+        ['messageId'],
+      );
+    } catch (err) {
+      this.logger.warn(`Failed to persist quote for reply ${message.id}`, { error: String(err) });
+    }
 
     let result: MessageResult;
     try {

--- a/src/modules/session/session.module.ts
+++ b/src/modules/session/session.module.ts
@@ -2,6 +2,8 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Session } from './entities/session.entity';
 import { Message } from '../message/entities/message.entity';
+import { MessageQuote } from '../message/entities/message-quote.entity';
+import { MessageReaction } from '../message/entities/message-reaction.entity';
 import { SessionService } from './session.service';
 import { SessionController } from './session.controller';
 import { WebhookModule } from '../webhook/webhook.module';
@@ -9,7 +11,7 @@ import { WebhookModule } from '../webhook/webhook.module';
 @Module({
   // WebhookModule does not import SessionModule back, so the dependency is one-directional —
   // no forwardRef() needed.
-  imports: [TypeOrmModule.forFeature([Session, Message], 'data'), WebhookModule],
+  imports: [TypeOrmModule.forFeature([Session, Message, MessageQuote, MessageReaction], 'data'), WebhookModule],
   controllers: [SessionController],
   providers: [SessionService],
   exports: [SessionService],

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -11,6 +11,8 @@ import {
 } from './session.service';
 import { Session, SessionStatus } from './entities/session.entity';
 import { Message, MessageDirection, MessageStatus } from '../message/entities/message.entity';
+import { MessageQuote } from '../message/entities/message-quote.entity';
+import { MessageReaction } from '../message/entities/message-reaction.entity';
 import { MessageBatch } from '../message/entities/message-batch.entity';
 import { Webhook } from '../webhook/entities/webhook.entity';
 import { Template } from '../template/entities/template.entity';
@@ -55,6 +57,8 @@ describe('SessionService', () => {
   let service: SessionService;
   let repository: jest.Mocked<Partial<Repository<Session>>>;
   let messageRepository: jest.Mocked<Partial<Repository<Message>>>;
+  let messageQuoteRepository: jest.Mocked<Partial<Repository<MessageQuote>>>;
+  let messageReactionRepository: jest.Mocked<Partial<Repository<MessageReaction>>>;
   let dataSource: jest.Mocked<Partial<DataSource>>;
   let engineFactory: jest.Mocked<Partial<EngineFactory>>;
   let eventsGateway: jest.Mocked<Partial<EventsGateway>>;
@@ -92,6 +96,11 @@ describe('SessionService', () => {
         raw: undefined,
       }),
       update: jest.fn().mockResolvedValue({ affected: 1 }),
+    };
+    messageQuoteRepository = { upsert: jest.fn().mockResolvedValue(undefined) };
+    messageReactionRepository = {
+      upsert: jest.fn().mockResolvedValue(undefined),
+      delete: jest.fn().mockResolvedValue({ affected: 1 }),
     };
 
     dataSource = {
@@ -172,6 +181,8 @@ describe('SessionService', () => {
           provide: getRepositoryToken(Message, 'data'),
           useValue: messageRepository,
         },
+        { provide: getRepositoryToken(MessageQuote, 'data'), useValue: messageQuoteRepository },
+        { provide: getRepositoryToken(MessageReaction, 'data'), useValue: messageReactionRepository },
         {
           provide: getDataSourceToken('data'),
           useValue: dataSource,
@@ -2065,6 +2076,20 @@ describe('SessionService', () => {
       );
     });
 
+    it('also persists the current reaction in the additive typed relation', async () => {
+      const callbacks = await startAndCaptureCallbacks();
+      (messageRepository.findOne as jest.Mock).mockResolvedValue({ id: 'message-uuid', metadata: {} });
+      (messageRepository.update as jest.Mock).mockResolvedValue({ affected: 1 });
+
+      callbacks.onMessageReaction!({ messageId: 'wa-1', chatId: 'c', senderId: 'alice@lid', reaction: '👍' });
+      for (let i = 0; i < 3; i++) await flush();
+
+      expect(messageReactionRepository.upsert).toHaveBeenCalledWith(
+        { messageId: 'message-uuid', senderId: 'alice@lid', sessionId: 'sess-uuid-1', emoji: '👍' },
+        ['messageId', 'senderId'],
+      );
+    });
+
     it('removes a sender reaction on a cleared reaction event (delete branch)', async () => {
       const callbacks = await startAndCaptureCallbacks();
       type Row = { metadata?: Record<string, unknown> };
@@ -2217,6 +2242,31 @@ describe('SessionService', () => {
       expect(payload.message.id).toBeTruthy(); // the DB-generated id, not undefined
       expect(payload.message.id).toBe('gen-uuid-1'); // merged from InsertResult.identifiers[0]
       expect(persistedCalls[0][2]).toMatchObject({ sessionId: 'sess-uuid-1', source: 'SessionService' });
+    });
+
+    it('persists a live inbound quote in the additive typed relation', async () => {
+      (hookManager.execute as jest.Mock).mockImplementation((_event: string, data: unknown) =>
+        Promise.resolve({ continue: true, data }),
+      );
+      const callbacks = await startAndCaptureCallbacks();
+
+      callbacks.onMessage!(
+        makeMessage({
+          id: 'wa-quoted-reply',
+          quotedMessage: { id: 'wa-parent', body: 'parent body' },
+        }),
+      );
+      await flush();
+
+      expect(messageQuoteRepository.upsert).toHaveBeenCalledWith(
+        {
+          messageId: 'gen-uuid-1',
+          sessionId: 'sess-uuid-1',
+          quotedWaMessageId: 'wa-parent',
+          body: 'parent body',
+        },
+        ['messageId'],
+      );
     });
 
     it('does not emit message:persisted on a duplicate re-fire (loses the dedup insert race)', async () => {

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -13,6 +13,7 @@ import { Session, SessionStatus } from './entities/session.entity';
 import { Message, MessageDirection, MessageStatus } from '../message/entities/message.entity';
 import { MessageQuote } from '../message/entities/message-quote.entity';
 import { MessageReaction } from '../message/entities/message-reaction.entity';
+import { MessageAnnotationService } from '../message/message-annotation.service';
 import { MessageBatch } from '../message/entities/message-batch.entity';
 import { Webhook } from '../webhook/entities/webhook.entity';
 import { Template } from '../template/entities/template.entity';
@@ -66,6 +67,7 @@ describe('SessionService', () => {
   let hookManager: jest.Mocked<Partial<HookManager>>;
   let configService: jest.Mocked<Partial<ConfigService>>;
   let lidMappingStore: jest.Mocked<Partial<LidMappingStoreService>>;
+  let messageAnnotationService: { requestForMessage: jest.Mock };
   let mockEngine: Record<string, jest.Mock>;
 
   beforeEach(async () => {
@@ -169,6 +171,7 @@ describe('SessionService', () => {
       getCached: jest.fn().mockReturnValue(undefined),
       lidsForPhone: jest.fn().mockReturnValue([]),
     };
+    messageAnnotationService = { requestForMessage: jest.fn().mockResolvedValue(undefined) };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -193,6 +196,7 @@ describe('SessionService', () => {
         { provide: HookManager, useValue: hookManager },
         { provide: ConfigService, useValue: configService },
         { provide: LidMappingStoreService, useValue: lidMappingStore },
+        { provide: MessageAnnotationService, useValue: messageAnnotationService },
       ],
     }).compile();
 
@@ -1663,6 +1667,20 @@ describe('SessionService', () => {
       expect(messageRepository.insert).toHaveBeenCalled();
       expect(dispatchedEvents('message.received')).toHaveLength(1);
       expect(eventsGateway.emitMessage).toHaveBeenCalled();
+    });
+
+    it('announces a persisted inbound media row through the annotation lifecycle', async () => {
+      (hookManager.execute as jest.Mock).mockImplementation((_event: string, data: unknown) =>
+        Promise.resolve({ continue: true, data }),
+      );
+      const callbacks = await startAndCaptureCallbacks();
+
+      callbacks.onMessage?.(makeMessage({ id: 'wa-voice-1', type: 'voice', body: '', fromMe: false }));
+      await flush();
+
+      expect(messageAnnotationService.requestForMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'gen-uuid-1', sessionId: 'sess-uuid-1', type: 'voice' }),
+      );
     });
 
     it('still persists and dispatches an outgoing message when a plugin stops the hook chain', async () => {

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -16,6 +16,8 @@ import { Repository, In, Not, IsNull, DataSource, FindManyOptions } from 'typeor
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 import { Session, SessionStatus } from './entities/session.entity';
 import { Message, MessageDirection, MessageStatus } from '../message/entities/message.entity';
+import { MessageQuote } from '../message/entities/message-quote.entity';
+import { MessageReaction } from '../message/entities/message-reaction.entity';
 import { MessageBatch } from '../message/entities/message-batch.entity';
 import { Webhook } from '../webhook/entities/webhook.entity';
 import { Template } from '../template/entities/template.entity';
@@ -228,6 +230,10 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
     private readonly sessionRepository: Repository<Session>,
     @InjectRepository(Message, 'data')
     private readonly messageRepository: Repository<Message>,
+    @InjectRepository(MessageQuote, 'data')
+    private readonly messageQuoteRepository: Repository<MessageQuote>,
+    @InjectRepository(MessageReaction, 'data')
+    private readonly messageReactionRepository: Repository<MessageReaction>,
     @InjectDataSource('data')
     private readonly dataSource: DataSource,
     private readonly engineFactory: EngineFactory,
@@ -975,6 +981,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
             // in the DB. The webhook/WS dispatch below stays fail-open — a real inbound message must
             // never be dropped on a transient DB failure; only the hook requires a durable row.
             if (persisted) {
+              await this.persistMessageQuote(id, dbMessage, incoming.quotedMessage);
               void this.hookManager
                 .execute(
                   'message:persisted',
@@ -1101,6 +1108,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
                 }
               }
               if (persisted) {
+                await this.persistMessageQuote(id, dbMessage, outgoing.quotedMessage);
                 // Fire-and-forget, mirroring onMessage: plugin providers (search etc.) see phone-
                 // composed sends exactly like API sends.
                 void this.hookManager
@@ -1458,12 +1466,46 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
         metadata,
       } as QueryDeepPartialEntity<Message>);
 
+      // Keep the existing JSON snapshot for public websocket/webhook compatibility, while writing
+      // the minimal typed current state used by the opt-in agent projection. This does not retain a
+      // reaction-event log: a cleared reaction removes the sender's current row.
+      if (!event.reaction) {
+        await this.messageReactionRepository.delete({ messageId: msg.id, senderId: event.senderId });
+      } else {
+        await this.messageReactionRepository.upsert(
+          { messageId: msg.id, senderId: event.senderId, sessionId: id, emoji: event.reaction },
+          ['messageId', 'senderId'],
+        );
+      }
+
       this.eventsGateway.emitMessageReaction(id, { ...event, reactions });
       // Webhook parity with the WebSocket broadcast: same payload (event + post-apply snapshot), so a
       // webhook-only consumer observes reactions too. Idempotency for this event is salted per dispatch.
       void this.webhookService.dispatch(id, 'message.reaction', { ...event, reactions });
     } catch (err) {
       this.logger.error(`Failed to update message reaction: ${event.messageId}`, String(err));
+    }
+  }
+
+  /** Persist only known quote fields; failure must never block a real WhatsApp event. */
+  private async persistMessageQuote(
+    sessionId: string,
+    message: Pick<Message, 'id'>,
+    quote?: { id: string; body: string },
+  ): Promise<void> {
+    if (!message.id || !quote?.id) return;
+    try {
+      await this.messageQuoteRepository.upsert(
+        {
+          messageId: message.id,
+          sessionId,
+          quotedWaMessageId: quote.id,
+          body: quote.body || undefined,
+        },
+        ['messageId'],
+      );
+    } catch (err) {
+      this.logger.error(`Failed to persist message quote for ${message.id}`, String(err));
     }
   }
 

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -56,6 +56,7 @@ import {
   deliveryStatusToAck,
   ackStatusTransitionFrom,
 } from '../message/message-status.util';
+import { MessageAnnotationService } from '../message/message-annotation.service';
 
 // Message types that carry downloadable media. Any persisted row of these types must have a media
 // marker in metadata — never NULL — or the dashboard renders an empty bubble (no placeholder) and the
@@ -251,6 +252,8 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
     // service degrades to today's behaviour if it is ever constructed without the (global) LoggerModule.
     @Optional()
     private readonly shutdownService?: ShutdownService,
+    @Optional()
+    private readonly messageAnnotationService?: MessageAnnotationService,
   ) {}
 
   /**
@@ -982,6 +985,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
             // never be dropped on a transient DB failure; only the hook requires a durable row.
             if (persisted) {
               await this.persistMessageQuote(id, dbMessage, incoming.quotedMessage);
+              void this.messageAnnotationService?.requestForMessage(dbMessage).catch(() => undefined);
               void this.hookManager
                 .execute(
                   'message:persisted',

--- a/test/agent-context.e2e-spec.ts
+++ b/test/agent-context.e2e-spec.ts
@@ -1,0 +1,210 @@
+// archiver v8 is ESM-only and is pulled in by the global storage module.
+jest.mock('archiver', () => ({ TarArchive: jest.fn() }));
+
+// This must be set before AppModule is evaluated because the route is feature-gated at module load.
+process.env.ALLOW_DEV_API_KEY = 'true';
+process.env.AGENT_CONTEXT_ENABLED = 'true';
+
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from '../src/app.module';
+import { applyGlobalValidation } from '../src/config/app-validation';
+import { AuthService } from '../src/modules/auth/auth.service';
+import { ApiKeyRole } from '../src/modules/auth/entities/api-key.entity';
+import { Message, MessageDirection, MessageStatus } from '../src/modules/message/entities/message.entity';
+import { MessageQuote } from '../src/modules/message/entities/message-quote.entity';
+import { MessageReaction } from '../src/modules/message/entities/message-reaction.entity';
+import { LidMappingStoreService } from '../src/engine/identity/lid-mapping-store.service';
+
+describe('GET /api/sessions/:sessionId/agent-context/messages/:messageId (e2e)', () => {
+  let app: INestApplication<App>;
+  let messages: Repository<Message>;
+  let quotes: Repository<MessageQuote>;
+  let reactions: Repository<MessageReaction>;
+  let viewerKey: string;
+  const sessionId = 'agent-session';
+  const targetId = '11111111-1111-4111-8111-111111111111';
+  const base = `/api/sessions/${sessionId}/agent-context/messages/${targetId}`;
+
+  beforeAll(async () => {
+    const moduleFixture = await Test.createTestingModule({ imports: [AppModule] }).compile();
+    app = moduleFixture.createNestApplication();
+    applyGlobalValidation(app);
+    await app.init();
+
+    messages = app.get<Repository<Message>>(getRepositoryToken(Message, 'data'));
+    quotes = app.get<Repository<MessageQuote>>(getRepositoryToken(MessageQuote, 'data'));
+    reactions = app.get<Repository<MessageReaction>>(getRepositoryToken(MessageReaction, 'data'));
+    const auth = app.get(AuthService);
+    viewerKey = (
+      await auth.createApiKey({ name: 'agent-context-viewer', role: ApiKeyRole.VIEWER, allowedSessions: [sessionId] })
+    ).rawKey;
+    await app.get(LidMappingStoreService).remember('bridge-lid', '15551234567', sessionId);
+
+    await messages.insert([
+      {
+        id: targetId,
+        sessionId,
+        chatId: '15551234567@c.us',
+        from: '15551234567@c.us',
+        to: 'self@c.us',
+        body: 'latest incoming message',
+        type: 'text',
+        direction: MessageDirection.INCOMING,
+        timestamp: 1700000000,
+        status: MessageStatus.READ,
+        metadata: { media: { data: 'never expose this' }, raw: 'never expose this either' },
+      },
+      ...Array.from({ length: 7 }, (_, index) => ({
+        id: `00000000-0000-4000-8000-00000000000${index}`,
+        sessionId,
+        chatId: '15551234567@c.us',
+        from: index % 2 ? 'self@c.us' : '15551234567@c.us',
+        to: index % 2 ? '15551234567@c.us' : 'self@c.us',
+        body: `recent ${index}`,
+        type: 'text',
+        direction: index % 2 ? MessageDirection.OUTGOING : MessageDirection.INCOMING,
+        timestamp: 1699999000 + index,
+      })),
+      {
+        id: '00000000-0000-4000-8000-000000000007',
+        sessionId,
+        chatId: 'bridge-lid@lid',
+        from: 'bridge-lid@lid',
+        to: 'self@c.us',
+        body: 'mapped LID history is in the canonical chat bucket',
+        type: 'text',
+        direction: MessageDirection.INCOMING,
+        timestamp: 1699999999,
+      },
+      {
+        id: '00000000-0000-4000-8000-000000000010',
+        sessionId,
+        chatId: '15551234567@s.whatsapp.net',
+        from: '15551234567@s.whatsapp.net',
+        to: 'self@c.us',
+        body: 'direct protocol JID history is in the canonical chat bucket',
+        type: 'text',
+        direction: MessageDirection.INCOMING,
+        timestamp: 1699999998,
+      },
+      {
+        id: '00000000-0000-4000-8000-000000000009',
+        sessionId,
+        chatId: '15551234567@c.us',
+        from: '15551234567@c.us',
+        to: 'self@c.us',
+        body: 'must be excluded: after trigger',
+        type: 'text',
+        direction: MessageDirection.INCOMING,
+        // Delayed DB arrival does not matter: this WhatsApp event happened after the selected trigger.
+        timestamp: 1700000001,
+      },
+      {
+        // Lower UUID must not be mistaken for an earlier event when WhatsApp timestamps tie.
+        id: '00000000-0000-4000-8000-000000000008',
+        sessionId,
+        chatId: '15551234567@c.us',
+        from: '15551234567@c.us',
+        to: 'self@c.us',
+        body: 'must be excluded: later same-second message',
+        type: 'text',
+        direction: MessageDirection.INCOMING,
+        timestamp: 1700000000,
+      },
+    ]);
+    await quotes.insert({ messageId: targetId, sessionId, quotedWaMessageId: 'quoted-wa-id', body: 'quoted context' });
+    await reactions.insert({ messageId: targetId, senderId: '15551234567@c.us', sessionId, emoji: '👍' });
+  });
+
+  afterAll(async () => {
+    try {
+      await app?.close();
+    } catch {
+      /* named TypeORM connection shutdown quirk in the e2e harness */
+    }
+  });
+
+  it('is viewer-readable but session-scoped, bounded, and does not expose metadata or send capability', async () => {
+    const response = await request(app.getHttpServer())
+      .get(`${base}?limit=1000`)
+      .set('X-API-Key', viewerKey)
+      .expect(200);
+
+    const body = response.body as {
+      schema: string;
+      message: {
+        canonicalChat: { canonicalJid: string };
+        body: string;
+        receipt: { status: string };
+        quote: { messageId: string };
+        reactions: unknown[];
+      };
+      conversation: Array<{ id: string; body?: string }>;
+    };
+    expect(body.schema).toBe('openwa.agent-context.v1');
+    expect(body.message.canonicalChat.canonicalJid).toBe('15551234567@c.us');
+    expect(body.message.body).toBe('latest incoming message');
+    expect(body.message.receipt).toEqual({ status: MessageStatus.READ });
+    expect(body.message.quote).toEqual({ messageId: 'quoted-wa-id', body: 'quoted context' });
+    expect(body.message.reactions).toEqual([
+      { sender: { canonicalJid: '15551234567@c.us', kind: 'person', resolution: 'phone-resolved' }, emoji: '👍' },
+    ]);
+    expect(body.conversation).toHaveLength(6);
+    expect(body.conversation.map(message => message.id)).toContain(targetId); // trigger is included in its own bounded window
+    expect(body.conversation.map(message => message.body)).toContain(
+      'mapped LID history is in the canonical chat bucket',
+    );
+    expect(body.conversation.map(message => message.body)).toContain(
+      'direct protocol JID history is in the canonical chat bucket',
+    );
+    expect(body.conversation.map(message => message.body)).not.toContain('must be excluded: after trigger');
+    expect(body.conversation.map(message => message.body)).not.toContain('must be excluded: later same-second message');
+    expect(JSON.stringify(body)).not.toContain('never expose');
+
+    await request(app.getHttpServer()).post(base).set('X-API-Key', viewerKey).send({ text: 'send this' }).expect(404);
+    await request(app.getHttpServer()).get(base).expect(401);
+  });
+
+  it('does not allow a session-scoped key to read another session', async () => {
+    await request(app.getHttpServer())
+      .get(`/api/sessions/other-session/agent-context/messages/${targetId}`)
+      .set('X-API-Key', viewerKey)
+      // AuthService treats a session allow-list mismatch as an authentication failure, matching the
+      // existing session-scoped API contract. The important boundary is that no context is returned.
+      .expect(401);
+  });
+});
+
+describe('AGENT_CONTEXT_ENABLED gate (real AppModule imports)', () => {
+  const moduleImportedWhen = (value: string | undefined): boolean => {
+    const previous = process.env.AGENT_CONTEXT_ENABLED;
+    if (value === undefined) delete process.env.AGENT_CONTEXT_ENABLED;
+    else process.env.AGENT_CONTEXT_ENABLED = value;
+    try {
+      let imported = false;
+      jest.isolateModules(() => {
+        /* eslint-disable @typescript-eslint/no-require-imports -- evaluate the actual module gate fresh. */
+        const { AppModule: IsolatedAppModule } = require('../src/app.module') as typeof import('../src/app.module');
+        const { AgentContextModule } =
+          require('../src/modules/agent-context/agent-context.module') as typeof import('../src/modules/agent-context/agent-context.module');
+        /* eslint-enable @typescript-eslint/no-require-imports */
+        const imports: unknown[] = (Reflect.getMetadata('imports', IsolatedAppModule) as unknown[]) ?? [];
+        imported = imports.includes(AgentContextModule);
+      });
+      return imported;
+    } finally {
+      if (previous === undefined) delete process.env.AGENT_CONTEXT_ENABLED;
+      else process.env.AGENT_CONTEXT_ENABLED = previous;
+    }
+  };
+
+  it('is absent by default and only imports when explicitly enabled', () => {
+    expect(moduleImportedWhen(undefined)).toBe(false);
+    expect(moduleImportedWhen('true')).toBe(true);
+  });
+});


### PR DESCRIPTION
> **Stacked on #873.** This branch builds on the Phase 2 agent-context commit, so #873 shows up here until it merges. The annotation slice genuinely depends on that work (`docs/bridge-hybrid-design.md` is introduced there), so it cannot be based on `main` as an independent branch. Review the second commit (`feat(annotations): ...`) for the changes this PR is about; merge #873 first and this diff reduces to that commit alone.

## What this adds

An additive, session-scoped store for provider-produced derived content, so a transcription provider can persist a transcript **beside** a message without widening any existing payload.

- **`message_annotations` table + entity**, keyed on `(sessionId, messageId, provider, kind)`, with an additive, idempotent, reversible migration.
- **Write-only `ctx.annotations.upsert` capability** behind a new `message-annotations:write` permission. The host binds `provider` to the manifest id (not caller-supplied) and applies the existing session-scope and activation checks. There is deliberately **no get, list, or search** operation.
- **Generic lifecycle hooks** `message:annotation-requested` and `message:annotation-updated`. Both carry text-free projections.
- **Bounded validation** for transcript text, language tag, SHA-256 media fingerprint, processor version, expiry, and a small scalar-only metadata object.

## What this deliberately does not add

No transcription provider, no external AI dependency, no media-read permission, and no annotation HTTP endpoint. Nothing is enabled by default.

Transcript text stays out of `Message`, webhook payloads, and agent context. Any future transcript retrieval needs an explicit, separately authorized read contract — and any future media processor needs a dedicated, separately reviewed media-read permission with its own consent/retention boundaries.

## Note on `createdAt`

`createdAt` is a bare `@CreateDateColumn`, matching every other entity in the project. Pairing a generated create-date with `dateColumnType()`/`DateTransformer` resolves to `text` on SQLite, which TypeORM does not treat as a date type — it then writes NULL and **every** annotation write trips the `NOT NULL` constraint.

Because the service spec mocks the repository, it cannot catch a disagreement between the entity and the migration that creates its table. `message-annotation.persistence.spec.ts` drives the entity through the real migration on `better-sqlite3` to keep that contract covered.

## Test plan

- [x] `npm test` — 210 suites passed, 2885 tests (5 pre-existing skips)
- [x] `npm --prefix dashboard run build`
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] `npm run lint` — 0 errors (1 pre-existing unrelated warning in `dto-strict-coercion.spec.ts`)
- [x] `npm run format -- --check`
- [x] `git diff --check`
- [x] New persistence spec verifies insert, update-on-conflict, and round-trip of `expiresAt`/`metadata`/`externalProcessing` against the migrated SQLite schema