### PR TITLE
chore(deps): upgrade TypeORM to 1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **TypeORM upgraded from 0.3 to 1.1.** The ORM underneath every database operation moves off the
+  now-legacy 0.3 line onto the actively developed 1.x line. No schema change is involved: all existing
+  migrations apply unchanged, database files and PostgreSQL deployments are untouched, and the API
+  surface of the gateway is identical. One behavioral improvement ships with the upgrade: a database
+  lookup or write whose criteria would previously have been silently dropped (a bug class, not a
+  feature) now fails loudly instead of returning or modifying the wrong rows. Every such code path in
+  the gateway was audited as part of this upgrade. For self-hosters running from source, the minimum
+  Node.js version rises from 22.12 to **22.13** (the Docker image is unaffected — it already ships a
+  newer Node).
+
 ## [0.10.6] - 2026-07-22
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "rxjs": "^7.8.1",
         "socket.io": "^4.8.3",
         "tar-stream": "^3.2.0",
-        "typeorm": "^0.3.31",
+        "typeorm": "^1.1.0",
         "undici": "^8.8.0",
         "whatsapp-web.js": "^1.34.7",
         "zod": "^4.4.3"
@@ -80,7 +80,7 @@
         "typescript-eslint": "^8.65.0"
       },
       "engines": {
-        "node": ">=22.12"
+        "node": ">=22.13"
       }
     },
     "node_modules/@angular-devkit/core": {
@@ -2573,6 +2573,7 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -2590,6 +2591,7 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2602,6 +2604,7 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2614,12 +2617,14 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -2637,6 +2642,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.2.2"
@@ -2652,6 +2658,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -5801,15 +5808,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/app-root-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-3.1.0.tgz",
-      "integrity": "sha512-biN3PwB2gUtjaYy/isrU3aNWI5w+fAfvHkSvCKeQGxhmYpwKFUxudR3Yya+KqVRHBmEDYh+/lTozYCFbmzX4nA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
     "node_modules/append-field": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
@@ -6018,21 +6016,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/available-typed-arrays": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "possible-typed-array-names": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/b4a": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
@@ -6150,6 +6133,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/bare-events": {
@@ -6623,24 +6607,6 @@
       "license": "MIT",
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
-      }
-    },
-    "node_modules/call-bind": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
-      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "get-intrinsic": "^1.3.0",
-        "set-function-length": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -7579,23 +7545,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/degenerator": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
@@ -7843,6 +7792,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/ee-first": {
@@ -8712,7 +8662,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -8853,25 +8802,11 @@
         "which": "bin/which"
       }
     },
-    "node_modules/for-each": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
-      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-callable": "^1.2.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -9070,7 +9005,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
       "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -9310,18 +9244,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -9338,6 +9260,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -9599,18 +9522,6 @@
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "license": "MIT"
     },
-    "node_modules/is-callable": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -9682,21 +9593,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-typed-array": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
-      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "which-typed-array": "^1.1.16"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -9709,12 +9605,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -9806,6 +9696,7 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -11067,6 +10958,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -11688,6 +11580,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "devOptional": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/parent-module": {
@@ -11909,7 +11802,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -12060,15 +11952,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/possible-typed-array-names": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
-      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/postgres-array": {
@@ -13068,48 +12951,11 @@
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "license": "ISC"
     },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
