### PR TITLE
fix(plugins): fail closed when a conversation mapping belongs to another session

### DIFF
--- a/src/core/plugins/plugin-capability.spec.ts
+++ b/src/core/plugins/plugin-capability.spec.ts
@@ -13,6 +13,7 @@ import {
 } from './plugin.interfaces';
 import { MessageService } from '../../modules/message/message.service';
 import { SessionService } from '../../modules/session/session.service';
+import { ConversationMappingService } from '../../modules/integration/conversation-mapping.service';
 
 function makePlugin(
   sessions?: string[],
@@ -280,5 +281,85 @@ describe('PluginLoaderService capability facade — ctx.net', () => {
   it('denies net.fetch when the host is not in the manifest net.allow list', async () => {
     const ctx = contextFor(loaderWith(), netPlugin(['net:fetch'], ['only.example.com:443']));
     await expect(ctx.net.fetch('https://api.example.com/x')).rejects.toBeInstanceOf(PluginCapabilityError);
+  });
+});
+
+describe('PluginLoaderService capability facade — ctx.conversations', () => {
+  let loader: PluginLoaderService;
+  let mappingService: { getByProvider: jest.Mock };
+  let messageService: { sendText: jest.Mock; reply: jest.Mock };
+
+  beforeEach(() => {
+    mappingService = { getByProvider: jest.fn() };
+    messageService = {
+      sendText: jest.fn().mockResolvedValue({ messageId: 'wamid', timestamp: 1 }),
+      reply: jest.fn().mockResolvedValue({ messageId: 'wamid', timestamp: 1 }),
+    };
+    const moduleRef = {
+      get: jest
+        .fn()
+        .mockImplementation((token: unknown) =>
+          token === ConversationMappingService ? mappingService : messageService,
+        ),
+    };
+    const configService = { get: jest.fn().mockReturnValue(undefined) } as unknown as ConfigService;
+    const pluginStorage = {
+      createPluginStorage: jest.fn().mockReturnValue({}),
+    } as unknown as PluginStorageService;
+    loader = new PluginLoaderService(
+      configService,
+      new HookManager(),
+      pluginStorage,
+      moduleRef as unknown as ModuleRef,
+    );
+  });
+
+  function contextFor(plugin: PluginInstance): PluginContext {
+    return (loader as unknown as { createPluginContext: (p: PluginInstance) => PluginContext }).createPluginContext(
+      plugin,
+    );
+  }
+
+  const sendEnv = {
+    type: 'text' as const,
+    text: 'hi',
+    instanceId: 'inst-1',
+    source: { provider: 'chatwoot', externalConversationId: 'conv-42' },
+  };
+  const mapping = (sessionId: string) => ({
+    id: 'm-1',
+    sessionId,
+    chatId: '628@c.us',
+    pluginId: 'test-ext',
+    instanceId: 'inst-1',
+    providerConversationId: 'conv-42',
+  });
+
+  it('resolves chatId from a mapping on the SAME session as the envelope, then sends', async () => {
+    mappingService.getByProvider.mockResolvedValue(mapping('sess-1'));
+    const ctx = contextFor(makePlugin(['*'], ['conversation:send']));
+    await ctx.conversations.send({ ...sendEnv, sessionId: 'sess-1' });
+    expect(mappingService.getByProvider).toHaveBeenCalledWith('test-ext', 'inst-1', 'conv-42');
+    expect(messageService.sendText).toHaveBeenCalledWith('sess-1', { chatId: '628@c.us', text: 'hi' });
+  });
+
+  it('rejects a mapping owned by ANOTHER session and never sends (wrong-session send)', async () => {
+    // The plugin is activated for BOTH sessions, so the per-session activation gate passes — only the
+    // mapping's own sessionId stops a stale mapping (e.g. left over after a scope move) from routing
+    // sess-1's envelope out through sess-2's chat.
+    mappingService.getByProvider.mockResolvedValue(mapping('sess-2'));
+    const ctx = contextFor(makePlugin(['*'], ['conversation:send'], ['sess-1', 'sess-2']));
+    await expect(ctx.conversations.send({ ...sendEnv, sessionId: 'sess-1' })).rejects.toThrow(
+      /belongs to session sess-2, not sess-1/,
+    );
+    expect(messageService.sendText).not.toHaveBeenCalled();
+    expect(messageService.reply).not.toHaveBeenCalled();
+  });
+
+  it('sends with an explicit chatId without consulting the mapping service', async () => {
+    const ctx = contextFor(makePlugin(['*'], ['conversation:send']));
+    await ctx.conversations.send({ type: 'text', text: 'hi', sessionId: 'sess-1', chatId: '628@c.us' });
+    expect(mappingService.getByProvider).not.toHaveBeenCalled();
+    expect(messageService.sendText).toHaveBeenCalledWith('sess-1', { chatId: '628@c.us', text: 'hi' });
   });
 });

--- a/src/core/plugins/plugin-loader.service.ts
+++ b/src/core/plugins/plugin-loader.service.ts
@@ -1263,6 +1263,16 @@ export class PluginLoaderService implements OnModuleInit, OnApplicationBootstrap
               `Plugin ${plugin.manifest.id}: no conversation mapping for instance ${env.instanceId} / ${env.source.externalConversationId}`,
             );
           }
