### PR TITLE
fix(dashboard): status tab error state, live viewer, picker fixes, i18n cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   select; and picking an image file then immediately switching to a URL no longer lets the
   late-arriving file bytes override the URL.
 
+- **Status tab: clearer errors, a fresher viewer, and picker fixes.** A failed statuses fetch now
+  shows an explicit error instead of looking like "no active statuses". The open status viewer
+  stays in sync when statuses refetch — newly arrived items appear without re-opening the contact,
+  and a contact whose statuses have all expired closes cleanly. The compose recipient search now
+  matches name, pushName, number, or JID, and selection is capped at 256 like the backend instead
+  of failing on submit. Contacts known only by their pushName now show it in the list and viewer
+  instead of a raw JID. The locales drop two dead keys, and Arabic, Hebrew, and Telugu get proper
+  plural forms for the status item count.
+
 ## [0.10.8] - 2026-07-23
 
 ### Added

--- a/dashboard/src/i18n/locales/ar.json
+++ b/dashboard/src/i18n/locales/ar.json
@@ -123,11 +123,15 @@
       "status": "الحالة"
     },
     "status": {
-      "placeholderTitle": "الحالة",
-      "placeholderDesc": "ستتوفر تحديثات الحالة لكل جهة اتصال في تحديث مستقبلي.",
       "itemCount": "تحديث {{count}}",
+      "itemCount_zero": "{{count}} تحديثات",
+      "itemCount_one": "تحديث واحد",
+      "itemCount_two": "تحديثان",
+      "itemCount_few": "{{count}} تحديثات",
+      "itemCount_many": "{{count}} تحديثًا",
       "itemCount_other": "{{count}} تحديثات",
       "empty": "لا توجد جهات اتصال لديها حالة نشطة.",
+      "loadError": "تعذر تحميل الحالات.",
       "mediaUnavailable": "الوسائط غير متوفرة",
       "compose": "نشر حالة",
       "composeText": "نص",

--- a/dashboard/src/i18n/locales/de.json
+++ b/dashboard/src/i18n/locales/de.json
@@ -123,11 +123,10 @@
       "status": "Status"
     },
     "status": {
-      "placeholderTitle": "Status",
-      "placeholderDesc": "Status-Updates pro Kontakt werden in einem zukünftigen Update verfügbar sein.",
       "itemCount": "{{count}} Update",
       "itemCount_other": "{{count}} Updates",
       "empty": "Kein Kontakt hat einen aktiven Status.",
+      "loadError": "Statusmeldungen konnten nicht geladen werden.",
       "mediaUnavailable": "Medien nicht verfügbar",
       "compose": "Status posten",
       "composeText": "Text",

--- a/dashboard/src/i18n/locales/en.json
+++ b/dashboard/src/i18n/locales/en.json
@@ -123,11 +123,10 @@
       "status": "Status"
     },
     "status": {
-      "placeholderTitle": "Status",
-      "placeholderDesc": "Per-contact status updates arrive in a future update.",
       "itemCount": "{{count}} update",
       "itemCount_other": "{{count}} updates",
       "empty": "No contacts have an active status.",
+      "loadError": "Failed to load statuses.",
       "mediaUnavailable": "Media unavailable",
       "compose": "Post a status",
       "composeText": "Text",

--- a/dashboard/src/i18n/locales/es.json
+++ b/dashboard/src/i18n/locales/es.json
@@ -123,11 +123,10 @@
       "status": "Estado"
     },
     "status": {
-      "placeholderTitle": "Estado",
-      "placeholderDesc": "Las actualizaciones de estado por contacto llegarán en una futura actualización.",
       "itemCount": "{{count}} actualización",
       "itemCount_other": "{{count}} actualizaciones",
       "empty": "Ningún contacto tiene un estado activo.",
+      "loadError": "No se pudieron cargar los estados.",
       "mediaUnavailable": "Contenido multimedia no disponible",
       "compose": "Publicar un estado",
       "composeText": "Texto",

--- a/dashboard/src/i18n/locales/fr.json
+++ b/dashboard/src/i18n/locales/fr.json
@@ -123,11 +123,10 @@
       "status": "Statut"
     },
     "status": {
-      "placeholderTitle": "Statut",
-      "placeholderDesc": "Les mises à jour de statut par contact arriveront dans une future mise à jour.",
       "itemCount": "{{count}} mise à jour",
       "itemCount_other": "{{count}} mises à jour",
       "empty": "Aucun contact n'a de statut actif.",
+      "loadError": "Échec du chargement des statuts.",
       "mediaUnavailable": "Média indisponible",
       "compose": "Publier un statut",
       "composeText": "Texte",

--- a/dashboard/src/i18n/locales/he.json
+++ b/dashboard/src/i18n/locales/he.json
@@ -123,11 +123,13 @@
       "status": "סטטוס"
     },
     "status": {
-      "placeholderTitle": "סטטוס",
-      "placeholderDesc": "עדכוני סטטוס לפי איש קשר יגיעו בעדכון עתידי.",
       "itemCount": "עדכון {{count}}",
+      "itemCount_one": "עדכון {{count}}",
+      "itemCount_two": "{{count}} עדכונים",
+      "itemCount_many": "{{count}} עדכונים",
       "itemCount_other": "{{count}} עדכונים",
       "empty": "לאף איש קשר אין סטטוס פעיל.",
+      "loadError": "טעינת הסטטוסים נכשלה.",
       "mediaUnavailable": "המדיה אינה זמינה",
       "compose": "פרסם סטטוס",
       "composeText": "טקסט",

--- a/dashboard/src/i18n/locales/it.json
+++ b/dashboard/src/i18n/locales/it.json
@@ -123,11 +123,10 @@
       "status": "Stato"
     },
     "status": {
-      "placeholderTitle": "Stato",
-      "placeholderDesc": "Gli aggiornamenti di stato per contatto arriveranno in un aggiornamento futuro.",
       "itemCount": "{{count}} aggiornamento",
       "itemCount_other": "{{count}} aggiornamenti",
       "empty": "Nessun contatto ha uno stato attivo.",
+      "loadError": "Impossibile caricare gli stati.",
       "mediaUnavailable": "Contenuto multimediale non disponibile",
       "compose": "Pubblica uno stato",
       "composeText": "Testo",

--- a/dashboard/src/i18n/locales/ko.json
+++ b/dashboard/src/i18n/locales/ko.json
@@ -123,11 +123,10 @@
       "status": "상태"
     },
     "status": {
-      "placeholderTitle": "상태",
-      "placeholderDesc": "연락처별 상태 업데이트는 향후 업데이트에서 제공될 예정입니다.",
       "itemCount": "업데이트 {{count}}개",
       "itemCount_other": "업데이트 {{count}}개",
       "empty": "활성 상태가 있는 연락처가 없습니다.",
+      "loadError": "상태를 불러오지 못했습니다.",
       "mediaUnavailable": "미디어를 사용할 수 없음",
       "compose": "상태 게시",
       "composeText": "텍스트",

--- a/dashboard/src/i18n/locales/pt-BR.json
+++ b/dashboard/src/i18n/locales/pt-BR.json
@@ -123,11 +123,10 @@
       "status": "Status"
     },
     "status": {
-      "placeholderTitle": "Status",
-      "placeholderDesc": "As atualizações de status por contato chegarão em uma atualização futura.",
       "itemCount": "{{count}} atualização",
       "itemCount_other": "{{count}} atualizações",
       "empty": "Nenhum contato tem um status ativo.",
+      "loadError": "Falha ao carregar os status.",
       "mediaUnavailable": "Mídia indisponível",
       "compose": "Publicar um status",
       "composeText": "Texto",

--- a/dashboard/src/i18n/locales/te.json
+++ b/dashboard/src/i18n/locales/te.json
@@ -123,11 +123,10 @@
       "status": "స్థితి"
     },
     "status": {
-      "placeholderTitle": "స్థితి",
-      "placeholderDesc": "Per-contact status updates arrive in a future update.",
-      "itemCount": "{{count}} update",
-      "itemCount_other": "{{count}} updates",
+      "itemCount": "{{count}} నవీకరణ",
+      "itemCount_other": "{{count}} నవీకరణలు",
       "empty": "No contacts have an active status.",
+      "loadError": "స్థితులను లోడ్ చేయడం విఫలమైంది.",
       "mediaUnavailable": "Media unavailable",
       "compose": "Post a status",
       "composeText": "Text",

--- a/dashboard/src/i18n/locales/zh-CN.json
+++ b/dashboard/src/i18n/locales/zh-CN.json
@@ -123,11 +123,10 @@
       "status": "状态"
     },
     "status": {
-      "placeholderTitle": "状态",
-      "placeholderDesc": "单个联系人的状态更新将在未来版本中推出。",
       "itemCount": "{{count}} 条更新",
       "itemCount_other": "{{count}} 条更新",
       "empty": "没有联系人有活跃的状态。",
+      "loadError": "无法加载状态。",
       "mediaUnavailable": "媒体不可用",
       "compose": "发布状态",
       "composeText": "文字",

--- a/dashboard/src/i18n/locales/zh-HK.json
+++ b/dashboard/src/i18n/locales/zh-HK.json
@@ -123,11 +123,10 @@
       "status": "狀態"
     },
     "status": {
-      "placeholderTitle": "狀態",
-      "placeholderDesc": "個別聯絡人的狀態更新將於日後更新中推出。",
       "itemCount": "{{count}} 則更新",
       "itemCount_other": "{{count}} 則更新",
       "empty": "沒有聯絡人有活躍的狀態。",
+      "loadError": "無法載入狀態。",
       "mediaUnavailable": "媒體無法使用",
       "compose": "發佈狀態",
       "composeText": "文字",

--- a/dashboard/src/pages/Chats.tsx
+++ b/dashboard/src/pages/Chats.tsx
@@ -183,6 +183,10 @@ function StatusMedia({
   return <img className="channel-media" src={src} alt="" />;
 }
 
+// Mirrors @ArrayMaxSize(256) on the send-status DTOs — the picker caps selection client-side so the
+// user can't build a list the backend is guaranteed to reject.
+const STATUS_RECIPIENTS_MAX = 256;
+
 export function Chats() {
   const { t } = useTranslation();
   useDocumentTitle(t('nav.chats'));
@@ -202,7 +206,11 @@ export function Chats() {
   // Selected chat & message history
   const [activeChat, setActiveChat] = useState<Chat | null>(null);
   const [activeChannel, setActiveChannel] = useState<Channel | null>(null);
-  const [activeStatusContact, setActiveStatusContact] = useState<ContactStatusGroup | null>(null);
+  // Only the contact id is state — the open group is derived from groupedStatuses at render, so a
+  // refetch (window focus, post-compose) flows straight into the open viewer instead of leaving it
+  // pinned to the snapshot captured at click time. A group that disappears (all items expired)
+  // simply closes the viewer.
+  const [activeStatusContactId, setActiveStatusContactId] = useState<string | null>(null);
 
   // Chats/Channels/Status tab selection. Switching tabs closes whatever conversation is open so a
   // press on another tab doesn't leave a Chats-tab room rendered underneath a Channels/Status list.
@@ -211,7 +219,7 @@ export function Chats() {
     setActiveTab(tab);
     setActiveChat(null);
     setActiveChannel(null);
-    setActiveStatusContact(null);
+    setActiveStatusContactId(null);
   }, []);
 
   // Channels tab: only whatsapp-web.js implements channel listing/reading — Baileys throws 501 for
@@ -238,14 +246,6 @@ export function Chats() {
     const el = channelFeedRef.current;
     if (el) el.scrollTop = el.scrollHeight;
   }, [activeChannel?.id, channelMessages.data]);
-
-  // Same open-at-newest behavior for the status viewer pane, keyed off the active contact and its
-  // item list.
-  const statusFeedRef = useRef<HTMLDivElement | null>(null);
-  useEffect(() => {
-    const el = statusFeedRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
-  }, [activeStatusContact?.contact.id, activeStatusContact?.items]);
 
   // --- Status compose modal ---
   // Baileys targets a status post to an explicit allow-list (statusJidList); whatsapp-web.js has no
@@ -279,7 +279,8 @@ export function Chats() {
   const composeContacts = composeContactsQuery.data ?? [];
   const composeRecipientSearchLower = composeRecipientSearch.toLowerCase();
   const filteredComposeContacts = composeContacts.filter(c =>
-    (c.name ?? c.pushName ?? c.number ?? c.id).toLowerCase().includes(composeRecipientSearchLower),
+    // Match against every identity field — a named contact must still be findable by number/JID.
+    [c.name, c.pushName, c.number, c.id].some(v => v?.toLowerCase().includes(composeRecipientSearchLower)),
   );
 
   const resetComposeForm = useCallback(() => {
@@ -302,7 +303,13 @@ export function Chats() {
   }, [resetComposeForm]);
 
   const toggleComposeRecipient = (id: string) => {
-    setComposeRecipients(prev => (prev.includes(id) ? prev.filter(r => r !== id) : [...prev, id]));
+    setComposeRecipients(prev =>
+      prev.includes(id)
+        ? prev.filter(r => r !== id)
+        : prev.length >= STATUS_RECIPIENTS_MAX
+          ? prev
+          : [...prev, id],
+    );
   };
 
   const handleComposeImageUrlChange = (value: string) => {
@@ -521,7 +528,7 @@ export function Chats() {
       void loadChats(selectedSessionId);
       setActiveChat(null);
       setActiveChannel(null);
-      setActiveStatusContact(null);
+      setActiveStatusContactId(null);
       setAttachment(null);
       setPreviewUrl(null);
     }
@@ -877,12 +884,12 @@ export function Chats() {
             setActiveTab('status');
             setActiveChat(chat);
             setActiveChannel(null);
-            setActiveStatusContact(null);
+            setActiveStatusContactId(null);
           } else {
             setActiveTab('chats');
             setActiveChat(chat);
             setActiveChannel(null);
-            setActiveStatusContact(null);
+            setActiveStatusContactId(null);
           }
         } else {
           pendingHitRef.current = null;
@@ -905,12 +912,12 @@ export function Chats() {
         setActiveTab('status');
         setActiveChat(chat);
         setActiveChannel(null);
-        setActiveStatusContact(null);
+        setActiveStatusContactId(null);
       } else {
         setActiveTab('chats');
         setActiveChat(chat);
         setActiveChannel(null);
-        setActiveStatusContact(null);
+        setActiveStatusContactId(null);
       }
     }
   }, [chats, activeChat, switchTab]);
@@ -1156,9 +1163,24 @@ export function Chats() {
     .filter(
       g =>
         (g.contact.name ?? '').toLowerCase().includes(searchQueryLower) ||
+        (g.contact.pushName ?? '').toLowerCase().includes(searchQueryLower) ||
         g.contact.id.toLowerCase().includes(searchQueryLower),
     )
     .sort((a, b) => (a.latest < b.latest ? 1 : a.latest > b.latest ? -1 : 0));
+
+  // The open status group, derived — see the activeStatusContactId declaration.
+  const activeStatusGroup = activeStatusContactId
+    ? (groupedStatuses.find(g => g.contact.id === activeStatusContactId) ?? null)
+    : null;
+
+  // Same open-at-newest behavior for the status viewer pane, keyed off the active contact and its
+  // item list. Declared after activeStatusGroup: the viewer follows refetches because the deps are
+  // the derived group's items, not a click-time snapshot.
+  const statusFeedRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    const el = statusFeedRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [activeStatusGroup?.contact.id, activeStatusGroup?.items]);
 
   // Shared row markup for the Chats and Status lists — a plain function (not memoized) since it
   // closes over render-scoped state (activeChat, listPics) that already changes every render.
@@ -1252,7 +1274,7 @@ export function Chats() {
           </p>
         </div>
       ) : (
-        <div className={`chats-layout ${activeChat || activeChannel || activeStatusContact ? 'has-active-chat' : ''}`}>
+        <div className={`chats-layout ${activeChat || activeChannel || activeStatusGroup ? 'has-active-chat' : ''}`}>
           {/* LEFT SIDEBAR: session & chat rooms */}
           <aside className="chats-sidebar">
             <div className="sidebar-header-box">
@@ -1388,6 +1410,11 @@ export function Chats() {
                   <div className="chats-list-loading">
                     <Loader2 className="animate-spin" size={24} />
                   </div>
+                ) : statusesQuery.isError ? (
+                  <div className="chats-list-empty">
+                    <AlertCircle size={24} className="text-warn" />
+                    <span>{t('chats.status.loadError')}</span>
+                  </div>
                 ) : groupedStatuses.length === 0 ? (
                   <div className="chats-list-empty">
                     <span>{t('chats.status.empty')}</span>
@@ -1396,15 +1423,17 @@ export function Chats() {
                   groupedStatuses.map(group => (
                     <div
                       key={group.contact.id}
-                      className={`chat-item-card ${activeStatusContact?.contact.id === group.contact.id ? 'active' : ''}`}
-                      onClick={() => setActiveStatusContact(group)}
+                      className={`chat-item-card ${activeStatusContactId === group.contact.id ? 'active' : ''}`}
+                      onClick={() => setActiveStatusContactId(group.contact.id)}
                     >
                       <div className="chat-avatar">
                         <CircleDashed size={20} />
                       </div>
                       <div className="chat-item-info">
                         <div className="chat-item-top">
-                          <span className="chat-item-name">{group.contact.name || group.contact.id}</span>
+                          <span className="chat-item-name">
+                            {group.contact.name ?? group.contact.pushName ?? group.contact.id}
+                          </span>
                           <span className="chat-item-time">
                             {formatChatTime(Math.floor(new Date(group.latest).getTime() / 1000))}
                           </span>
@@ -1874,23 +1903,23 @@ export function Chats() {
                   )}
                 </div>
               </div>
-            ) : activeStatusContact ? (
+            ) : activeStatusGroup ? (
               // Read-only status viewer: no send footer, reactions, delete, reply, or markChatRead —
               // statuses are ephemeral broadcast posts, not a two-way conversation.
-              <div key={activeStatusContact.contact.id} className="channel-room">
+              <div key={activeStatusGroup.contact.id} className="channel-room">
                 <header className="chats-room-header">
                   <button
                     className="room-back"
-                    onClick={() => setActiveStatusContact(null)}
+                    onClick={() => setActiveStatusContactId(null)}
                     aria-label={t('common.back')}
                   >
                     <ArrowLeft size={20} />
                   </button>
                   <CircleDashed size={20} />
-                  <h2>{activeStatusContact.contact.name ?? activeStatusContact.contact.id}</h2>
+                  <h2>{activeStatusGroup.contact.name ?? activeStatusGroup.contact.pushName ?? activeStatusGroup.contact.id}</h2>
                 </header>
                 <div className="messages-list" ref={statusFeedRef}>
-                  {activeStatusContact.items.map(item => (
+                  {activeStatusGroup.items.map(item => (
                     <div key={item.id} className="message-bubble incoming">
                       {item.mediaUrl && (
                         <StatusMedia
@@ -2044,6 +2073,7 @@ export function Chats() {
                       <input
                         type="checkbox"
                         checked={composeRecipients.includes(c.id)}
+                        disabled={!composeRecipients.includes(c.id) && composeRecipients.length >= STATUS_RECIPIENTS_MAX}
                         onChange={() => toggleComposeRecipient(c.id)}
                       />
                       <span>{c.name || c.pushName || c.number || c.id}</span>


### PR DESCRIPTION
## Summary

Polish batch for the dashboard Status tab. No backend changes.

## Changes

**Error state for the Status tab.** A failed `GET /sessions/:id/status` previously rendered as the "no active statuses" empty state, indistinguishable from a healthy empty list. The tab now shows an explicit error row (new `chats.status.loadError` key, translated across all 12 locales), mirroring the Channels tab's error branch.

**The open viewer follows refetches.** The Status tab stored the clicked `ContactStatusGroup` object, so when the query refetched (window focus via `refetchOnWindowFocus`, or the post-compose refetch) the open viewer stayed pinned to the stale snapshot and newly arrived statuses never rendered until re-click. The tab now stores only the contact id and derives the open group from the fresh data at render time; a group whose items have all expired simply closes the viewer. The viewer's open-at-newest scroll effect keys off the derived group's items, so it also follows fresh data.

**Recipient picker fixes.** Search matched only the first non-empty identity field via a `??` chain, so a named contact could never be found by number or JID — it now matches across name, pushName, number, and id. Selection is also capped at 256 client-side (mirroring the DTO's `@ArrayMaxSize(256)`), disabling unchecked rows at the cap instead of failing the submit with a 400.

**pushName fallback.** Status contacts resolved with only a pushName (common for seeded `@lid` posters) rendered as a raw JID and were unsearchable; the list row, viewer header, and search filter now fall back `name ?? pushName ?? id`.

**i18n cleanup.** Removed the dead `chats.status.placeholderTitle` / `placeholderDesc` keys ("arrive in a future update") from all 12 locales, translated `itemCount` for Telugu, and added the missing Arabic (`zero`/`one`/`two`/`few`/`many`) and Hebrew (`one`/`two`/`many`) plural forms for `itemCount`.

## Testing

- Dashboard build, lint (0 errors), and 135 unit tests pass.
- `i18n:check` passes; all 12 locale files validated as JSON with the live `chats.placeholderTitle` keys confirmed untouched.

