### PR TITLE
docs(api): fix history and reactions cURL paths

### DIFF
--- a/docs/07-api-collection.md
+++ b/docs/07-api-collection.md
@@ -221,7 +221,7 @@ curl "$BASE/api/sessions/my-session/messages?chatId=628123456789@c.us&limit=20&o
 Fetch chat history live from WhatsApp, bypassing the DB.
 
 ```bash
-curl "$BASE/api/sessions/my-session/628123456789@c.us/history?limit=100&deep=true" \
+curl "$BASE/api/sessions/my-session/messages/628123456789@c.us/history?limit=100&deep=true" \
   -H "X-API-Key: $API_KEY"
 ```
 
@@ -230,7 +230,7 @@ curl "$BASE/api/sessions/my-session/628123456789@c.us/history?limit=100&deep=tru
 Get reactions for a message, grouped by emoji.
 
 ```bash
-curl "$BASE/api/sessions/my-session/628123456789@c.us/true_628123456789@c.us_3EB0ABCD/reactions" \
+curl "$BASE/api/sessions/my-session/messages/628123456789@c.us/true_628123456789@c.us_3EB0ABCD/reactions" \
   -H "X-API-Key: $API_KEY"
 ```
 


### PR DESCRIPTION
## What

The runnable cURL examples for chat history and message reactions in `docs/07-api-collection.md` targeted paths without the `/messages` segment:

- `/api/sessions/my-session/628123456789@c.us/history?...`
- `/api/sessions/my-session/628123456789@c.us/true_.../reactions`

Neither matches a registered route, so both return 404 when copied as-is.

## Fix

Insert the missing `/messages` segment so the examples match the actual routes (`@Controller('sessions/:sessionId/messages')` with `@Get(':chatId/history')` and `@Get(':chatId/:messageId/reactions')`):

- `/api/sessions/my-session/messages/628123456789@c.us/history?...`
- `/api/sessions/my-session/messages/628123456789@c.us/true_.../reactions`

Every other cURL example in the file already includes the segment; a sweep of the document confirmed these were the only two diverging paths.

Closes #908