### PR TITLE
fix(engine): match the orphan-Chromium session marker token-exactly

### DIFF
--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -3338,6 +3338,32 @@ describe('WhatsAppWebJsAdapter orphaned Chromium sweep (pre-launch)', () => {
     expect(killSpy).not.toHaveBeenCalled();
   });
 
+  it('does NOT kill a live sibling whose marker merely SHARES A PREFIX with ours (sess vs sess-2)', async () => {
+    // `--openwa-session=sess-orphan` is a substring of `--openwa-session=sess-orphan-2`: a substring
+    // match would SIGKILL the sibling's live browser; the token-exact match must spare it.
+    mockPsResult({
+      stdout: psTable([
+        [1801, `/usr/lib/chromium/chromium --headless --no-sandbox --openwa-session=${SESSION_ID}-2`],
+        [1802, `/usr/lib/chromium/chromium --headless --no-sandbox --openwa-session=${SESSION_ID}extra`],
+      ]),
+    });
+
+    await newAdapter().initialize({});
+
+    expect(killSpy).not.toHaveBeenCalled();
+  });
+
+  it('kills the orphan when the marker is the LAST token on the command line', async () => {
+    mockPsResult({
+      stdout: psTable([[1803, `/usr/lib/chromium/chromium --headless --no-sandbox --openwa-session=${SESSION_ID}`]]),
+    });
+
+    await newAdapter().initialize({});
+
+    expect(killSpy).toHaveBeenCalledTimes(1);
+    expect(killSpy).toHaveBeenCalledWith(1803, 'SIGKILL');
+  });
+
   it('skips the sweep on platforms other than darwin/linux (no ps, no kill)', async () => {
     const platform = Object.getOwnPropertyDescriptor(process, 'platform') as PropertyDescriptor;
     Object.defineProperty(process, 'platform', { value: 'win32' });

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -1168,14 +1168,18 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
           else resolve(stdout);
         });
       });
+      // Token-exact marker match: the marker is a single argv token, so it must appear delimited by
+      // whitespace or string boundaries. A plain substring test would let restarting session
+      // `sales` SIGKILL the LIVE browser of sibling `sales2` (their markers share a prefix).
       const marker = `--openwa-session=${this.config.sessionId}`;
+      const markerRe = new RegExp('(?:^|\\s)' + marker.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '(?=\\s|$)');
       const killedPids: number[] = [];
       for (const line of psOutput.split('\n')) {
         const match = /^\s*(\d+)\s+(.*)$/.exec(line);
         if (!match) continue;
         const pid = Number(match[1]);
         const args = match[2];
-        if (pid === process.pid || !args.includes(marker)) continue;
+        if (pid === process.pid || !markerRe.test(args)) continue;
         // Never kill a non-browser process that happens to carry the marker string
         // (e.g. a `grep --openwa-session=…` probing the process table).
         if (!/chrome|chromium|headless/i.test(args)) continue;


### PR DESCRIPTION
## Problem

The orphan-Chromium sweep (`killOrphanedChromiumProcesses`, runs at every wwjs session start) identifies browsers left behind by a previous process lifetime via the `--openwa-session=<id>` marker arg in `ps` output. The match was a plain substring test: restarting session `sales` would SIGKILL the **live** browser of sibling session `sales2`, because `--openwa-session=sales` is a substring of `--openwa-session=sales2`. (The existing different-session test only covered a non-prefix name.)

## Fix

The marker is matched as a single argv token — delimited by whitespace or string boundaries — with the session id regex-escaped. A prefix sibling's marker no longer matches; the session's own orphan is still killed whether the marker appears mid-command or as the last token.

## Tests

- New: a live sibling whose marker shares a prefix (`sess-orphan-2`, `sess-orphanextra`) is spared.
- New: the orphan is still killed when its marker is the last token on the command line.
- Full adapter suite (279 tests) and engine suites (792 tests) green; lint + build green.