### PR TITLE
ci(release): pin actions, guard promotion order, and stop latest re-pointing on main pushes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -71,6 +71,9 @@ updates:
       - dependency-name: "typescript"
         versions: [">=7.0.0"]
 
+  # All workflow action refs are pinned to commit SHAs (with a `# vX.Y.Z` comment). Dependabot
+  # understands that form: it proposes the new SHA and rewrites the version comment, so the pins
+  # stay current without ever floating on a mutable major tag.
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -61,10 +61,10 @@ jobs:
     name: Security audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -83,10 +83,10 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -101,7 +101,7 @@ jobs:
         run: npm run test:e2e
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         if: always()
         with:
           files: ./coverage/lcov.info
@@ -125,10 +125,10 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -168,10 +168,10 @@ jobs:
     name: Dashboard
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -200,10 +200,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, audit, test, dashboard]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -215,7 +215,7 @@ jobs:
         run: npm run build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dist
           path: dist/
@@ -229,17 +229,17 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Login to GitHub Container Registry
         if: github.event_name == 'push'
-        uses: docker/login-action@v4
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -247,16 +247,19 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ghcr.io/${{ github.repository }}
+          # Branch + SHA tags only. `latest` is deliberately NOT set here: re-pointing it on
+          # every main push would bypass the boot-smoke → promote discipline in release.yml
+          # (a main-push image is build-gated only, never boot-tested). `latest` moves exclusively
+          # through the tested release path.
           tags: |
             type=ref,event=branch
             type=sha,prefix=
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and optionally push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           # Fork pull requests receive a read-only token, so they validate both image architectures

--- a/.github/workflows/java-sdk-release.yml
+++ b/.github/workflows/java-sdk-release.yml
@@ -1,7 +1,8 @@
 name: Java SDK Release
 
-# Publishes com.rmyndharis:openwa to Maven Central from sdk/java. Cleanly no-ops
-# until the one-time setup is done (see sdk/java/README.md -> RELEASING):
+# Publishes com.rmyndharis:openwa to Maven Central from sdk/java. Requires the one-time setup
+# (see sdk/java/README.md -> RELEASING); the publish secrets are verified up front and their
+# absence FAILS the run instead of silently no-oping green:
 #   - MAVEN_CENTRAL_USERNAME / MAVEN_CENTRAL_PASSWORD  (Sonatype Central user token halves)
 #   - GPG_PRIVATE_KEY                                   (ASCII-armored signing key)
 #   - GPG_PASSPHRASE
@@ -23,23 +24,64 @@ jobs:
       run:
         working-directory: sdk/java
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - name: Guard — skip if publish credentials are absent
-        id: guard
+      # All guards are textual and secret-free, so a misconfigured release fails BEFORE any
+      # credential is touched or any artifact is built.
+      - name: Guard — ref must be a java-sdk-v* release tag
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          # workflow_dispatch can start this workflow on ANY ref; deploying an arbitrary branch
+          # or a monorepo app tag to Maven Central must not be possible. Restrict dispatch to the
+          # same tag shape a push triggers on.
+          case "$REF" in
+            refs/tags/java-sdk-v*) ;;
+            *)
+              echo "::error::This workflow deploys to Maven Central and must run from a java-sdk-v* tag (got '$REF'). For workflow_dispatch, select the release tag as the run ref."
+              exit 1
+              ;;
+          esac
+
+      - name: Guard — tag version matches pom.xml version
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          TAG_VERSION="${REF_NAME#java-sdk-v}"
+          # pom.xml has no <parent> block, so its first <version> element is the project version.
+          POM_VERSION="$(grep -m1 -o '<version>[^<]*</version>' pom.xml | sed -e 's/<[^>]*>//g')"
+          if [ -z "$POM_VERSION" ]; then
+            echo "::error::could not read the project version from pom.xml"
+            exit 1
+          fi
+          if [ "$TAG_VERSION" != "$POM_VERSION" ]; then
+            echo "::error::Tag '$REF_NAME' (version '$TAG_VERSION') does not match pom.xml version '$POM_VERSION'. Bump the pom or fix the tag before releasing."
+            exit 1
+          fi
+          echo "Tag $REF_NAME matches pom.xml $POM_VERSION"
+
+      - name: Guard — publish credentials are present
         env:
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |
-          if [ -z "${MAVEN_CENTRAL_USERNAME:-}" ]; then
-            echo "::notice::MAVEN_CENTRAL_USERNAME not set — skipping publish. See sdk/java/README.md -> RELEASING."
-            echo "publish=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "publish=true" >> "$GITHUB_OUTPUT"
+          # Missing credentials used to downgrade the publish to a green no-op — indistinguishable
+          # from a real release in the run list. Both events that can reach this job (a java-sdk-v*
+          # tag push, or a dispatch on such a tag — enforced by the ref guard above) intend to
+          # publish, so absence of any credential is a hard failure.
+          missing=""
+          for name in MAVEN_CENTRAL_USERNAME MAVEN_CENTRAL_PASSWORD GPG_PRIVATE_KEY GPG_PASSPHRASE; do
+            if [ -z "${!name:-}" ]; then missing="$missing $name"; fi
+          done
+          if [ -n "$missing" ]; then
+            echo "::error::Missing publish secret(s):$missing — configure them (see sdk/java/README.md -> RELEASING) before tagging a release."
+            exit 1
           fi
 
       - name: Set up JDK + signing key
