### PR TITLE
feat(status): broadcast ingested statuses over the websocket in real time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **New statuses now appear in the dashboard in real time.** A freshly ingested contact status is
+  broadcast over the websocket as `status.received` (same payload as the webhook), and the Status
+  tab refreshes immediately instead of waiting for a focus refetch — including while a contact's
+  viewer is already open.
+
 ### Fixed
 
 - **Contacts with both a @lid and a phone identity now appear once in the status list.** Statuses

--- a/dashboard/src/hooks/useWebSocket.ts
+++ b/dashboard/src/hooks/useWebSocket.ts
@@ -65,6 +65,12 @@ interface MessageRevokedEvent {
   timestamp: number;
 }
 
+/** A freshly ingested contact status (story) — the dashboard uses it purely as a refetch signal. */
+interface StatusReceivedEvent {
+  sessionId: string;
+  timestamp: string;
+}
+
 interface WebSocketEvents {
   onSessionStatus?: (event: SessionStatusEvent) => void;
   onQRCode?: (event: QRCodeEvent) => void;
@@ -73,6 +79,7 @@ interface WebSocketEvents {
   onMessageReaction?: (event: MessageReactionEvent) => void;
   onMessageRevoked?: (event: MessageRevokedEvent) => void;
   onMessageEdited?: (event: MessageEditedEvent) => void;
+  onStatusReceived?: (event: StatusReceivedEvent) => void;
 }
 
 // Shape of the server -> client event envelope produced by the NestJS gateway.
@@ -206,6 +213,9 @@ export function useWebSocket(events: WebSocketEvents = {}) {
         case 'message.received':
         case 'message.sent':
           events.onMessage?.({ sessionId, message: data, timestamp: msg.timestamp });
+          break;
+        case 'status.received':
+          events.onStatusReceived?.({ sessionId, timestamp: msg.timestamp });
           break;
         case 'message.ack':
           events.onMessageAck?.({

--- a/dashboard/src/pages/Chats.tsx
+++ b/dashboard/src/pages/Chats.tsx
@@ -736,12 +736,23 @@ export function Chats() {
     [selectedSessionId, queryClient, loadChats],
   );
 
+  // A contact's new story lands here instead of in the message pipeline; invalidate the statuses
+  // query so the Status tab refetches live. A disabled query (another tab active) just goes stale
+  // and refetches on open — no background fetch either way.
+  const handleStatusReceived = useCallback(
+    (event: { sessionId: string }) => {
+      queryClient.invalidateQueries({ queryKey: ['contact-statuses', event.sessionId] });
+    },
+    [queryClient],
+  );
+
   const { isConnected, connectionFailed, reconnect, subscribe, unsubscribe } = useWebSocket({
     onMessage: handleIncomingMessage,
     onMessageAck: handleIncomingMessageAck,
     onMessageReaction: handleIncomingMessageReaction,
     onMessageRevoked: handleIncomingMessageRevoked,
     onMessageEdited: handleIncomingMessageEdited,
+    onStatusReceived: handleStatusReceived,
   });
 
   // A transient WebSocket gap means message.received/ack/revoke events were missed, and the chat
@@ -772,6 +783,7 @@ export function Chats() {
         'message.reaction',
         'message.revoked',
         'message.edited',
+        'status.received',
       ]);
       return () => {
         unsubscribe(selectedSessionId);

--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -3075,7 +3075,7 @@ Webhooks are configured per session and managed under `/api/sessions/:sessionId/
 
 Two fields — `secret` and `headers` — are **write-only**: they are accepted on create/update but are **never** returned in any response (the response DTO has no `@Expose` for them, so `fromEntity` drops them). The `secret` is used to compute the `X-OpenWA-Signature: sha256=<hex>` HMAC-SHA256 header on deliveries.
 
-The `events` array accepts these members plus the `*` wildcard: `message.received`, `message.sent`, `message.ack`, `message.failed`, `message.revoked`, `message.reaction`, `message.edited`, `session.status`, `session.qr`, `session.authenticated`, `session.disconnected`, `session.reconnect_loop`, `group.join`, `group.leave`, `group.update`, `call.received`. All of them are actively dispatched by the engines.
+The `events` array accepts these members plus the `*` wildcard: `message.received`, `message.sent`, `message.ack`, `message.failed`, `message.revoked`, `message.reaction`, `message.edited`, `session.status`, `session.qr`, `session.authenticated`, `session.disconnected`, `session.reconnect_loop`, `group.join`, `group.leave`, `group.update`, `call.received`, `status.received`. All of them are actively dispatched by the engines.
 
 #### GET /api/sessions/:sessionId/webhooks
 
@@ -4827,6 +4827,7 @@ group.join
 group.leave
 group.update
 call.received
+status.received
 ```
 
 A subscribe request whose `events` array contains no recognized name (after filtering) is rejected with `INVALID_EVENTS`. Unknown names mixed with valid ones are silently dropped; the `subscribed` reply echoes only the accepted events.

--- a/src/modules/events/dto/ws-messages.dto.ts
+++ b/src/modules/events/dto/ws-messages.dto.ts
@@ -27,6 +27,7 @@ export const SUBSCRIBABLE_EVENTS = [
   'group.leave',
   'group.update',
   'call.received',
+  'status.received',
 ] as const;
 
 export type SubscribableEvent = (typeof SUBSCRIBABLE_EVENTS)[number] | '*';

--- a/src/modules/events/events.gateway.ts
+++ b/src/modules/events/events.gateway.ts
@@ -498,4 +498,13 @@ export class EventsGateway implements OnGatewayInit, OnGatewayConnection, OnGate
   emitCallReceived(sessionId: string, data: Record<string, unknown>) {
     this.emitToRooms(sessionId, 'call.received', data);
   }
+
+  /**
+   * Emit a freshly ingested contact status (story). Payload mirrors the `status.received`
+   * webhook — no media bytes, just identity/type/flags — so the dashboard can refresh its
+   * statuses view live instead of waiting for a focus refetch.
+   */
+  emitStatusReceived(sessionId: string, data: Record<string, unknown>) {
+    this.emitToRooms(sessionId, 'status.received', data);
+  }
 }

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -145,6 +145,7 @@ describe('SessionService', () => {
       emitGroupLeave: jest.fn(),
       emitGroupUpdate: jest.fn(),
       emitCallReceived: jest.fn(),
+      emitStatusReceived: jest.fn(),
       emitQRCode: jest.fn(),
     };
 
@@ -2255,6 +2256,11 @@ describe('SessionService', () => {
           expiresAt: 1000 + 86400000,
         }),
       );
+      // …and the same payload goes over the websocket so the dashboard refreshes live.
+      expect(eventsGateway.emitStatusReceived).toHaveBeenCalledWith(
+        'sess-uuid-1',
+        expect.objectContaining({ statusId: 'st1', contact: { id: '628111@c.us', name: 'Alice' } }),
+      );
     });
 
     it('does not dispatch status.received for a duplicate delivery (ingest resolves created=false)', async () => {
@@ -2279,6 +2285,7 @@ describe('SessionService', () => {
       await flush();
 
       expect(dispatchedEvents('status.received')).toHaveLength(0);
+      expect(eventsGateway.emitStatusReceived).not.toHaveBeenCalled();
     });
 
     it('skips persist and dispatch for ephemeral messages when STORE_EPHEMERAL_MESSAGES=false', async () => {

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -730,13 +730,14 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
   }
 
   /**
-   * Dispatches the opt-in `status.received` webhook once an inbound status row is ingested.
-   * `WebhookService.dispatch` already filters delivery to webhooks whose `events` array includes
-   * `status.received`, so no extra gating is needed here. No media bytes are included in the
-   * payload — consumers fetch media via the status media endpoint.
+   * Dispatches the opt-in `status.received` webhook once an inbound status row is ingested, and
+   * mirrors it over the websocket so the dashboard's statuses view refreshes live instead of
+   * waiting for a focus refetch. `WebhookService.dispatch` already filters delivery to webhooks
+   * whose `events` array includes `status.received`, so no extra gating is needed here. No media
+   * bytes are included in the payload — consumers fetch media via the status media endpoint.
    */
   private dispatchStatusReceived(sessionId: string, row: StatusUpdate): void {
-    void this.webhookService.dispatch(sessionId, 'status.received', {
+    const payload = {
       sessionId,
       statusId: row.waStatusId,
       contact: {
@@ -751,7 +752,9 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
       ...(row.omitReason ? { omitReason: row.omitReason } : {}),
       postedAt: row.postedAt,
       expiresAt: row.expiresAt,
-    });
+    };
+    void this.webhookService.dispatch(sessionId, 'status.received', payload);
+    this.eventsGateway.emitStatusReceived(sessionId, payload);
   }
 
   /**


### PR DESCRIPTION
## Summary

A contact's newly posted story previously appeared in the dashboard only on tab mount, window focus, or after composing — inbound status broadcasts are ingested into the store but never reached the websocket pipeline, so the Status tab had no live signal. This closes that gap end to end.

## Changes

**Backend.** When a live status is ingested as a fresh insert (the same `created` gate that guards the webhook, so engine redeliveries don't re-notify), the session service now also broadcasts `status.received` over the websocket via a new `EventsGateway.emitStatusReceived`, with a payload identical to the webhook's (identity, type, media flags — no media bytes). The event is registered in `SUBSCRIBABLE_EVENTS` so clients can actually subscribe to it; the drift-guard spec that asserts emitter/catalog parity covers the pairing, and the session spec asserts the WS emission fires on a fresh insert and not on a duplicate delivery.

**Dashboard.** The chat page subscribes to `status.received` per session and invalidates the `contact-statuses` query on arrival. While the Status tab is open the list refetches immediately (and an already-open viewer follows, since it derives from the query cache rather than a click-time snapshot); on other tabs the query is disabled, so invalidation just marks it stale for the next open — no background fetch either way.

**Docs.** `status.received` is listed as socket-subscribable in the API specification, and added to the webhook management section's `events` list, which the DTO has accepted since the event was introduced.

## Testing

- Full jest suite: 2964 passed (new assertions: WS emission on fresh insert, no emission on duplicate, catalog/emitter drift guard).
- Full-program `tsc --noEmit`, eslint, prettier clean; dashboard build/lint/unit (135) pass.