-    },
-    "node_modules/sha.js": {
-      "version": "2.4.12",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
-      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
-      "license": "(MIT AND BSD-3-Clause)",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "safe-buffer": "^5.2.1",
-        "to-buffer": "^1.2.0"
-      },
-      "bin": {
-        "sha.js": "bin.js"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/sharp": {
       "version": "0.35.1",
@@ -13266,6 +13112,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -13631,6 +13478,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -13658,6 +13506,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -14107,7 +13956,6 @@
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -14126,20 +13974,6 @@
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/to-buffer": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
-      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
-      "license": "MIT",
-      "dependencies": {
-        "isarray": "^2.0.5",
-        "safe-buffer": "^5.2.1",
-        "typed-array-buffer": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
@@ -14464,20 +14298,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/typed-array-buffer": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
-      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "is-typed-array": "^1.1.14"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/typed-query-selector": {
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
@@ -14491,26 +14311,21 @@
       "license": "MIT"
     },
     "node_modules/typeorm": {
-      "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.31.tgz",
-      "integrity": "sha512-6u9EFtdLBgHjnPm78NStVeM+I/1MolTzKykDDcydzKUkh6E++YS6XViU/fePJbvDvEGU4Xq34KOM/CLeer9I2A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-1.1.0.tgz",
+      "integrity": "sha512-iX/kvsV42/htCNAQUyElGW87E4Z12neZc6YUFBTEu0BnLiREYDNT5Wfw3wRqZw9vyOEC36zUBAY6Qvywoig06Q==",
       "license": "MIT",
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.3.1",
-        "app-root-path": "^3.1.0",
-        "buffer": "^6.0.3",
         "dayjs": "^1.11.21",
         "debug": "^4.4.3",
         "dedent": "^1.7.2",
-        "dotenv": "^16.6.1",
-        "glob": "^10.5.0",
         "reflect-metadata": "^0.2.2",
-        "sha.js": "^2.4.12",
         "sql-highlight": "^6.1.0",
+        "tinyglobby": "^0.2.17",
         "tslib": "^2.8.1",
-        "uuid": "^11.1.1",
-        "yargs": "^17.7.3"
+        "yargs": "^18.0.0"
       },
       "bin": {
         "typeorm": "cli.js",
@@ -14518,28 +14333,27 @@
         "typeorm-ts-node-esm": "cli-ts-node-esm.js"
       },
       "engines": {
-        "node": ">=16.13.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24.11.0"
       },
       "funding": {
         "url": "https://opencollective.com/typeorm"
       },
       "peerDependencies": {
-        "@google-cloud/spanner": "^5.18.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "@google-cloud/spanner": "^8.0.0",
         "@sap/hana-client": "^2.14.22",
-        "better-sqlite3": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0",
+        "better-sqlite3": "^12.0.0",
         "ioredis": "^5.0.4",
-        "mongodb": "^5.8.0 || ^6.0.0",
-        "mssql": "^9.1.1 || ^10.0.0 || ^11.0.0 || ^12.0.0",
-        "mysql2": "^2.2.5 || ^3.0.1",
+        "mongodb": "^7.0.0",
+        "mssql": "^12.0.0",
+        "mysql2": "^3.15.3",
         "oracledb": "^6.3.0 || ^7.0.0",
         "pg": "^8.5.1",
         "pg-native": "^3.0.0",
         "pg-query-stream": "^4.0.0",
-        "redis": "^3.1.1 || ^4.0.0 || ^5.0.14",
+        "redis": "^5.0.0 || ^6.0.0",
         "sql.js": "^1.4.0",
-        "sqlite3": "^5.0.3 || ^6.0.0",
-        "ts-node": "^10.7.0",
-        "typeorm-aurora-data-api-driver": "^2.0.0 || ^3.0.0"
+        "ts-node": "^10.9.2",
+        "typeorm-aurora-data-api-driver": "^3.0.0"
       },
       "peerDependenciesMeta": {
         "@google-cloud/spanner": {
@@ -14581,15 +14395,36 @@
         "sql.js": {
           "optional": true
         },
-        "sqlite3": {
-          "optional": true
-        },
         "ts-node": {
           "optional": true
         },
         "typeorm-aurora-data-api-driver": {
           "optional": true
         }
+      }
+    },
+    "node_modules/typeorm/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/typeorm/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/typeorm/node_modules/ansis": {
@@ -14601,120 +14436,99 @@
         "node": ">=14"
       }
     },
-    "node_modules/typeorm/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-      "license": "MIT",
+    "node_modules/typeorm/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
-    "node_modules/typeorm/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
+    "node_modules/typeorm/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/typeorm/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "license": "MIT",
       "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/typeorm/node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "license": "BSD-2-Clause",
+    "node_modules/typeorm/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
       "engines": {
         "node": ">=12"
       },
       "funding": {
-        "url": "https://dotenvx.com"
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "node_modules/typeorm/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/typeorm/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
-    },
-    "node_modules/typeorm/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/typeorm/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/typeorm/node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
+    "node_modules/typeorm/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
       "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/typeorm/node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/typeorm/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/typescript": {
@@ -15374,27 +15188,6 @@
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
       "license": "ISC"
     },