-        if: steps.guard.outputs.publish == 'true'
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
           distribution: temurin
           java-version: '17'
@@ -50,10 +92,11 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: GPG_PASSPHRASE
 
+      # No -DskipTests: the artifact published to Maven Central must be the one `mvn verify`
+      # proved, matching what sdk-ci.yml gates on every SDK change.
       - name: Deploy to Maven Central
-        if: steps.guard.outputs.publish == 'true'
         env:
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        run: mvn -B -Prelease deploy -DskipTests
+        run: mvn -B -Prelease deploy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,16 @@ on:
   push:
     tags: ['v*']
 
+# Serialize ALL release runs on one global queue — deliberately not a per-tag group
+# (`release-${{ github.ref_name }}`). The mutable channels (the X.Y minor tag and `latest`)
+# are shared state across releases: a per-tag group would let two overlapping releases complete
+# out of order, with the older build re-pointing those channels last. cancel-in-progress: false
+# so a newer tag can never abort a promotion already in flight — a half-promoted registry state
+# is worse than a queued release.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 env:
   NODE_VERSION: '22'
   DOCKER_PLATFORMS: linux/amd64,linux/arm64
@@ -21,10 +31,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -74,10 +84,10 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -109,10 +119,10 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -152,10 +162,10 @@ jobs:
     name: Dashboard
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -184,10 +194,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, test, dashboard]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -211,7 +221,7 @@ jobs:
     # safety.
     needs: [lint, test, test-postgres, dashboard, build, docker, boot-smoke, image-scan, promote, verify-published]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
@@ -236,7 +246,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           # Author the release as a real user (the PAT owner) instead of github-actions[bot].
           # Add a repo secret RELEASE_PAT — a fine-grained PAT scoped to this repo with
@@ -257,17 +267,23 @@ jobs:
       contents: read
       packages: write
     needs: [lint, test, test-postgres, dashboard, build]
+    # The promote and verify-published jobs consume exactly what this build produced — the pushed
+    # manifest digest and the tag set computed once here — instead of re-deriving tags from the
+    # tag pattern downstream. What is promoted and verified is by construction what was built.
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+      tags: ${{ steps.meta.outputs.tags }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -285,16 +301,24 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
-          images: ghcr.io/${{ github.repository }}
+          # Both registries the promote job tags. Computed once here and handed to promote /
+          # verify-published via job outputs, so the promoted set cannot drift from the build.
+          images: |
+            ghcr.io/${{ github.repository }}
+            docker.io/rmyndharis/openwa
           tags: |
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            # The mutable channels (X.Y, latest) are disabled for prereleases: an rc/beta/alpha
+            # build must never become what `docker pull openwa:0.11` or `:latest` resolves to.
+            # The exact prerelease tag ({{version}}) is still published.
+            type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(github.ref_name, '-') }}
             type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
 
       - name: Build and push (staging tag only)
-        uses: docker/build-push-action@v7
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           push: true
@@ -324,10 +348,10 @@ jobs:
     needs: [docker]
     steps:
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -400,7 +424,7 @@ jobs:
         platform: [linux/amd64, linux/arm64]
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -413,7 +437,7 @@ jobs:
         run: echo "ref=ghcr.io/${REPO,,}:smoke-${{ github.run_id }}" >> "$GITHUB_OUTPUT"
 
       - name: Trivy image scan
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         env:
           # trivy reads TRIVY_PLATFORM for its --platform flag. Scanning is static (it reads the
           # image layers, it does not run the image), so no QEMU is needed to inspect the arm64
