### PR TITLE
fix(plugins): require ALLOW_UNSIGNED_INGRESS opt-in for none-scheme routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -319,6 +319,15 @@ RATE_LIMIT_MEDIUM_LIMIT=100         # max requests per window
 # WEBHOOK_WORKER_CONCURRENCY=10     # webhook delivery workers (default 10)
 # INGRESS_WORKER_CONCURRENCY=10     # integration ingress workers (default 10)
 
+# Opt-in to load plugins whose ingress routes declare signature.scheme 'none'.
+# Such a route is an unauthenticated @Public endpoint: once an instance is provisioned
+# against it, anyone who can reach the host can POST a forged payload that triggers
+# outbound WhatsApp sends. Default off — every major provider (Meta/Svix, Twilio,
+# Chatwoot) offers HMAC, and both official ingress plugins (chatwoot-adapter,
+# supabase-otp-hook) use a signed scheme. Only set this for a provider that genuinely
+# offers no HMAC, and front the route with a network/reverse-proxy ACL.
+# ALLOW_UNSIGNED_INGRESS=false
+
 # =============================================================================
 # MCP (Model Context Protocol) — Agent / AI-assistant tool server
 # =============================================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Plugin ingress routes with `signature.scheme: 'none'` now require an explicit opt-in.** A `none`-scheme
+  route is an unauthenticated `@Public()` endpoint that, once an integration instance is provisioned
+  against it, lets anyone who can reach the host POST a forged payload that triggers outbound WhatsApp
+  sends on the bound session. The loader previously only logged a warning for such routes, so the
+  surface lit up silently as soon as an operator installed a plugin declaring one. `validateIngressManifest`
+  now rejects any `none`-scheme route unless `ALLOW_UNSIGNED_INGRESS=true` is set; signed schemes
+  (`hmac-sha256`, `standard-webhooks`, `shared-secret`) are unaffected, and both official ingress
+  plugins (`chatwoot-adapter`, `supabase-otp-hook`) declare signed schemes. When the opt-in is set, the
+  existing boot warning still fires so the operator is reminded to front the route with a network ACL.
+
 - **Secret comparisons on the `/api/metrics` Bearer and ingress `shared-secret` auth surfaces no
   longer leak the expected token's byte-length.** Both `safeEqualStr` (ingress `shared-secret` verify)
   and `MetricsService.safeEqual` (`/api/metrics` Bearer) used the common `timingSafeEqual` idiom of

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -184,6 +184,16 @@ export default () => ({
     })(),
   },
 
+  // Integration Fabric ingress configuration
+  ingress: {
+    // Opt-in to load plugins whose ingress routes declare signature.scheme: 'none'. Such a route is a
+    // fully-unauthenticated @Public() endpoint: once an instance is provisioned against it, anyone who can
+    // reach the host can POST a forged payload that triggers outbound WhatsApp sends. Default off — only
+    // set ALLOW_UNSIGNED_INGRESS=true for a provider that genuinely offers no HMAC, and front the route
+    // with a network/reverse-proxy ACL. Refused in production by the boot guard unless explicitly set.
+    allowUnsigned: process.env.ALLOW_UNSIGNED_INGRESS === 'true',
+  },
+
   // Status/Stories store configuration
   status: {
     // Per-file cap on status media persisted to disk/S3 (default 10 MiB). A status whose media exceeds

--- a/src/core/plugins/plugin-loader.service.ts
+++ b/src/core/plugins/plugin-loader.service.ts
@@ -318,12 +318,14 @@ export class PluginLoaderService implements OnModuleInit, OnApplicationBootstrap
     }
     // Reject a malformed ingress declaration (SDK-major mismatch, missing webhook:ingress permission,
     // duplicate/empty routes, non-positive toleranceSec) at load time instead of letting it silently
-    // load and become provisionable. No-op for plugins that declare no ingress.
-    validateIngressManifest(manifest);
+    // load and become provisionable. No-op for plugins that declare no ingress. A route declaring
+    // signature.scheme 'none' is rejected unless the operator opted in via ALLOW_UNSIGNED_INGRESS=true.
+    validateIngressManifest(manifest, this.configService.get<boolean>('ingress.allowUnsigned', false));
 
     // Surface a loud warning for any ingress route that skips signature verification — a scheme:'none'
-    // route is a fully-unauthenticated public endpoint that can trigger WhatsApp sends. Additive (a
-    // warning, not a refusal) so a legit scheme:'none' deployment still boots.
+    // route is a fully-unauthenticated public endpoint that can trigger WhatsApp sends. Only reachable
+    // when the operator opted in (otherwise validateIngressManifest above rejected it); the warning
+    // reminds them to front the URL with a network/reverse-proxy ACL.
     warnUnauthenticatedIngressRoutes(manifest, this.logger);
 
     // Check if plugin already loaded

