### PR TITLE
fix(throttler): fail fast and shut down cleanly when the Redis backend is offline

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,8 +5,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ThrottlerModule } from '@nestjs/throttler';
-import Redis from 'ioredis';
 import { RedisThrottlerStorage } from './common/throttler/redis-throttler.storage';
+import { createThrottlerRedisClient } from './common/throttler/throttler-redis.client';
 import configuration from './config/configuration';
 import { validateEnv } from './config/env.validation';
 import { SessionModule } from './modules/session/session.module';
@@ -241,19 +241,12 @@ if (dashboardServingEnabled && dashboardBuildPresent) {
             limit: configService.get<number>('api.rateLimit.longLimit', 1000),
           },
         ];
-        // Fail-open on Redis error (see RedisThrottlerStorage), so a Redis outage never blocks the API.
+        // Fail-open on Redis error (see RedisThrottlerStorage), so a Redis outage never blocks the
+        // API. The client is built fail-fast (see throttler-redis.client.ts) so that fail-open
+        // engages immediately instead of after a queue/timeout stall per request.
         const redisStorage =
           process.env.REDIS_ENABLED === 'true'
-            ? new RedisThrottlerStorage(
-                new Redis({
-                  host: configService.get<string>('redis.host', 'localhost'),
-                  port: configService.get<number>('redis.port', 6379),
-                  username: configService.get<string>('redis.username'),
-                  password: configService.get<string>('redis.password'),
-                  connectTimeout: configService.get<number>('redis.connectTimeoutMs', 5000),
-                  maxRetriesPerRequest: 3,
-                }),
-              )
+            ? new RedisThrottlerStorage(createThrottlerRedisClient(configService))
             : undefined;
         return { throttlers, ...(redisStorage ? { storage: redisStorage } : {}) };
       },