@@ -428,24 +452,26 @@ jobs:
           ignore-unfixed: true
           exit-code: '1'
 
-  # Applies the release tags (X.Y.Z, X.Y, latest) to the image boot-smoke just proved can start, on
-  # BOTH registries (GHCR + Docker Hub — the metadata-action `images` list emits both, and the loop
-  # below promotes each). `imagetools create` re-points tags at the existing manifest list without
-  # rebuilding, so the promoted image is bit-identical to the one tested on both registries, and its
-  # provenance and SBOM attestations travel with it. If boot-smoke fails, this job never runs and the
-  # release tags never appear anywhere.
+  # Applies the release tags (X.Y.Z — plus X.Y and latest for non-prereleases) to the image
+  # boot-smoke just proved can start, on BOTH registries (GHCR + Docker Hub — the tag set computed
+  # once by the docker job's metadata-action covers both, and arrives here via job outputs, so the
+  # promoted set is by construction the build's own tag set, never a re-derived pattern).
+  # `imagetools create` re-points tags at the existing manifest list without rebuilding, so the
+  # promoted image is bit-identical to the one tested on both registries, and its provenance and
+  # SBOM attestations travel with it. If boot-smoke fails, this job never runs and the release
+  # tags never appear anywhere.
   promote:
     name: Promote image to release tags
     runs-on: ubuntu-latest
     permissions:
       packages: write
-    needs: [boot-smoke, image-scan]
+    needs: [docker, boot-smoke, image-scan]
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -455,45 +481,56 @@ jobs:
       # pull count lives (GHCR exposes no download metrics). Requires the DOCKERHUB_USERNAME /
       # DOCKERHUB_TOKEN repo secrets; without them this step fails before any tag is applied.
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: |
-            ghcr.io/${{ github.repository }}
-            docker.io/rmyndharis/openwa
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
-
       - name: Tag the smoke-tested image with the release tags
         env:
           REPO: ${{ github.repository }}
-          TAGS: ${{ steps.meta.outputs.tags }}
+          REF_NAME: ${{ github.ref_name }}
+          TAGS: ${{ needs.docker.outputs.tags }}
+          EXPECTED_DIGEST: ${{ needs.docker.outputs.digest }}
         run: |
           set -euo pipefail
           staging="ghcr.io/${REPO,,}:smoke-${{ github.run_id }}"
-          # metadata-action emits one tag per line. A here-string rather than a pipe, so the loop
-          # runs in this shell and `set -e` actually aborts the step on a failed promotion instead
-          # of the pipeline swallowing it.
+          # Identity gate before anything is re-pointed: the staging manifest must be exactly the
+          # manifest the docker job built (and boot-smoke/image-scan tested). A mismatch means the
+          # tag under promotion is not the tested content, so stop.
+          actual="$(docker buildx imagetools inspect "$staging" --format '{{.Manifest.Digest}}')"
+          if [ "$actual" != "$EXPECTED_DIGEST" ]; then
+            echo "::error::staging digest $actual != build digest $EXPECTED_DIGEST — refusing to promote untested content"
+            exit 1
+          fi
+          # One tag per line. A here-string rather than a pipe, so the loop runs in this shell and
+          # `set -e` actually aborts the step on a failed promotion instead of the pipeline
+          # swallowing it.
           promoted=0
           while IFS= read -r tag; do
             [ -n "$tag" ] || continue
+            # Defense in depth on top of the metadata `enable=` guards: a minor tag (X.Y) must
+            # never be promoted from prerelease content, even if the tag set upstream changes.
+            if [[ "$REF_NAME" == *-* ]] && [[ "$tag" =~ :[0-9]+\.[0-9]+$ ]]; then
+              echo "skipping $tag — minor tags are not promoted from a prerelease"
+              continue
+            fi
             echo "promoting -> $tag"
             docker buildx imagetools create --tag "$tag" "$staging"
+            # Each promoted tag must resolve to the build digest — the promotion is a re-point,
+            # never new content.
+            promoted_digest="$(docker buildx imagetools inspect "$tag" --format '{{.Manifest.Digest}}')"
+            if [ "$promoted_digest" != "$EXPECTED_DIGEST" ]; then
+              echo "::error::$tag resolved to $promoted_digest after promotion, expected $EXPECTED_DIGEST"
+              exit 1
+            fi
             promoted=$((promoted + 1))
           done <<< "$TAGS"
           if [ "$promoted" -eq 0 ]; then
             echo "::error::no release tags were produced by metadata-action — nothing was promoted"
             exit 1
           fi
