### PR TITLE
docs(sandbox): k8s OS-containment parity; drop removed built-in ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   remains the source of truth), so the cap trades a re-resolution for bounded memory, never data loss.
   `LID_MAPPING_CACHE_MAX=0` restores the legacy unbounded behaviour.
 
+- **The Kubernetes deployment example now ships with OS-level containment, matching the shipped
+  Docker image.** The StatefulSet in `docs/13-horizontal-scaling.md` previously had no
+  `securityContext`, so an operator following the manifest ran the plugin sandbox without its
+  OS-containment half (read-only rootfs, non-root, `cap_drop: ALL`) — weaker than the threat model
+  assumes. The manifest now sets `runAsNonRoot`, `readOnlyRootFilesystem`, `allowPrivilegeEscalation:
+  false`, and `capabilities.drop: ['ALL']`, with the writable `/app/data` and `/tmp` mounts that
+  `readOnlyRootFilesystem` requires. The stale image tag (`0.4.6`) was also bumped to the current
+  release.
+
+- **The plugin sandboxing doc no longer lists `auto-reply` and `translation` as built-in extensions.**
+  Both ids were removed in v0.7 (`LEGACY_REMOVED_PLUGIN_IDS`), but `docs/23-plugin-sandboxing.md`'s
+  trust-tiers table still named them as built-in examples — misleading an operator about what counts
+  as a trusted in-process plugin. The table now names only the two engine adapters, matching
+  `docs/19-plugin-architecture.md` and the code.
+
 ## [0.10.10] - 2026-07-25
 
 ### Added

--- a/docs/13-horizontal-scaling.md
+++ b/docs/13-horizontal-scaling.md
@@ -261,9 +261,17 @@ spec:
       labels:
         app: openwa
     spec:
+      # OS-level containment is the second half of the plugin sandbox boundary (see docs/23-plugin-
+      # sandboxing.md). Without it a worker_thread plugin that abuses Node built-ins (fs, net) runs with
+      # the same privileges as the API and can read host files / open raw sockets outside the capability
+      # model. The shipped Docker image already runs read-only + non-root + cap_drop:ALL; the manifest
+      # below mirrors that so a k8s deploy is not silently weaker.
+      securityContext:
+        runAsNonRoot: true
+        fsGroup: 1000
       containers:
         - name: openwa
-          image: ghcr.io/rmyndharis/openwa:0.4.6
+          image: ghcr.io/rmyndharis/openwa:0.10.10
           ports:
             - containerPort: 2785
               name: http
@@ -277,6 +285,14 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+          # Container-level hardening. readOnlyRootFilesystem requires every writable path to be an
+          # explicitly mounted volume — /app/data (SQLite, sessions, media, plugin storage) and /tmp
+          # (Chromium needs a writable HOME/XDG for whatsapp-web.js).
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ['ALL']
           resources:
             requests:
               memory: '512Mi'
@@ -285,8 +301,10 @@ spec:
               memory: '2Gi'
               cpu: '1000m'
           volumeMounts:
-            - name: session-data
-              mountPath: /app/data/sessions
+            - name: openwa-data
+              mountPath: /app/data
+            - name: tmp
+              mountPath: /tmp
           livenessProbe:
             httpGet:
               path: /api/health
@@ -299,9 +317,12 @@ spec:
               port: 2785
             initialDelaySeconds: 10
             periodSeconds: 5
+      volumes:
+        - name: tmp
+          emptyDir: {}
   volumeClaimTemplates:
     - metadata:
-        name: session-data
+        name: openwa-data
       spec:
         accessModes: ['ReadWriteOnce']
         resources:

--- a/docs/23-plugin-sandboxing.md
+++ b/docs/23-plugin-sandboxing.md
@@ -9,7 +9,7 @@ it does not — and what changes for plugin authors.
 
 | Tier | Examples | Runs | Capabilities |
 |------|----------|------|--------------|
-| **Built-in (trusted)** | engines (whatsapp-web.js, baileys), bundled extensions (auto-reply, translation) | in-process | direct, full speed |
+| **Built-in (trusted)** | the two engine adapters (whatsapp-web.js, baileys) | in-process | direct, full speed |
 | **Untrusted** | anything in the plugins directory | in a `worker_thread` | only via the host-validated bridge |
 
 The loader routes by tier automatically: a plugin registered programmatically is built-in; one loaded


### PR DESCRIPTION
## Summary

Two operator-guidance fixes from the sandbox audit — both in the core repo's own `docs/`, not the docs site.

## Changes

### `docs/13-horizontal-scaling.md` — k8s manifest OS-containment parity
The k8s StatefulSet shipped with no `securityContext`, so an operator following the manifest ran weaker than the threat model assumes: the Docker image runs read-only + non-root + `cap_drop:ALL`, but the k8s example silently dropped that half of the plugin-sandbox boundary. Added a pod `securityContext` (`runAsNonRoot`, `fsGroup`) and a container `securityContext` (`readOnlyRootFilesystem`, `allowPrivilegeEscalation: false`, `capabilities.drop: ['ALL']`), plus the writable mounts `readOnlyRootFilesystem` requires (`/app/data` as the PVC, `/tmp` as an `emptyDir` — Chromium needs a writable HOME/XDG for whatsapp-web.js). A note under the manifest cross-references `docs/23-plugin-sandboxing.md`. Also bumped the stale image tag (`0.4.6` → `0.10.10`).

### `docs/23-plugin-sandboxing.md` — drop removed built-in ids
The trust-tiers table listed "bundled extensions (auto-reply, translation)" as built-in examples, but both ids were removed in v0.7 (`LEGACY_REMOVED_PLUGIN_IDS` in `plugin-loader.service.ts`) and `docs/19-plugin-architecture.md` already states they no longer exist. The table now names only the two engine adapters, matching §19 and the code.

## Verification

Doc-only changes; no code or test impact.

## Notes

- The dashboard plugin-install modal caveat ("install only plugins you trust" / "not an OS-level sandbox") is the remaining sandbox operator-guidance item; it touches the dashboard React component and is tracked separately.