### PR TITLE
chore(deps): drop the unused @nestjs-modules/ioredis dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@bull-board/express": "^8.1.2",
         "@bull-board/nestjs": "^8.1.2",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@nestjs-modules/ioredis": "^2.2.2",
         "@nestjs/bullmq": "^11.0.4",
         "@nestjs/common": "^11.1.28",
         "@nestjs/config": "^4.0.2",
@@ -3457,20 +3456,6 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
-    "node_modules/@nestjs-modules/ioredis": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@nestjs-modules/ioredis/-/ioredis-2.2.2.tgz",
-      "integrity": "sha512-8y/lzpP7CuBRXboPN9EdCBycg5PwzEY+wW6EkqjR+jYAxidlBVakxVLPPVtzDK7Yr0SiUiZu8hjuGwuB7uhicw==",
-      "license": "MIT",
-      "optionalDependencies": {
-        "@nestjs/terminus": "11.1.1"
-      },
-      "peerDependencies": {
-        "@nestjs/common": ">=6.7.0",
-        "@nestjs/core": ">=6.7.0",
-        "ioredis": ">=5.0.0"
-      }
-    },
     "node_modules/@nestjs/bull-shared": {
       "version": "11.0.4",
       "resolved": "https://registry.npmjs.org/@nestjs/bull-shared/-/bull-shared-11.0.4.tgz",
@@ -3887,77 +3872,6 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.mjs"
-      }
-    },
-    "node_modules/@nestjs/terminus": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/@nestjs/terminus/-/terminus-11.1.1.tgz",
-      "integrity": "sha512-Ssql79H+EQY/Wg108eJqN4NiNsO/tLrj+qbzOWSQUf2JE4vJQ2RG3WTqUOrYjfjWmVHD3+Ys0+azed7LSMKScw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "boxen": "5.1.2",
-        "check-disk-space": "3.4.0"
-      },
-      "peerDependencies": {
-        "@grpc/grpc-js": "*",
-        "@grpc/proto-loader": "*",
-        "@mikro-orm/core": "*",
-        "@mikro-orm/nestjs": "*",
-        "@nestjs/axios": "^2.0.0 || ^3.0.0 || ^4.0.0",
-        "@nestjs/common": "^10.0.0 || ^11.0.0",
-        "@nestjs/core": "^10.0.0 || ^11.0.0",
-        "@nestjs/microservices": "^10.0.0 || ^11.0.0",
-        "@nestjs/mongoose": "^11.0.0",
-        "@nestjs/sequelize": "^10.0.0 || ^11.0.0",
-        "@nestjs/typeorm": "^10.0.0 || ^11.0.0",
-        "@prisma/client": "*",
-        "mongoose": "*",
-        "reflect-metadata": "0.1.x || 0.2.x",
-        "rxjs": "7.x",
-        "sequelize": "*",
-        "typeorm": "*"
-      },
-      "peerDependenciesMeta": {
-        "@grpc/grpc-js": {
-          "optional": true
-        },
-        "@grpc/proto-loader": {
-          "optional": true
-        },
-        "@mikro-orm/core": {
-          "optional": true
-        },
-        "@mikro-orm/nestjs": {
-          "optional": true
-        },
-        "@nestjs/axios": {
-          "optional": true
-        },
-        "@nestjs/microservices": {
-          "optional": true
-        },
-        "@nestjs/mongoose": {
-          "optional": true
-        },
-        "@nestjs/sequelize": {
-          "optional": true
-        },
-        "@nestjs/typeorm": {
-          "optional": true
-        },
-        "@prisma/client": {
-          "optional": true
-        },
-        "mongoose": {
-          "optional": true
-        },
-        "sequelize": {
-          "optional": true
-        },
-        "typeorm": {
-          "optional": true
-        }
       }
     },
     "node_modules/@nestjs/testing": {
@@ -5712,16 +5626,6 @@
         "ajv": "^6.9.1"
       }
     },
-    "node_modules/ansi-align": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
-      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "string-width": "^4.1.0"
-      }
-    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -6399,47 +6303,6 @@
       "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
       "license": "MIT"
     },
-    "node_modules/boxen": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
-      "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ansi-align": "^3.0.0",
-        "camelcase": "^6.2.0",
-        "chalk": "^4.1.0",
-        "cli-boxes": "^2.2.1",
-        "string-width": "^4.2.2",
-        "type-fest": "^0.20.2",
-        "widest-line": "^3.1.0",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/boxen/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.16",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
@@ -6665,7 +6528,7 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -6699,7 +6562,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -6728,16 +6591,6 @@
       "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/check-disk-space": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/check-disk-space/-/check-disk-space-3.4.0.tgz",
-      "integrity": "sha512-drVkSqfwA+TvuEhFipiR1OC9boEGZL5RrWvVsOthdcvQNXyCCuKkEiTOTXZ7qxSf/GLwq4GvzfrQD/Wz325hgw==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
@@ -6825,19 +6678,6 @@
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
         "validator": "^13.15.22"
-      }
-    },
-    "node_modules/cli-boxes": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
-      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-cursor": {
@@ -9252,7 +9092,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13618,7 +13458,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -14266,19 +14106,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "license": "(MIT OR CC0-1.0)",
-      "optional": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -15201,19 +15028,6 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
       "license": "ISC"
-    },
-    "node_modules/widest-line": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
-      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "string-width": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/win-guid": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "@bull-board/express": "^8.1.2",
     "@bull-board/nestjs": "^8.1.2",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@nestjs-modules/ioredis": "^2.2.2",
     "@nestjs/bullmq": "^11.0.4",
     "@nestjs/common": "^11.1.28",
     "@nestjs/config": "^4.0.2",


### PR DESCRIPTION
## Summary

Removes `@nestjs-modules/ioredis` from dependencies. It has been a direct dependency since the initial commit (v0.1.0) but was never wired up: the gateway talks to Redis through the raw `ioredis` driver (`app.module.ts`, `cache.service.ts`, `redis-throttler.storage.ts`, `queue/redis-connection.ts`), and nothing imports the NestJS wrapper — no `IoredisModule` registration, no `@InjectRedis`, anywhere in `src/` or `test/`.

Removing it also drops its orphaned transitive subtree — **9 packages in total** (`@nestjs-modules/ioredis`, `@nestjs/terminus`, `boxen`, `ansi-align`, `cli-boxes`, `widest-line`, `wrap-ansi`, `type-fest`, `check-disk-space`), each verified to have zero references in the codebase.

## Impact

- No runtime or behavior change — nothing imported any of the removed packages.
- Trims the dependency surface (9 fewer packages to install and audit) and stops dependabot from opening bump PRs for a package the project does not use.

## Verification

- Backend build, lint, and the full unit suite (2846 tests) — green with only the dependency removed, no code changes.
- `npm ci --dry-run` — lockfile consistent; `dashboard/package-lock.json` unaffected.