-          echo "promoted $promoted tag(s)"
+          echo "promoted $promoted tag(s), all digest-identical to the tested build"
 
       - name: Verify the release tag resolves and is multi-arch
         env:
@@ -505,20 +542,32 @@ jobs:
             grep -q "$want" /tmp/inspect.txt || { echo "MISSING PLATFORM: $want"; exit 1; }
           done
 
-      # Best-effort tidy-up of the staging tag, and it MUST refuse to act unless that tag is the only
-      # one on its version.
-      #
-      # GHCR deletes by *version*, not by tag, and a version carries every tag pointing at it. The
-      # promote step above re-points the release tags at content identical to the staging image, so
-      # they resolve to the same digest and therefore the same version — whose tag list is
-      # ["smoke-<run>", "X.Y.Z", "X.Y", "latest"]. Deleting that version by id took the release tags
-      # with it: v0.10.5 published a GitHub Release while `latest`, `0.10` and `0.10.5` all vanished
-      # from the registry, so `docker pull` failed for everyone until they were restored.
-      #
-      # On the happy path this is now a no-op, which is correct — a stray staging tag is harmless, and
-      # far cheaper than un-publishing a release. It still cleans up the case it was written for: a run
-      # where promotion never happened, leaving the staging tag alone on its version.
+  # ──── Staging tag cleanup (happy path AND failure path) ───────────
+  # Best-effort tidy-up of the staging tag, and it MUST refuse to act unless that tag is the only
+  # one on its version.
+  #
+  # GHCR deletes by *version*, not by tag, and a version carries every tag pointing at it. The
+  # promote job re-points the release tags at content identical to the staging image, so they
+  # resolve to the same digest and therefore the same version — whose tag list is
+  # ["smoke-<run>", "X.Y.Z", "X.Y", "latest"]. Deleting that version by id took the release tags
+  # with it: v0.10.5 published a GitHub Release while `latest`, `0.10` and `0.10.5` all vanished
+  # from the registry, so `docker pull` failed for everyone until they were restored.
+  #
+  # This lives in its own `if: always()` job — not inside promote — because the failure path is
+  # exactly when cleanup matters most: when boot-smoke or image-scan fails, promote is skipped and
+  # the staging tag would otherwise leak. On the happy path the release tags share the staging
+  # version, so the step below keeps it (the deliberate retention documented above); on a failed
+  # run the staging tag is alone and gets removed.
+  cleanup-staging:
+    name: Clean up the staging tag
+    runs-on: ubuntu-latest
+    if: always()
+    permissions:
+      packages: write
+    needs: [docker, boot-smoke, image-scan, promote]
+    steps:
       - name: Remove the staging tag (only when it is alone on its version)
+        # Best-effort: a failed tidy-up must not turn an otherwise successful release red.
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -527,7 +576,7 @@ jobs:
           version_json=$(gh api "/users/${{ github.repository_owner }}/packages/container/openwa/versions" \
             --jq ".[] | select(.metadata.container.tags[]? == \"$staging\") | {id, tags: .metadata.container.tags}" | head -1)
           if [ -z "$version_json" ]; then
-            echo "staging tag not found (already cleaned up)"
+            echo "staging tag not found (docker job failed before pushing, or already cleaned up)"
             exit 0
           fi
           version_id=$(printf '%s' "$version_json" | jq -r .id)
@@ -551,57 +600,63 @@ jobs:
   #
   # This job fixes both blind spots. It runs after promote (so it sees the final state, cleanup
   # included) and it never logs in, so it fails on a tag that exists but is not publicly readable —
-  # which is indistinguishable from a missing tag to everyone downstream. It checks every tag a user
-  # might pull, not just the exact version.
+  # which is indistinguishable from a missing tag to everyone downstream. The checked set is the
+  # docker job's own tag output (both registries), so it matches whatever was actually promoted —
+  # for a prerelease that is only the exact X.Y.Z-pre tag, with no stale expectation that `latest`
+  # or X.Y moved. Every tag must also resolve to the build's digest, so a re-pointed channel can
+  # never silently serve content other than the tested image.
   verify-published:
     name: Verify published tags (anonymous)
     runs-on: ubuntu-latest
