### PR TITLE
chore(deps): upgrade TypeScript to 6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ The key can be passed as `Authorization: Bearer …` or `X-API-Key: …`. Every 
 | ------------- | ------------------------------------------------------- |
 | **Runtime**   | Node.js 22 LTS                                          |
 | **Framework** | NestJS 11.x                                             |
-| **Language**  | TypeScript 5.x                                          |
+| **Language**  | TypeScript 6.x                                          |
 | **WA Engine** | whatsapp-web.js (default) / baileys — set `ENGINE_TYPE` |
 | **Database**  | SQLite / PostgreSQL                                     |
 | **Cache**     | Redis (optional)                                        |

--- a/docs/README.md
+++ b/docs/README.md
@@ -204,7 +204,7 @@ socket.on('message', msg => {
 | --------- | ----------------------------- |
 | Runtime   | Node.js 22 LTS                |
 | Framework | NestJS 11.x                   |
-| Language  | TypeScript 5.x                |
+| Language  | TypeScript 6.x                |
 | WA Engine | Pluggable (`ENGINE_TYPE`): whatsapp-web.js (default) or Baileys |
 | WebSocket | Socket.IO                     |
 | Database  | SQLite (default) / PostgreSQL |

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "@types/multer": "^2.2.0",
         "@types/node": "^26.1.1",
         "@types/qrcode": "^1.5.5",
-        "@types/supertest": "^6.0.2",
+        "@types/supertest": "^7.2.1",
         "@types/tar-stream": "^3.1.4",
         "concurrently": "^10.0.3",
         "eslint": "^10.7.0",
@@ -76,7 +76,7 @@
         "ts-loader": "^9.6.2",
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",
-        "typescript": "^5.7.3",
+        "typescript": "~6.0.3",
         "typescript-eslint": "^8.65.0"
       },
       "engines": {
@@ -3625,6 +3625,20 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@nestjs/cli/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/@nestjs/common": {
       "version": "11.1.28",
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.28.tgz",
@@ -4718,9 +4732,9 @@
       }
     },
     "node_modules/@types/supertest": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.3.tgz",
-      "integrity": "sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-7.2.1.tgz",
+      "integrity": "sha512-4CbBvoYVLHL7+yhbYrZET0vsvuyXTC05aRe7dNQkwMzm56auceoy6Yu3K50uZmwfHna1os3CMSgM/3QVkUtPTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14532,9 +14546,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "@types/multer": "^2.2.0",
     "@types/node": "^26.1.1",
     "@types/qrcode": "^1.5.5",
-    "@types/supertest": "^6.0.2",
+    "@types/supertest": "^7.2.1",
     "@types/tar-stream": "^3.1.4",
     "concurrently": "^10.0.3",
     "eslint": "^10.7.0",
@@ -123,7 +123,7 @@
     "ts-loader": "^9.6.2",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "^5.7.3",
+    "typescript": "~6.0.3",
     "typescript-eslint": "^8.65.0"
   },
   "jest": {
@@ -141,7 +141,8 @@
           "tsconfig": {
             "module": "CommonJS",
             "moduleResolution": "node",
-            "resolvePackageJsonExports": false
+            "resolvePackageJsonExports": false,
+            "ignoreDeprecations": "6.0"
           }
         }
       ]

--- a/src/core/plugins/plugin-loader.service.spec.ts
+++ b/src/core/plugins/plugin-loader.service.spec.ts
@@ -790,6 +790,8 @@ describe('PluginLoaderService — search-provider enable-failure cleanup', () =>
     module: 'commonjs',
     moduleResolution: 'node',
     resolvePackageJsonExports: false,
+    // TypeScript 6 rejects the legacy resolution pair unless acknowledged. Revisit before TS 7.
+    ignoreDeprecations: '6.0',
   });
 
   // Runs the REAL worker (ts-node) instead of the compiled dist bootstrap, so enableSandboxed
@@ -865,6 +867,8 @@ describe('PluginLoaderService — search-provider worker-crash fallback', () => 
     module: 'commonjs',
     moduleResolution: 'node',
     resolvePackageJsonExports: false,
+    // TypeScript 6 rejects the legacy resolution pair unless acknowledged. Revisit before TS 7.
+    ignoreDeprecations: '6.0',
   });
 
   // Real ts-node worker (so enableSandboxed runs its true path) that captures the host so the test can

