### PR TITLE
fix(build): keep tsbuildinfo inside dist so nest deleteOutDir cannot strand it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`npm run dev` no longer crashes on the second launch with `Cannot find module '.../dist/main'`.**
+  The TypeScript 6 upgrade moved the incremental build cache (`tsbuildinfo`) out of `dist/` to the
+  project root, where the dev server's `deleteOutDir` wipe could no longer remove it. On every start
+  after the first, the compiler trusted the stale cache, emitted no JavaScript at all, and the
+  freshly spawned `node dist/main` crashed with `MODULE_NOT_FOUND` (#891). The cache is pinned back
+  inside `dist/` so it is wiped together with the build output, restoring a full emit on every start.
+  Thanks @Magnarks.
+
 - **Outbound `withSafeFetch` no longer crashes the process on unread webhook response bodies.**
   Status-only callers (queued webhook delivery, webhook test, deprecated direct delivery) left the
   undici response body unread; when the peer reset the TLS socket — or the per-request dispatcher

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,7 +2,11 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     // TypeScript 6 requires the output layout anchor to be explicit (TS5011).
-    "rootDir": "./src"
+    "rootDir": "./src",
+    // Keep the incremental cache inside outDir: TypeScript 6 moved the default next to this
+    // config file, where nest's deleteOutDir no longer wipes it — tsc then trusted the stale
+    // cache, emitted nothing, and `node dist/main` crashed with MODULE_NOT_FOUND (issue #891).
+    "tsBuildInfoFile": "./dist/tsconfig.build.tsbuildinfo"
   },
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts", "dashboard"],
   "include": ["src"]


### PR DESCRIPTION
## Summary

Fixes the `Cannot find module '.../dist/main'` crash that made every `npm run dev` after the first fail with `MODULE_NOT_FOUND`, first reported in #891.

## Root cause

PR #877 upgraded TypeScript 5 → 6. TypeScript 6 changed the default `tsbuildinfo` location: it now sits **next to the tsconfig file** (project root) instead of inside `outDir`.

`nest-cli.json` sets `deleteOutDir: true`, so every `nest start --watch` wipes `dist/` — but the incremental cache at the project root survived the wipe. On the next start, tsc trusted the stale cache, reported `Found 0 errors`, **emitted zero JS files**, and the spawned `node dist/main` then crashed because `dist/main.js` did not exist. First run always worked (no cache yet); every subsequent run failed.

Reproduced locally: with a populated root `tsconfig.build.tsbuildinfo` and an empty `dist/`, `tsc -p tsconfig.build.json --listEmittedFiles` emits only the tsbuildinfo and no JS.

## Fix

Pin `tsBuildInfoFile` to `./dist/tsconfig.build.tsbuildinfo` in `tsconfig.build.json` so the cache lives inside `outDir` again and is wiped together with the output by `deleteOutDir` — restoring the pre-TS6 full-emit-on-start behavior. One-line config change; watch-mode stays incremental while the process runs.

## Verification

- Clean build emits `dist/main.js` and places `tsconfig.build.tsbuildinfo` inside `dist/`; no cache remains at the project root.
- Simulated second run (`rm -rf dist`, as `deleteOutDir` does) now triggers a full emit instead of a zero-emit no-op.

## Thanks

Closes #891 — thank you @Magnarks for the clear report and reproduction steps. The detail that it worked on the first launch but failed on every launch after that was the key clue that pointed straight at the incremental build cache.