+          // Fail closed on a cross-session mapping: getByProvider keys on (pluginId, instanceId,
+          // providerConversationId) only, so a stale row can resolve to a chat owned by a DIFFERENT
+          // session than the envelope's. Parity with the assertSessionActive(m.sessionId) check on
+          // mappings.getByProvider below — never send through a session the mapping does not belong to.
+          // (mapping.sessionId is NOT NULL in the entity, so a plain inequality check suffices.)
+          if (mapping.sessionId !== env.sessionId) {
+            throw new PluginCapabilityError(
+              `Plugin ${plugin.manifest.id}: conversation mapping for instance ${env.instanceId} / ${env.source.externalConversationId} belongs to session ${mapping.sessionId}, not ${env.sessionId}`,
+            );
+          }
           return mapping.chatId;
         },
         // Re-establish the in-flight hook context around the downstream send so an adapter that calls


### PR DESCRIPTION
## Problem

`conversation.send` resolves the outbound WA `chatId` from `conversation_mappings` when the envelope omits it. The lookup keys on `(pluginId, instanceId, providerConversationId)` only — it never verified that the resolved mapping belongs to the same session as the envelope's `sessionId`.

A plugin activated on two sessions could therefore send through `sessionId=A` using a `chatId` resolved from a mapping owned by session B — a wrong-session send, reachable for example through a stale mapping left behind after a scope move.

## Root cause

In `PluginLoaderService`'s `resolveChatId` (the `conversations` capability binding), the resolved mapping's `chatId` was returned directly after the existence check, with no session-parity check. The neighboring `mappings.getByProvider` path already enforces `assertSessionActive(m.sessionId)`; the send path had no equivalent.

## Fix

`resolveChatId` now fails closed: when the resolved mapping's `sessionId` differs from the envelope's `sessionId`, the send is rejected with a `PluginCapabilityError` naming both sessions, before any downstream `MessageService` call. This mirrors the existing parity check on the mappings read path. The `mapping.sessionId` column is `NOT NULL` in the entity, so no null fallback is needed. Envelopes carrying an explicit `chatId` never touch the mapping lookup and are unaffected.

## Tests

New `ctx.conversations` block in `plugin-capability.spec.ts` exercising the loader-bound facade end to end:

- mapping on the **same** session as the envelope → resolves and sends (existing behavior preserved);
- mapping owned by **another** session (plugin activated on both, so the activation gate passes) → rejects, and `MessageService.sendText`/`reply` are never called;
- explicit `env.chatId` → sends without consulting the mapping service.

## Verification

- `npx jest src/core` — 28 suites / 327 tests pass
- `npx jest src/modules/integration` — 18 suites / 129 tests pass
- `npx eslint src/core` — clean
- `npm run build` — no errors