### PR TITLE
fix(engine): disclose the remote-HTML trust posture of the default WA Web pin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,12 +97,19 @@ OPENWA_MEM_LIMIT=2g
 # and uses a handful of PIDs regardless. Raise for larger fleets; do NOT set -1 (drops the guard).
 OPENWA_PIDS_LIMIT=2048
 
-# Optional WhatsApp Web client version pin. Leave unset (or use "latest", "auto", or "off") to
-# let whatsapp-web.js auto-select. If sessions get stuck at "authenticating" after scanning the QR,
-# set this to a known-good version from https://github.com/wppconnect-team/wa-version (browse the
-# html/ folder). WWEBJS_WEB_VERSION_REMOTE_PATH overrides the URL template (use {version} as the
-# placeholder) if you self-host the version HTML.
+# Optional WhatsApp Web client version pin. DEFAULT (unset, "auto", or "latest"): OpenWA fetches
+# the current known-good build from the third-party wppconnect-team/wa-version registry and pins
+# it — the pinned HTML is downloaded and executed inside the web.whatsapp.com origin with NO
+# integrity check, which is the reliable default (avoids the "stuck at authenticating" hang, #488)
+# but means trusting that registry's published HTML. Set "off" to disable pinning and use the
+# first-party build served by WhatsApp (whatsapp-web.js native behavior). Set an exact version
+# string to pin a specific build from the same registry (browse the html/ folder at
+# https://github.com/wppconnect-team/wa-version). WWEBJS_WEB_VERSION_REMOTE_PATH overrides the
+# HTML URL template (use {version} as the placeholder) to fetch from an operator-controlled copy
+# instead. The active build + its source (pinned/auto/native) is shown on the dashboard's
+# Infrastructure page.
 # WWEBJS_WEB_VERSION=2.3000.1040641150-alpha
+# WWEBJS_WEB_VERSION=off
 
 # Extend the initial boot/inject wait (milliseconds) before QR generation. On slow first boots
 # (WSL2 or low-resource containers) the default 30000ms can expire before WhatsApp Web finishes

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -67,9 +67,10 @@ services:
       - SESSION_DATA_PATH=${SESSION_DATA_PATH:-/app/data/sessions}
       - PUPPETEER_HEADLESS=${PUPPETEER_HEADLESS:-true}
       - PUPPETEER_ARGS=${PUPPETEER_ARGS:---no-sandbox,--disable-setuid-sandbox,--disable-dev-shm-usage,--disable-gpu}
-      # Optional WhatsApp Web version override. Leave empty for whatsapp-web.js auto-selection.
-      # If a session hangs at "authenticating", set WWEBJS_WEB_VERSION to a known-good cached build
-      # from wppconnect-team/wa-version; latest|auto|off also forces auto-selection.
+      # Optional WhatsApp Web version override. DEFAULT (empty, "latest", or "auto"): OpenWA auto-resolves a
+      # settled build from the third-party wppconnect-team/wa-version registry and pins its remote HTML
+      # (fetched into the web.whatsapp.com origin without an integrity check). Set "off" to disable pinning
+      # and use the first-party build served by WhatsApp, or an exact version to pin a specific build.
       - WWEBJS_WEB_VERSION=${WWEBJS_WEB_VERSION:-}
       - WWEBJS_WEB_VERSION_REMOTE_PATH=${WWEBJS_WEB_VERSION_REMOTE_PATH:-}
       # Raise whatsapp-web.js's first-boot init wait (default 30000ms) on slow boots. Empty = default.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,9 +126,10 @@ services:
       - SESSION_DATA_PATH=${SESSION_DATA_PATH:-}
       - PUPPETEER_HEADLESS=${PUPPETEER_HEADLESS:-}
       - PUPPETEER_ARGS=${PUPPETEER_ARGS:-}
