### PR TITLE
fix(session): purge both engines' auth dirs when a session is deleted

### DIFF
--- a/src/engine/engine.factory.spec.ts
+++ b/src/engine/engine.factory.spec.ts
@@ -138,62 +138,73 @@ describe('EngineFactory', () => {
       fs.rmSync(tmpRoot, { recursive: true, force: true });
     });
 
-    it('removes the whatsapp-web.js LocalAuth dir (session-<name> under sessionDataPath)', async () => {
+    // Both auth-dir shapes live under tmpRoot so the tests are hermetic regardless of CWD.
+    const buildBothDirFactory = (engineType: string) => {
       const sessionDataPath = path.join(tmpRoot, 'sessions');
-      const dir = path.join(sessionDataPath, 'session-alice');
-      fs.mkdirSync(dir, { recursive: true });
-      fs.writeFileSync(path.join(dir, 'creds.json'), '{}');
-
-      const factory = new EngineFactory(
-        buildConfigService({ 'engine.type': 'whatsapp-web.js', 'engine.sessionDataPath': sessionDataPath }),
-        noPluginLoader(),
-        buildMessageStore(),
-        buildLidStore(),
-      );
-      await factory.purgeSessionData('alice');
-
-      expect(fs.existsSync(dir)).toBe(false);
-    });
-
-    it('removes the baileys auth dir (<authDir>/<name>) when the active engine is baileys', async () => {
       const authDir = path.join(tmpRoot, 'baileys');
-      const dir = path.join(authDir, 'bob');
-      fs.mkdirSync(dir, { recursive: true });
-      fs.writeFileSync(path.join(dir, 'creds.json'), '{}');
-
       const factory = new EngineFactory(
-        buildConfigService({ 'engine.type': 'baileys', 'engine.baileys.authDir': authDir }),
+        buildConfigService({
+          'engine.type': engineType,
+          'engine.sessionDataPath': sessionDataPath,
+          'engine.baileys.authDir': authDir,
+        }),
         noPluginLoader(),
         buildMessageStore(),
         buildLidStore(),
       );
-      await factory.purgeSessionData('bob');
+      return { factory, wwjsDir: path.join(sessionDataPath, 'session-alice'), baileysDir: path.join(authDir, 'alice') };
+    };
 
-      expect(fs.existsSync(dir)).toBe(false);
+    it.each(['whatsapp-web.js', 'baileys'])(
+      "removes BOTH engines' auth dirs when the active engine is %s (engine-switch residue)",
+      async engineType => {
+        const { factory, wwjsDir, baileysDir } = buildBothDirFactory(engineType);
+        fs.mkdirSync(wwjsDir, { recursive: true });
+        fs.mkdirSync(baileysDir, { recursive: true });
+        fs.writeFileSync(path.join(wwjsDir, 'creds.json'), '{}');
+        fs.writeFileSync(path.join(baileysDir, 'creds.json'), '{}');
+
+        await factory.purgeSessionData('alice');
+
+        expect(fs.existsSync(wwjsDir)).toBe(false);
+        expect(fs.existsSync(baileysDir)).toBe(false);
+      },
+    );
+
+    it('still purges the other engine dir (and resolves) when one rm fails', async () => {
+      const { factory, wwjsDir, baileysDir } = buildBothDirFactory('baileys');
+      fs.mkdirSync(wwjsDir, { recursive: true });
+      fs.mkdirSync(baileysDir, { recursive: true });
+
+      const realRm = fs.promises.rm.bind(fs.promises);
+      const spy = jest
+        .spyOn(fs.promises, 'rm')
+        .mockImplementation(async (...args: Parameters<typeof fs.promises.rm>) => {
+          if (String(args[0]) === baileysDir) throw new Error('EIO: simulated disk failure');
+          return realRm(...args);
+        });
+      try {
+        await expect(factory.purgeSessionData('alice')).resolves.toBeUndefined();
+      } finally {
+        spy.mockRestore();
+      }
+
+      // The healthy engine's purge still ran; the failed one is left behind (logged, never thrown).
+      expect(fs.existsSync(wwjsDir)).toBe(false);
+      expect(fs.existsSync(baileysDir)).toBe(true);
     });
 
-    it('is a no-op (no throw) when the auth dir does not exist', async () => {
-      const factory = new EngineFactory(
-        buildConfigService({ 'engine.type': 'baileys', 'engine.baileys.authDir': path.join(tmpRoot, 'baileys') }),
-        noPluginLoader(),
-        buildMessageStore(),
-        buildLidStore(),
-      );
+    it('is a no-op (no throw) when neither auth dir exists', async () => {
+      const { factory } = buildBothDirFactory('baileys');
       await expect(factory.purgeSessionData('never-linked')).resolves.toBeUndefined();
     });
 
     it('refuses to purge an unsafe session name (no rm on a traversal path)', async () => {
-      const authDir = path.join(tmpRoot, 'baileys');
       // A sibling that a '../' name would resolve to — it must survive the refused purge.
       const sibling = path.join(tmpRoot, 'baileys-evil');
       fs.mkdirSync(sibling, { recursive: true });
 
-      const factory = new EngineFactory(
-        buildConfigService({ 'engine.type': 'baileys', 'engine.baileys.authDir': authDir }),
-        noPluginLoader(),
-        buildMessageStore(),
-        buildLidStore(),
-      );
+      const { factory } = buildBothDirFactory('baileys');
       await factory.purgeSessionData('../baileys-evil');
 
       expect(fs.existsSync(sibling)).toBe(true);

--- a/src/engine/engine.factory.ts
+++ b/src/engine/engine.factory.ts
@@ -13,7 +13,7 @@ import { LidMappingStoreService } from './identity/lid-mapping-store.service';
 import { isSafeSessionName } from '../common/utils/path-safety';
 
 export interface EngineCreateOptions {
-  /** Session NAME — the on-disk auth-directory key (matches purgeSessionData/sessionAuthDir). */
+  /** Session NAME — the on-disk auth-directory key (matches the dirs purgeSessionData removes). */
   sessionId: string;
   /** Session UUID (Session.id) — the DB-row key for FK-bound stores (e.g. baileys_stored_messages). */
   dbSessionId: string;
@@ -127,14 +127,24 @@ export class EngineFactory implements OnModuleInit {
   }
 
   /**
-   * Remove a session's persistent on-disk auth/store directory for the active engine, so deleting a
-   * session fully purges its footprint. The dir is keyed by session NAME — the same key {@link create}
-   * uses (`path.join(authDir, name)` for baileys, `session-${name}` under sessionDataPath for
+   * Remove a session's persistent on-disk auth/store directories so deleting a session fully purges
+   * its footprint. The dir is keyed by session NAME — the same key {@link create} uses
+   * (`path.join(authDir, name)` for baileys, `session-${name}` under sessionDataPath for
    * whatsapp-web.js) — and survives independently of any engine instance. On delete the engine is
-   * frequently not even loaded (a stopped session has none), so the path is derived from config here
-   * rather than from a live adapter; otherwise recreating a session under the same name would reload a
-   * stale store. Best-effort: an unsafe name or an rm failure is logged, never thrown, so it can't turn
-   * a successful delete into a 500.
+   * frequently not even loaded (a stopped session has none), so the paths are derived from config
+   * here rather than from a live adapter; otherwise recreating a session under the same name would
+   * reload a stale store.
+   *
+   * BOTH engine shapes are purged, not just the active engine's: ENGINE_TYPE is a deploy-level
+   * switch, so a session that ever ran under both engines leaves a live auth dir for each, and
+   * removing only the active engine's would strand the other's WhatsApp credentials on disk after
+   * "delete" — able to silently re-link if the engine is ever switched back (and carried into
+   * backups). Each rm is isolated best-effort: an unsafe name is refused up front, and one engine's
+   * rm failure is logged per-engine — it neither fails the delete nor skips the other engine's purge.
+   *
+   * Note: session START deliberately does NOT purge the inactive engine's residue. An operator
+   * trialling the other engine keeps the previous engine's link so switching back doesn't force a
+   * re-pair; the residue is removed only when the session itself is deleted.
    */
   async purgeSessionData(sessionName: string): Promise<void> {
     if (!isSafeSessionName(sessionName)) {
@@ -145,33 +155,43 @@ export class EngineFactory implements OnModuleInit {
       });
       return;
     }
-    const dir = this.sessionAuthDir(sessionName);
-    try {
-      await fs.promises.rm(dir, { recursive: true, force: true });
-      this.logger.log('Purged session auth directory', { action: 'engine_purge', sessionName, dir });
-    } catch (error) {
-      this.logger.warn('Failed to purge session auth directory', {
-        action: 'engine_purge_failed',
-        sessionName,
-        dir,
-        error: error instanceof Error ? error.message : String(error),
-      });
+    const dirs: Array<{ engine: string; dir: string }> = [
+      { engine: 'whatsapp-web.js', dir: this.wwjsAuthDir(sessionName) },
+      { engine: 'baileys', dir: this.baileysAuthDir(sessionName) },
+    ];
+    for (const { engine, dir } of dirs) {
+      try {
+        await fs.promises.rm(dir, { recursive: true, force: true });
+        this.logger.log('Purged session auth directory', { action: 'engine_purge', engine, sessionName, dir });
+      } catch (error) {
+        this.logger.warn('Failed to purge session auth directory', {
+          action: 'engine_purge_failed',
+          engine,
+          sessionName,
+          dir,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
   }
 
   /**
-   * The on-disk auth directory the active engine keeps for `sessionName`, matching exactly what each
-   * adapter constructs: baileys uses `path.join(authDir, name)` (authDir left unresolved, as the
-   * adapter does); whatsapp-web.js resolves sessionDataPath and appends `session-${name}` (mirrors
+   * The on-disk auth directory whatsapp-web.js keeps for `sessionName`, matching exactly what the
+   * adapter constructs: sessionDataPath resolved, then `session-${name}` appended (mirrors
    * WhatsAppWebJsAdapter.clearLocalAuth).
    */
-  private sessionAuthDir(sessionName: string): string {
-    if (this.engineType === 'baileys') {
-      const authDir = this.configService.get<string>('engine.baileys.authDir') ?? './data/baileys';
-      return path.join(authDir, sessionName);
-    }
+  private wwjsAuthDir(sessionName: string): string {
     const sessionDataPath = this.configService.get<string>('engine.sessionDataPath') ?? './data/sessions';
     return path.join(path.resolve(sessionDataPath), `session-${sessionName}`);
+  }
+
+  /**
+   * The on-disk auth directory baileys keeps for `sessionName`: `path.join(authDir, name)`, with
+   * authDir left unresolved, as the adapter does.
+   */
+  private baileysAuthDir(sessionName: string): string {
+    const authDir = this.configService.get<string>('engine.baileys.authDir') ?? './data/baileys';
+    return path.join(authDir, sessionName);
   }
 
   private isEnginePlugin(instance: unknown): instance is IEnginePlugin {

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -237,7 +237,7 @@ describe('SessionService', () => {
       expect(dataSource.transaction).toHaveBeenCalled(); // DB removal still ran
     });
 
-    it('delete() purges the engine on-disk auth dir (keyed by session NAME) so a same-name recreate starts clean', async () => {
+    it('delete() purges the on-disk auth dirs (keyed by session NAME) so a same-name recreate starts clean', async () => {
       (repository.findOne as jest.Mock).mockResolvedValue(
         createMockSession({ id: 'sess-uuid-1', name: 'test-session' }),
       );
@@ -246,6 +246,23 @@ describe('SessionService', () => {
       await service.delete('sess-uuid-1');
 
       expect(engineFactory.purgeSessionData).toHaveBeenCalledWith('test-session');
+    });
+
+    it('delete() delegates the both-engines purge exactly once, after the DB rows are removed', async () => {
+      (repository.findOne as jest.Mock).mockResolvedValue(
+        createMockSession({ id: 'sess-uuid-1', name: 'test-session' }),
+      );
+
+      await expect(service.delete('sess-uuid-1')).resolves.toBeUndefined();
+
+      // The factory owns the per-engine best-effort isolation (covered in engine.factory.spec);
+      // the service hands it the session NAME once, only after the DB removal has committed.
+      expect(dataSource.transaction).toHaveBeenCalled();
+      expect(engineFactory.purgeSessionData).toHaveBeenCalledTimes(1);
+      expect(engineFactory.purgeSessionData).toHaveBeenCalledWith('test-session');
+      const txOrder = (dataSource.transaction as jest.Mock).mock.invocationCallOrder[0];
+      const purgeOrder = (engineFactory.purgeSessionData as jest.Mock).mock.invocationCallOrder[0];
+      expect(txOrder).toBeLessThan(purgeOrder);
     });
 
     it('delete() purges even when no engine is loaded (a stopped session has none)', async () => {

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -535,10 +535,12 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
         action: 'delete',
       });
 
-      // Purge the engine's persistent on-disk auth/store dir. It's keyed by session NAME and lives
-      // independently of the (now torn-down, and on delete often never-loaded) engine instance, so the
-      // teardown above doesn't touch it. Without this, recreating a session under the same name reloads
-      // a stale store. Best-effort inside the factory — never fails an otherwise-successful delete.
+      // Purge the persistent on-disk auth/store dirs — BOTH engine shapes (see EngineFactory), since
+      // an engine switch may have left a live link for the other engine behind. They're keyed by
+      // session NAME and live independently of the (now torn-down, and on delete often never-loaded)
+      // engine instance, so the teardown above doesn't touch them. Without this, recreating a session
+      // under the same name reloads a stale store. Best-effort inside the factory — never fails an
+      // otherwise-successful delete.
       await this.engineFactory.purgeSessionData(session.name);
     } finally {
       // Always clear the teardown mark so a later recreate/start with this id isn't suppressed.


### PR DESCRIPTION
## Problem

`ENGINE_TYPE` is a deploy-level switch between the whatsapp-web.js and baileys engines, but each session keeps its on-disk auth directory in an engine-specific location:

- whatsapp-web.js: `session-<name>` under `SESSION_DATA_PATH` (LocalAuth)
- baileys: `<name>` under `BAILEYS_AUTH_DIR`

Deleting a session (`DELETE /sessions/:id`) only purged the auth dir of the **currently active** engine. A session that ever ran under both engines — linked on whatsapp-web.js, then the deployment switched to baileys, or vice versa — kept the other engine's WhatsApp credentials on disk after "delete". Those leftovers could **silently re-link** the moment the engine is switched back, and they are carried into backups as well.

## Fix

`EngineFactory.purgeSessionData` now removes **both** engine dir shapes for the deleted session, keyed by session name exactly as each adapter constructs them (mirroring `WhatsAppWebJsAdapter.clearLocalAuth` and the baileys plugin's `path.join(authDir, name)`).

The existing safety posture is preserved, per engine shape:

- the `isSafeSessionName` guard runs up front — a name containing `.`, `/` or `\` never reaches an `rm -rf` sink;
- each `rm` is isolated best-effort: one engine's failure is logged with that engine's name and neither fails the delete nor skips the other engine's purge;
- a missing dir stays a quiet no-op (`force: true`).

`SessionService.delete()` still delegates once, after the DB rows are removed — only its comment was updated to describe the both-shapes behavior.

## Start-time purge: deliberately unchanged

Session **start** still does not purge the inactive engine's residue. An operator trialling the other engine keeps the previous engine's link, so switching back doesn't force a re-pair. Purging at start would break that legitimate migration/rollback workflow. The residue is removed only when the session itself is deleted. This decision is documented in the `purgeSessionData` docblock.

## Tests

`src/engine/engine.factory.spec.ts`:

- purge removes **both** engine auth dirs, parameterized over each active `engine.type`;
- when one `rm` fails (spied `fs.promises.rm` throwing for the baileys dir), the other engine's dir is still removed and the purge resolves — the delete cannot be failed by it;
- neither dir existing is a quiet no-op;
- an unsafe (traversal) session name is still refused before any `rm`.

`src/modules/session/session.service.spec.ts`:

- delete delegates the purge exactly once with the session **name**, after the DB transaction has run, and still resolves.

## Verification

- `npx jest src/modules/session src/engine` — 20 suites / 1040 tests pass
- `npx eslint src/modules/session src/engine` — clean
- `npm run build` — clean