--- a/src/core/plugins/plugin-manifest-ingress.spec.ts
+++ b/src/core/plugins/plugin-manifest-ingress.spec.ts
@@ -56,6 +56,40 @@ describe('validateIngressManifest', () => {
   });
 });
 
+describe('validateIngressManifest: signature.scheme "none" opt-in gate', () => {
+  // A none-scheme route is an unauthenticated @Public endpoint that can trigger WhatsApp sends.
+  // It must be rejected at load unless the operator explicitly opted in via ALLOW_UNSIGNED_INGRESS.
+  const noneManifest = () =>
+    ({
+      id: 'p',
+      name: 'p',
+      version: '1.0.0',
+      type: 'extension',
+      main: 'index.js',
+      sdkVersion: '1',
+      permissions: ['webhook:ingress'],
+      ingress: [{ route: 'r', mode: 'async', verify: 'core', maxBodyBytes: 1024, signature: { scheme: 'none' } }],
+    }) as never;
+
+  it('rejects a none-scheme route by default (no opt-in)', () => {
+    expect(() => validateIngressManifest(noneManifest())).toThrow(/ALLOW_UNSIGNED_INGRESS/i);
+    expect(() => validateIngressManifest(noneManifest())).toThrow(/unauthenticated/i);
+  });
+
+  it('rejects a none-scheme route when explicitly passed allowUnsignedIngress=false', () => {
+    expect(() => validateIngressManifest(noneManifest(), false)).toThrow(/ALLOW_UNSIGNED_INGRESS/i);
+  });
+
+  it('accepts a none-scheme route when the operator opted in (allowUnsignedIngress=true)', () => {
+    expect(() => validateIngressManifest(noneManifest(), true)).not.toThrow();
+  });
+
+  it('still accepts signed routes regardless of the opt-in flag', () => {
+    expect(() => validateIngressManifest(baseManifest() as never, false)).not.toThrow();
+    expect(() => validateIngressManifest(baseManifest() as never, true)).not.toThrow();
+  });
+});
+
 describe('warnUnauthenticatedIngressRoutes', () => {
   it('warns once per scheme:none route, naming the plugin and route', () => {
     const logger = { warn: jest.fn() };
@@ -92,7 +126,16 @@ function manifestWithRoute(overrides: Record<string, unknown> = {}) {
     sdkVersion: '1',
     permissions: ['webhook:ingress'],
     ingress: [
-      { route: 'r', mode: 'async', verify: 'core', maxBodyBytes: 1024, signature: { scheme: 'none' }, ...overrides },
+      // Default to a signed scheme so the response-contract / standard-webhooks suites below
+      // exercise fields other than the scheme. The scheme:'none' opt-in gate has its own block.
+      {
+        route: 'r',
+        mode: 'async',
+        verify: 'core',
+        maxBodyBytes: 1024,
+        signature: { scheme: 'hmac-sha256', header: 'X-Sig', contentTemplate: '{rawBody}', encoding: 'hex' },
+        ...overrides,
+      },
     ],
   } as never;
 }

--- a/src/core/plugins/plugin.interfaces.ts
+++ b/src/core/plugins/plugin.interfaces.ts
@@ -278,11 +278,16 @@ const HTTP_HEADER_VALUE_NO_CRLF = /^[^\r\n]*$/;
 
 /**
  * Validates a manifest's `ingress` declarations: SDK major compatibility, the `webhook:ingress`
- * permission, route uniqueness, and that a declared `toleranceSec` is usable (> 0 — a replay window
- * of zero or less would make the tolerance check a no-op). A manifest with no `ingress` entries is a
- * no-op. Called from PluginLoaderService.loadPlugin, so a malformed declaration is rejected at load time.
+ * permission, route uniqueness, that a declared `toleranceSec` is usable (> 0 — a replay window
+ * of zero or less would make the tolerance check a no-op), and that no route declares
+ * `signature.scheme: 'none'` unless the operator has explicitly opted in via
+ * `ALLOW_UNSIGNED_INGRESS=true`. A `none`-scheme route is a fully-unauthenticated `@Public()`
+ * endpoint — once an instance is provisioned, anyone who can reach the host can POST a forged
+ * payload that triggers outbound WhatsApp sends. Rejecting it at load (rather than only warning)
+ * keeps that surface from lighting up silently. A manifest with no `ingress` entries is a no-op.
+ * Called from PluginLoaderService.loadPlugin, so a malformed declaration is rejected at load time.
  */
-export function validateIngressManifest(manifest: PluginManifest): void {
+export function validateIngressManifest(manifest: PluginManifest, allowUnsignedIngress = false): void {
   if (!manifest.ingress?.length) return; // no ingress declared → nothing to validate
   const declaredMajor = Number.parseInt((manifest.sdkVersion ?? '1').split('.')[0], 10);
   if (!Number.isFinite(declaredMajor) || declaredMajor !== SUPPORTED_SDK_MAJOR) {
@@ -300,6 +305,13 @@ export function validateIngressManifest(manifest: PluginManifest): void {
       throw new Error(`Plugin ${manifest.id}: duplicate or empty ingress route '${r.route}'`);
     }
     seen.add(r.route);
+    if (r.signature.scheme === 'none' && !allowUnsignedIngress) {
+      throw new Error(
+        `Plugin ${manifest.id}: ingress route '${r.route}' declares signature.scheme 'none', which is an ` +
+          `unauthenticated public endpoint that can trigger WhatsApp sends. Set ALLOW_UNSIGNED_INGRESS=true to ` +
+          `opt in (and front the route with a network/reverse-proxy ACL).`,
+      );
+    }
     if (r.signature.toleranceSec !== undefined && r.signature.toleranceSec <= 0) {
       throw new Error(
         `Plugin ${manifest.id}: route '${r.route}' toleranceSec must be > 0 (a replay guard would be a no-op)`,
@@ -332,10 +344,11 @@ export function validateIngressManifest(manifest: PluginManifest): void {
 
 /**
  * Warns about each ingress route declared with `scheme: 'none'` — a fully-unauthenticated public endpoint
- * that anyone who can reach the host can use to trigger WhatsApp sends. Purely additive (a warning): a
- * deployment that legitimately relies on scheme:'none' (a provider that offers no HMAC) still boots; the
- * loud log surfaces the exposure so an operator can front the URL with a network/reverse-proxy guard.
- * Called from PluginLoaderService.loadPlugin at boot and on dynamic install.
+ * that anyone who can reach the host can use to trigger WhatsApp sends. Such a route only loads when the
+ * operator has opted in via `ALLOW_UNSIGNED_INGRESS=true` (otherwise `validateIngressManifest` rejects it);
+ * this warning keeps the exposure loud at boot and on dynamic install so an operator who enabled the flag
+ * for one provider is reminded to front the URL with a network/reverse-proxy ACL.
+ * Called from PluginLoaderService.loadPlugin.
  */
 export function warnUnauthenticatedIngressRoutes(
   manifest: PluginManifest,


### PR DESCRIPTION
## Summary

An ingress route declaring `signature.scheme: 'none'` is a fully-unauthenticated `@Public` endpoint: once an instance is provisioned against it, anyone who can reach the host can POST a forged payload that triggers outbound WhatsApp sends on the bound session. The loader previously only logged a warning for such routes (`warnUnauthenticatedIngressRoutes`), so the surface lit up silently as soon as an operator installed a plugin declaring one.

This adds an explicit operator opt-in: `validateIngressManifest` now rejects any route with `signature.scheme: 'none'` unless `ALLOW_UNSIGNED_INGRESS=true` is set.

## Changes

- `src/core/plugins/plugin.interfaces.ts` — `validateIngressManifest` takes an `allowUnsignedIngress` parameter (default `false`) and throws on a `none`-scheme route when the opt-in is absent. `warnUnauthenticatedIngressRoutes` JSDoc updated — it now only fires for routes that loaded under the opt-in, as a reminder to front the URL with a network ACL.
- `src/core/plugins/plugin-loader.service.ts` — `loadPlugin` reads `ingress.allowUnsigned` from config and passes it to the validator.
- `src/config/configuration.ts` — new `ingress.allowUnsigned` config key, sourced from `ALLOW_UNSIGNED_INGRESS` (default `false`).
- `.env.example` — documents the flag, names the two official plugins that use signed schemes, and points at the network-ACL mitigation.
- `src/core/plugins/plugin-manifest-ingress.spec.ts` — a dedicated `signature.scheme "none" opt-in gate` block covering default-reject, explicit-reject, opt-in-accept, and signed-routes-unaffected. The `manifestWithRoute()` helper now defaults to `hmac-sha256` so the response-contract and standard-webhooks suites exercise fields other than the scheme.

## Why an env flag, not a manifest field or a boot refusal

The opt-in is an env flag rather than a manifest field because the manifest is the plugin author's claim, not the operator's. It is not refused in production (`ALLOW_DEV_API_KEY` is, because `dev-admin-key` is a publicly-documented credential) — a `none`-scheme deployment can be legitimate when a provider genuinely offers no HMAC and the URL is fronted by a network ACL, so the loud boot warning is the right mitigation when the flag is set.

## Verification

- `npx tsc --noEmit` clean.
- `plugin-manifest-ingress.spec.ts`: 19/19 pass (4 new tests for the gate; response-contract and standard-webhooks suites still pass after the helper default changed).
- Broader run: `plugin-loader.service.spec.ts`, `src/modules/integration/**`, `plugins.service.spec.ts` — 20 suites, 206 tests, all pass.

## Notes

- No official plugin is affected: `chatwoot-adapter` uses `hmac-sha256`, `supabase-otp-hook` uses `standard-webhooks`, both with `verify: "core"`.
- Signed schemes (`hmac-sha256`, `standard-webhooks`, `shared-secret`) are entirely unaffected by this change.