--- a/src/core/plugins/sandbox/plugin-worker.integration.spec.ts
+++ b/src/core/plugins/sandbox/plugin-worker.integration.spec.ts
@@ -19,7 +19,14 @@ const flushAsync = (): Promise<void> => new Promise(resolve => setImmediate(reso
 // Run the TS bootstrap inside the worker via ts-node. The base tsconfig is nodenext; we pin the
 // worker's transpile to CommonJS (same override the jest/ts-jest config uses) so `require()` works.
 // Production loads the compiled `worker-bootstrap.js` directly and needs none of this.
-const TS_NODE_OPTS = JSON.stringify({ module: 'commonjs', moduleResolution: 'node', resolvePackageJsonExports: false });
+const TS_NODE_OPTS = JSON.stringify({
+  module: 'commonjs',
+  moduleResolution: 'node',
+  resolvePackageJsonExports: false,
+  // Same bridge as the jest/ts-jest override: TypeScript 6 rejects the legacy resolution pair
+  // outright unless the deprecation is acknowledged. Revisit before TypeScript 7.
+  ignoreDeprecations: '6.0',
+});
 
 const makeChannel = (): WorkerThreadChannel =>
   new WorkerThreadChannel({

--- a/src/modules/mcp/mcp-rate-limit.ts
+++ b/src/modules/mcp/mcp-rate-limit.ts
@@ -64,7 +64,7 @@ export class KeyRateLimiter {
     this.hits.delete(key);
     this.hits.set(key, recent);
     while (this.hits.size > Math.max(1, this.maxKeys)) {
-      const oldest = this.hits.keys().next().value as string | undefined;
+      const oldest = this.hits.keys().next().value;
       if (oldest === undefined) break;
       this.hits.delete(oldest);
     }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,9 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // TypeScript 6 requires the output layout anchor to be explicit (TS5011).
+    "rootDir": "./src"
+  },
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts", "dashboard"],
   "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,12 +13,24 @@
     "target": "ES2023",
     "sourceMap": true,
     "outDir": "./dist",
+    // TypeScript 6 requires the layout anchor to be explicit (TS5011). The build config narrows
+    // this to ./src; here it spans src + test for ts-jest and the editor.
+    "rootDir": ".",
     "incremental": true,
     "skipLibCheck": true,
+    // TypeScript 6 no longer auto-includes every node_modules/@types package: the globals the
+    // project relies on must be listed. node covers src; jest covers the colocated *.spec.ts.
+    "types": ["node", "jest"],
     "strictNullChecks": true,
     "forceConsistentCasingInFileNames": true,
     "noImplicitAny": true,
     "strictBindCallApply": true,
+    // TypeScript 6 defaults the whole strict family ON. This project opts into strict flags
+    // selectively (see the explicit trues above); these three stay off pending their own migrations —
+    // strictPropertyInitialization alone flags ~260 TypeORM entity properties.
+    "strictPropertyInitialization": false,
+    "strictFunctionTypes": false,
+    "useUnknownInCatchVariables": false,
     "noFallthroughCasesInSwitch": true
   },
   "exclude": ["node_modules", "dist", "dashboard"],


### PR DESCRIPTION
## Summary

Upgrades the TypeScript toolchain from 5.7 to **6.0.3** and `@types/supertest` to 7.x — the remaining two updates from the retired major-group bump (#849), now that TypeORM (#875) and the SQLite driver (#863) have landed. Dev-toolchain only: no runtime dependency, no gateway behavior, and no emitted-output layout changes.

`typescript` is pinned with a tilde (`~6.0.3`): typescript-eslint's peer range caps at `<6.1.0`, so a caret would break resolution on the first 6.1 release. This is pre-documented in `.github/dependabot.yml`, alongside the existing TypeScript 7 ignore.

## What TypeScript 6 changed, and how it is handled

- **The strict family now defaults on.** This project opts into strict flags selectively. The three not yet adopted are pinned `false` explicitly (`strictPropertyInitialization` — which alone would flag ~260 TypeORM entity properties — `strictFunctionTypes`, and `useUnknownInCatchVariables`), each a candidate for its own future migration. The remaining newly-on strict flags compile and lint cleanly and stay on.
- **`rootDir` must be explicit.** Set to `.` in the base config (spans `src` + `test` for ts-jest and the editor) and `./src` in `tsconfig.build.json` — the same output anchor `nest build` used before, so `dist/` layout is unchanged.
- **`@types` packages are no longer auto-included.** The globals the project relies on are now listed: `types: ["node", "jest"]`. Every other `@types` package is consumed via explicit imports and is unaffected.
- **The legacy `moduleResolution: "node"` is a hard error unless acknowledged.** The jest/ts-jest transform and the sandbox integration specs' real worker-thread ts-node bootstrap deliberately keep legacy CJS resolution; both now carry `ignoreDeprecations: "6.0"`, scoped to those test-only configs. Both must be revisited before TypeScript 7 (which is already ignored in dependabot until typescript-eslint and ts-jest support it).
- One type assertion TypeScript 6 now infers was dropped (`mcp-rate-limit.ts`).

## Verification

- Backend: lint, build, full unit suite (2851 tests), and e2e — green under 6.0.3, including the real worker-thread sandbox integration suites.
- `npx tsc --noEmit -p tsconfig.json` (the CI typecheck step) — clean.
- Dashboard: build + lint — green (it manages its own TypeScript independently).
- Peer graph clean: typescript-eslint (`<6.1.0`) and ts-jest (`<7`) both admit 6.0.3.