-    needs: [promote]
+    needs: [docker, promote]
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       # Deliberately NO docker/login-action here. Authenticating would defeat the purpose.
-      - name: Resolve every release tag without credentials
+      - name: Resolve every promoted tag without credentials
         env:
-          REPO: ${{ github.repository }}
+          TAGS: ${{ needs.docker.outputs.tags }}
+          EXPECTED_DIGEST: ${{ needs.docker.outputs.digest }}
         run: |
           # Fail closed. A verification step that reports success because something upstream of the
           # assertion broke is worse than no verification at all — `set -e` plus the checked-count
-          # assertion below mean this job cannot pass without having actually resolved all three tags.
+          # assertion below mean this job cannot pass without having actually resolved every
+          # promoted tag.
           set -euo pipefail
-          version="${GITHUB_REF#refs/tags/v}"
-          minor="${version%.*}"
-          expected=6
           checked=0
           failed=0
-          for tag in "$version" "$minor" latest; do
-            for ref in "ghcr.io/${REPO,,}:${tag}" "docker.io/rmyndharis/openwa:${tag}"; do
-              echo "::group::$ref"
-              if ! docker buildx imagetools inspect "$ref" > "/tmp/pub-${tag}.txt" 2>&1; then
-                echo "::error::$ref is not publicly pullable after promotion."
-                cat "/tmp/pub-${tag}.txt"
-                failed=1
-                echo "::endgroup::"
-                continue
-              fi
-              for want in linux/amd64 linux/arm64; do
-                if ! grep -q "$want" "/tmp/pub-${tag}.txt"; then
-                  echo "::error::$ref resolves but is missing $want"
-                  failed=1
-                fi
-              done
-              echo "$ref OK"
-              checked=$((checked + 1))
+          while IFS= read -r ref; do
+            [ -n "$ref" ] || continue
+            echo "::group::$ref"
+            if ! docker buildx imagetools inspect "$ref" > /tmp/pub.txt 2>&1; then
+              echo "::error::$ref is not publicly pullable after promotion."
+              cat /tmp/pub.txt
+              failed=1
               echo "::endgroup::"
+              continue
+            fi
+            for want in linux/amd64 linux/arm64; do
+              if ! grep -q "$want" /tmp/pub.txt; then
+                echo "::error::$ref resolves but is missing $want"
+                failed=1
+              fi
             done
-          done
-          if [ "$checked" -ne "$expected" ]; then
-            echo "::error::only verified $checked of $expected tags — treating that as a failed release."
+            digest="$(docker buildx imagetools inspect "$ref" --format '{{.Manifest.Digest}}')"
+            if [ "$digest" != "$EXPECTED_DIGEST" ]; then
+              echo "::error::$ref resolves to $digest, not the tested build digest $EXPECTED_DIGEST"
+              failed=1
+            fi
+            echo "$ref OK ($digest)"
+            checked=$((checked + 1))
+            echo "::endgroup::"
+          done <<< "$TAGS"
+          if [ "$checked" -eq 0 ]; then
+            echo "::error::no promoted tags were verified — treating that as a failed release."
             failed=1
           fi
           if [ "$failed" -ne 0 ]; then
             echo "::error::The release is not usable. Re-point the missing tags before announcing it."
             exit 1
           fi
-          echo "all $checked release tags are publicly pullable and multi-arch"
+          echo "all $checked release tags are publicly pullable, multi-arch, and digest-identical to the tested build"

--- a/.github/workflows/sdk-ci.yml
+++ b/.github/workflows/sdk-ci.yml
@@ -39,8 +39,8 @@ jobs:
       run:
         working-directory: sdk/javascript
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '22'
           cache: 'npm'
@@ -64,8 +64,8 @@ jobs:
       run:
         working-directory: sdk/python
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: ${{ matrix.python }}
       - run: pip install -e '.[dev]'
@@ -82,8 +82,8 @@ jobs:
       run:
         working-directory: sdk/php
     steps:
-      - uses: actions/checkout@v7
-      - uses: shivammathur/setup-php@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ matrix.php }}
       - run: composer install --no-interaction --no-progress
@@ -96,8 +96,8 @@ jobs:
       run:
         working-directory: sdk/java
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
           distribution: temurin
           java-version: '17'
@@ -111,8 +111,8 @@ jobs:
       run:
         working-directory: sdk/go
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: '1.22' # the go.mod minimum, so CI gates what the SDK claims to support
           cache: false # stdlib-only, no go.sum to cache

