### PR TITLE
fix(chats): give group messages a stable sender identity for attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Group messages now carry a stable sender identity, so same-named participants no longer blur
+  together.** Group messages persist the participant JID (new `author` column on `messages`) next
+  to the sender's display name, and the dashboard keys attribution runs and sender colors on that
+  identity instead of the name — two participants who share a pushName now get separate runs in
+  distinct colors instead of collapsing into one misattributed thread. Live, history-backfilled,
+  and websocket-delivered messages all carry it; legacy rows fall back to name-keying.
+
 ## [0.10.9] - 2026-07-24
 
 ### Added

--- a/dashboard/src/pages/Chats.tsx
+++ b/dashboard/src/pages/Chats.tsx
@@ -43,6 +43,7 @@ import {
   mergeDeliveryStatus,
   mergeOrAppend,
   findRevokedIndex,
+  senderKey,
   type ChatMessageView,
 } from '../utils/chatMessages';
 import { useWebSocket } from '../hooks/useWebSocket';
@@ -566,6 +567,7 @@ export function Chats() {
         // For a group post `from` is the group JID, so the sender's name is carried on `contact`.
         // Persisted rows keep the same value in `chatName`; normalize both to one field for the thread.
         chatName: newMsg.contact?.pushName ?? newMsg.contact?.name,
+        author: newMsg.author,
         from: newMsg.from,
         to: newMsg.to,
         body: newMsg.body,
@@ -1536,7 +1538,9 @@ export function Chats() {
                         activeChat?.isGroup &&
                           !isMe &&
                           msg.chatName &&
-                          (!prev || prev.direction === 'outgoing' || prev.chatName !== msg.chatName),
+                          // Key the run on the stable sender id (participant JID), not the display
+                          // name — two participants who share a pushName must still start a new run.
+                          (!prev || prev.direction === 'outgoing' || senderKey(prev) !== senderKey(msg)),
                       );
 
                       const isMediaMessage = msg.type !== 'text';
@@ -1654,8 +1658,11 @@ export function Chats() {
                               } ${isRevoked ? 'revoked-type' : ''}`}
                             >
                               {/* Group sender label (WhatsApp-style: coloured name atop the bubble) */}
+                              {/* Group sender label (WhatsApp-style: coloured name atop the bubble).
+                                  Colour keys on the stable sender id, so same-named participants
+                                  still get distinct colours; the label shows the human name. */}
                               {showSender && (
-                                <div className="message-sender" style={{ color: senderColor(msg.chatName!) }}>
+                                <div className="message-sender" style={{ color: senderColor(senderKey(msg)!) }}>
                                   {msg.chatName}
                                 </div>
                               )}

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -184,6 +184,12 @@ export interface ChatMessage {
    * on legacy rows or when the engine could not resolve a name.
    */
   chatName?: string;
+  /**
+   * Stable sender identity for a group message: the participant JID who actually posted (`from` is
+   * the group JID). Present on live/engine payloads and on rows persisted after the column was
+   * added; absent on 1:1 messages, outgoing echoes, and legacy rows.
+   */
+  author?: string;
   from: string;
   to: string;
   body: string;

--- a/dashboard/src/utils/chatMessages.test.ts
+++ b/dashboard/src/utils/chatMessages.test.ts
@@ -95,6 +95,7 @@ import {
   removeMessageById,
   findRevokedIndex,
   applyMessageEdit,
+  senderKey,
   type ChatMessageView,
 } from './chatMessages.ts';
 
@@ -281,4 +282,40 @@ test('applyMessageEdit is a referential no-op for an empty or unknown target id'
   const before = [msg({ id: 'm-1', body: 'old' })];
   assert.equal(applyMessageEdit(before, { messageId: '', body: 'new' }), before);
   assert.equal(applyMessageEdit(before, { messageId: 'missing', body: 'new' }), before);
+});
+
+test('mapEngineHistoryMessage: carries the group participant JID as author', () => {
+  const m = mapEngineHistoryMessage(hist({ author: '628111@c.us' }));
+  assert.equal(m.author, '628111@c.us');
+});
+
+test('mergeChatMessages: salvages author from the engine copy when the DB row predates the column', () => {
+  // A legacy DB row (no stable sender id) merged over an engine-history copy that has one must not
+  // lose it — that id is what keeps same-named participants in separate attribution runs.
+  const history = [mapEngineHistoryMessage(hist({ id: 'WA_S1', author: '628111@c.us' }))];
+  const rows = [db({ waMessageId: 'WA_S1', author: undefined })];
+  const merged = mergeChatMessages(rows, history);
+  assert.equal(merged.length, 1);
+  assert.equal(merged[0].author, '628111@c.us');
+  // …while the rest of the winning DB row (authoritative status) is untouched.
+  assert.equal(merged[0].status, 'delivered');
+});
+
+test('mergeChatMessages: a DB-persisted author wins over the engine copy', () => {
+  const history = [mapEngineHistoryMessage(hist({ id: 'WA_S2', author: '628111@c.us' }))];
+  const rows = [db({ waMessageId: 'WA_S2', author: '628222@c.us' })];
+  assert.equal(mergeChatMessages(rows, history)[0].author, '628222@c.us');
+});
+
+test('mergeOrAppend: an author-less echo keeps the cached author', () => {
+  const list = [msg({ id: 'WA_E1', waMessageId: 'WA_E1', author: '628111@c.us' })];
+  const echo = msg({ id: 'WA_E1', waMessageId: 'WA_E1', author: undefined, body: 'echo' });
+  const out = mergeOrAppend(list, echo);
+  assert.equal(out[0].author, '628111@c.us');
+});
+
+test('senderKey prefers the participant JID and falls back to the display name', () => {
+  assert.equal(senderKey({ author: '628111@c.us', chatName: 'Alice' }), '628111@c.us');
+  assert.equal(senderKey({ chatName: 'Alice' }), 'Alice');
+  assert.equal(senderKey({}), undefined);
 });

--- a/dashboard/src/utils/chatMessages.ts
+++ b/dashboard/src/utils/chatMessages.ts
@@ -16,6 +16,7 @@ export function mapEngineHistoryMessage(h: EngineHistoryMessage): ChatMessage {
     waMessageId: h.id,
     chatId: h.chatId,
     chatName: h.contact?.pushName ?? h.contact?.name,
+    author: h.author,
     from: h.from,
     to: h.to,
     body: h.body ?? '',
@@ -42,9 +43,24 @@ const msgTime = (m: ChatMessage): number =>
 export function mergeChatMessages(db: ChatMessage[], history: ChatMessage[]): ChatMessage[] {
   const byId = new Map<string, ChatMessage>();
   for (const m of history) byId.set(msgKey(m), m);
-  for (const m of db) byId.set(msgKey(m), m); // DB overwrites the engine copy (authoritative status)
+  for (const m of db) {
+    const key = msgKey(m);
+    const hist = byId.get(key);
+    // The DB copy wins (authoritative status) — but a legacy row has no stable sender id, so
+    // salvage the engine-history copy's author or two same-named participants collapse into one
+    // attribution run in the chat view.
+    byId.set(key, hist?.author && !m.author ? { ...m, author: hist.author } : m);
+  }
   return [...byId.values()].sort((a, b) => msgTime(a) - msgTime(b) || a.createdAt.localeCompare(b.createdAt));
 }
+
+/**
+ * Stable identity of a group message's sender, for attribution runs and sender colors: the
+ * participant JID (`author`) when present, falling back to the display name on legacy rows. Keying
+ * on this — not the name alone — keeps two participants who share a pushName from collapsing into
+ * one run with one color.
+ */
+export const senderKey = (m: Pick<ChatMessage, 'author' | 'chatName'>): string | undefined => m.author ?? m.chatName;
 
 // ChatMessageView extends ChatMessage with the view-only fields the chat page renders.
 // Lifted from Chats.tsx so hooks/utils can share the same shape.
@@ -125,6 +141,8 @@ export function mergeOrAppend(list: ChatMessageView[], incoming: ChatMessageView
   const next = list.slice();
   next[idx] = {
     ...incoming,
+    // An echo that lacks the stable sender id must not erase the one already cached.
+    author: incoming.author ?? existing.author,
     status: mergeDeliveryStatus(existing.status, incoming.status) ?? incoming.status,
     metadata: mergeMessageMetadata(existing.metadata, incoming.metadata),
   };

--- a/src/database/migrations/1784908800000-AddMessageAuthor.ts
+++ b/src/database/migrations/1784908800000-AddMessageAuthor.ts
@@ -21,13 +21,13 @@ export class AddMessageAuthor1784908800000 implements MigrationInterface {
 
   private async hasAuthorColumn(queryRunner: QueryRunner): Promise<boolean> {
     if (queryRunner.connection.options.type === 'postgres') {
-      const rows: unknown[] = await queryRunner.query(
+      const rows = (await queryRunner.query(
         `SELECT 1 FROM information_schema.columns
          WHERE table_schema = current_schema() AND table_name = 'messages' AND column_name = 'author'`,
-      );
+      )) as unknown[];
       return rows.length > 0;
     }
-    const rows: Array<{ name: string }> = await queryRunner.query(`PRAGMA table_info("messages")`);
+    const rows = (await queryRunner.query(`PRAGMA table_info("messages")`)) as Array<{ name: string }>;
     return rows.some(r => r.name === 'author');
   }
 

--- a/src/database/migrations/1784908800000-AddMessageAuthor.ts
+++ b/src/database/migrations/1784908800000-AddMessageAuthor.ts
@@ -8,22 +8,37 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  *
  * Hand-authored because `synchronize` is off for the `data` connection on PostgreSQL (and optional
  * on SQLite via DATABASE_SYNCHRONIZE=false). Idempotent: checks for column existence first.
+ *
+ * NOTE: the existence check deliberately avoids `queryRunner.getTable('messages')`. Since the FTS
+ * migration added the STORED generated column `body_ts`, loading the `messages` table metadata on
+ * Postgres makes TypeORM look the expression up in `typeorm_metadata` — a table nothing in this
+ * migration context creates (the schema builder only creates it for entity-declared generated
+ * columns), so the lookup fails with "relation typeorm_metadata does not exist". A raw
+ * dialect-aware probe sidesteps that path entirely.
  */
 export class AddMessageAuthor1784908800000 implements MigrationInterface {
   name = 'AddMessageAuthor1784908800000';
 
+  private async hasAuthorColumn(queryRunner: QueryRunner): Promise<boolean> {
+    if (queryRunner.connection.options.type === 'postgres') {
+      const rows: unknown[] = await queryRunner.query(
+        `SELECT 1 FROM information_schema.columns
+         WHERE table_schema = current_schema() AND table_name = 'messages' AND column_name = 'author'`,
+      );
+      return rows.length > 0;
+    }
+    const rows: Array<{ name: string }> = await queryRunner.query(`PRAGMA table_info("messages")`);
+    return rows.some(r => r.name === 'author');
+  }
+
   public async up(queryRunner: QueryRunner): Promise<void> {
-    const table = await queryRunner.getTable('messages');
-    const col = table?.findColumnByName('author');
-    if (col) return; // already added by synchronize or a previous run
+    if (await this.hasAuthorColumn(queryRunner)) return; // already added by synchronize or a previous run
 
     await queryRunner.query(`ALTER TABLE "messages" ADD COLUMN "author" varchar NULL`);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    const table = await queryRunner.getTable('messages');
-    const col = table?.findColumnByName('author');
-    if (!col) return;
+    if (!(await this.hasAuthorColumn(queryRunner))) return;
     await queryRunner.query(`ALTER TABLE "messages" DROP COLUMN "author"`);
   }
 }

--- a/src/database/migrations/1784908800000-AddMessageAuthor.ts
+++ b/src/database/migrations/1784908800000-AddMessageAuthor.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds `author` column to the `messages` table. For a group message this stores the participant
+ * JID who actually posted (the row's `from` is the group JID), giving the chat view a stable
+ * sender identity — two participants who share a pushName no longer collapse into one attribution
+ * run. Null for one-to-one messages, outgoing echoes, and legacy rows.
+ *
+ * Hand-authored because `synchronize` is off for the `data` connection on PostgreSQL (and optional
+ * on SQLite via DATABASE_SYNCHRONIZE=false). Idempotent: checks for column existence first.
+ */
+export class AddMessageAuthor1784908800000 implements MigrationInterface {
+  name = 'AddMessageAuthor1784908800000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const table = await queryRunner.getTable('messages');
+    const col = table?.findColumnByName('author');
+    if (col) return; // already added by synchronize or a previous run
+
+    await queryRunner.query(`ALTER TABLE "messages" ADD COLUMN "author" varchar NULL`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const table = await queryRunner.getTable('messages');
+    const col = table?.findColumnByName('author');
+    if (!col) return;
+    await queryRunner.query(`ALTER TABLE "messages" DROP COLUMN "author"`);
+  }
+}

--- a/src/modules/message/entities/message.entity.ts
+++ b/src/modules/message/entities/message.entity.ts
@@ -56,6 +56,14 @@ export class Message {
   @Column({ nullable: true })
   chatName?: string;
 
+  /**
+   * Stable sender identity for a group message: the participant JID who actually posted (`from` is
+   * the group JID). Lets the chat view tell two same-named participants apart. Null on 1:1
+   * messages, outgoing echoes, and legacy rows.
+   */
+  @Column({ nullable: true })
+  author?: string;
+
   @Column()
   from: string;
 

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -1833,6 +1833,35 @@ describe('SessionService', () => {
       expect(row.metadata).toEqual({ media: marker });
     });
 
+    it('persists the group participant as author (the stable sender id attribution keys on)', async () => {
+      const callbacks = await startAndCaptureCallbacks();
+      // Pass the message through the hook chain untouched (the default mock replaces data with {}).
+      (hookManager.execute as jest.Mock).mockImplementation((_e: string, data: unknown) =>
+        Promise.resolve({ continue: true, data }),
+      );
+
+      callbacks.onMessage!(
+        makeMessage({
+          id: 'wa-grp-1',
+          from: '120363@g.us',
+          to: 'me@c.us',
+          chatId: '120363@g.us',
+          fromMe: false,
+          isGroup: true,
+          kind: 'group',
+          author: '628111@c.us',
+          contact: { id: '628111@c.us', pushName: 'Alice' },
+        }),
+      );
+      await flush();
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const row = (messageRepository.create as jest.Mock).mock.calls[0][0] as Partial<Message>;
+      expect(row.author).toBe('628111@c.us');
+      expect(row.from).toBe('120363@g.us');
+      expect(row.chatName).toBe('Alice');
+    });
+
     it('scopes the ack status UPDATE by sessionId, not just waMessageId', async () => {
       const callbacks = await startAndCaptureCallbacks();
       expect(typeof callbacks.onMessageAck).toBe('function');

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -803,6 +803,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
             sessionId: id,
             waMessageId: m.id,
             chatId: m.chatId,
+            author: m.author,
             from: m.from,
             to: m.to,
             body: m.body,
@@ -1049,6 +1050,9 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
               waMessageId: incoming.id || undefined,
               chatId: incoming.chatId,
               chatName,
+              // Group poster (participant JID) — `from` is the group JID, so this is the stable
+              // sender identity the chat view keys attribution runs/colors on. Undefined for 1:1.
+              author: incoming.author,
               from: incoming.from,
               to: incoming.to,
               body: incoming.body,


### PR DESCRIPTION
## Summary

Group sender attribution was keyed on the sender's display name, so two participants who share a pushName collapsed into a single attribution run in one color — the second sender's messages read as the first sender's. This gives group messages a stable sender identity and keys runs/colors on it. The display still shows the human name; only the grouping logic changes.

## Changes

**Persist the participant JID.** New nullable `author` column on `messages` (idempotent migration, both dialects — a plain `varchar NULL`, no default). For a group message it stores the participant JID who actually posted (the row's `from` is the group JID); null on 1:1 messages, outgoing echoes, and legacy rows. Written on both persist paths: live `onMessage` and the pre-connection history backfill. The messages API exposes it automatically via the entity.

**Attribution keys on the stable identity.** The dashboard's run detection and per-sender color hash now key on `author ?? chatName` (exported `senderKey` helper) instead of the name alone. Same-named participants start separate runs in distinct colors; a participant whose name changes mid-thread no longer splits their own run.

**Every message path carries the identity.**
- Live websocket mapping passes `author` through.
- Engine-history mapping carries it into the thread.
- The DB/history merge salvages the engine copy's `author` when the winning DB row predates the column.
- `mergeOrAppend` keeps the cached `author` when an author-less echo replaces a row.

## Testing

- Full jest suite: 2961 passed, including a new persist test (group participant lands in `author`, group JID stays in `from`).
- Dashboard: 140 unit tests (history author mapping, merge salvage, DB-author precedence, echo preservation, `senderKey` fallback), plus build/lint/typecheck.
- Full-program `tsc --noEmit`, eslint, prettier all clean. The migration follows the existing hand-authored idempotent pattern; the Postgres migration smoke runs in CI.