-      # Optional WhatsApp Web version override. Leave empty for whatsapp-web.js auto-selection.
-      # If a session hangs at "authenticating", set WWEBJS_WEB_VERSION to a known-good cached build
-      # from wppconnect-team/wa-version; latest|auto|off also forces auto-selection.
+      # Optional WhatsApp Web version override. DEFAULT (empty, "latest", or "auto"): OpenWA auto-resolves a
+      # settled build from the third-party wppconnect-team/wa-version registry and pins its remote HTML
+      # (fetched into the web.whatsapp.com origin without an integrity check). Set "off" to disable pinning
+      # and use the first-party build served by WhatsApp, or an exact version to pin a specific build.
       - WWEBJS_WEB_VERSION=${WWEBJS_WEB_VERSION:-}
       - WWEBJS_WEB_VERSION_REMOTE_PATH=${WWEBJS_WEB_VERSION_REMOTE_PATH:-}
       # Raise whatsapp-web.js's first-boot init wait (default 30000ms) on slow boots — e.g. WSL2 or

--- a/docs/12-troubleshooting-faq.md
+++ b/docs/12-troubleshooting-faq.md
@@ -279,9 +279,11 @@ WWEBJS_WEB_VERSION=2.3000.1040641150-alpha
 ```
 
 Restart the container after changing it. Browse newer versions at
-[wppconnect-team/wa-version](https://github.com/wppconnect-team/wa-version) (the `html/` folder). Set
-`WWEBJS_WEB_VERSION=latest`, `auto`, or `off` (or leave it unset) to use whatsapp-web.js
-auto-version behavior.
+[wppconnect-team/wa-version](https://github.com/wppconnect-team/wa-version) (the `html/` folder). With
+`WWEBJS_WEB_VERSION` unset, `latest`, or `auto` (the default), OpenWA auto-resolves a settled build
+from that registry and pins its HTML — note this HTML is fetched from a third-party repository and
+executed inside the `web.whatsapp.com` origin without an integrity check. Set
+`WWEBJS_WEB_VERSION=off` to disable pinning and use the first-party build served by WhatsApp.
 
 ### Issue: QR generation times out on slow first boot (WSL2 / low-resource)
 

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -502,8 +502,10 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
       // output later (after a hard kill of the OpenWA process orphaned them).
       puppeteerArgs.push(`--openwa-session=${this.config.sessionId}`);
 
-      // Pin the WA-Web version when configured (fixes the 1.34.x "stuck at authenticating"
-      // hang on some setups, #251). Opt-in: unset leaves whatsapp-web.js to auto-select.
+      // Pin the WA-Web version (fixes the 1.34.x "stuck at authenticating" hang on some setups,
+      // #251/#488). DEFAULT: auto-resolve a settled build from the wa-version registry and pin its
+      // remote HTML (no integrity check — resolveWebVersionPin logs a loud warning); only
+      // WWEBJS_WEB_VERSION=off leaves whatsapp-web.js to use the first-party build from WhatsApp.
       const versionPin = await resolveWebVersionPin();
       if (this.tearingDown) {
         this.setStatus(EngineStatus.DISCONNECTED);

--- a/src/engine/wa-web-version.spec.ts
+++ b/src/engine/wa-web-version.spec.ts
@@ -1,7 +1,13 @@
+const mockWarn = jest.fn();
+jest.mock('../common/services/logger.service', () => ({
+  createLogger: () => ({ warn: mockWarn, log: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() }),
+}));
+
 import {
   __resetWebVersionCache,
   pickSettledWebVersion,
   resolveCurrentWebVersion,
+  resolveWebVersionPin,
   WEB_VERSION_SETTLE_MS,
 } from './wa-web-version';
 
@@ -118,5 +124,52 @@ describe('resolveCurrentWebVersion', () => {
   it('falls back to currentVersion when the registry carries no versions[]', async () => {
     const fetcher = jest.fn(() => Promise.resolve(json({ currentBeta: null, currentVersion: '2.3000.SOLO-alpha' })));
     await expect(resolveCurrentWebVersion(fetcher as never)).resolves.toBe('2.3000.SOLO-alpha');
+  });
+});
+
+// Remote-HTML pins execute inside the authenticated web.whatsapp.com origin with no integrity
+// check, so taking one MUST be visible to the operator — once per process, with the source and
+// the opt-outs. 'off' (first-party) is the only path that must stay silent.
+describe('resolveWebVersionPin remote-trust warning', () => {
+  const ORIGINAL_ENV = process.env.WWEBJS_WEB_VERSION;
+  const json = (body: unknown) => ({ ok: true, status: 200, json: () => Promise.resolve(body) });
+
+  beforeEach(() => {
+    __resetWebVersionCache();
+    mockWarn.mockClear();
+  });
+  afterEach(() => {
+    __resetWebVersionCache();
+    if (ORIGINAL_ENV === undefined) delete process.env.WWEBJS_WEB_VERSION;
+    else process.env.WWEBJS_WEB_VERSION = ORIGINAL_ENV;
+  });
+
+  it('warns once (with version, source URL, and opt-out) when an exact version is pinned', async () => {
+    process.env.WWEBJS_WEB_VERSION = '2.3000.1234-alpha';
+    await resolveWebVersionPin();
+    await resolveWebVersionPin(); // second resolve must NOT re-warn
+    expect(mockWarn).toHaveBeenCalledTimes(1);
+    const [message, meta] = mockWarn.mock.calls[0] as [string, Record<string, string>];
+    expect(message).toContain('WITHOUT an integrity check');
+    expect(meta.webVersion).toBe('2.3000.1234-alpha');
+    expect(meta.remotePath).toContain('2.3000.1234-alpha');
+    expect(meta.optOut).toContain('WWEBJS_WEB_VERSION=off');
+  });
+
+  it('stays silent when pinning is off (first-party build)', async () => {
+    process.env.WWEBJS_WEB_VERSION = 'off';
+    await expect(resolveWebVersionPin()).resolves.toBeUndefined();
+    expect(mockWarn).not.toHaveBeenCalled();
+  });
+
+  it('warns for the auto-resolved registry pin (the default posture)', async () => {
+    delete process.env.WWEBJS_WEB_VERSION;
+    const fetcher = jest.fn(() => Promise.resolve(json({ currentVersion: '2.3000.SOLO-alpha' })));
+    await resolveWebVersionPin(fetcher as never);
+    expect(mockWarn).toHaveBeenCalledTimes(1);
+    expect(mockWarn).toHaveBeenCalledWith(
+      expect.stringContaining('WITHOUT an integrity check'),
+      expect.objectContaining({ webVersion: '2.3000.SOLO-alpha' }),
+    );
   });
 });

--- a/src/engine/wa-web-version.ts
+++ b/src/engine/wa-web-version.ts
@@ -1,8 +1,12 @@
 /**
- * WhatsApp Web build resolution for the whatsapp-web.js engine — kept dependency-free (process.env +
- * fetch only) so the infra status endpoint can import it without pulling in the heavy whatsapp-web.js
- * module and breaking engine lazy-loading.
+ * WhatsApp Web build resolution for the whatsapp-web.js engine — kept free of whatsapp-web.js
+ * imports (env + fetch + the app logger only) so the infra status endpoint can import it without
+ * pulling in the heavy whatsapp-web.js module and breaking engine lazy-loading.
  */
+
+import { createLogger } from '../common/services/logger.service';
+
+const logger = createLogger('WebVersion');
 
 export type WebVersionPin = { webVersion: string; webVersionCache: { type: 'remote'; remotePath: string } };
 
@@ -30,11 +34,35 @@ let cachedCurrentVersion: string | undefined;
 let inFlight: Promise<string | null> | null = null;
 let lastFailureAt = 0;
 
+let warnedRemoteTrust = false;
+
 /** Test-only: reset the resolved-version cache between cases. */
 export function __resetWebVersionCache(): void {
   cachedCurrentVersion = undefined;
   inFlight = null;
   lastFailureAt = 0;
+  warnedRemoteTrust = false;
+}
+
+/**
+ * Warn once per process when a remote-HTML pin takes effect. The pinned HTML is fetched over the
+ * network and executed inside the authenticated web.whatsapp.com origin with no integrity check,
+ * so pinning is a trust decision the operator must make knowingly — the log states the source and
+ * the opt-outs. Once-only: resolveWebVersionPin runs on every session (re)start.
+ */
+function warnRemoteTrustOnce(pin: WebVersionPin): void {
+  if (warnedRemoteTrust) return;
+  warnedRemoteTrust = true;
+  logger.warn(
+    'WhatsApp Web build pinned to remote HTML served into the web.whatsapp.com origin WITHOUT an integrity check',
+    {
+      action: 'web_version_remote_pin',
+      webVersion: pin.webVersion,
+      remotePath: pin.webVersionCache.remotePath,
+      optOut:
+        'set WWEBJS_WEB_VERSION=off for the first-party build served by WhatsApp, or point WWEBJS_WEB_VERSION_REMOTE_PATH at an operator-controlled copy',
+    },
+  );
 }
 
 function buildRemotePin(version: string): WebVersionPin {
@@ -129,11 +157,16 @@ export async function resolveWebVersionPin(fetcher: typeof fetch = fetch): Promi
   const raw = process.env.WWEBJS_WEB_VERSION?.trim();
   const lc = raw?.toLowerCase();
   if (raw && lc !== 'off' && lc !== 'latest' && lc !== 'auto') {
-    return buildRemotePin(raw); // operator-pinned exact version
+    const pin = buildRemotePin(raw); // operator-pinned exact version
+    warnRemoteTrustOnce(pin);
+    return pin;
   }
   if (lc === 'off') return undefined; // explicit escape hatch → native auto-select
   const current = await resolveCurrentWebVersion(fetcher);
-  return current ? buildRemotePin(current) : undefined;
+  if (!current) return undefined;
+  const pin = buildRemotePin(current);
+  warnRemoteTrustOnce(pin);
+  return pin;
 }
 
 /**


### PR DESCRIPTION
## Problem

By default (`WWEBJS_WEB_VERSION` unset, `auto`, or `latest`) OpenWA resolves a WhatsApp Web build from the third-party `wppconnect-team/wa-version` registry and pins it: whatsapp-web.js then fetches that HTML over the network and serves it into the authenticated `web.whatsapp.com` origin via request interception — **without any integrity check**. This auto-pin exists for a good reason (it fixes the scan → stuck-at-authenticating → disconnect-loop class, #488/#684), but it is a trust decision that was invisible to operators.

Worse, the configuration surface misdocumented the behavior: `.env.example`, both compose files, the adapter comment, and the troubleshooting FAQ all claimed that unset/`auto`/`latest`/`off` "lets whatsapp-web.js auto-select" — when in fact only `off` disables the pin, and everything else actively pins third-party HTML.

## Changes

- **Loud startup warning**: `resolveWebVersionPin()` now logs a once-per-process WARN whenever a remote-HTML pin takes effect (exact pin or auto-resolved), naming the resolved version, the source URL, and the opt-outs (`WWEBJS_WEB_VERSION=off` for the first-party build served by WhatsApp, or `WWEBJS_WEB_VERSION_REMOTE_PATH` for an operator-controlled copy). The `off` path stays silent.
- **Corrected docs**: `.env.example`, `docker-compose.yml`, `docker-compose.dev.yml`, `docs/12-troubleshooting-faq.md`, and the adapter comment now describe the real default (registry auto-pin), the trust implication, and that the active build + source (`pinned`/`auto`/`native`) is already visible on the dashboard's Infrastructure page.

No behavior change: pinning logic, defaults, caching, and the `off` escape hatch are all untouched.

## Tests

- New specs assert the warning fires exactly once for exact pins and for the auto-resolved default (with version, source URL, and opt-out guidance), and never fires for `off`.
- Full `src/engine` + `src/modules/infra` suites green (857 tests); `check:versions` and build green.