--- a/.github/workflows/split-php-sdk.yml
+++ b/.github/workflows/split-php-sdk.yml
@@ -36,8 +36,8 @@ jobs:
       run:
         working-directory: sdk/php
     steps:
-      - uses: actions/checkout@v7
-      - uses: shivammathur/setup-php@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.2'
       - run: composer install --no-interaction --no-progress
@@ -49,7 +49,7 @@ jobs:
     needs: [test]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0 # full history is required for `git subtree split`
           persist-credentials: false # stop the GITHUB_TOKEN extraheader from shadowing the PAT in the push URL


### PR DESCRIPTION
## Summary

Hardening pass over the CI/release workflows: every action ref is pinned to a commit SHA, the `latest` channel can only move through the boot-tested release path, release runs are serialized, promotion is derived from and verified against the build's own outputs, staging tags are cleaned up on failure paths, and the Java SDK publish gained fail-fast guards.

## Changes, per item

### 1. `latest` no longer re-points on main pushes (ci.yml)

The docker metadata in `ci.yml` emitted `type=raw,value=latest` on every push to `main`. That image is build-gated only — it never goes through the boot-smoke → promote discipline in `release.yml` — so a broken-but-buildable image could become `latest`. The metadata now emits branch + SHA tags only; `latest` moves exclusively through the tested release path.

### 2. Release runs are serialized (release.yml)

Added a global `concurrency: { group: release, cancel-in-progress: false }`.

Considered a per-tag group (`release-${{ github.ref_name }}`) and rejected it: the mutable channels (`X.Y` minor tag, `latest`) are shared state across releases, so two overlapping releases in separate groups could complete out of order and let the older build re-point those channels last. A global group serializes all releases; `cancel-in-progress: false` ensures a newer tag can never abort a promotion already in flight (a half-promoted registry state is worse than a queued release). Documented in a comment at the top of the workflow.

### 3. All action refs pinned to commit SHAs

All 61 `uses:` refs across the five workflows were floating on mutable major tags, including jobs that receive secrets (registry logins, GPG via setup-java, gh-release token, GHCR build-push). Every ref is now pinned to the commit SHA its tag resolves to (resolved with `git ls-remote`, annotated tags dereferenced to the commit), with a `# vX.Y.Z` comment alongside:

