### PR TITLE
fix(engine): report INITIALIZING instead of READY while the Baileys socket is in reconnect backoff

### DIFF
--- a/src/engine/adapters/baileys.adapter.spec.ts
+++ b/src/engine/adapters/baileys.adapter.spec.ts
@@ -661,6 +661,97 @@ describe('BaileysAdapter reconnect socket teardown (no leak)', () => {
   });
 });
 
+describe('BaileysAdapter status honesty across the reconnect backoff', () => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+  const baileys = () => jest.requireMock('@whiskeysockets/baileys') as { default: jest.Mock };
+
+  const fireRecoverableClose = (): void => {
+    fakeSock.fire('connection.update', {
+      connection: 'close',
+      lastDisconnect: { error: { output: { statusCode: 515 } } },
+    });
+  };
+
+  const initReady = async (over: Partial<EngineEventCallbacks> = {}): Promise<BaileysAdapter> => {
+    fakeSock.user = undefined;
+    fakeSock.resetEmitter();
+    jest.clearAllMocks();
+    const adapter = newAdapter();
+    await adapter.initialize(noopCallbacks(over));
+    fakeSock.fire('connection.update', { connection: 'open' });
+    return adapter;
+  };
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('a transient close drops the session to INITIALIZING immediately — no READY across the backoff', async () => {
+    const states: EngineStatus[] = [];
+    const adapter = await initReady({ onStateChanged: s => states.push(s) });
+    expect(adapter.getStatus()).toBe(EngineStatus.READY);
+    states.length = 0; // count only the transitions from READY onward
+
+    jest.useFakeTimers();
+    fireRecoverableClose();
+
+    // The reconnect timer is still pending (first attempt is ~1 s out, later ones up to 60 s) and
+    // the socket is already dead — the session must NOT read READY in this window.
+    expect(adapter.getStatus()).toBe(EngineStatus.INITIALIZING);
+    await expect(adapter.probeLiveness()).resolves.toBe(false);
+    expect(states).toEqual([EngineStatus.INITIALIZING]);
+  });
+
+  it('stays INITIALIZING until the reconnected socket actually opens, then reports READY again', async () => {
+    const adapter = await initReady({});
+    baileys().default.mockClear();
+    jest.useFakeTimers();
+    jest.spyOn(Math, 'random').mockReturnValue(0); // deterministic 1 s first-attempt delay
+
+    fireRecoverableClose();
+    expect(adapter.getStatus()).toBe(EngineStatus.INITIALIZING);
+
+    await jest.advanceTimersByTimeAsync(1_000); // attempt 1 runs → new socket created
+    expect(baileys().default).toHaveBeenCalledTimes(1);
+    // The new socket exists but has not opened yet — still not READY.
+    expect(adapter.getStatus()).toBe(EngineStatus.INITIALIZING);
+
+    fakeSock.fire('connection.update', { connection: 'open' });
+    expect(adapter.getStatus()).toBe(EngineStatus.READY);
+    await expect(adapter.probeLiveness()).resolves.toBe(true);
+  });
+
+  it('back-to-back transient closes do not flap onStateChanged', async () => {
+    const states: EngineStatus[] = [];
+    await initReady({ onStateChanged: s => states.push(s) });
+    states.length = 0; // count only the transitions from READY onward
+
+    jest.useFakeTimers();
+    fireRecoverableClose();
+    fireRecoverableClose(); // duplicate for the same drop — ignored, no extra transition
+    expect(states).toEqual([EngineStatus.INITIALIZING]);
+
+    await jest.advanceTimersByTimeAsync(2_000); // let the pending attempt run (1 s + jitter)
+    fireRecoverableClose(); // the next drop lands while already INITIALIZING — still no emission
+    expect(states).toEqual([EngineStatus.INITIALIZING]);
+  });
+
+  it('a logged-out close still reports DISCONNECTED (terminal behavior unchanged)', async () => {
+    const onDisconnected = jest.fn();
+    const adapter = await initReady({ onDisconnected });
+
+    fakeSock.fire('connection.update', {
+      connection: 'close',
+      lastDisconnect: { error: { output: { statusCode: 401 } } },
+    });
+
+    expect(adapter.getStatus()).toBe(EngineStatus.DISCONNECTED);
+    expect(onDisconnected).toHaveBeenCalledWith('logged out');
+    await expect(adapter.probeLiveness()).resolves.toBe(false);
+  });
+});
+
 describe('BaileysAdapter capability gating', () => {
   it('throws EngineNotSupportedError for still-gated methods (e.g. getChatHistory)', async () => {
     const adapter = newAdapter();

--- a/src/engine/adapters/baileys.adapter.ts
+++ b/src/engine/adapters/baileys.adapter.ts
@@ -438,8 +438,15 @@ export class BaileysAdapter implements IWhatsAppEngine {
       // backoff and NO attempt ceiling — a long network outage must
       // not kill the session. The counter resets on 'open' and via the stability window below.
       // Do NOT fire onDisconnected here; this is a transient drop, not a terminal disconnect.
-      // connect() calls setStatus(INITIALIZING) which fires onStateChanged — that is the correct signal.
       this.logger.log('Baileys connection dropped; reconnecting', { statusCode });
+
+      // The socket is dead NOW, but the reconnect attempt only runs after the backoff delay below
+      // (up to 60 s + jitter; connectInner's own setStatus(INITIALIZING) fires just before the new
+      // socket is created). Staying READY across that window makes probeLiveness() report a live
+      // session and lets sends fail against the dead socket, so drop to INITIALIZING here — the
+      // 'open' branch restores READY. setStatus no-ops on an unchanged status, so the duplicate
+      // closes Baileys can emit per drop do not flap onStateChanged.
+      this.setStatus(EngineStatus.INITIALIZING);
 
       // Duplicate close while a reconnect timer is already pending — ignore it WITHOUT burning an
       // attempt (Baileys can emit more than one close per drop; the increment must come after this).
@@ -580,7 +587,8 @@ export class BaileysAdapter implements IWhatsAppEngine {
   /**
    * Cheap local liveness check for the session watchdog. Genuine dead-connection detection is owned
    * by Baileys' built-in keepalive, which surfaces a close event (408) within ~35 s of a silent
-   * drop and drives the reconnect path above — so READY + a live socket is sufficient here.
+   * drop — and the close handler above drops the status to INITIALIZING for the whole reconnect
+   * backoff, so READY + a live socket is sufficient here.
    */
   // eslint-disable-next-line @typescript-eslint/require-await
   async probeLiveness(): Promise<boolean> {


### PR DESCRIPTION
## Problem

A transient Baileys close — the WebSocket drops and the library retries with backoff — left the adapter reporting **READY with a dead socket** for the entire pre-attempt backoff window. The reconnect timer only fires after the delay (1 s doubling up to a 60 s cap, plus jitter), and `INITIALIZING` was only set inside `connect()` when the attempt actually started. In between:

- `probeLiveness()` returned `true` (status READY + socket object still assigned), so the session watchdog considered the session healthy;
- API callers passed the `ensureReady()` gate and sends failed against the closed socket.

Measured worst case: ~61 s of false READY per incident once the backoff reaches its cap.

## Fix

`handleConnectionUpdate` now calls `setStatus(INITIALIZING)` immediately when a **transient** close is detected (any close that is not loggedOut / 403 / 440 / intentional), before the reconnect backoff is scheduled. The existing `connection === 'open'` branch restores READY once the new socket is actually open.

- Terminal closes are untouched: loggedOut still reports DISCONNECTED + clears auth, 403/440 still report FAILED + `onError`, and `disconnect()`/`logout()`/`destroy()` behave as before.
- No flap: `setStatus` no-ops when the status is unchanged, so the duplicate closes Baileys emits per drop (and back-to-back transient incidents) emit a single `READY → INITIALIZING` transition per incident, and `INITIALIZING → READY` only on a real `open`.
- Side effect that motivated the fix: during the backoff, sends now fail fast with `EngineNotReadyError` instead of writing to a dead socket, and the liveness probe reports the truth.

## Tests

New `status honesty across the reconnect backoff` suite in `baileys.adapter.spec.ts`:

- transient close (515) while READY → INITIALIZING immediately, `probeLiveness()` false, no READY across the pending-backoff window;
- reconnect attempt creates the socket but status stays INITIALIZING until `open` fires → then READY and probe true again;
- duplicate / back-to-back transient closes emit exactly one `INITIALIZING` transition (no `onStateChanged` flap);
- loggedOut close still reports DISCONNECTED + `onDisconnected('logged out')` (terminal behavior unchanged).

## Verification

- `npx jest src/engine` — 15 suites, 842 tests, all pass
- `npx eslint src/engine` — clean
- `npm run build` — clean

## Risks

- Low. The only behavioral change is the reported status during the reconnect backoff window (READY → INITIALIZING). The session watchdog only probes READY sessions, so a session in backoff is simply skipped (owned by the engine's reconnect flow) — no new restart path is triggered.
- Consumers polling session status will now see `initializing` during transient drops (previously a false `ready`); this matches what the whatsapp-web.js engine already reports while it re-initializes.