--- a/src/common/throttler/redis-throttler.storage.lifecycle.spec.ts
+++ b/src/common/throttler/redis-throttler.storage.lifecycle.spec.ts
@@ -1,0 +1,32 @@
+import { Test } from '@nestjs/testing';
+import { ThrottlerStorage } from '@nestjs/throttler';
+import { RedisThrottlerStorage } from './redis-throttler.storage';
+import type { Redis } from 'ioredis';
+
+describe('RedisThrottlerStorage lifecycle wiring', () => {
+  it('Nest invokes onModuleDestroy on the storage instance registered via a factory provider', async () => {
+    const redis = {
+      eval: jest.fn(),
+      on: jest.fn(),
+      quit: jest.fn().mockResolvedValue('OK'),
+      disconnect: jest.fn(),
+    };
+    const storage = new RedisThrottlerStorage(redis as unknown as Redis);
+
+    // Mirror @nestjs/throttler's ThrottlerStorageProvider: a useFactory returning options.storage.
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        { provide: 'THROTTLER_OPTIONS', useValue: { storage } },
+        {
+          provide: ThrottlerStorage,
+          useFactory: (options: { storage: RedisThrottlerStorage }) => options.storage,
+          inject: ['THROTTLER_OPTIONS'],
+        },
+      ],
+    }).compile();
+
+    await moduleRef.close();
+    expect(redis.quit).toHaveBeenCalledTimes(1);
+    expect(redis.disconnect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/common/throttler/redis-throttler.storage.spec.ts
+++ b/src/common/throttler/redis-throttler.storage.spec.ts
@@ -1,10 +1,13 @@
-import { RedisThrottlerStorage } from './redis-throttler.storage';
+import { RedisThrottlerStorage, THROTTLER_REDIS_QUIT_TIMEOUT_MS } from './redis-throttler.storage';
 import type { Redis } from 'ioredis';
 
-type MockRedis = { eval: jest.Mock };
+type MockRedis = { eval: jest.Mock; on: jest.Mock; quit: jest.Mock; disconnect: jest.Mock };
 
 const makeRedis = (opts: { hits: number; ttlMs: number }): MockRedis => ({
   eval: jest.fn().mockResolvedValue([opts.hits, opts.ttlMs]),
+  on: jest.fn(),
+  quit: jest.fn().mockResolvedValue('OK'),
+  disconnect: jest.fn(),
 });
 
 describe('RedisThrottlerStorage', () => {
@@ -51,5 +54,61 @@ describe('RedisThrottlerStorage', () => {
     redis.eval.mockRejectedValue(new Error('ECONNREFUSED'));
     const rec = await new RedisThrottlerStorage(redis as unknown as Redis).increment('k', 1000, 10, 60000, 'short');
     expect(rec).toEqual({ totalHits: 0, timeToExpire: 0, isBlocked: false, timeToBlockExpire: 0 });
+  });
+
+  it('fails open FAST when the client rejects while disconnected (no queue/timeout stall)', async () => {
+    const redis = makeRedis({ hits: 1, ttlMs: 1000 });
+    // The exact rejection ioredis produces with enableOfflineQueue:false — issued commands must not
+    // wait for reconnect; the request is decided on the fail-open path immediately.
+    redis.eval.mockRejectedValue(new Error("Stream isn't writeable and enableOfflineQueue options is false"));
+    const storage = new RedisThrottlerStorage(redis as unknown as Redis);
+    const result = await Promise.race([
+      storage.increment('k', 1000, 10, 60000, 'short'),
+      new Promise<'slow'>(resolve => setTimeout(() => resolve('slow'), 100)),
+    ]);
+    expect(result).toEqual({ totalHits: 0, timeToExpire: 0, isBlocked: false, timeToBlockExpire: 0 });
+  });
+
+  it('attaches an error listener so connection failures surface as structured logs, never unhandled events', () => {
+    const redis = makeRedis({ hits: 1, ttlMs: 1000 });
+    new RedisThrottlerStorage(redis as unknown as Redis);
+    expect(redis.on).toHaveBeenCalledWith('error', expect.any(Function));
+    const calls = redis.on.mock.calls as Array<[string, (error: Error) => void]>;
+    const errorCall = calls.find(([event]) => event === 'error');
+    expect(errorCall).toBeDefined();
+    const listener = errorCall![1];
+    expect(() => listener(new Error('ECONNREFUSED'))).not.toThrow();
+  });
+
+  it('onModuleDestroy drains the client with quit() and always disconnects the socket', async () => {
+    const redis = makeRedis({ hits: 1, ttlMs: 1000 });
+    await new RedisThrottlerStorage(redis as unknown as Redis).onModuleDestroy();
+    expect(redis.quit).toHaveBeenCalledTimes(1);
+    expect(redis.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('onModuleDestroy still disconnects when quit() rejects (client already offline)', async () => {
+    const redis = makeRedis({ hits: 1, ttlMs: 1000 });
+    // With enableOfflineQueue:false a quit() issued mid-outage rejects instantly WITHOUT closing the
+    // socket — teardown must not propagate that rejection nor skip the disconnect.
+    redis.quit.mockRejectedValue(new Error("Stream isn't writeable and enableOfflineQueue options is false"));
+    const storage = new RedisThrottlerStorage(redis as unknown as Redis);
+    await expect(storage.onModuleDestroy()).resolves.toBeUndefined();
+    expect(redis.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('onModuleDestroy does not hang when quit() never settles (deadline, then force disconnect)', async () => {
+    jest.useFakeTimers();
+    try {
+      const redis = makeRedis({ hits: 1, ttlMs: 1000 });
+      redis.quit.mockReturnValue(new Promise(() => undefined)); // half-open socket: QUIT never answered
+      const storage = new RedisThrottlerStorage(redis as unknown as Redis);
+      const destroy = storage.onModuleDestroy();
+      await jest.advanceTimersByTimeAsync(THROTTLER_REDIS_QUIT_TIMEOUT_MS);
+      await destroy;
+      expect(redis.disconnect).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });

--- a/src/common/throttler/redis-throttler.storage.ts
+++ b/src/common/throttler/redis-throttler.storage.ts
@@ -1,7 +1,10 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, OnModuleDestroy } from '@nestjs/common';
 import type { Redis } from 'ioredis';
 import { ThrottlerStorage } from '@nestjs/throttler';
 import { createLogger } from '../services/logger.service';
+
+/** Max time to await a graceful `redis.quit()` on shutdown before force-disconnecting (see onModuleDestroy). */
+export const THROTTLER_REDIS_QUIT_TIMEOUT_MS = 2000;
 
 /** The 4-field record @nestjs/throttler's guard reads (not re-exported from the package root). */
 interface ThrottlerRecord {
@@ -37,12 +40,47 @@ return {hits, ttl}
  * conventions are SECONDS — so the values here are ceil(ms / 1000), matching the default in-memory
  * storage. Fail-OPEN on Redis error: rate limiting is a secondary control, and fail-closed would
  * self-DoS the gateway (every request 500s on the storage call).
+ *
+ * This class owns the client lifecycle: it is registered as the `ThrottlerStorage` provider by
+ * @nestjs/throttler (its ThrottlerStorageProvider returns the configured instance), so Nest invokes
+ * onModuleDestroy on it at shutdown.
  */
 @Injectable()
-export class RedisThrottlerStorage implements ThrottlerStorage {
+export class RedisThrottlerStorage implements ThrottlerStorage, OnModuleDestroy {
   private readonly logger = createLogger('RedisThrottlerStorage');
 
-  constructor(private readonly redis: Redis) {}
+  constructor(private readonly redis: Redis) {
+    // An ioredis client with no 'error' listener reports every connection failure via an unstructured
+    // console dump; log it through the structured logger instead. Never rethrow — the client keeps
+    // reconnecting in the background and increment() already fails open per request.
+    this.redis.on('error', (error: Error) => {
+      this.logger.warn('Throttler Redis client error', { error: error.message });
+    });
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    const redis = this.redis;
+
+    // Bound the teardown: redis.quit() waits for the QUIT reply, which never arrives on a half-open /
+    // partitioned socket — leaving app.close() blocked until the orchestrator SIGKILLs the process.
+    // Race a graceful QUIT (drain, not a hard cut) against a short deadline so shutdown proceeds.
+    let timer: NodeJS.Timeout | undefined;
+    const deadline = new Promise<void>(resolve => {
+      timer = setTimeout(resolve, THROTTLER_REDIS_QUIT_TIMEOUT_MS);
+      timer.unref();
+    });
+
+    try {
+      await Promise.race([redis.quit().catch(() => undefined), deadline]);
+    } finally {
+      if (timer) clearTimeout(timer);
+      // Always release the socket. With enableOfflineQueue:false and the client mid-reconnect, quit()
+      // rejects instantly WITHOUT closing it — so ioredis's reconnect timer would outlive teardown.
+      // disconnect() is idempotent, so calling it after a clean quit is harmless; this guarantees no
+      // live handle survives onModuleDestroy regardless of connection state.
+      redis.disconnect();
+    }
+  }
 
   async increment(
     key: string,

--- a/src/common/throttler/throttler-redis.client.spec.ts
+++ b/src/common/throttler/throttler-redis.client.spec.ts
@@ -1,0 +1,68 @@
+import { ConfigService } from '@nestjs/config';
+import {
+  buildThrottlerRedisOptions,
+  createThrottlerRedisClient,
+  THROTTLER_REDIS_COMMAND_TIMEOUT_MS,
+} from './throttler-redis.client';
+
+const makeConfig = (values: Record<string, unknown>): ConfigService =>
+  ({
+    get: jest.fn((key: string, fallback?: unknown) => values[key] ?? fallback),
+  }) as unknown as ConfigService;
+
+describe('buildThrottlerRedisOptions', () => {
+  it('maps the redis.* config keys onto the client', () => {
+    const options = buildThrottlerRedisOptions(
+      makeConfig({
+        'redis.host': 'redis.internal',
+        'redis.port': 6380,
+        'redis.username': 'throttler',
+        'redis.password': 'secret',
+        'redis.connectTimeoutMs': 3000,
+      }),
+    );
+    expect(options).toMatchObject({
+      host: 'redis.internal',
+      port: 6380,
+      username: 'throttler',
+      password: 'secret',
+      connectTimeout: 3000,
+    });
+  });
+
+  it('falls back to localhost defaults', () => {
+    const options = buildThrottlerRedisOptions(makeConfig({}));
+    expect(options).toMatchObject({ host: 'localhost', port: 6379, connectTimeout: 5000 });
+  });
+
+  it('fails fast instead of queueing or replaying commands across an outage', () => {
+    const options = buildThrottlerRedisOptions(makeConfig({}));
+    // Commands issued while disconnected reject immediately so the storage's fail-open path
+    // engages per request — no offline-queue stall, no post-recovery replay of queued evals.
+    expect(options.enableOfflineQueue).toBe(false);
+    // An eval in flight when the socket dies is never resent: the INCR is not idempotent, so a
+    // resend could double-count or land in a fresh window.
+    expect(options.autoResendUnfulfilledCommands).toBe(false);
+    // Every command is deadline-bounded, so a dropped in-flight call cannot hang the request.
+    expect(options.commandTimeout).toBe(THROTTLER_REDIS_COMMAND_TIMEOUT_MS);
+    // No queue-based retry flushing — per-command latency is bounded by commandTimeout alone.
+    expect(options.maxRetriesPerRequest).toBeNull();
+  });
+});
+
+describe('createThrottlerRedisClient', () => {
+  it('passes the fail-fast options through to the ioredis constructor', () => {
+    const client = createThrottlerRedisClient(makeConfig({ 'redis.host': '127.0.0.1' }));
+    try {
+      expect(client.options.enableOfflineQueue).toBe(false);
+      expect(client.options.autoResendUnfulfilledCommands).toBe(false);
+      expect(client.options.commandTimeout).toBe(THROTTLER_REDIS_COMMAND_TIMEOUT_MS);
+      expect(client.options.maxRetriesPerRequest).toBeNull();
+      expect(client.options.host).toBe('127.0.0.1');
+    } finally {
+      // Stop the eager connect/reconnect loop so the test leaves no live handle behind.
+      client.on('error', () => undefined);
+      client.disconnect();
+    }
+  });
+});

--- a/src/common/throttler/throttler-redis.client.ts
+++ b/src/common/throttler/throttler-redis.client.ts
@@ -1,0 +1,46 @@
+import { ConfigService } from '@nestjs/config';
+import Redis, { RedisOptions } from 'ioredis';
+
+/**
+ * Upper bound for one throttler command. The storage fails OPEN on command error, so a bounded
+ * rejection is how a slow/partitioned Redis degrades to "allow" instead of stalling the request.
+ * It also settles commands ioredis drops on reconnect (autoResendUnfulfilledCommands: false below),
+ * which would otherwise never resolve.
+ */
+export const THROTTLER_REDIS_COMMAND_TIMEOUT_MS = 2000;
+
+/**
+ * Client options for the throttler's Redis backend, tuned so the fail-open posture of
+ * RedisThrottlerStorage engages IMMEDIATELY instead of after a stall:
+ *
+ * - enableOfflineQueue: false — a command issued while disconnected rejects at once
+ *   ("Stream isn't writeable...") rather than sitting in the offline queue until reconnect.
+ *   The default (queue + flush on recovery) both stalls every request for seconds and replays
+ *   the non-idempotent INCR evals late, corrupting the fixed-window counts.
+ * - autoResendUnfulfilledCommands: false — an eval in flight when the socket dies is NOT resent
+ *   after reconnect: a resent INCR can double-count (if it already ran server-side) or land in a
+ *   fresh window. Dropping it is safe because commandTimeout settles the awaiting caller.
+ * - commandTimeout — per-command deadline covering the two cases above (dropped in-flight
+ *   commands never settle on their own) plus a live-but-slow Redis.
+ * - maxRetriesPerRequest: null — disables ioredis's periodic pending-queue flush; with the
+ *   offline queue disabled there is nothing to flush, and per-command latency is bounded by
+ *   commandTimeout instead of a retry counter.
+ */
+export function buildThrottlerRedisOptions(configService: ConfigService): RedisOptions {
+  return {
+    host: configService.get<string>('redis.host', 'localhost'),
+    port: configService.get<number>('redis.port', 6379),
+    username: configService.get<string>('redis.username'),
+    password: configService.get<string>('redis.password'),
+    connectTimeout: configService.get<number>('redis.connectTimeoutMs', 5000),
+    enableOfflineQueue: false,
+    autoResendUnfulfilledCommands: false,
+    commandTimeout: THROTTLER_REDIS_COMMAND_TIMEOUT_MS,
+    maxRetriesPerRequest: null,
+  };
+}
+
+/** Dedicated client for throttler hit-count storage — separate from cache/queue clients. */
+export function createThrottlerRedisClient(configService: ConfigService): Redis {
+  return new Redis(buildThrottlerRedisOptions(configService));
+}


### PR DESCRIPTION
## Problem

When `REDIS_ENABLED=true`, rate-limit hit counts live in Redis and the storage is deliberately fail-OPEN: on any Redis error it returns a non-blocking record so an outage never blocks the API. The Redis client behind it, however, was created with ioredis defaults plus `maxRetriesPerRequest: 3` — notably **without** `enableOfflineQueue: false`. During a Redis outage that default defeats the fail-open design:

- **Requests stall instead of failing open.** Every command issued while disconnected waits in ioredis's offline queue until reconnect. The guard evaluates three named throttlers (`short`/`medium`/`long`) sequentially per request, so each request hung for multiple queue/connect-timeout cycles (~8s per increment, ~24s+ per request) before the fail-open path ever ran.
- **Window counters miscount after recovery.** On reconnect the queued `INCR`-based Lua evals are flushed and executed late, landing hits in the wrong fixed window. The same applies to an eval in flight when the socket dies: ioredis resends unfulfilled commands after reconnect, and `INCR` is not idempotent, so a resent eval can double-count.
- **No error listener, no teardown.** Connection failures surfaced as unstructured `console.error` dumps, and the client was never quit on shutdown — its reconnect timer could outlive `app.close()` and block a clean exit.

## Fix

The throttler's Redis client is now built fail-fast (`src/common/throttler/throttler-redis.client.ts`):

- `enableOfflineQueue: false` — a command issued while disconnected rejects immediately, so the storage's fail-open path engages per request with no queue stall and no post-recovery replay.
- `autoResendUnfulfilledCommands: false` — an eval in flight when the connection drops is never resent (a resent `INCR` could double-count or land in a fresh window).
- `commandTimeout: 2000ms` — every command is deadline-bounded, which both caps a live-but-slow Redis and settles the dropped in-flight calls above (whose promises would otherwise never resolve).
- `maxRetriesPerRequest: null` — with no offline queue there is no pending-command flush left to govern; per-command latency is bounded by `commandTimeout` alone. (Verified against the installed ioredis 5.11.1: `null` only disables the periodic queue flush, which is inert once the offline queue is off.)

And `RedisThrottlerStorage` now owns the client lifecycle:

- A structured `error` listener logs connection failures through the app logger (never rethrows; the client keeps reconnecting in the background while `increment()` fails open per request).
- `onModuleDestroy` drains the client with `quit()` raced against a 2s deadline, then always `disconnect()`s — required because with the offline queue disabled, a `quit()` issued mid-outage rejects *without* closing the socket. The storage instance is registered as the `ThrottlerStorage` provider by @nestjs/throttler, so Nest invokes the hook at shutdown (covered by a dedicated wiring test).

The fail-open posture itself is unchanged — only its latency and cleanliness.

## Tests

- Unit (`src/common/throttler`, 14 tests): client options carry the fail-fast set and map the `redis.*` config keys; options reach the real ioredis constructor; error listener attached and non-throwing; `onModuleDestroy` calls `quit()` + `disconnect()`, tolerates a rejecting `quit()`, and never hangs on a half-open socket (fake-timer deadline); fail-open record returned fast when the client rejects disconnected; Nest lifecycle wiring invokes the hook on the provider-registered instance.
- `npx jest src/common/security src/config` — 233 passed.
- `npx jest --config ./test/jest-e2e.json test/ingress-instance-throttle.e2e-spec.ts` — passed (in-memory storage path unaffected).
- `npx eslint src/common/security src/config src/app.module.ts src/common/throttler` — clean; `npm run build` — clean.

## Risks

- Only active when `REDIS_ENABLED=true`; the in-memory default path is untouched.
- A Redis that is up but consistently slower than 2s now degrades to fail-open (allow) instead of eventually answering — consistent with the documented posture that rate limiting is a secondary control.
- During an outage, rate limits are effectively per-request-allowed (fail-open), exactly as previously designed; after recovery, counters resume cleanly instead of absorbing replayed increments.