| Action | Tag | Commit SHA |
|---|---|---|
| actions/checkout | v7 | `3d3c42e5aac5ba805825da76410c181273ba90b1` |
| actions/setup-node | v7 | `820762786026740c76f36085b0efc47a31fe5020` |
| actions/upload-artifact | v7 | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` |
| actions/setup-java | v5 | `03ad4de0992f5dab5e18fcb136590ce7c4a0ac95` |
| actions/setup-python | v7 | `5fda3b95a4ea91299a34e894583c3862153e4b97` |
| actions/setup-go | v7 | `b7ad1dad31e06c5925ef5d2fc7ad053ef454303e` |
| codecov/codecov-action | v7 | `fb8b3582c8e4def4969c97caa2f19720cb33a72f` |
| docker/setup-qemu-action | v4 | `96fe6ef7f33517b61c61be40b68a1882f3264fb8` |
| docker/setup-buildx-action | v4 | `bb05f3f5519dd87d3ba754cc423b652a5edd6d2c` |
| docker/login-action | v4 | `abd2ef45e78c5afb21d64d4ca52ee8550d9572c7` |
| docker/metadata-action | v6 | `dc802804100637a589fabce1cb79ff13a1411302` |
| docker/build-push-action | v7 | `53b7df96c91f9c12dcc8a07bcb9ccacbed38856a` |
| softprops/action-gh-release | v3 | `3d0d9888cb7fd7b750713d6e236d1fcb99157228` |
| aquasecurity/trivy-action | v0.36.0 | `ed142fd0673e97e23eac54620cfb913e5ce36c25` |
| shivammathur/setup-php | v2 | `f3e473d116dcccaddc5834248c87452386958240` |

`dependabot.yml` already covers the `github-actions` ecosystem (monthly); it understands the SHA-plus-comment form and proposes the new SHA while rewriting the comment, so pins stay current without floating. Added a comment documenting that contract.

### 4. Prerelease promote/verify semantics (release.yml)

- The `docker` job now exposes `outputs.digest` (build-push output) and `outputs.tags` (metadata-action, computed once, both registries). `promote` and `verify-published` consume these instead of re-deriving the tag set from the tag pattern — what is promoted and verified is by construction what was built.
- The mutable channels (`X.Y` via `type=semver,pattern={{major}}.{{minor}}`, and `latest`) now carry `enable=${{ !contains(github.ref_name, '-') }}`, so prerelease builds never become what `:0.11` or `:latest` resolves to. The exact prerelease tag (`{{version}}`) is still published.
- `promote` additionally guards in-shell: for a prerelease ref, any minor-pattern tag (`:N.M`) is skipped even if the upstream tag set changes (defense in depth, verified by simulation).
- Digest identity is now checked at three points: the staging manifest must equal the build digest before anything is re-pointed; each promoted tag must resolve to the build digest immediately after `imagetools create`; and `verify-published` re-checks every promoted tag's digest anonymously.
- `verify-published` previously hardcoded `{version, minor, latest} × 2 registries = 6` — wrong for prereleases (stale `latest`/`X.Y` expectation, and `minor` computed as `0.11.0-rc` for an rc tag). It now iterates exactly the docker job's promoted tag set.

### 5. Staging-tag cleanup on failure paths (release.yml)

The `smoke-<run_id>` cleanup step lived inside `promote`, so a failed `boot-smoke`/`image-scan` skipped it and leaked the staging tag. It is now a standalone `cleanup-staging` job with `if: always()` and `needs: [docker, boot-smoke, image-scan, promote]`. The safety rule is unchanged: it deletes the GHCR version only when the staging tag is alone on it. On the happy path the release tags share that version, so the deliberate retention is preserved (deleting it would unpublish the release tags); on a failure path the staging tag is alone and gets removed. Still `continue-on-error: true` — a failed tidy-up must not turn a successful release red.

### 6. Java SDK publish guards (java-sdk-release.yml)

All guards are textual and secret-free, so a misconfigured release fails before any credential is touched:

- **Ref guard**: `workflow_dispatch` could deploy an arbitrary ref; the workflow now fails unless `github.ref` is a `java-sdk-v*` tag (dispatch must select the release tag).
- **Tag ↔ pom guard**: the tag version (`java-sdk-vX.Y.Z`) must equal the pom `<version>` (extracted textually; the pom has no `<parent>`, so its first `<version>` is the project version). Verified by simulation against the current pom (`0.1.1`): matching tag passes, mismatching tag fails.
- **Credentials guard**: any missing publish secret (`MAVEN_CENTRAL_USERNAME`/`MAVEN_CENTRAL_PASSWORD`/`GPG_PRIVATE_KEY`/`GPG_PASSPHRASE`) is now a hard failure naming the missing secrets, instead of a green no-op indistinguishable from a real release. Both events that can reach the job intend to publish (enforced by the ref guard).
- **Tests run during deploy**: dropped `-DskipTests` from `mvn -B -Prelease deploy`, so the published artifact is the one `mvn verify` proved, matching what `sdk-ci.yml` gates.

## Verification

- `yaml.safe_load` parses all five workflows and `dependabot.yml`; the release.yml `needs` graph was checked for dangling references.
- `git grep "uses:" .github/workflows/` — all 61 refs are SHA-pinned (`owner/repo@<40-hex> # vX.Y.Z`); none floating.
- Every `run:` script in the touched workflows passes `bash -n`.
- Guard logic simulated textually: ref-shape guard (tag passes, branch/app-tag fails), tag↔pom guard (match passes, mismatch fails), missing-secret enumeration, and the prerelease minor-tag skip (`:0.11` skipped for `v0.11.0-rc.1`, promoted for `v0.11.0`).
- `actionlint` is not installed in this environment; YAML parse + `bash -n` + needs-graph checks stand in for it.
- No workflow was executed as part of this change.

## Risks / notes

- Release-flow changes are validated statically only; the first real tag after merge exercises the new promote/verify path end to end. The happy path is intentionally behavior-preserving (same tags, same registries, same retention).
- `verify-published` on a prerelease now checks only the exact prerelease tag — the previous hardcoded `latest`/`X.Y` checks would have failed for a first-of-line rc.
- The Java SDK publish now fails where it used to no-op green until the four secrets are configured; that is the intended behavior change, called out in the workflow header.
- Dependabot will open SHA-bump PRs for actions monthly; review load is small and grouped by the existing `ci` label.