-    "node_modules/which-typed-array": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
-      "license": "MIT",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "for-each": "^0.3.5",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/widest-line": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
@@ -15450,6 +15243,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "license": "MIT",
   "engines": {
-    "node": ">=22.12"
+    "node": ">=22.13"
   },
   "scarfSettings": {
     "enabled": false
@@ -90,7 +90,7 @@
     "rxjs": "^7.8.1",
     "socket.io": "^4.8.3",
     "tar-stream": "^3.2.0",
-    "typeorm": "^0.3.31",
+    "typeorm": "^1.1.0",
     "undici": "^8.8.0",
     "whatsapp-web.js": "^1.34.7",
     "zod": "^4.4.3"

--- a/src/common/utils/dto-strict-coercion.spec.ts
+++ b/src/common/utils/dto-strict-coercion.spec.ts
@@ -50,7 +50,7 @@ function dtoFiles(dir: string, out: string[] = []): string[] {
 // module has been loaded, so this has to happen before the registry is read.
 const SRC = join(__dirname, '..', '..');
 dtoFiles(SRC).forEach(file => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-call
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   require(file);
 });
 

--- a/src/core/plugins/plugin-loader.service.ts
+++ b/src/core/plugins/plugin-loader.service.ts
@@ -1248,7 +1248,7 @@ export class PluginLoaderService implements OnModuleInit, OnApplicationBootstrap
         assertPermission: this.assertPermission.bind(this),
         assertSessionActive: (sessionId: string) => this.assertSessionActive(plugin, sessionId),
         resolveChatId: async env => {
-          if (!env.instanceId || !env.source) {
+          if (!env.instanceId || !env.source?.externalConversationId) {
             throw new PluginCapabilityError(
               `Plugin ${plugin.manifest.id}: conversation.send requires chatId, or both instanceId and source to resolve one`,
             );

--- a/src/core/plugins/sandbox/capability-router.spec.ts
+++ b/src/core/plugins/sandbox/capability-router.spec.ts
@@ -113,6 +113,30 @@ describe('dispatchCapabilityVerb', () => {
     ]);
   });
 
+  it('rejects malformed worker args before they reach the ORM (undefined/empty criteria)', async () => {
+    const ctx = makeContext();
+    // Missing positional string args — the 0.3-era silent-drop would have matched arbitrary rows.
+    await expect(
+      dispatchCapabilityVerb(ctx as unknown as CapabilityContext, 'mappings.getByProvider', []),
+    ).rejects.toThrow(/non-empty string/i);
+    await expect(
+      dispatchCapabilityVerb(ctx as unknown as CapabilityContext, 'messages.sendText', ['s', undefined, 'hi']),
+    ).rejects.toThrow(/non-empty string/i);
+    // Mapping keys must be complete { sessionId, chatId, instanceId } string triples.
+    await expect(
+      dispatchCapabilityVerb(ctx as unknown as CapabilityContext, 'mappings.get', [{ sessionId: 's' }]),
+    ).rejects.toThrow(/sessionId, chatId, instanceId/);
+    await expect(
+      dispatchCapabilityVerb(ctx as unknown as CapabilityContext, 'handover.set', [undefined, 'agent']),
+    ).rejects.toThrow(/sessionId, chatId, instanceId/);
+    await expect(
+      dispatchCapabilityVerb(ctx as unknown as CapabilityContext, 'mappings.upsert', [
+        { sessionId: 's', chatId: 'c', instanceId: 'i' },
+        undefined,
+      ]),
+    ).rejects.toThrow(/non-empty string/i);
+  });
+
   it('rejects an unknown verb — only allowlisted capabilities are reachable', async () => {
     const ctx = makeContext();
     await expect(dispatchCapabilityVerb(ctx as unknown as CapabilityContext, 'process.exit', [0])).rejects.toThrow(

--- a/src/core/plugins/sandbox/capability-router.ts
+++ b/src/core/plugins/sandbox/capability-router.ts
@@ -33,7 +33,23 @@ export async function dispatchCapabilityVerb(
   verb: string,
   args: unknown[],
 ): Promise<unknown> {
-  const s = (index: number): string => args[index] as string;
+  // Worker args cross a trust boundary: validate here so a malformed RPC fails the calling plugin
+  // with a clear error instead of reaching the ORM with undefined criteria (TypeORM 1.x throws on
+  // those, and older versions silently DROPPED them — matching rows it should never have matched).
+  const s = (index: number): string => {
+    const v = args[index];
+    if (typeof v !== 'string' || v.length === 0) {
+      throw new Error(`Capability ${verb}: argument ${index} must be a non-empty string`);
+    }
+    return v;
+  };
+  const mappingKey = (index: number): { sessionId: string; chatId: string; instanceId: string } => {
+    const k = args[index] as { sessionId?: unknown; chatId?: unknown; instanceId?: unknown } | null | undefined;
+    if (!k || [k.sessionId, k.chatId, k.instanceId].some(v => typeof v !== 'string' || v.length === 0)) {
+      throw new Error(`Capability ${verb}: argument ${index} must be { sessionId, chatId, instanceId } strings`);
+    }
+    return k as { sessionId: string; chatId: string; instanceId: string };
+  };
   switch (verb) {
     case 'messages.sendText':
       return context.messages.sendText(s(0), s(1), s(2));
@@ -66,14 +82,11 @@ export async function dispatchCapabilityVerb(
     case 'conversation.send':
       return context.conversations.send(args[0] as ConversationSendEnvelope);
     case 'handover.set':
-      return context.handover.set(
-        args[0] as { sessionId: string; chatId: string; instanceId: string },
-        args[1] as HandoverState,
-      );
+      return context.handover.set(mappingKey(0), args[1] as HandoverState);
     case 'mappings.upsert':
-      return context.mappings.upsert(args[0] as { sessionId: string; chatId: string; instanceId: string }, s(1));
+      return context.mappings.upsert(mappingKey(0), s(1));
     case 'mappings.get':
-      return context.mappings.get(args[0] as { sessionId: string; chatId: string; instanceId: string });
+      return context.mappings.get(mappingKey(0));
     case 'mappings.getByProvider':
       return context.mappings.getByProvider(s(0), s(1));
     default:

--- a/src/database/add-integration-uuid-defaults.spec.ts
+++ b/src/database/add-integration-uuid-defaults.spec.ts
@@ -12,7 +12,7 @@ function makeQueryRunner(type: string, existingTables: Set<string>, versionNum =
     return Promise.resolve(undefined);
   });
   return {
-    connection: { options: { type } },
+    dataSource: { options: { type } },
     hasTable: jest.fn((t: string) => Promise.resolve(existingTables.has(t))),
     query,
   };

--- a/src/database/add-uuid-defaults-migration.spec.ts
+++ b/src/database/add-uuid-defaults-migration.spec.ts
@@ -24,7 +24,7 @@ function makeQueryRunner(type: string, existingTables: Set<string>, opts: Runner
     return Promise.resolve(undefined);
   });
   return {
-    connection: { options: { type } },
+    dataSource: { options: { type } },
     hasTable: jest.fn((t: string) => Promise.resolve(existingTables.has(t))),
     query,
   };

--- a/src/database/add-webhooks-sessionid-index.spec.ts
+++ b/src/database/add-webhooks-sessionid-index.spec.ts
@@ -6,7 +6,7 @@ import { AddWebhooksSessionIdIndex1782200000000 } from './migrations/17822000000
 function makeQueryRunner(type: string, hasWebhooks = true) {
   const query = jest.fn(() => Promise.resolve(undefined));
   return {
-    connection: { options: { type } },
+    dataSource: { options: { type } },
     hasTable: jest.fn((t: string) => Promise.resolve(t === 'webhooks' && hasWebhooks)),
     query,
   };

--- a/src/database/migrations/1770108659848-AddMessageStatus.ts
+++ b/src/database/migrations/1770108659848-AddMessageStatus.ts
@@ -14,7 +14,7 @@ export class AddMessageStatus1770108659848 implements MigrationInterface {
       return;
     }
 
-    const isPostgres = queryRunner.connection.options.type === 'postgres';
+    const isPostgres = queryRunner.dataSource.options.type === 'postgres';
 
     if (isPostgres) {
       await this.upPostgres(queryRunner);
@@ -24,7 +24,7 @@ export class AddMessageStatus1770108659848 implements MigrationInterface {
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    const isPostgres = queryRunner.connection.options.type === 'postgres';
+    const isPostgres = queryRunner.dataSource.options.type === 'postgres';
 
     if (isPostgres) {
       await this.downPostgres(queryRunner);

--- a/src/database/migrations/1770200000000-NormalizeSynchronizeUuidColumns.ts
+++ b/src/database/migrations/1770200000000-NormalizeSynchronizeUuidColumns.ts
@@ -49,7 +49,7 @@ export class NormalizeSynchronizeUuidColumns1770200000000 implements MigrationIn
   ];
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    if (queryRunner.connection.options.type !== 'postgres') return;
+    if (queryRunner.dataSource.options.type !== 'postgres') return;
     // Gate: synchronize builds the WHOLE schema atomically (all-uuid, or synchronize itself errors), so a
     // single representative probe on sessions.id is sufficient to detect a drifted schema. Per-column
     // guards inside the loops below add defense-in-depth for the (non-reachable) partial-drift case.
@@ -104,7 +104,7 @@ export class NormalizeSynchronizeUuidColumns1770200000000 implements MigrationIn
   public async down(queryRunner: QueryRunner): Promise<void> {
     // Best-effort inverse (varchar -> native uuid); only meaningful to re-enable synchronize. USING id::uuid
     // validates every value — Postgres aborts on non-uuid strings (no silent corruption).
-    if (queryRunner.connection.options.type !== 'postgres') return;
+    if (queryRunner.dataSource.options.type !== 'postgres') return;
     if (await this.columnIsUuid(queryRunner, 'sessions', 'id')) return; // already native uuid: nothing to revert
 
     await queryRunner.query(`SET LOCAL statement_timeout = 0`);

--- a/src/database/migrations/1779235200000-AddUuidDefaultsForPostgres.ts
+++ b/src/database/migrations/1779235200000-AddUuidDefaultsForPostgres.ts
@@ -30,7 +30,7 @@ export class AddUuidDefaultsForPostgres1779235200000 implements MigrationInterfa
   private readonly tables = ['sessions', 'webhooks', 'messages', 'message_batches'];
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    if (queryRunner.connection.options.type !== 'postgres') return;
+    if (queryRunner.dataSource.options.type !== 'postgres') return;
 
     // gen_random_uuid() is a core built-in from PostgreSQL 13+, so on any modern server we need NO
     // extension — and CREATE EXTENSION requires a privilege that managed Postgres (RDS/Cloud SQL/…)
@@ -71,7 +71,7 @@ export class AddUuidDefaultsForPostgres1779235200000 implements MigrationInterfa
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    if (queryRunner.connection.options.type !== 'postgres') return;
+    if (queryRunner.dataSource.options.type !== 'postgres') return;
 
     for (const table of this.tables) {
       const exists = await queryRunner.hasTable(table);

--- a/src/database/migrations/1779840000000-AddTemplates.ts
+++ b/src/database/migrations/1779840000000-AddTemplates.ts
@@ -12,7 +12,7 @@ export class AddTemplates1779840000000 implements MigrationInterface {
   name = 'AddTemplates1779840000000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    const isPostgres = queryRunner.connection.options.type === 'postgres';
+    const isPostgres = queryRunner.dataSource.options.type === 'postgres';
 
     const exists = await queryRunner.hasTable('templates');
     if (exists) return;

--- a/src/database/migrations/1781000000000-AddBaileysStoredMessages.ts
+++ b/src/database/migrations/1781000000000-AddBaileysStoredMessages.ts
@@ -10,7 +10,7 @@ export class AddBaileysStoredMessages1781000000000 implements MigrationInterface
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     if (await queryRunner.hasTable('baileys_stored_messages')) return;
-    const isPostgres = queryRunner.connection.options.type === 'postgres';
+    const isPostgres = queryRunner.dataSource.options.type === 'postgres';
 
     if (isPostgres) {
       await queryRunner.query(

--- a/src/database/migrations/1781100000000-AddTemplateNameUnique.ts
+++ b/src/database/migrations/1781100000000-AddTemplateNameUnique.ts
@@ -17,7 +17,7 @@ export class AddTemplateNameUnique1781100000000 implements MigrationInterface {
   name = 'AddTemplateNameUnique1781100000000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    if (queryRunner.connection.options.type === 'postgres') {
+    if (queryRunner.dataSource.options.type === 'postgres') {
       // See AddMessagesWaMessageIdUnique: lift the runtime statement_timeout for this migration
       // transaction so the dedup UPDATE / CREATE UNIQUE INDEX over templates is not aborted. SET LOCAL is
       // transaction-scoped and a no-op on SQLite (which rejects it syntactically — hence the guard).

--- a/src/database/migrations/1781200000000-AddLidMappings.ts
+++ b/src/database/migrations/1781200000000-AddLidMappings.ts
@@ -10,7 +10,7 @@ export class AddLidMappings1781200000000 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     if (await queryRunner.hasTable('lid_mappings')) return;
-    const isPostgres = queryRunner.connection.options.type === 'postgres';
+    const isPostgres = queryRunner.dataSource.options.type === 'postgres';
 
     if (isPostgres) {
       await queryRunner.query(

--- a/src/database/migrations/1781300000000-AddMessagesWaMessageIdUnique.ts
+++ b/src/database/migrations/1781300000000-AddMessagesWaMessageIdUnique.ts
@@ -14,7 +14,7 @@ export class AddMessagesWaMessageIdUnique1781300000000 implements MigrationInter
   name = 'AddMessagesWaMessageIdUnique1781300000000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    if (queryRunner.connection.options.type === 'postgres') {
+    if (queryRunner.dataSource.options.type === 'postgres') {
       // The runtime 'data' pool carries a statement_timeout (app.module.ts) and migrations run on it at
       // boot. Lift it for THIS transaction so the dedup DELETE / CREATE UNIQUE INDEX over the hot messages
       // table is never aborted mid-flight. SET LOCAL is transaction-scoped (auto-reverts at COMMIT) and is

--- a/src/database/migrations/1781700000000-AddWebhookDeliveryFailures.ts
+++ b/src/database/migrations/1781700000000-AddWebhookDeliveryFailures.ts
@@ -12,7 +12,7 @@ export class AddWebhookDeliveryFailures1781700000000 implements MigrationInterfa
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     if (await queryRunner.hasTable('webhook_delivery_failures')) return;
-    const isPostgres = queryRunner.connection.options.type === 'postgres';
+    const isPostgres = queryRunner.dataSource.options.type === 'postgres';
 
     if (isPostgres) {
       await queryRunner.query(

--- a/src/database/migrations/1781900000000-AddIntegrationFabric.ts
+++ b/src/database/migrations/1781900000000-AddIntegrationFabric.ts
@@ -4,7 +4,7 @@ export class AddIntegrationFabric1781900000000 implements MigrationInterface {
   name = 'AddIntegrationFabric1781900000000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    const isPostgres = queryRunner.connection.options.type === 'postgres';
+    const isPostgres = queryRunner.dataSource.options.type === 'postgres';
     const ts = isPostgres ? 'timestamp' : 'datetime';
     const now = isPostgres ? 'NOW()' : "(datetime('now'))";
     const boolTrue = isPostgres ? 'true' : '1';

--- a/src/database/migrations/1782200000000-AddWebhooksSessionIdIndex.ts
+++ b/src/database/migrations/1782200000000-AddWebhooksSessionIdIndex.ts
@@ -12,7 +12,7 @@ export class AddWebhooksSessionIdIndex1782200000000 implements MigrationInterfac
   name = 'AddWebhooksSessionIdIndex1782200000000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    if (queryRunner.connection.options.type === 'postgres') {
+    if (queryRunner.dataSource.options.type === 'postgres') {
       // Lift the runtime pool's statement_timeout (app.module.ts) for THIS transaction so a CREATE INDEX
       // over a large webhooks table at boot is never aborted. SET LOCAL auto-reverts at COMMIT; SQLite
       // rejects it syntactically, hence the guard.

--- a/src/database/migrations/1782300000000-AddIntegrationUuidDefaults.ts
+++ b/src/database/migrations/1782300000000-AddIntegrationUuidDefaults.ts
@@ -24,7 +24,7 @@ export class AddIntegrationUuidDefaults1782300000000 implements MigrationInterfa
   private readonly tables = ['conversation_mappings', 'integration_delivery_failures'];
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    if (queryRunner.connection.options.type !== 'postgres') return;
+    if (queryRunner.dataSource.options.type !== 'postgres') return;
 
     // Probe the server version with a non-erroring catalog query (a caught SQL exception would poison the
     // migration transaction). Only touch pgcrypto on PG <= 12; on 13+ gen_random_uuid() is core and
@@ -57,7 +57,7 @@ export class AddIntegrationUuidDefaults1782300000000 implements MigrationInterfa
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    if (queryRunner.connection.options.type !== 'postgres') return;
+    if (queryRunner.dataSource.options.type !== 'postgres') return;
 
     for (const table of this.tables) {
       if (!(await queryRunner.hasTable(table))) continue;

--- a/src/database/migrations/1782400000000-AddMessagesFts.ts
+++ b/src/database/migrations/1782400000000-AddMessagesFts.ts
@@ -14,7 +14,7 @@ export class AddMessagesFts1782400000000 implements MigrationInterface {
   name = 'AddMessagesFts1782400000000';
 
   async up(qr: QueryRunner): Promise<void> {
-    const isPostgres = qr.connection.options.type === 'postgres';
+    const isPostgres = qr.dataSource.options.type === 'postgres';
     if (isPostgres) {
       // Lift the runtime statement_timeout (30000ms on the data pool — see app.module.ts) for this
       // migration transaction: the STORED generated column is a full-table rewrite, and the GIN index
@@ -65,7 +65,7 @@ export class AddMessagesFts1782400000000 implements MigrationInterface {
   }
 
   async down(qr: QueryRunner): Promise<void> {
-    const isPostgres = qr.connection.options.type === 'postgres';
+    const isPostgres = qr.dataSource.options.type === 'postgres';
     if (isPostgres) {
       await qr.query(`DROP INDEX IF EXISTS "idx_messages_body_ts"`);
       await qr.query(`ALTER TABLE "messages" DROP COLUMN IF EXISTS "body_ts"`);

--- a/src/database/migrations/__tests__/1770200000000-NormalizeSynchronizeUuidColumns.spec.ts
+++ b/src/database/migrations/__tests__/1770200000000-NormalizeSynchronizeUuidColumns.spec.ts
@@ -64,7 +64,7 @@ function makeQueryRunner(opts: SchemaOpts) {
   });
 
   return {
-    connection: { options: { type } },
+    dataSource: { options: { type } },
     hasTable: jest.fn((t: string) => Promise.resolve(existingTables.has(t))),
     query,
   };

--- a/src/database/migrations/__tests__/1781100000000-AddTemplateNameUnique.spec.ts
+++ b/src/database/migrations/__tests__/1781100000000-AddTemplateNameUnique.spec.ts
@@ -81,7 +81,7 @@ describe('AddTemplateNameUnique migration', () => {
     // dedup UPDATE / CREATE UNIQUE INDEX over templates must not be aborted mid-flight.
     const queries: string[] = [];
     const pgRunner = {
-      connection: { options: { type: 'postgres' } },
+      dataSource: { options: { type: 'postgres' } },
       hasTable: jest.fn().mockResolvedValue(true),
       query: jest.fn((sql: string) => {
         queries.push(sql);

--- a/src/database/migrations/__tests__/1781300000000-AddMessagesWaMessageIdUnique.spec.ts
+++ b/src/database/migrations/__tests__/1781300000000-AddMessagesWaMessageIdUnique.spec.ts
@@ -70,7 +70,7 @@ describe('AddMessagesWaMessageIdUnique migration', () => {
     // connection; this DELETE / CREATE UNIQUE INDEX over the hot messages table must not be aborted.
     const queries: string[] = [];
     const pgRunner = {
-      connection: { options: { type: 'postgres' } },
+      dataSource: { options: { type: 'postgres' } },
       hasTable: jest.fn().mockResolvedValue(true),
       query: jest.fn((sql: string) => {
         queries.push(sql);

--- a/src/database/migrations/__tests__/1782400000000-AddMessagesFts.spec.ts
+++ b/src/database/migrations/__tests__/1782400000000-AddMessagesFts.spec.ts
@@ -115,7 +115,7 @@ describe('AddMessagesFts migration (sqlite)', () => {
     // return early (no CREATE VIRTUAL TABLE) so a non-FTS5 build doesn't crash boot.
     const calls: string[] = [];
     const stub = {
-      connection: { options: { type: 'better-sqlite3' as const } },
+      dataSource: { options: { type: 'better-sqlite3' as const } },
       query: jest.fn((stmt: string) => {
         calls.push(stmt);
         if (stmt.includes("sqlite_compileoption_used('ENABLE_FTS5')")) {

--- a/src/engine/adapters/baileys-message-store.service.ts
+++ b/src/engine/adapters/baileys-message-store.service.ts
@@ -88,6 +88,9 @@ export class BaileysMessageStoreService implements BaileysMessageStore {
   }
 
   async getMessage(sessionId: string, messageId: string): Promise<WAMessage | null> {
+    // Baileys retry/poll paths can hand over a key with no id; treat that as not-found rather than
+    // letting an undefined criterion reach the ORM (TypeORM 1.x throws; 0.3 matched an arbitrary row).
+    if (!messageId) return null;
     const row = await this.repo.findOne({ where: { sessionId, waMessageId: messageId } });
     if (!row) {
       return null;
@@ -108,7 +111,7 @@ export class BaileysMessageStoreService implements BaileysMessageStore {
       order: { createdAt: 'DESC', id: 'DESC' },
       skip: limit,
       take: 1,
-      select: ['id', 'createdAt'],
+      select: { id: true, createdAt: true },
     });
     if (cutoff.length === 0) {
       return; // under the cap — nothing to evict

--- a/src/modules/message/bulk-message.service.ts
+++ b/src/modules/message/bulk-message.service.ts
@@ -351,7 +351,7 @@ export class BulkMessageService implements OnApplicationBootstrap {
         // Honor a cancellation issued by ANOTHER instance / after a restart — the in-memory Map only
         // sees same-process cancels. Re-read the status BEFORE saving so we don't clobber a CANCELLED
         // back to PROCESSING.
-        const fresh = await this.batchRepository.findOne({ where: { id: batch.id }, select: ['status'] });
+        const fresh = await this.batchRepository.findOne({ where: { id: batch.id }, select: { status: true } });
         if (fresh?.status === BatchStatus.CANCELLED) {
           cancelledByDb = true;
           this.logger.log(`Batch ${batch.batchId} cancelled (DB) at index ${i}`);
@@ -373,7 +373,7 @@ export class BulkMessageService implements OnApplicationBootstrap {
     // unconditional save below would clobber it back to a terminal non-cancelled status, so re-read
     // once more here unless we already know the batch was cancelled.
     if (!cancelledByDb) {
-      const fresh = await this.batchRepository.findOne({ where: { id: batch.id }, select: ['status'] });
+      const fresh = await this.batchRepository.findOne({ where: { id: batch.id }, select: { status: true } });
       if (fresh?.status === BatchStatus.CANCELLED) {
         cancelledByDb = true;
       }

--- a/src/modules/message/message.service.ts
+++ b/src/modules/message/message.service.ts
@@ -2,7 +2,7 @@ import { Injectable, BadRequestException, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
+import { QueryDeepPartialEntity } from 'typeorm';
 import { SessionService } from '../session/session.service';
 import { SendTextMessageDto, SendMediaMessageDto, SendAudioMessageDto, MessageResponseDto } from './dto';
 import { SendTemplateMessageDto } from './dto/send-template.dto';

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -13,7 +13,7 @@ import {
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository, InjectDataSource } from '@nestjs/typeorm';
 import { Repository, In, Not, IsNull, DataSource, FindManyOptions } from 'typeorm';
-import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
+import { QueryDeepPartialEntity } from 'typeorm';
 import { Session, SessionStatus } from './entities/session.entity';
 import { Message, MessageDirection, MessageStatus } from '../message/entities/message.entity';
 import { MessageBatch } from '../message/entities/message-batch.entity';
@@ -676,7 +676,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
       const chunkIds = ids.slice(i, i + CHUNK);
       const existing = await this.messageRepository.find({
         where: { sessionId: id, waMessageId: In(chunkIds) },
-        select: ['waMessageId'],
+        select: { waMessageId: true },
       });
       const seen = new Set(existing.map(r => r.waMessageId));
       const rows = chunkIds

--- a/src/modules/stats/stats.service.ts
+++ b/src/modules/stats/stats.service.ts
@@ -87,7 +87,7 @@ export class StatsService {
 
   /** The data-connection dialect ('sqlite' | 'postgres'), used to pick portable date SQL. */
   private get dataDbType(): string {
-    return this.messageRepo.manager.connection.options.type;
+    return this.messageRepo.manager.dataSource.options.type;
   }
 
   async getOverview(): Promise<OverviewStats> {


### PR DESCRIPTION
## Summary

Upgrades TypeORM from 0.3.31 to **1.1.0**. The 0.3 line is now TypeORM's `legacy` dist-tag; 1.x is where fixes and development happen. The prerequisites landed ahead of this PR: `better-sqlite3@^12` (#863) matches 1.x's SQLite driver peer exactly, and `@nestjs/typeorm@11.0.1+` (we pin `^11.0.3`) declares peer support for 1.x — the install resolves cleanly under strict peer resolution with no overrides.

The gateway's API surface, the database schema, and all existing database files are untouched. All data and main migrations apply unchanged. For self-hosters running from source, the minimum Node.js rises from 22.12 to **22.13** to match TypeORM's own engines floor; the Docker image already ships a newer Node and is unaffected.

## What changed in code

- **Four `select: ['col', …]` sites** converted to the object syntax (`select: { col: true }`) — the string-array form was removed in TypeORM 1.0. Same columns, same semantics.
- **`.connection` → `.dataSource`** across the 13 migrations that branch on dialect, `stats.service.ts`, and the query-runner stubs in the affected specs. The old name still works in 1.x as a deprecated alias; this removes the deprecation ahead of 2.0.
- **Two deep imports** of `QueryDeepPartialEntity` moved to the top-level `typeorm` entry.

## Behavioral change handled: where-criteria validation

TypeORM 1.x **throws** when a `where` criterion value is `undefined`/`null` (`invalidWhereValuesBehavior`, default `throw`). 0.3 silently **dropped** such criteria — a bug class, not a feature: a dropped key meant the query matched rows it should never have matched (e.g. a lookup keyed by `{sessionId, chatId, instanceId}` degrading to a broader match and returning another conversation's mapping).

Every criteria callsite in the gateway (197 across `src/`) was audited for runtime-reachable `undefined`/`null` values. The only reachable paths were **plugin-sandbox RPC inputs**, where worker-supplied args crossed the boundary through bare type casts. Fixes, at the trust boundary rather than per-callsite:

- `capability-router.ts` now validates worker args before dispatch: positional string args must be non-empty strings, and the `{sessionId, chatId, instanceId}` mapping keys used by `handover.set` / `mappings.*` must be complete string triples. A malformed RPC now fails the calling plugin with a clear error instead of reaching the ORM. Covered by new router specs.
- The `conversation.send` resolve guard additionally requires `source.externalConversationId` before the provider-mapping lookup.
- The Baileys message store treats a missing message id as not-found instead of querying with it (Baileys retry/poll paths can produce keys without an id).

One flagged site needed no change: the reply-preview lookup in `message.service.ts` is already a best-effort `try/catch` — under 0.3 a dropped criterion silently fetched an *arbitrary* row for the preview; under 1.x it throws into the existing catch and renders no preview, which is strictly more correct.

The default `throw` behavior is deliberately kept — reverting to the 0.3 semantics would preserve the wrong-rows bug class.

## Verification

- Backend: lint, build, full unit suite (2846 tests incl. the new router-validation specs), e2e — green.
- Dashboard: build + lint — green.
- All 19 data migrations + main migrations compile and run (up and down) unmodified under typeorm 1.1.0 with better-sqlite3.
- Peer graph: `npm ls` clean; `better-sqlite3@12.11.1` and `pg@^8` both inside typeorm 1.1.0's peer ranges.
- Staging boot smoke (amd64): the production image was built from this branch and booted on a staging host — the gateway came up on typeorm 1.1.0 with all 19 data migrations applied to a fresh volume, both connections initialized (main created `api_keys`/`audit_logs`), glob-based entity/migration discovery working under 1.x's loader, `/api/health/live` ok, and the FTS search path serving through `builtin-fts`. No errors in the boot log.
