### PR TITLE
feat(status): capture and render text-status styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Text statuses keep their posted look.** The background color and font of a text status are now
+  captured on ingest (from the Baileys engine, which carries them on the wire) and rendered in the
+  dashboard viewer — colored bubble with white text and an approximated font family — instead of
+  every text story looking identical. The fields already existed on the API and SDK `StatusRecord`
+  shapes; whatsapp-web.js does not expose styling, so statuses from that engine render as before.
+
 ### Fixed
 
 - **Contacts with both a @lid and a phone identity now appear once in the status list.** Statuses

--- a/dashboard/src/pages/Chats.tsx
+++ b/dashboard/src/pages/Chats.tsx
@@ -187,6 +187,16 @@ function StatusMedia({
 // user can't build a list the backend is guaranteed to reject.
 const STATUS_RECIPIENTS_MAX = 256;
 
+// Approximate WhatsApp's text-status font slots with generic families (the actual faces are
+// proprietary); index 0 and unknown slots keep the UI default.
+const STATUS_FONT_FAMILY: Record<number, string> = {
+  1: 'serif',
+  2: 'monospace',
+  3: 'cursive',
+  4: 'fantasy',
+  5: 'ui-rounded, system-ui, sans-serif',
+};
+
 export function Chats() {
   const { t } = useTranslation();
   useDocumentTitle(t('nav.chats'));
@@ -1920,7 +1930,25 @@ export function Chats() {
                 </header>
                 <div className="messages-list" ref={statusFeedRef}>
                   {activeStatusGroup.items.map(item => (
-                    <div key={item.id} className="message-bubble incoming">
+                    <div
+                      key={item.id}
+                      className="message-bubble incoming"
+                      // A text status keeps the look it was posted with: background colour (white
+                      // text like WhatsApp) and the closest generic font family we have for the
+                      // proprietary WhatsApp font slots.
+                      style={
+                        item.type === 'text' && (item.backgroundColor || item.font)
+                          ? {
+                              ...(item.backgroundColor
+                                ? { backgroundColor: item.backgroundColor, color: '#fff' }
+                                : {}),
+                              ...(item.font && STATUS_FONT_FAMILY[item.font]
+                                ? { fontFamily: STATUS_FONT_FAMILY[item.font] }
+                                : {}),
+                            }
+                          : undefined
+                      }
+                    >
                       {item.mediaUrl && (
                         <StatusMedia
                           sessionId={selectedSessionId || null}

--- a/src/engine/adapters/baileys-message-mapper.spec.ts
+++ b/src/engine/adapters/baileys-message-mapper.spec.ts
@@ -212,6 +212,24 @@ describe('buildIncomingMessageFromBaileys', () => {
     expect(r.author).toBe('628111@s.whatsapp.net');
   });
 
+  it('converts extended-text status styling: backgroundArgb -> #RRGGBB, font passed through', () => {
+    const r = buildIncomingMessageFromBaileys({
+      ...base,
+      remoteJid: 'status@broadcast',
+      participant: '628111@s.whatsapp.net',
+      backgroundArgb: 0xff25d366, // ARGB, alpha in the high byte
+      font: 2,
+    });
+    expect(r.backgroundColor).toBe('#25d366');
+    expect(r.font).toBe(2);
+  });
+
+  it('leaves styling undefined when the message carries none', () => {
+    const r = buildIncomingMessageFromBaileys({ ...base });
+    expect(r.backgroundColor).toBeUndefined();
+    expect(r.font).toBeUndefined();
+  });
+
   it('carries the push name onto contact when present', () => {
     const r = buildIncomingMessageFromBaileys({ ...base, pushName: 'Alice' });
     expect(r.contact).toEqual({ pushName: 'Alice' });

--- a/src/engine/adapters/baileys-message-mapper.ts
+++ b/src/engine/adapters/baileys-message-mapper.ts
@@ -156,6 +156,10 @@ export interface BaileysIncomingFields {
   ephemeralDuration?: number;
   /** @mentioned engine JIDs from `contextInfo.mentionedJid`; normalized and surfaced as `mentionedIds`. */
   mentionedJids?: string[];
+  /** Styling of an extended-text (status) message: proto `backgroundArgb` (fixed32 ARGB). */
+  backgroundArgb?: number;
+  /** Styling of an extended-text (status) message: proto `font` (WhatsApp font index). */
+  font?: number;
 }
 
 /**
@@ -207,6 +211,14 @@ export function buildIncomingMessageFromBaileys(
 
   if (fields.pushName) {
     incoming.contact = { pushName: fields.pushName };
+  }
+
+  // Extended-text (status) styling: proto ARGB → the #RRGGBB the API/outbound DTOs speak.
+  if (fields.backgroundArgb !== undefined && Number.isFinite(fields.backgroundArgb)) {
+    incoming.backgroundColor = `#${(fields.backgroundArgb & 0xffffff).toString(16).padStart(6, '0')}`;
+  }
+  if (fields.font !== undefined) {
+    incoming.font = fields.font;
   }
 
   if (fields.media) {

--- a/src/engine/adapters/baileys.adapter.spec.ts
+++ b/src/engine/adapters/baileys.adapter.spec.ts
@@ -937,6 +937,28 @@ describe('BaileysAdapter inbound fan-out', () => {
     expect(msg).toMatchObject({ id: 'ST1', isStatusBroadcast: true, author: '628111@c.us' });
   });
 
+  it('extracts text-status styling (backgroundArgb/font) from the extended-text content', async () => {
+    baileys.getContentType.mockReturnValue('extendedTextMessage');
+    const onMessage = jest.fn();
+    const adapter = newAdapter();
+    await adapter.initialize({ onMessage });
+    fakeSock.fire('messages.upsert', {
+      type: 'notify',
+      messages: [
+        {
+          key: { remoteJid: 'status@broadcast', participant: '628111@s.whatsapp.net', fromMe: false, id: 'ST2' },
+          message: { extendedTextMessage: { text: 'styled story', backgroundArgb: 0xff123456, font: 3 } },
+          messageTimestamp: 1700000002,
+        },
+      ],
+    });
+    await new Promise(r => setImmediate(r));
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const msg = onMessage.mock.calls[0][0] as { backgroundColor?: string; font?: number };
+    expect(msg.backgroundColor).toBe('#123456');
+    expect(msg.font).toBe(3);
+  });
+
   it('extracts coordinates from an ephemeral (disappearing) location message', async () => {
     const onMessage = jest.fn();
     const adapter = newAdapter();

--- a/src/engine/adapters/baileys.adapter.ts
+++ b/src/engine/adapters/baileys.adapter.ts
@@ -1767,6 +1767,9 @@ export class BaileysAdapter implements IWhatsAppEngine {
       normalizedForContext.documentMessage ??
       normalizedForContext.stickerMessage ??
       normalizedForContext.locationMessage;
+    // A text status's styling rides on the extended-text content (proto backgroundArgb/font) —
+    // surface it so the store/viewer can render the story the way it was posted.
+    const extText = normalizedForContext.extendedTextMessage;
     const contextInfo = (
       subForContext as
         | {
@@ -1814,6 +1817,8 @@ export class BaileysAdapter implements IWhatsAppEngine {
         quotedMessage,
         ephemeralDuration: contextInfo?.expiration ?? undefined,
         mentionedJids: contextInfo?.mentionedJid ?? undefined,
+        backgroundArgb: typeof extText?.backgroundArgb === 'number' ? extText.backgroundArgb : undefined,
+        font: typeof extText?.font === 'number' ? extText.font : undefined,
       },
       jid => this.sessionStore.toNeutralJid(jid),
     );

--- a/src/engine/interfaces/whatsapp-engine.interface.ts
+++ b/src/engine/interfaces/whatsapp-engine.interface.ts
@@ -106,6 +106,10 @@ export interface IncomingMessage {
   senderPhone?: string | null;
   /** Sender contact info, best-effort from the WhatsApp Web cache. Sync fields only (no network). */
   contact?: MessageContact;
+  /** Styling of a text status/story: background as `#RRGGBB`. Only set by engines that expose it. */
+  backgroundColor?: string;
+  /** Styling of a text status/story: the WhatsApp font index. Only set by engines that expose it. */
+  font?: number;
   media?: {
     mimetype: string;
     filename?: string;

--- a/src/modules/status-store/incoming-status.spec.ts
+++ b/src/modules/status-store/incoming-status.spec.ts
@@ -37,6 +37,12 @@ it('carries media and collapses the type to the status union', () => {
   expect(s.media).toEqual({ mimetype: 'image/jpeg', data: 'AAAA' });
 });
 
+it('carries text-status styling through to the store row', () => {
+  const s = buildIncomingStatus({ ...base, backgroundColor: '#25d366', font: 2 })!;
+  expect(s.backgroundColor).toBe('#25d366');
+  expect(s.font).toBe(2);
+});
+
 it('returns null when the message is not a status', () => {
   expect(buildIncomingStatus({ ...base, isStatusBroadcast: false })).toBeNull();
 });

--- a/src/modules/status-store/incoming-status.ts
+++ b/src/modules/status-store/incoming-status.ts
@@ -37,6 +37,8 @@ export function buildIncomingStatus(msg: IncomingMessage): IncomingStatus | null
     contactPushName: msg.contact?.pushName,
     type: statusType(msg.type),
     caption: msg.body || undefined,
+    backgroundColor: msg.backgroundColor,
+    font: msg.font,
     media: msg.media
       ? {
           mimetype: msg.media.mimetype,

--- a/src/modules/status-store/status-store.service.spec.ts
+++ b/src/modules/status-store/status-store.service.spec.ts
@@ -58,6 +58,24 @@ describe('StatusStoreService (ingest / list / getMedia)', () => {
     expect(row.mediaPath).toBeFalsy();
   });
 
+  it('ingest persists text-status styling and serves it back in the API shape', async () => {
+    const { row } = await service.ingest('sess', {
+      waStatusId: 'styled',
+      contactJid: '628111@c.us',
+      type: 'text',
+      caption: 'hi',
+      backgroundColor: '#25d366',
+      font: 2,
+      postedAt: Date.now(),
+    });
+    expect(row.backgroundColor).toBe('#25d366');
+    expect(row.font).toBe(2);
+
+    const styled = (await service.list('sess')).find(s => s.id === 'styled')!;
+    expect(styled.backgroundColor).toBe('#25d366');
+    expect(styled.font).toBe(2);
+  });
+
   it('ingest persists media to a file under the cap and records mediaPath', async () => {
     const { row } = await service.ingest('sess', {
       waStatusId: 'w2',


### PR DESCRIPTION
## Summary

Text statuses lose their look: a story posted with a colored background and a chosen font renders in the dashboard as a plain bubble, and the `backgroundColor`/`font` fields that the API and every SDK's `StatusRecord` already declare are always empty. This populates them on ingest and renders them — no schema or contract changes.

## Changes

**Capture (Baileys).** WhatsApp carries text-status styling on the extended-text message content (`backgroundArgb`, `font` in the proto). The Baileys inbound pipeline now extracts both: the mapper converts the fixed32 ARGB to the `#RRGGBB` the API speaks (alpha stripped) and passes the font index through, threaded onto `IncomingMessage` and into `buildIncomingStatus` — the store's columns and the `Status` API shape simply start receiving real values.

**whatsapp-web.js.** Exposes no styling metadata, so statuses ingested there keep the fields absent and render exactly as before.

**Viewer.** A text status now renders with its posted look: the bubble takes the story's background color with white text (like WhatsApp), and the font index maps to the closest generic CSS family (the actual faces are proprietary; index 0 and unknown slots keep the UI default). Unstyled text statuses and media statuses are untouched.

## Testing

- Mapper spec: ARGB → `#RRGGBB` conversion, font passthrough, absent-fields stay undefined.
- Adapter spec: a status upsert carrying extended-text styling arrives at `onMessage` with `backgroundColor`/`font`.
- Store specs: `IncomingStatus` mapping and persistence through to the `Status` API shape.
- Full jest suite: 2969 passed; full-program `tsc --noEmit`, eslint, prettier clean; dashboard build/lint/unit pass.
