### PR TITLE
ci(release): scan release image for OS-package CVEs before promoting tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,7 +209,7 @@ jobs:
     # a matching container image, and a runtime boot check on both architectures (boot-smoke runs the
     # published image on amd64 + arm64). Trades a few minutes of buildx/boot latency for release
     # safety.
-    needs: [lint, test, test-postgres, dashboard, build, docker, boot-smoke, promote, verify-published]
+    needs: [lint, test, test-postgres, dashboard, build, docker, boot-smoke, image-scan, promote, verify-published]
     steps:
       - uses: actions/checkout@v7
         with:
@@ -378,6 +378,56 @@ jobs:
           done
           exit "$exit_code"
 
+  # ──── Image Vulnerability Scan (amd64 + arm64) ────────────────────
+  # Scans the just-pushed staging image for OS-package and library CVEs and blocks promotion of a
+  # vulnerable image to the public release tags. This is the coverage the `npm audit` gate in ci.yml
+  # cannot give: audit sees the npm tree, but the Debian packages baked into node:22-slim — and, on
+  # arm64 only, the `chromium`/`chromium-sandbox` packages the amd64 image never installs (amd64 uses
+  # a downloaded Chrome-for-Testing binary, not a .deb) — are visible only by scanning the built
+  # artifact. Both architectures are scanned because their OS package sets diverge. Runs at release
+  # time, not on every PR, so it never hits the fork-PR permission limits a push/PR scan would.
+  # `ignore-unfixed` keeps a release from being blocked by a CVE with no fix yet; a fixable
+  # HIGH/CRITICAL fails the job and — via promote's `needs` below — stops the release tags.
+  image-scan:
+    name: Image scan (${{ matrix.platform }})
+    runs-on: ubuntu-latest
+    permissions:
+      packages: read
+    needs: [docker]
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [linux/amd64, linux/arm64]
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve staging image ref
+        id: image
+        env:
+          REPO: ${{ github.repository }}
+        run: echo "ref=ghcr.io/${REPO,,}:smoke-${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+
+      - name: Trivy image scan
+        uses: aquasecurity/trivy-action@v0.36.0
+        env:
+          # trivy reads TRIVY_PLATFORM for its --platform flag. Scanning is static (it reads the
+          # image layers, it does not run the image), so no QEMU is needed to inspect the arm64
+          # variant of the manifest — only a pull, which the GHCR login above authorizes.
+          TRIVY_PLATFORM: ${{ matrix.platform }}
+        with:
+          scan-type: image
+          image-ref: ${{ steps.image.outputs.ref }}
+          format: table
+          vuln-type: os,library
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '1'
+
   # Applies the release tags (X.Y.Z, X.Y, latest) to the image boot-smoke just proved can start, on
   # BOTH registries (GHCR + Docker Hub — the metadata-action `images` list emits both, and the loop
   # below promotes each). `imagetools create` re-points tags at the existing manifest list without
@@ -389,7 +439,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
-    needs: [boot-smoke]
+    needs: [boot-smoke, image-scan]
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the overrides consolidate the tree onto the fixed versions with no source
   changes and shrink `package-lock.json` by ~240 lines from dedup.
 
+- **Release images are now scanned for OS-package CVEs before they get public tags.** A new
+  `image-scan` job in the release workflow runs `trivy image` against the freshly-built staging
+  image on both `linux/amd64` and `linux/arm64`, and blocks the `promote` step (which applies the
+  `X.Y.Z`/`X.Y`/`latest` tags) on any fixable HIGH/CRITICAL. This covers the Debian packages baked
+  into `node:22-slim` — and the arm64-only `chromium` packages — that the source-tree `npm audit`
+  gate cannot see. Runs at release time only, so it never touches fork-PR token permissions.
+
 ### Changed
 
 - **Dockerfile `apt-get install` invocations now use `--no-install-recommends`**


### PR DESCRIPTION
## Summary

Follow-up to #909, as discussed in review — the piece Trivy is genuinely best at and the source-tree scans can't do: **OS-package CVEs in the shipped image.**

Adds an `image-scan` job to `release.yml` that runs `trivy image` against the freshly-built **staging** image (before it gets release tags) on **both `linux/amd64` and `linux/arm64`**, and gates the `promote` step on it. A fixable HIGH/CRITICAL now stops the `X.Y.Z` / `X.Y` / `latest` tags from ever being applied.

## Why this and not `trivy fs` on every PR

`trivy fs` / `npm audit` read manifests in the source tree. The Debian packages baked into `node:22-slim` — and, **on arm64 only**, the `chromium` / `chromium-sandbox` packages the amd64 image never installs (amd64 uses a downloaded Chrome-for-Testing binary, not a `.deb`) — are visible only by scanning the built artifact. That's the same class of problem that broke the 0.10.3 image. Both architectures are scanned because their OS package sets genuinely diverge.

## Design notes

- **Placed at `promote`'s gate**, next to `boot-smoke`: an image that fails the scan never receives public release tags. Also added to the final Release job's `needs`.
- **Release-time only** (tag push), not on every PR — so it never hits the `security-events` / `packages` permission downgrade GitHub applies to fork PRs (the exact problem that would have made the push/PR workflow from #909 misbehave).
- **`ignore-unfixed`** — a CVE with no available fix does not block a release; only a fixable HIGH/CRITICAL does.
- **Static scan** — trivy reads image layers, it does not run the image, so no QEMU is needed for the arm64 variant, only a GHCR pull (authorized by the existing login).
- **`trivy-action` pinned to `v0.36.0`** (current release; tags carry the `v` prefix — the miss from #909).

## Test plan

- [ ] `release.yml` parses (validated locally with `yaml.safe_load`; job graph: `image-scan` needs `docker`, `promote` needs `[boot-smoke, image-scan]`).
- [ ] On the next tag, `image-scan (linux/amd64)` and `image-scan (linux/arm64)` both run after `docker` and before `promote`.
- [ ] A seeded fixable HIGH in the image fails the job and blocks promotion (confirms the gate bites).
- [ ] Clean image promotes as before (no false block from `ignore-unfixed`).

Depends on nothing in #909 — independent files (`release.yml` + `CHANGELOG.md`), can land in either order.