### PR TITLE
fix(cache): guarantee client teardown on shutdown; drop a dead audit metadata field

### DIFF
--- a/src/common/cache/cache.service.spec.ts
+++ b/src/common/cache/cache.service.spec.ts
@@ -19,15 +19,18 @@ describe('CacheService.onModuleDestroy (bounded shutdown)', () => {
     await expect(makeService().onModuleDestroy()).resolves.toBeUndefined();
   });
 
-  it('completes via a clean quit() without force-disconnecting', async () => {
+  it('prefers a graceful quit() but always releases the socket afterward', async () => {
     const service = makeService();
     const redis = { quit: jest.fn().mockResolvedValue('OK'), disconnect: jest.fn() };
     withRedis(service, redis);
 
     await service.onModuleDestroy();
 
+    // A clean quit() is used, and disconnect() still runs as the guaranteed final release — a
+    // never-ready client (down Redis + never-give-up retryStrategy) would otherwise leak a live
+    // reconnect timer past teardown. disconnect() is idempotent, so this is safe after a clean quit.
     expect(redis.quit).toHaveBeenCalledTimes(1);
-    expect(redis.disconnect).not.toHaveBeenCalled();
+    expect(redis.disconnect).toHaveBeenCalledTimes(1);
   });
 
   it('force-disconnects when quit() hangs past the deadline (shutdown still completes)', async () => {
@@ -46,11 +49,28 @@ describe('CacheService.onModuleDestroy (bounded shutdown)', () => {
       jest.useRealTimers();
     }
   });
+
+  it('releases a never-ready client whose quit() rejects fast (no leaked reconnect timer)', async () => {
+    const service = makeService();
+    // A down/reconnecting client with enableOfflineQueue:false rejects quit() immediately WITHOUT
+    // closing the socket; onModuleDestroy must still disconnect() it so ioredis's forever-retry timer
+    // does not outlive teardown.
+    const redis = { quit: jest.fn().mockRejectedValue(new Error("Stream isn't writeable")), disconnect: jest.fn() };
+    withRedis(service, redis);
+
+    await expect(service.onModuleDestroy()).resolves.toBeUndefined();
+
+    expect(redis.disconnect).toHaveBeenCalledTimes(1);
+  });
 });
 
-// Regression coverage for the Redis-outage recovery bug: the cache used to give up reconnecting after a
-// fixed number of failures and never cleared a dead client, so a Redis restart (or a Redis that was down
-// at boot and came back) left the cache permanently dead until the whole app was restarted.
+// Redis-outage recovery. The old cache gave up reconnecting after a fixed number of failures and never
+// cleared a dead client, so a restart (or a Redis down at boot) left the cache dead until the app
+// restarted. The client mock here always resolves connect(), so these first tests pin the NEW contract
+// — one client for the process lifetime, isAvailable() tracking live ping state and never latching off —
+// rather than the old-vs-new difference itself. That difference lives entirely in the ioredis options
+// (retryStrategy never null + enableOfflineQueue:false), which the 'configures ioredis…' test below
+// asserts directly; it is the one test that fails against the pre-fix code.
 describe('CacheService Redis-outage resilience', () => {
   const RedisMock = Redis as unknown as jest.Mock;
 
@@ -103,9 +123,11 @@ describe('CacheService Redis-outage resilience', () => {
     expect(RedisMock).toHaveBeenCalledTimes(1);
   });
 
-  it('never permanently gives up: recovers even after many boot-time failures', async () => {
+  it('never latches off: keeps reflecting live state and recovers after a long run of failures', async () => {
     const ping = jest.fn();
-    for (let i = 0; i < 8; i++) ping.mockRejectedValueOnce(new Error('down')); // 8 > the old hard cap of 5
+    // Many consecutive unavailable polls (more than the old code's 5-attempt give-up cap) must not make
+    // isAvailable() stick at false — the single client keeps being re-pinged, never abandoned.
+    for (let i = 0; i < 8; i++) ping.mockRejectedValueOnce(new Error('down'));
     ping.mockResolvedValue('PONG'); // Redis finally reachable
     useClient(ping);
     const service = new CacheService(enabledConfig());

--- a/src/common/cache/cache.service.ts
+++ b/src/common/cache/cache.service.ts
@@ -114,20 +114,24 @@ export class CacheService implements OnModuleDestroy {
 
     // Bound the teardown: redis.quit() waits for the QUIT reply, which never arrives on a half-open /
     // partitioned socket — leaving app.close() blocked until the orchestrator SIGKILLs the process.
-    // Force-disconnect after a short deadline so shutdown always completes.
+    // Race a graceful QUIT against a short deadline so shutdown always proceeds.
     let timer: NodeJS.Timeout | undefined;
-    const forceDisconnect = new Promise<void>(resolve => {
-      timer = setTimeout(() => {
-        redis.disconnect();
-        resolve();
-      }, CACHE_QUIT_TIMEOUT_MS);
+    const deadline = new Promise<void>(resolve => {
+      timer = setTimeout(resolve, CACHE_QUIT_TIMEOUT_MS);
       timer.unref();
     });
 
     try {
-      await Promise.race([redis.quit().catch(() => undefined), forceDisconnect]);
+      await Promise.race([redis.quit().catch(() => undefined), deadline]);
     } finally {
       if (timer) clearTimeout(timer);
+      // Always release the socket. With the never-give-up retryStrategy, a Redis that is down at
+      // shutdown leaves the client stuck 'reconnecting', and (enableOfflineQueue:false) quit() rejects
+      // instantly WITHOUT closing it — so ioredis's reconnect timer would outlive teardown. disconnect()
+      // is idempotent, so calling it after a clean quit is harmless; this guarantees no live handle
+      // survives onModuleDestroy regardless of connection state, rather than relying on process.exit to
+      // reap it.
+      redis.disconnect();
     }
   }
 

--- a/src/modules/infra/infra.controller.ts
+++ b/src/modules/infra/infra.controller.ts
@@ -1706,10 +1706,10 @@ export class InfraController {
       await queryRunner.commitTransaction();
 
       // Audit the destructive replace-all restore, only on the committed-success path (the rollback /
-      // refused-empty branches above return without emitting, since no data actually changed).
-      await this.auditService?.logInfo(AuditAction.INFRA_DATA_IMPORTED, {
-        metadata: { counts, warnings: warnings.length },
-      });
+      // refused-empty branches above return without emitting, since no data actually changed). Any
+      // warnings would have taken the rollback branch, so warnings.length is always 0 here — record
+      // only the per-table counts.
+      await this.auditService?.logInfo(AuditAction.INFRA_DATA_IMPORTED, { metadata: { counts } });
 
       return { imported: true, counts, warnings };
     } catch (error) {


### PR DESCRIPTION
## Summary

Small, source-level hardening follow-ups from a self-review of the two changes shipped this cycle (#883 infra audit trail, #885 cache resilience — both still unreleased). No user-facing behavior changes; no regressions (full backend suite green).

## Changes

**1. Guarantee the Redis client is released on shutdown.** `CacheService.onModuleDestroy` now always calls `disconnect()` in its `finally`. #885's never-give-up `retryStrategy` keeps a down-at-shutdown client in `reconnecting`, and `enableOfflineQueue:false` makes `quit()` reject instantly *without* closing the socket — so ioredis's reconnect timer could survive teardown (it was only reaped by `ShutdownService`'s `process.exit`, so there was no observable hang, but `onModuleDestroy`'s job is to release the handle itself). `disconnect()` is idempotent, so it is harmless after a clean `quit()`; the graceful-quit-vs-deadline race is unchanged. A new regression test asserts a never-ready client whose `quit()` rejects fast is still disconnected — it fails against the pre-change teardown.

**2. Drop a dead audit-metadata field.** The `INFRA_DATA_IMPORTED` emit recorded `warnings: warnings.length`, but every path that reaches it has already passed the `warnings.length > 0` rollback-and-return guard, so the value is structurally always `0`. Removing it keeps the audit row honest (no field an auditor could mistake for a live signal).

**3. Fix misleading test comments.** Two of the cache resilience tests use a mock that always resolves `connect()`, so they pin the *new* single-client contract (one client for the process lifetime; `isAvailable()` tracks live ping state and never latches off) rather than the old-vs-new difference. The comments now say so and point at the `configures ioredis…` test, which is the one that actually fails against the pre-fix code (via the `retryStrategy`-never-null / `enableOfflineQueue:false` assertions).

## Verification

Full backend suite green (2882 passed); build, ESLint, Prettier all pass. The new teardown regression test was confirmed to fail against the pre-change `onModuleDestroy` and pass with the fix.
