### PR TITLE
feat(sdk): align webhook filter types and close method coverage gaps across all SDKs

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -25,15 +25,15 @@ All five SDKs expose the same fluent resource surface:
 | Resource   | Methods                                                                                                                                                                                |
 | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `sessions` | list, get, create, delete, start, stop, forceKill, getQrCode, requestPairingCode, stats                                                                                                |
-| `messages` | list, sendText, sendImage/Video/Audio/Document/Sticker, sendLocation, sendContact, sendTemplate, reply, forward, react, delete, editMessage, history, reactions, sendBulk, batchStatus, cancelBatch |
-| `contacts` | list, get, check, profilePicture, phone, block, unblock                                                                                                                                |
+| `messages` | list, sendText, sendImage/Video/Audio/Document/Sticker, sendLocation, sendContact, sendTemplate, sendPoll, reply, forward, react, delete, editMessage, history, reactions, sendBulk, batchStatus, cancelBatch |
+| `contacts` | list, get, check, profilePicture, profilePictures, phone, block, unblock                                                                                                                                |
 | `groups`   | list, get, create, joinGroup, add/remove/promote/demoteParticipants, setSubject, setDescription, get/updateGroupSettings, leave, inviteCode, revokeInviteCode                          |
 | `webhooks` | list, get, create, update, delete, test                                                                                                                                                |
 | `chats`    | list, markRead, markUnread, delete, sendState                                                                                                                                          |
 | `labels`   | list, get, forChat, addToChat, removeFromChat _(WhatsApp Business)_                                                                                                                    |
 | `channels` | list, get, messages, subscribe, unsubscribe _(Newsletters)_                                                                                                                            |
 | `catalog`  | info, products, product, sendProduct, sendCatalog _(WhatsApp Business)_                                                                                                                |
-| `status`   | list, fromContact, sendText, sendImage, sendVideo, delete _(Stories)_                                                                                                                  |
+| `status`   | list, fromContact, media, sendText, sendImage, sendVideo, delete _(Stories)_                                                                                                            |
 | `search`   | search _(Operator)_                                                                                                                                                                  |
 | `templates`| list, get, create, update, delete                                                                                                                                                     |
 | `profile`  | setProfileName, setProfileStatus, setProfilePicture _(OPERATOR)_                                                                                                                       |

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -185,17 +185,49 @@ func warnIfInsecure(cfg *config) {
 // Do issues a raw request against the API and decodes the JSON response into
 // out (pass nil to ignore the body). It is the escape hatch for endpoints the
 // typed services do not cover. path must begin with "/".
+//
+// A 2xx body is assigned verbatim when out is a *[]byte, and a non-JSON 2xx
+// body falls back to the raw text when out is a *string — mirroring the
+// JS/Python/PHP transports, which return the raw text instead of failing.
+// Any other out type still requires a JSON body.
 func (c *Client) Do(ctx context.Context, method, path string, query url.Values, body, out any) error {
 	return c.do(ctx, method, path, query, body, out)
 }
 
 func (c *Client) do(ctx context.Context, method, path string, query url.Values, body, out any) error {
+	data, _, err := c.doRaw(ctx, method, path, query, body)
+	if err != nil {
+		return err
+	}
+	if out == nil || len(data) == 0 {
+		return nil
+	}
+	// A *[]byte target always takes the body verbatim (media bytes are not JSON).
+	if raw, ok := out.(*[]byte); ok {
+		*raw = data
+		return nil
+	}
+	if err := json.Unmarshal(data, out); err != nil {
+		// A *string target accepts a non-JSON 2xx body as raw text rather than
+		// failing to decode.
+		if text, ok := out.(*string); ok {
+			*text = string(data)
+			return nil
+		}
+		return fmt.Errorf("openwa: decoding response: %w", err)
+	}
+	return nil
+}
+
+// doRaw performs the request and returns the response body and Content-Type.
+// Any non-2xx status (including an unfollowed 3xx) is an error.
+func (c *Client) doRaw(ctx context.Context, method, path string, query url.Values, body any) ([]byte, string, error) {
 	var bodyBytes []byte
 	var reader io.Reader
 	if body != nil {
 		b, err := json.Marshal(body)
 		if err != nil {
-			return fmt.Errorf("openwa: encoding request body: %w", err)
+			return nil, "", fmt.Errorf("openwa: encoding request body: %w", err)
 		}
 		bodyBytes = b
 		reader = bytes.NewReader(b)
@@ -208,7 +240,7 @@ func (c *Client) do(ctx context.Context, method, path string, query url.Values, 
 
 	req, err := http.NewRequestWithContext(ctx, method, rawURL, reader)
 	if err != nil {
-		return fmt.Errorf("openwa: building request: %w", err)
+		return nil, "", fmt.Errorf("openwa: building request: %w", err)
 	}
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
@@ -222,28 +254,22 @@ func (c *Client) do(ctx context.Context, method, path string, query url.Values, 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		if isTimeout(err) {
-			return &TimeoutError{Timeout: c.timeout, Err: err}
+			return nil, "", &TimeoutError{Timeout: c.timeout, Err: err}
 		}
-		return fmt.Errorf("openwa: %s %s: %w", method, path, err)
+		return nil, "", fmt.Errorf("openwa: %s %s: %w", method, path, err)
 	}
 	defer resp.Body.Close()
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("openwa: reading response body: %w", err)
+		return nil, "", fmt.Errorf("openwa: reading response body: %w", err)
 	}
 
 	// Any non-2xx (including an unfollowed 3xx) is an error.
 	if resp.StatusCode >= 300 {
-		return parseAPIError(resp.StatusCode, data, method+" "+path)
+		return nil, "", parseAPIError(resp.StatusCode, data, method+" "+path)
 	}
-	if out == nil || resp.StatusCode == http.StatusNoContent || len(data) == 0 {
-		return nil
-	}
-	if err := json.Unmarshal(data, out); err != nil {
-		return fmt.Errorf("openwa: decoding response: %w", err)
-	}
-	return nil
+	return data, resp.Header.Get("Content-Type"), nil
 }
 
 func isTimeout(err error) bool {

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -1047,3 +1047,229 @@ func TestCallReceivedPayloadDecodes(t *testing.T) {
 		t.Fatalf("call decode: %+v", p)
 	}
 }
+
+func TestSendTextForwardsMentions(t *testing.T) {
+	rt := &recordTransport{status: 200, body: `{"messageId":"m1","timestamp":1}`}
+	c := newTestClient(t, rt)
+
+	if _, err := c.Messages.SendText(context.Background(), "s1", SendTextRequest{
+		ChatID:   "g@g.us",
+		Text:     "hi @628123",
+		Mentions: []string{"628123@c.us"},
+	}); err != nil {
+		t.Fatalf("SendText: %v", err)
+	}
+
+	var sent map[string]any
+	if err := json.Unmarshal(rt.lastRaw, &sent); err != nil {
+		t.Fatalf("body not JSON: %v", err)
+	}
+	mentions, ok := sent["mentions"].([]any)
+	if !ok || len(mentions) != 1 || mentions[0] != "628123@c.us" {
+		t.Fatalf("sent body = %v", sent)
+	}
+}
+
+func TestSendPollHitsCorrectPath(t *testing.T) {
+	rt := &recordTransport{status: 200, body: `{"messageId":"m2","timestamp":2}`}
+	c := newTestClient(t, rt)
+
+	res, err := c.Messages.SendPoll(context.Background(), "s1", SendPollRequest{
+		ChatID:               "a@c.us",
+		Name:                 "Where?",
+		Options:              []string{"Park", "Beach"},
+		AllowMultipleAnswers: Ptr(true),
+	})
+	if err != nil {
+		t.Fatalf("SendPoll: %v", err)
+	}
+	if res.MessageID != "m2" {
+		t.Fatalf("unexpected response: %+v", res)
+	}
+
+	wantPath := "/api/sessions/s1/messages/send-poll"
+	if got := rt.lastReq.URL.Path; got != wantPath {
+		t.Fatalf("path = %q, want %q", got, wantPath)
+	}
+	if rt.lastReq.Method != "POST" {
+		t.Fatalf("method = %q, want POST", rt.lastReq.Method)
+	}
+
+	var sent map[string]any
+	if err := json.Unmarshal(rt.lastRaw, &sent); err != nil {
+		t.Fatalf("body not JSON: %v", err)
+	}
+	if sent["name"] != "Where?" || sent["allowMultipleAnswers"] != true {
+		t.Fatalf("sent body = %v", sent)
+	}
+	options, ok := sent["options"].([]any)
+	if !ok || len(options) != 2 || options[0] != "Park" || options[1] != "Beach" {
+		t.Fatalf("sent options = %v", sent["options"])
+	}
+}
+
+func TestProfilePicturesBatchQuery(t *testing.T) {
+	rt := &recordTransport{status: 200, body: `{"pictures":{"a@c.us":"http://p/a","b@c.us":null}}`}
+	c := newTestClient(t, rt)
+
+	res, err := c.Contacts.ProfilePictures(context.Background(), "s1", []string{"a@c.us", "b@c.us"})
+	if err != nil {
+		t.Fatalf("ProfilePictures: %v", err)
+	}
+
+	if rt.lastReq.Method != "GET" {
+		t.Fatalf("method = %q, want GET", rt.lastReq.Method)
+	}
+	wantPath := "/api/sessions/s1/contacts/profile-pictures"
+	if got := rt.lastReq.URL.Path; got != wantPath {
+		t.Fatalf("path = %q, want %q", got, wantPath)
+	}
+	if got := rt.lastReq.URL.Query().Get("ids"); got != "a@c.us,b@c.us" {
+		t.Fatalf("ids query = %q", got)
+	}
+
+	if res.Pictures["a@c.us"] == nil || *res.Pictures["a@c.us"] != "http://p/a" {
+		t.Fatalf("pictures[a@c.us] = %v", res.Pictures["a@c.us"])
+	}
+	if url, present := res.Pictures["b@c.us"]; !present || url != nil {
+		t.Fatalf("pictures[b@c.us] should decode as an explicit null, got %v (present=%v)", url, present)
+	}
+}
+
+func TestStatusMediaReturnsBytes(t *testing.T) {
+	rt := &recordTransport{
+		status: 200,
+		body:   "PNG_BYTES",
+		header: http.Header{"Content-Type": []string{"image/png"}},
+	}
+	c := newTestClient(t, rt)
+
+	media, err := c.Status.Media(context.Background(), "s1", "w1")
+	if err != nil {
+		t.Fatalf("Media: %v", err)
+	}
+	if string(media.Data) != "PNG_BYTES" || media.ContentType != "image/png" {
+		t.Fatalf("media = %q (%q)", media.Data, media.ContentType)
+	}
+
+	wantPath := "/api/sessions/s1/status/w1/media"
+	if got := rt.lastReq.URL.Path; got != wantPath {
+		t.Fatalf("path = %q, want %q", got, wantPath)
+	}
+	if rt.lastReq.Method != "GET" {
+		t.Fatalf("method = %q, want GET", rt.lastReq.Method)
+	}
+}
+
+// A status with no stored media surfaces as 404.
+func TestStatusMediaNotFound(t *testing.T) {
+	rt := &recordTransport{
+		status: 404,
+		body:   `{"statusCode":404,"message":"Status media not found or expired","error":"Not Found"}`,
+	}
+	c := newTestClient(t, rt)
+
+	_, err := c.Status.Media(context.Background(), "s1", "w1")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("errors.Is ErrNotFound = false for %v", err)
+	}
+}
+
+// The escape hatch mirrors the JS/Python/PHP raw-text fallback for non-JSON
+// 2xx bodies: *[]byte takes the body verbatim, *string falls back to raw text,
+// and a typed target still requires JSON.
+func TestDoRawFallbacks(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("bytes take the body verbatim", func(t *testing.T) {
+		rt := &recordTransport{status: 200, body: "PNG_BYTES", header: http.Header{"Content-Type": []string{"image/png"}}}
+		c := newTestClient(t, rt)
+		var raw []byte
+		if err := c.Do(ctx, "GET", "/api/x", nil, nil, &raw); err != nil {
+			t.Fatalf("Do: %v", err)
+		}
+		if string(raw) != "PNG_BYTES" {
+			t.Fatalf("raw = %q", raw)
+		}
+	})
+
+	t.Run("string falls back to raw text on non-JSON", func(t *testing.T) {
+		rt := &recordTransport{status: 200, body: "plain text"}
+		c := newTestClient(t, rt)
+		var s string
+		if err := c.Do(ctx, "GET", "/api/x", nil, nil, &s); err != nil {
+			t.Fatalf("Do: %v", err)
+		}
+		if s != "plain text" {
+			t.Fatalf("s = %q", s)
+		}
+	})
+
+	t.Run("string still decodes a JSON string body", func(t *testing.T) {
+		rt := &recordTransport{status: 200, body: `"quoted"`}
+		c := newTestClient(t, rt)
+		var s string
+		if err := c.Do(ctx, "GET", "/api/x", nil, nil, &s); err != nil {
+			t.Fatalf("Do: %v", err)
+		}
+		if s != "quoted" {
+			t.Fatalf("s = %q", s)
+		}
+	})
+
+	t.Run("typed target still requires JSON", func(t *testing.T) {
+		rt := &recordTransport{status: 200, body: "plain text"}
+		c := newTestClient(t, rt)
+		var out MessageResponse
+		if err := c.Do(ctx, "GET", "/api/x", nil, nil, &out); err == nil {
+			t.Fatal("expected a decode error for a non-JSON body into a typed target")
+		}
+	})
+}
+
+// The filter value is polymorphic on the wire: a string for text fields, a
+// string array for id/enum fields, a bool for boolean fields, plus the
+// caseSensitive flag — all must serialize verbatim.
+func TestWebhookFiltersPolymorphicWireShape(t *testing.T) {
+	rt := &recordTransport{status: 200, body: `{"id":"w1"}`}
+	c := newTestClient(t, rt)
+
+	_, err := c.Webhooks.Create(context.Background(), "s1", CreateWebhookRequest{
+		URL:    "https://example.com/hook",
+		Events: []string{EventMessageReceived},
+		Filters: &WebhookFilters{
+			Conditions: []WebhookFilterCondition{
+				{Field: "sender", Operator: "is", Value: []string{"123@c.us"}},
+				{Field: "body", Operator: "contains", Value: "invoice", CaseSensitive: Ptr(true)},
+				{Field: "isGroup", Operator: "is", Value: false},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	var sent map[string]any
+	if err := json.Unmarshal(rt.lastRaw, &sent); err != nil {
+		t.Fatalf("body not JSON: %v", err)
+	}
+	conditions := sent["filters"].(map[string]any)["conditions"].([]any)
+	if len(conditions) != 3 {
+		t.Fatalf("conditions = %v", conditions)
+	}
+	first := conditions[0].(map[string]any)
+	if values, ok := first["value"].([]any); !ok || len(values) != 1 || values[0] != "123@c.us" {
+		t.Fatalf("id condition value = %v", first["value"])
+	}
+	second := conditions[1].(map[string]any)
+	if second["value"] != "invoice" || second["caseSensitive"] != true {
+		t.Fatalf("text condition = %v", second)
+	}
+	third := conditions[2].(map[string]any)
+	if third["value"] != false {
+		t.Fatalf("boolean condition value = %v", third["value"])
+	}
+	if _, present := first["caseSensitive"]; present {
+		t.Fatal("caseSensitive should be omitted when unset")
+	}
+}

--- a/sdk/go/contacts.go
+++ b/sdk/go/contacts.go
@@ -1,6 +1,10 @@
 package openwa
 
-import "context"
+import (
+	"context"
+	"net/url"
+	"strings"
+)
 
 // ContactsService looks up and manages contacts.
 // Backed by src/modules/contact/contact.controller.ts.
@@ -41,6 +45,19 @@ func (s *ContactsService) Check(ctx context.Context, sessionID, number string) (
 func (s *ContactsService) ProfilePicture(ctx context.Context, sessionID, contactID string) (*ProfilePictureResponse, error) {
 	var out ProfilePictureResponse
 	err := s.client.do(ctx, "GET", s.base(sessionID)+"/"+pathEscape(contactID)+"/profile-picture", nil, nil, &out)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// ProfilePictures batch-resolves profile picture URLs for up to 50 contacts
+// in one request. The result maps each requested id to its URL (nil when the
+// lookup failed).
+func (s *ContactsService) ProfilePictures(ctx context.Context, sessionID string, ids []string) (*ProfilePicturesResponse, error) {
+	var out ProfilePicturesResponse
+	q := url.Values{"ids": []string{strings.Join(ids, ",")}}
+	err := s.client.do(ctx, "GET", s.base(sessionID)+"/profile-pictures", q, nil, &out)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/messages.go
+++ b/sdk/go/messages.go
@@ -66,6 +66,11 @@ func (s *MessagesService) SendTemplate(ctx context.Context, sessionID string, bo
 	return s.send(ctx, sessionID, "send-template", body)
 }
 
+// SendPoll sends a native WhatsApp poll (2–12 options).
+func (s *MessagesService) SendPoll(ctx context.Context, sessionID string, body SendPollRequest) (*MessageResponse, error) {
+	return s.send(ctx, sessionID, "send-poll", body)
+}
+
 func (s *MessagesService) send(ctx context.Context, sessionID, segment string, body any) (*MessageResponse, error) {
 	var out MessageResponse
 	err := s.client.do(ctx, "POST", s.base(sessionID)+"/"+segment, nil, body, &out)

--- a/sdk/go/routing_test.go
+++ b/sdk/go/routing_test.go
@@ -38,6 +38,7 @@ func TestRouting(t *testing.T) {
 		{"Messages.SendLocation", func(c *Client) { c.Messages.SendLocation(ctx, "s1", SendLocationRequest{}) }, "POST", "/api/sessions/s1/messages/send-location"},
 		{"Messages.SendContact", func(c *Client) { c.Messages.SendContact(ctx, "s1", SendContactRequest{}) }, "POST", "/api/sessions/s1/messages/send-contact"},
 		{"Messages.SendTemplate", func(c *Client) { c.Messages.SendTemplate(ctx, "s1", SendTemplateRequest{}) }, "POST", "/api/sessions/s1/messages/send-template"},
+		{"Messages.SendPoll", func(c *Client) { c.Messages.SendPoll(ctx, "s1", SendPollRequest{}) }, "POST", "/api/sessions/s1/messages/send-poll"},
 		{"Messages.Reply", func(c *Client) { c.Messages.Reply(ctx, "s1", ReplyMessageRequest{}) }, "POST", "/api/sessions/s1/messages/reply"},
 		{"Messages.Forward", func(c *Client) { c.Messages.Forward(ctx, "s1", ForwardMessageRequest{}) }, "POST", "/api/sessions/s1/messages/forward"},
 		{"Messages.React", func(c *Client) { c.Messages.React(ctx, "s1", ReactMessageRequest{}) }, "POST", "/api/sessions/s1/messages/react"},
@@ -53,6 +54,7 @@ func TestRouting(t *testing.T) {
 		{"Contacts.Get", func(c *Client) { c.Contacts.Get(ctx, "s1", "u1") }, "GET", "/api/sessions/s1/contacts/u1"},
 		{"Contacts.Check", func(c *Client) { c.Contacts.Check(ctx, "s1", "628") }, "GET", "/api/sessions/s1/contacts/check/628"},
 		{"Contacts.ProfilePicture", func(c *Client) { c.Contacts.ProfilePicture(ctx, "s1", "u1") }, "GET", "/api/sessions/s1/contacts/u1/profile-picture"},
+		{"Contacts.ProfilePictures", func(c *Client) { c.Contacts.ProfilePictures(ctx, "s1", []string{"u1"}) }, "GET", "/api/sessions/s1/contacts/profile-pictures"},
 		{"Contacts.Phone", func(c *Client) { c.Contacts.Phone(ctx, "s1", "u1") }, "GET", "/api/sessions/s1/contacts/u1/phone"},
 		{"Contacts.Block", func(c *Client) { c.Contacts.Block(ctx, "s1", "u1") }, "POST", "/api/sessions/s1/contacts/u1/block"},
 		{"Contacts.Unblock", func(c *Client) { c.Contacts.Unblock(ctx, "s1", "u1") }, "DELETE", "/api/sessions/s1/contacts/u1/block"},
@@ -88,6 +90,7 @@ func TestRouting(t *testing.T) {
 
 		{"Status.List", func(c *Client) { c.Status.List(ctx, "s1") }, "GET", "/api/sessions/s1/status"},
 		{"Status.FromContact", func(c *Client) { c.Status.FromContact(ctx, "s1", "u1") }, "GET", "/api/sessions/s1/status/u1"},
+		{"Status.Media", func(c *Client) { c.Status.Media(ctx, "s1", "st1") }, "GET", "/api/sessions/s1/status/st1/media"},
 		{"Status.SendText", func(c *Client) { c.Status.SendText(ctx, "s1", SendTextStatusRequest{}) }, "POST", "/api/sessions/s1/status/send-text"},
 		{"Status.SendImage", func(c *Client) { c.Status.SendImage(ctx, "s1", SendImageStatusRequest{}) }, "POST", "/api/sessions/s1/status/send-image"},
 		{"Status.SendVideo", func(c *Client) { c.Status.SendVideo(ctx, "s1", SendVideoStatusRequest{}) }, "POST", "/api/sessions/s1/status/send-video"},

--- a/sdk/go/status.go
+++ b/sdk/go/status.go
@@ -27,6 +27,16 @@ func (s *StatusService) FromContact(ctx context.Context, sessionID, contactID st
 	return out.Statuses, err
 }
 
+// Media fetches the stored media bytes for a status update. The server
+// answers 404 when no media is stored (text status, omitted, or expired).
+func (s *StatusService) Media(ctx context.Context, sessionID, statusID string) (*StatusMedia, error) {
+	data, contentType, err := s.client.doRaw(ctx, "GET", s.base(sessionID)+"/"+pathEscape(statusID)+"/media", nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &StatusMedia{Data: data, ContentType: contentType}, nil
+}
+
 // SendText posts a text status.
 func (s *StatusService) SendText(ctx context.Context, sessionID string, body SendTextStatusRequest) (*StatusResult, error) {
 	return s.send(ctx, sessionID, "/send-text", body)

--- a/sdk/go/types_contact.go
+++ b/sdk/go/types_contact.go
@@ -24,6 +24,12 @@ type ProfilePictureResponse struct {
 	URL *string `json:"url,omitempty"`
 }
 
+// ProfilePicturesResponse is a batch profile-picture lookup: a map of contact
+// id → picture URL (null when the lookup failed).
+type ProfilePicturesResponse struct {
+	Pictures map[string]*string `json:"pictures"`
+}
+
 // ContactPhoneResponse resolves a contact's phone number.
 type ContactPhoneResponse struct {
 	ContactID string  `json:"contactId"`

--- a/sdk/go/types_message.go
+++ b/sdk/go/types_message.go
@@ -12,6 +12,9 @@ type MessageResponse struct {
 type SendTextRequest struct {
 	ChatID string `json:"chatId"`
 	Text   string `json:"text"`
+	// Mentions lists WIDs to @mention (e.g. ["62811@c.us"]). The text must
+	// also contain the @<number> token.
+	Mentions []string `json:"mentions,omitempty"`
 }
 
 // SendMediaRequest sends image/video/document/sticker media. Provide exactly
@@ -60,6 +63,17 @@ type SendTemplateRequest struct {
 	TemplateID   string            `json:"templateId,omitempty"`
 	TemplateName string            `json:"templateName,omitempty"`
 	Vars         map[string]string `json:"vars,omitempty"`
+}
+
+// SendPollRequest sends a native WhatsApp poll. Options holds the choices to
+// vote on (WhatsApp allows between 2 and 12).
+type SendPollRequest struct {
+	ChatID string `json:"chatId"`
+	// Name is the poll question / title (max 255 chars).
+	Name    string   `json:"name"`
+	Options []string `json:"options"`
+	// AllowMultipleAnswers lets voters pick several options (default single choice).
+	AllowMultipleAnswers *bool `json:"allowMultipleAnswers,omitempty"`
 }
 
 // ReplyMessageRequest replies to a quoted message.

--- a/sdk/go/types_status.go
+++ b/sdk/go/types_status.go
@@ -39,6 +39,14 @@ type StatusResult struct {
 	ExpiresAt time.Time `json:"expiresAt,omitempty"`
 }
 
+// StatusMedia is the one non-JSON shape on the wire: the raw bytes of a stored
+// status media file plus the Content-Type the server served them as. Returned
+// by StatusService.Media; a 404 surfaces when no media is stored.
+type StatusMedia struct {
+	Data        []byte
+	ContentType string
+}
+
 // SendTextStatusRequest posts a text status. Recipients is required on the Baileys
 // engine only (absent/empty → 400 there); whatsapp-web.js ignores it — leave nil.
 type SendTextStatusRequest struct {

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/OpenWAClient.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/OpenWAClient.java
@@ -1,8 +1,10 @@
 package com.rmyndharis.openwa;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonParseException;
 import com.rmyndharis.openwa.errors.OpenWAApiError;
 import com.rmyndharis.openwa.errors.OpenWAError;
+import com.rmyndharis.openwa.http.BinaryResponse;
 import com.rmyndharis.openwa.http.DefaultHttpTransport;
 import com.rmyndharis.openwa.http.Http;
 import com.rmyndharis.openwa.http.HttpMethod;
@@ -27,6 +29,7 @@ import com.rmyndharis.openwa.resources.TemplatesResource;
 import com.rmyndharis.openwa.resources.WebhooksResource;
 import java.io.IOException;
 import java.lang.reflect.Array;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -80,30 +83,85 @@ public final class OpenWAClient {
 
     // ── Internal request API used by all resources ─────────────────────
 
-    /** Issue a request and deserialize a single object (or {@code null} for 204/empty). */
+    /**
+     * Issue a request and deserialize a single object (or {@code null} for 204/empty).
+     *
+     * <p>A {@code String} target receives a non-JSON 2xx body as raw text — the same
+     * fallback the JS/Python/PHP transports apply. For any other target the body must
+     * be JSON; a non-JSON body surfaces as a tidy {@link OpenWAError}, never a raw
+     * Gson exception.
+     */
+    @SuppressWarnings("unchecked")
     public <T> T request(HttpMethod method, String path, Object query, Object body, Class<T> type) {
         HttpResponseData res = execute(method, path, query, body);
-        if (res.status() == 204 || res.body() == null || res.body().isEmpty()) {
+        String text = utf8(res.body());
+        if (res.status() == 204 || text.isEmpty()) {
             return null;
         }
-        return gson.fromJson(res.body(), type);
+        if (type == String.class) {
+            // A String target mirrors the JS/Python/PHP raw-text fallback: decode a
+            // JSON string body, accept a non-JSON 2xx body as the raw text.
+            try {
+                T parsed = gson.fromJson(text, type);
+                if (parsed != null) {
+                    return parsed;
+                }
+            } catch (JsonParseException ignore) {
+                // fall through to the raw text
+            }
+            return (T) text;
+        }
+        try {
+            return gson.fromJson(text, type);
+        } catch (JsonParseException e) {
+            throw new OpenWAError("Non-JSON response — " + method + " " + path);
+        }
     }
 
     /** Issue a request and deserialize a JSON array into a {@code List} (empty for 204/empty). */
     @SuppressWarnings("unchecked")
     public <T> List<T> requestList(HttpMethod method, String path, Object query, Object body, Class<T> elementType) {
         HttpResponseData res = execute(method, path, query, body);
-        if (res.status() == 204 || res.body() == null || res.body().isEmpty()) {
+        String text = utf8(res.body());
+        if (res.status() == 204 || text.isEmpty()) {
             return List.of();
         }
         Class<T[]> arrayType = (Class<T[]>) Array.newInstance(elementType, 0).getClass();
-        T[] arr = gson.fromJson(res.body(), arrayType);
-        return arr == null ? List.of() : List.of(arr);
+        try {
+            T[] arr = gson.fromJson(text, arrayType);
+            return arr == null ? List.of() : List.of(arr);
+        } catch (JsonParseException e) {
+            throw new OpenWAError("Non-JSON response — " + method + " " + path);
+        }
     }
 
     /** Issue a request that returns no body. */
     public void requestVoid(HttpMethod method, String path, Object query, Object body) {
         execute(method, path, query, body);
+    }
+
+    /**
+     * Issue a request for a non-JSON (binary) 2xx body — e.g. stored status media —
+     * and return the raw bytes plus the served Content-Type. A 204/empty body yields
+     * empty data and a {@code null} content type.
+     */
+    public BinaryResponse requestBytes(HttpMethod method, String path, Object query) {
+        HttpResponseData res = execute(method, path, query, null);
+        if (res.status() == 204 || res.body() == null || res.body().length == 0) {
+            return new BinaryResponse(new byte[0], null);
+        }
+        String contentType = null;
+        for (Map.Entry<String, List<String>> e : res.headers().entrySet()) {
+            if ("content-type".equalsIgnoreCase(e.getKey()) && !e.getValue().isEmpty()) {
+                contentType = e.getValue().get(0);
+                break;
+            }
+        }
+        return new BinaryResponse(res.body(), contentType);
+    }
+
+    private static String utf8(byte[] body) {
+        return body == null ? "" : new String(body, StandardCharsets.UTF_8);
     }
 
     private HttpResponseData execute(HttpMethod method, String path, Object query, Object body) {
@@ -126,7 +184,7 @@ public final class OpenWAClient {
             throw new OpenWAError("Invalid request — " + method + " " + path + ": " + e.getMessage());
         }
         if (res.status() < 200 || res.status() >= 300) {
-            throw OpenWAApiError.fromResponse(res.status(), "", res.body(), method + " " + path);
+            throw OpenWAApiError.fromResponse(res.status(), "", utf8(res.body()), method + " " + path);
         }
         return res;
     }

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/http/BinaryResponse.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/http/BinaryResponse.java
@@ -1,0 +1,8 @@
+package com.rmyndharis.openwa.http;
+
+/**
+ * A binary (non-JSON) 2xx body, e.g. the stored status media bytes: the raw
+ * payload plus the Content-Type the server served it as ({@code null} when the
+ * response carried no Content-Type header or was empty).
+ */
+public record BinaryResponse(byte[] data, String contentType) {}

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/http/DefaultHttpTransport.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/http/DefaultHttpTransport.java
@@ -24,7 +24,7 @@ public final class DefaultHttpTransport implements HttpTransport {
             .method(req.method().name(), pub);
         req.headers().forEach(b::header);
         try {
-            HttpResponse<String> res = client.send(b.build(), HttpResponse.BodyHandlers.ofString());
+            HttpResponse<byte[]> res = client.send(b.build(), HttpResponse.BodyHandlers.ofByteArray());
             return new HttpResponseData(res.statusCode(), res.headers().map(), res.body());
         } catch (HttpTimeoutException e) {
             throw new OpenWATimeoutError(req.timeout().toMillis());

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/http/HttpResponseData.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/http/HttpResponseData.java
@@ -3,5 +3,10 @@ package com.rmyndharis.openwa.http;
 import java.util.List;
 import java.util.Map;
 
-/** A raw response: status, headers, and the undecoded body text. */
-public record HttpResponseData(int status, Map<String, List<String>> headers, String body) {}
+/**
+ * A raw response: status, headers, and the undecoded body bytes. Bytes (not a
+ * decoded String) so binary payloads — e.g. a stored status media stream —
+ * survive the transport without charset corruption; the client decodes UTF-8
+ * only on the JSON/text paths.
+ */
+public record HttpResponseData(int status, Map<String, List<String>> headers, byte[] body) {}

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/model/ProfilePicturesResponse.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/model/ProfilePicturesResponse.java
@@ -1,0 +1,6 @@
+package com.rmyndharis.openwa.model;
+
+import java.util.Map;
+
+/** Batch profile-picture lookup: a map of contact id → picture URL (null when the lookup failed). */
+public record ProfilePicturesResponse(Map<String, String> pictures) {}

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/model/SendPollRequest.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/model/SendPollRequest.java
@@ -1,0 +1,44 @@
+package com.rmyndharis.openwa.model;
+
+import java.util.List;
+
+/** Request body for sending a native WhatsApp poll (2–12 options). */
+public record SendPollRequest(String chatId, String name, List<String> options, Boolean allowMultipleAnswers) {
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private String chatId;
+        private String name;
+        private List<String> options;
+        private Boolean allowMultipleAnswers;
+
+        public Builder chatId(String v) {
+            this.chatId = v;
+            return this;
+        }
+
+        /** Poll question / title (max 255 chars). */
+        public Builder name(String v) {
+            this.name = v;
+            return this;
+        }
+
+        /** Options to vote on (WhatsApp allows between 2 and 12). */
+        public Builder options(List<String> v) {
+            this.options = v;
+            return this;
+        }
+
+        /** Allow voters to pick several options (default single choice). */
+        public Builder allowMultipleAnswers(Boolean v) {
+            this.allowMultipleAnswers = v;
+            return this;
+        }
+
+        public SendPollRequest build() {
+            return new SendPollRequest(chatId, name, options, allowMultipleAnswers);
+        }
+    }
+}

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/model/SendTextRequest.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/model/SendTextRequest.java
@@ -1,7 +1,14 @@
 package com.rmyndharis.openwa.model;
 
+import java.util.List;
+
 /** Request body for sending a text message. */
-public record SendTextRequest(String chatId, String text) {
+public record SendTextRequest(String chatId, String text, List<String> mentions) {
+    /** Back-compatible constructor without mentions. */
+    public SendTextRequest(String chatId, String text) {
+        this(chatId, text, null);
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -9,6 +16,7 @@ public record SendTextRequest(String chatId, String text) {
     public static final class Builder {
         private String chatId;
         private String text;
+        private List<String> mentions;
 
         public Builder chatId(String v) {
             this.chatId = v;
@@ -21,8 +29,14 @@ public record SendTextRequest(String chatId, String text) {
             return this;
         }
 
+        /** WIDs to @mention (e.g. {@code ["62811@c.us"]}). The text must also contain the {@code @<number>} token. */
+        public Builder mentions(List<String> v) {
+            this.mentions = v;
+            return this;
+        }
+
         public SendTextRequest build() {
-            return new SendTextRequest(chatId, text);
+            return new SendTextRequest(chatId, text, mentions);
         }
     }
 }

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/model/WebhookFilterCondition.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/model/WebhookFilterCondition.java
@@ -2,5 +2,17 @@ package com.rmyndharis.openwa.model;
 
 import java.util.List;
 
-/** A single condition evaluated against an event before delivery. */
-public record WebhookFilterCondition(String field, String operator, List<String> value) {}
+/**
+ * A single condition evaluated against an event before delivery.
+ *
+ * <p>{@code value} is polymorphic per field kind: a {@link String} (text fields),
+ * a {@code List<String>} (id/idArray/enum fields), or a {@link Boolean} (boolean
+ * fields). {@code caseSensitive} only applies to text fields
+ * ({@code contains}/{@code equals}) and defaults to false when {@code null}.
+ */
+public record WebhookFilterCondition(String field, String operator, Object value, Boolean caseSensitive) {
+    /** Back-compatible constructor: id/enum value list, no caseSensitivity. */
+    public WebhookFilterCondition(String field, String operator, List<String> value) {
+        this(field, operator, (Object) value, null);
+    }
+}

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/resources/ContactsResource.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/resources/ContactsResource.java
@@ -9,8 +9,10 @@ import com.rmyndharis.openwa.model.ContactPhoneResponse;
 import com.rmyndharis.openwa.model.ContactRecord;
 import com.rmyndharis.openwa.model.ListContactsQuery;
 import com.rmyndharis.openwa.model.ProfilePictureResponse;
+import com.rmyndharis.openwa.model.ProfilePicturesResponse;
 import com.rmyndharis.openwa.model.SuccessResult;
 import java.util.List;
+import java.util.Map;
 
 /** Contacts resource — contact lookup and management. */
 public final class ContactsResource {
@@ -58,6 +60,19 @@ public final class ContactsResource {
             null,
             null,
             ProfilePictureResponse.class);
+    }
+
+    /**
+     * Batch-resolve profile picture URLs for up to 50 contacts in one request.
+     * Returns a map of contact id → URL (null when a lookup fails).
+     */
+    public ProfilePicturesResponse profilePictures(String sessionId, List<String> ids) {
+        return client.request(
+            HttpMethod.GET,
+            "/api/sessions/" + encodeSegment(sessionId) + "/contacts/profile-pictures",
+            Map.of("ids", String.join(",", ids)),
+            null,
+            ProfilePicturesResponse.class);
     }
 
     /** Resolve a contact id (e.g. a {@code @lid}) to a phone number. */

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/resources/MessagesResource.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/resources/MessagesResource.java
@@ -22,6 +22,7 @@ import com.rmyndharis.openwa.model.SendContactRequest;
 import com.rmyndharis.openwa.model.SendLocationRequest;
 import com.rmyndharis.openwa.model.SendMediaRequest;
 import com.rmyndharis.openwa.model.SendAudioRequest;
+import com.rmyndharis.openwa.model.SendPollRequest;
 import com.rmyndharis.openwa.model.SendTemplateRequest;
 import com.rmyndharis.openwa.model.SendTextRequest;
 import com.rmyndharis.openwa.model.SuccessResult;
@@ -109,6 +110,16 @@ public final class MessagesResource {
         return client.request(
             HttpMethod.POST,
             "/api/sessions/" + encodeSegment(sessionId) + "/messages/send-template",
+            null,
+            body,
+            MessageResponse.class);
+    }
+
+    /** Send a native WhatsApp poll (2–12 options). */
+    public MessageResponse sendPoll(String sessionId, SendPollRequest body) {
+        return client.request(
+            HttpMethod.POST,
+            "/api/sessions/" + encodeSegment(sessionId) + "/messages/send-poll",
             null,
             body,
             MessageResponse.class);

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/resources/StatusResource.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/resources/StatusResource.java
@@ -3,6 +3,7 @@ package com.rmyndharis.openwa.resources;
 import static com.rmyndharis.openwa.http.Http.encodeSegment;
 
 import com.rmyndharis.openwa.OpenWAClient;
+import com.rmyndharis.openwa.http.BinaryResponse;
 import com.rmyndharis.openwa.http.HttpMethod;
 import com.rmyndharis.openwa.model.SendImageStatusRequest;
 import com.rmyndharis.openwa.model.SendTextStatusRequest;
@@ -40,6 +41,14 @@ public final class StatusResource {
             null,
             null,
             StatusListResult.class);
+    }
+
+    /** Fetch the stored media bytes for a status update (404 when there is no stored media). */
+    public BinaryResponse media(String sessionId, String statusId) {
+        return client.requestBytes(
+            HttpMethod.GET,
+            "/api/sessions/" + encodeSegment(sessionId) + "/status/" + encodeSegment(statusId) + "/media",
+            null);
     }
 
     /** Post a text status update. */

--- a/sdk/java/src/test/java/com/rmyndharis/openwa/ClientTest.java
+++ b/sdk/java/src/test/java/com/rmyndharis/openwa/ClientTest.java
@@ -1,14 +1,20 @@
 package com.rmyndharis.openwa;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.rmyndharis.openwa.errors.OpenWAError;
 import com.rmyndharis.openwa.errors.OpenWANotFoundError;
+import com.rmyndharis.openwa.http.BinaryResponse;
 import com.rmyndharis.openwa.http.HttpMethod;
 import com.rmyndharis.openwa.model.SuccessResult;
 import com.rmyndharis.openwa.support.MockTransport;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class ClientTest {
@@ -54,5 +60,41 @@ class ClientTest {
         tx.respond(204, "");
         SuccessResult r = client.request(HttpMethod.DELETE, "/api/x", null, null, SuccessResult.class);
         assertNull(r);
+    }
+
+    @Test
+    void nonJson2xxFallsBackToRawTextForStringTargets() {
+        tx.respond(200, "plain text");
+        String r = client.request(HttpMethod.GET, "/api/x", null, null, String.class);
+        assertEquals("plain text", r);
+    }
+
+    @Test
+    void nonJson2xxForTypedTargetsThrowsTidySdkError() {
+        tx.respond(200, "plain text");
+        // Must surface the SDK's own error type — a raw Gson JsonSyntaxException
+        // leaking to callers is the bug this guards.
+        OpenWAError e = assertThrows(OpenWAError.class,
+            () -> client.request(HttpMethod.GET, "/api/x", null, null, SuccessResult.class));
+        assertEquals(OpenWAError.class, e.getClass());
+    }
+
+    @Test
+    void requestBytesReturnsRawBodyAndContentType() {
+        tx.respondRaw(
+            200,
+            "PNG_BYTES".getBytes(StandardCharsets.UTF_8),
+            Map.of("content-type", List.of("image/png")));
+        BinaryResponse r = client.requestBytes(HttpMethod.GET, "/api/x", null);
+        assertArrayEquals("PNG_BYTES".getBytes(StandardCharsets.UTF_8), r.data());
+        assertEquals("image/png", r.contentType());
+    }
+
+    @Test
+    void requestBytes204ReturnsEmptyData() {
+        tx.respond(204, "");
+        BinaryResponse r = client.requestBytes(HttpMethod.GET, "/api/x", null);
+        assertEquals(0, r.data().length);
+        assertNull(r.contentType());
     }
 }

--- a/sdk/java/src/test/java/com/rmyndharis/openwa/resources/ContactsResourceTest.java
+++ b/sdk/java/src/test/java/com/rmyndharis/openwa/resources/ContactsResourceTest.java
@@ -1,12 +1,16 @@
 package com.rmyndharis.openwa.resources;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.rmyndharis.openwa.ClientConfig;
 import com.rmyndharis.openwa.OpenWAClient;
 import com.rmyndharis.openwa.http.HttpMethod;
 import com.rmyndharis.openwa.model.ListContactsQuery;
+import com.rmyndharis.openwa.model.ProfilePicturesResponse;
 import com.rmyndharis.openwa.support.MockTransport;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class ContactsResourceTest {
@@ -52,6 +56,19 @@ class ContactsResourceTest {
         client.contacts.profilePicture("s", "a@c.us");
         assertEquals("http://h/api/sessions/s/contacts/a@c.us/profile-picture", tx.lastRequest().url());
         assertEquals(HttpMethod.GET, tx.lastRequest().method());
+    }
+
+    @Test
+    void profilePicturesBatchResolvesIdsQuery() {
+        tx.respond(200, "{\"pictures\":{\"a@c.us\":\"http://p/a\",\"b@c.us\":null}}");
+        ProfilePicturesResponse res = client.contacts.profilePictures("s", List.of("a@c.us", "b@c.us"));
+        assertEquals(
+            "http://h/api/sessions/s/contacts/profile-pictures?ids=a%40c.us%2Cb%40c.us",
+            tx.lastRequest().url());
+        assertEquals(HttpMethod.GET, tx.lastRequest().method());
+        assertEquals("http://p/a", res.pictures().get("a@c.us"));
+        assertTrue(res.pictures().containsKey("b@c.us"));
+        assertNull(res.pictures().get("b@c.us"));
     }
 
     @Test

--- a/sdk/java/src/test/java/com/rmyndharis/openwa/resources/MessagesResourceTest.java
+++ b/sdk/java/src/test/java/com/rmyndharis/openwa/resources/MessagesResourceTest.java
@@ -21,6 +21,7 @@ import com.rmyndharis.openwa.model.SendContactRequest;
 import com.rmyndharis.openwa.model.SendLocationRequest;
 import com.rmyndharis.openwa.model.SendMediaRequest;
 import com.rmyndharis.openwa.model.SendAudioRequest;
+import com.rmyndharis.openwa.model.SendPollRequest;
 import com.rmyndharis.openwa.model.SendTemplateRequest;
 import com.rmyndharis.openwa.model.SendTextRequest;
 import com.rmyndharis.openwa.support.MockTransport;
@@ -57,6 +58,37 @@ class MessagesResourceTest {
         assertEquals("http://h/api/sessions/s/messages/send-text", tx.lastRequest().url());
         assertEquals(HttpMethod.POST, tx.lastRequest().method());
         assertTrue(tx.lastRequest().body().contains("hello-text"));
+    }
+
+    @Test
+    void sendTextForwardsMentionsVerbatim() {
+        tx.respond(200, MSG);
+        client.messages.sendText(
+            "s",
+            SendTextRequest.builder()
+                .chatId("120363@g.us")
+                .text("hi @628123")
+                .mentions(List.of("628123@c.us"))
+                .build());
+        assertTrue(tx.lastRequest().body().contains("\"mentions\":[\"628123@c.us\"]"));
+    }
+
+    @Test
+    void sendPollResolvesToSendPollPath() {
+        tx.respond(200, MSG);
+        client.messages.sendPoll(
+            "s",
+            SendPollRequest.builder()
+                .chatId("628@c.us")
+                .name("Where?")
+                .options(List.of("Park", "Beach"))
+                .allowMultipleAnswers(true)
+                .build());
+        assertEquals("http://h/api/sessions/s/messages/send-poll", tx.lastRequest().url());
+        assertEquals(HttpMethod.POST, tx.lastRequest().method());
+        assertTrue(tx.lastRequest().body().contains("\"name\":\"Where?\""));
+        assertTrue(tx.lastRequest().body().contains("\"options\":[\"Park\",\"Beach\"]"));
+        assertTrue(tx.lastRequest().body().contains("\"allowMultipleAnswers\":true"));
     }
 
     @Test

--- a/sdk/java/src/test/java/com/rmyndharis/openwa/resources/StatusResourceTest.java
+++ b/sdk/java/src/test/java/com/rmyndharis/openwa/resources/StatusResourceTest.java
@@ -1,10 +1,14 @@
 package com.rmyndharis.openwa.resources;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.rmyndharis.openwa.ClientConfig;
 import com.rmyndharis.openwa.OpenWAClient;
+import com.rmyndharis.openwa.errors.OpenWANotFoundError;
+import com.rmyndharis.openwa.http.BinaryResponse;
 import com.rmyndharis.openwa.http.HttpMethod;
 import com.rmyndharis.openwa.model.SendImageStatusRequest;
 import com.rmyndharis.openwa.model.SendTextStatusRequest;
@@ -12,7 +16,9 @@ import com.rmyndharis.openwa.model.SendVideoStatusRequest;
 import com.rmyndharis.openwa.model.StatusMediaInput;
 import com.rmyndharis.openwa.model.StatusRecord;
 import com.rmyndharis.openwa.support.MockTransport;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class StatusResourceTest {
@@ -117,5 +123,24 @@ class StatusResourceTest {
         status.delete("s", "status/1");
         assertEquals("http://h/api/sessions/s/status/status%2F1", tx.lastRequest().url());
         assertEquals(HttpMethod.DELETE, tx.lastRequest().method());
+    }
+
+    @Test
+    void mediaReturnsStoredBytes() {
+        tx.respondRaw(
+            200,
+            "PNG_BYTES".getBytes(StandardCharsets.UTF_8),
+            Map.of("content-type", List.of("image/png")));
+        BinaryResponse media = status.media("s", "w1");
+        assertEquals("http://h/api/sessions/s/status/w1/media", tx.lastRequest().url());
+        assertEquals(HttpMethod.GET, tx.lastRequest().method());
+        assertArrayEquals("PNG_BYTES".getBytes(StandardCharsets.UTF_8), media.data());
+        assertEquals("image/png", media.contentType());
+    }
+
+    @Test
+    void media404MapsToNotFoundError() {
+        tx.respond(404, "{\"statusCode\":404,\"message\":\"Status media not found or expired\",\"error\":\"Not Found\"}");
+        assertThrows(OpenWANotFoundError.class, () -> status.media("s", "w1"));
     }
 }

--- a/sdk/java/src/test/java/com/rmyndharis/openwa/resources/WebhooksResourceTest.java
+++ b/sdk/java/src/test/java/com/rmyndharis/openwa/resources/WebhooksResourceTest.java
@@ -9,6 +9,8 @@ import com.rmyndharis.openwa.http.HttpMethod;
 import com.rmyndharis.openwa.model.CreateWebhookRequest;
 import com.rmyndharis.openwa.model.UpdateWebhookRequest;
 import com.rmyndharis.openwa.model.WebhookEvent;
+import com.rmyndharis.openwa.model.WebhookFilterCondition;
+import com.rmyndharis.openwa.model.WebhookFilters;
 import com.rmyndharis.openwa.support.MockTransport;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -94,5 +96,27 @@ class WebhooksResourceTest {
         assertTrue(tx.lastRequest().body().contains("group.leave"));
         assertTrue(tx.lastRequest().body().contains("group.update"));
         assertTrue(tx.lastRequest().body().contains("call.received"));
+    }
+
+    @Test
+    void createSerializesPolymorphicFilterValues() {
+        tx.respond(200, WEBHOOK_JSON);
+        // The filter value is polymorphic on the wire: string list (id/enum
+        // fields), single string (text fields, optionally caseSensitive), and
+        // boolean (boolean fields).
+        client.webhooks.create(
+            "s",
+            CreateWebhookRequest.builder()
+                .url("https://example.test/hook")
+                .filters(new WebhookFilters(List.of(
+                    new WebhookFilterCondition("sender", "is", List.of("123@c.us")),
+                    new WebhookFilterCondition("body", "contains", "invoice", true),
+                    new WebhookFilterCondition("isGroup", "is", false, null))))
+                .build());
+        String body = tx.lastRequest().body();
+        assertTrue(body.contains("\"value\":[\"123@c.us\"]"), body);
+        assertTrue(body.contains("\"value\":\"invoice\""), body);
+        assertTrue(body.contains("\"caseSensitive\":true"), body);
+        assertTrue(body.contains("\"value\":false"), body);
     }
 }

--- a/sdk/java/src/test/java/com/rmyndharis/openwa/support/MockTransport.java
+++ b/sdk/java/src/test/java/com/rmyndharis/openwa/support/MockTransport.java
@@ -3,6 +3,7 @@ package com.rmyndharis.openwa.support;
 import com.rmyndharis.openwa.http.HttpRequestData;
 import com.rmyndharis.openwa.http.HttpResponseData;
 import com.rmyndharis.openwa.http.HttpTransport;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -10,11 +11,21 @@ import java.util.Map;
 public final class MockTransport implements HttpTransport {
     private HttpRequestData last;
     private int status = 200;
-    private String body = "";
+    private byte[] body = new byte[0];
+    private Map<String, List<String>> headers = Map.of();
 
     public MockTransport respond(int status, String jsonBody) {
         this.status = status;
-        this.body = jsonBody;
+        this.body = jsonBody.getBytes(StandardCharsets.UTF_8);
+        this.headers = Map.of();
+        return this;
+    }
+
+    /** Respond with a raw (non-JSON) body and explicit headers — e.g. a binary media stream. */
+    public MockTransport respondRaw(int status, byte[] body, Map<String, List<String>> headers) {
+        this.status = status;
+        this.body = body;
+        this.headers = headers;
         return this;
     }
 
@@ -25,6 +36,6 @@ public final class MockTransport implements HttpTransport {
     @Override
     public HttpResponseData send(HttpRequestData request) {
         this.last = request;
-        return new HttpResponseData(status, Map.<String, List<String>>of(), body);
+        return new HttpResponseData(status, headers, body);
     }
 }

--- a/sdk/javascript/src/client.ts
+++ b/sdk/javascript/src/client.ts
@@ -23,7 +23,7 @@
  * @packageDocumentation
  */
 
-import { request, encodeSegment, warnIfInsecureHttpUrl, type ClientConfig, type FetchLike, type RequestOptions } from './http.js';
+import { request, requestBytes, encodeSegment, warnIfInsecureHttpUrl, type BinaryResponse, type ClientConfig, type FetchLike, type RequestOptions } from './http.js';
 import { CallsResource } from './resources/calls.js';
 import { CatalogResource } from './resources/catalog.js';
 import { ChannelsResource } from './resources/channels.js';
@@ -102,6 +102,11 @@ export class OpenWAClient {
   /** Issue a raw request against the API. (Public for advanced use.) */
   request<T>(options: RequestOptions): Promise<T> {
     return request<T>(this.config, options);
+  }
+
+  /** Issue a raw request expecting a non-JSON (binary) body. (Public for advanced use.) */
+  requestBytes(options: RequestOptions): Promise<BinaryResponse> {
+    return requestBytes(this.config, options);
   }
 
   /**

--- a/sdk/javascript/src/http.ts
+++ b/sdk/javascript/src/http.ts
@@ -76,6 +76,54 @@ export async function request<T>(
   config: Required<Omit<ClientConfig, 'fetch'>> & { fetch: FetchLike },
   options: RequestOptions,
 ): Promise<T> {
+  return send(config, options, async res => {
+    if (res.status === 204) {
+      return null as T;
+    }
+    const text = await res.text();
+    if (!text) return null as T;
+    try {
+      return JSON.parse(text) as T;
+    } catch {
+      return text as unknown as T;
+    }
+  });
+}
+
+/** A binary (non-JSON) 2xx body, e.g. the stored status media bytes. */
+export interface BinaryResponse {
+  data: Uint8Array;
+  contentType: string | null;
+}
+
+/**
+ * Like {@link request}, but for endpoints that stream raw bytes instead of
+ * JSON (e.g. status media). Returns the body verbatim plus the served
+ * Content-Type; a 204/empty body resolves to zero-length data.
+ */
+export async function requestBytes(
+  config: Required<Omit<ClientConfig, 'fetch'>> & { fetch: FetchLike },
+  options: RequestOptions,
+): Promise<BinaryResponse> {
+  return send(config, options, async res => {
+    if (res.status === 204) {
+      return { data: new Uint8Array(0), contentType: null };
+    }
+    return { data: new Uint8Array(await res.arrayBuffer()), contentType: res.headers.get('content-type') };
+  });
+}
+
+/**
+ * Shared transport for {@link request} and {@link requestBytes}: builds the
+ * URL/headers, performs the fetch under the per-request timeout, translates a
+ * non-2xx into a typed error, then hands the response to `consume` — still
+ * inside the timeout window, so a stalled body read aborts too.
+ */
+async function send<T>(
+  config: Required<Omit<ClientConfig, 'fetch'>> & { fetch: FetchLike },
+  options: RequestOptions,
+  consume: (res: Response) => Promise<T>,
+): Promise<T> {
   const url = buildUrl(config.baseUrl, options.path, options.query);
   const timeoutMs = options.timeoutMs ?? config.timeoutMs;
 
@@ -110,16 +158,7 @@ export async function request<T>(
       throw classifyApiError(apiError.status, apiError.message, apiError.body, apiError.errorKind);
     }
 
-    if (res.status === 204) {
-      return null as T;
-    }
-    const text = await res.text();
-    if (!text) return null as T;
-    try {
-      return JSON.parse(text) as T;
-    } catch {
-      return text as unknown as T;
-    }
+    return await consume(res);
   } catch (err) {
     if (err instanceof Error && err.name === 'AbortError') {
       throw new OpenWATimeoutError(timeoutMs);

--- a/sdk/javascript/src/index.ts
+++ b/sdk/javascript/src/index.ts
@@ -28,5 +28,5 @@ export { default } from './client.js';
 export type { OpenWAClientOptions } from './client.js';
 export * from './errors.js';
 export type * from './types.js';
-export type { ClientConfig, FetchLike, HttpMethod, RequestOptions } from './http.js';
+export type { BinaryResponse, ClientConfig, FetchLike, HttpMethod, RequestOptions } from './http.js';
 export { buildUrl, warnIfInsecureHttpUrl } from './http.js';

--- a/sdk/javascript/src/resources/contacts.ts
+++ b/sdk/javascript/src/resources/contacts.ts
@@ -12,6 +12,7 @@ import type {
   ContactPhoneResponse,
   ContactRecord,
   ProfilePictureResponse,
+  ProfilePicturesResponse,
   SuccessResult,
 } from '../types.js';
 
@@ -53,6 +54,18 @@ export class ContactsResource {
     return this.client.request<ProfilePictureResponse>({
       method: 'GET',
       path: `/api/sessions/${encodeSegment(sessionId)}/contacts/${encodeSegment(contactId)}/profile-picture`,
+    });
+  }
+
+  /**
+   * Batch-resolve profile picture URLs for up to 50 contacts in one request.
+   * Returns a map of contact id → URL (null when a lookup fails).
+   */
+  profilePictures(sessionId: string, ids: string[]): Promise<ProfilePicturesResponse> {
+    return this.client.request<ProfilePicturesResponse>({
+      method: 'GET',
+      path: `/api/sessions/${encodeSegment(sessionId)}/contacts/profile-pictures`,
+      query: { ids: ids.join(',') },
     });
   }
 

--- a/sdk/javascript/src/resources/messages.ts
+++ b/sdk/javascript/src/resources/messages.ts
@@ -27,6 +27,7 @@ import type {
   SendLocationRequest,
   SendAudioRequest,
   SendMediaRequest,
+  SendPollRequest,
   SendTemplateRequest,
   SendTextRequest,
   SuccessResult,
@@ -101,6 +102,15 @@ export class MessagesResource {
     return this.client.request<MessageResponse>({
       method: 'POST',
       path: `/api/sessions/${encodeSegment(sessionId)}/messages/send-template`,
+      body,
+    });
+  }
+
+  /** Send a native WhatsApp poll (2–12 options). */
+  sendPoll(sessionId: string, body: SendPollRequest): Promise<MessageResponse> {
+    return this.client.request<MessageResponse>({
+      method: 'POST',
+      path: `/api/sessions/${encodeSegment(sessionId)}/messages/send-poll`,
       body,
     });
   }

--- a/sdk/javascript/src/resources/status.ts
+++ b/sdk/javascript/src/resources/status.ts
@@ -7,6 +7,7 @@
  */
 
 import { encodeSegment } from '../http.js';
+import type { BinaryResponse } from '../http.js';
 import type { OpenWAClient } from '../client.js';
 import type {
   SendImageStatusRequest,
@@ -32,6 +33,14 @@ export class StatusResource {
     return this.client.request<{ statuses: StatusRecord[] }>({
       method: 'GET',
       path: `/api/sessions/${encodeSegment(sessionId)}/status/${encodeSegment(contactId)}`,
+    });
+  }
+
+  /** Fetch the stored media bytes for a status update (404 when there is no stored media). */
+  media(sessionId: string, statusId: string): Promise<BinaryResponse> {
+    return this.client.requestBytes({
+      method: 'GET',
+      path: `/api/sessions/${encodeSegment(sessionId)}/status/${encodeSegment(statusId)}/media`,
     });
   }
 

--- a/sdk/javascript/src/types.ts
+++ b/sdk/javascript/src/types.ts
@@ -92,6 +92,8 @@ export interface SendTextRequest {
   chatId: Jid;
   /** Max 4096 chars. */
   text: string;
+  /** WIDs to @mention (e.g. `["62811@c.us"]`). The text must also contain the `@<number>` token. */
+  mentions?: string[];
 }
 
 export interface SendMediaRequest {
@@ -177,6 +179,16 @@ export interface SendTemplateRequest {
   templateName?: string;
   /** Template variables (server DTO field is `vars`). */
   vars?: Record<string, string>;
+}
+
+export interface SendPollRequest {
+  chatId: Jid;
+  /** Poll question / title (max 255 chars). */
+  name: string;
+  /** Options to vote on (WhatsApp allows between 2 and 12). */
+  options: string[];
+  /** Allow voters to pick several options (default single choice). */
+  allowMultipleAnswers?: boolean;
 }
 
 export interface ListMessagesQuery {
@@ -364,6 +376,11 @@ export interface ProfilePictureResponse {
   url: string | null;
 }
 
+/** Batch profile-picture lookup: a map of contact id → picture URL (null when the lookup failed). */
+export interface ProfilePicturesResponse {
+  pictures: Record<string, string | null>;
+}
+
 export interface ContactPhoneResponse {
   contactId: Jid;
   phone: string | null;
@@ -502,7 +519,13 @@ export type WebhookEvent =
 export interface WebhookFilterCondition {
   field: string;
   operator: string;
-  value: string[];
+  /**
+   * Polymorphic per field kind: a single string (text fields), a string array
+   * (id/idArray/enum fields), or a boolean (boolean fields).
+   */
+  value: string | string[] | boolean;
+  /** Only meaningful for text fields (`contains`/`equals`). Defaults to false. */
+  caseSensitive?: boolean;
 }
 
 export interface WebhookFilters {

--- a/sdk/javascript/test/helpers.ts
+++ b/sdk/javascript/test/helpers.ts
@@ -16,6 +16,8 @@ export interface MockResponseSpec {
   status?: number;
   body?: unknown;
   text?: string;
+  /** Overrides the default `application/json` response content type. */
+  contentType?: string;
 }
 
 /** A scripted mock transport. Throws if a call doesn't match a route. */
@@ -97,7 +99,7 @@ export class MockTransport {
       const responseBody: BodyInit | null = noBody
         ? null
         : (spec.text ?? (spec.body === undefined ? '' : JSON.stringify(spec.body)));
-      const resHeaders: Record<string, string> = noBody ? {} : { 'content-type': 'application/json' };
+      const resHeaders: Record<string, string> = noBody ? {} : { 'content-type': spec.contentType ?? 'application/json' };
       return new Response(responseBody, { status, headers: resHeaders });
     }) as FetchLike;
   }

--- a/sdk/javascript/test/messages.test.ts
+++ b/sdk/javascript/test/messages.test.ts
@@ -14,6 +14,30 @@ describe('MessagesResource — exact paths', () => {
     expect(t.lastCall!.body).toEqual({ chatId: 'a@c.us', text: 'hi' });
   });
 
+  it('sendText forwards mentions verbatim', async () => {
+    const t = new MockTransport().on('POST', /send-text$/, { body: { messageId: 'm1', timestamp: 1 } });
+    await client(t).messages.sendText('s1', { chatId: 'g@g.us', text: 'hi @628123', mentions: ['628123@c.us'] });
+    expect(t.lastCall!.body).toEqual({ chatId: 'g@g.us', text: 'hi @628123', mentions: ['628123@c.us'] });
+  });
+
+  it('sendPoll posts to /messages/send-poll', async () => {
+    const t = new MockTransport().on('POST', /send-poll$/, { body: { messageId: 'm2', timestamp: 2 } });
+    const res = await client(t).messages.sendPoll('s1', {
+      chatId: 'a@c.us',
+      name: 'Where?',
+      options: ['Park', 'Beach'],
+      allowMultipleAnswers: true,
+    });
+    expect(t.lastCall!.url).toBe('http://x/api/sessions/s1/messages/send-poll');
+    expect(t.lastCall!.body).toEqual({
+      chatId: 'a@c.us',
+      name: 'Where?',
+      options: ['Park', 'Beach'],
+      allowMultipleAnswers: true,
+    });
+    expect(res.messageId).toBe('m2');
+  });
+
   it('sendImage posts to /messages/send-image', async () => {
     const t = new MockTransport().on('POST', /send-image$/, { body: { messageId: 'm', timestamp: 2 } });
     await client(t).messages.sendImage('s', { chatId: 'a@c.us', url: 'http://img' });

--- a/sdk/javascript/test/resources.test.ts
+++ b/sdk/javascript/test/resources.test.ts
@@ -144,6 +144,16 @@ describe('ContactsResource — exact paths', () => {
     await c.contacts.unblock('s', 'a@c.us');
     expect(t.lastCall!.method).toBe('DELETE');
   });
+
+  it('profilePictures batch-resolves ids via the ids query param', async () => {
+    const t = new MockTransport().on('GET', /\/contacts\/profile-pictures$/, {
+      body: { pictures: { 'a@c.us': 'http://p/a', 'b@c.us': null } },
+    });
+    const res = await client(t).contacts.profilePictures('s', ['a@c.us', 'b@c.us']);
+    expect(t.lastCall!.method).toBe('GET');
+    expect(t.lastCall!.url).toBe('http://x/api/sessions/s/contacts/profile-pictures?ids=a%40c.us%2Cb%40c.us');
+    expect(res.pictures).toEqual({ 'a@c.us': 'http://p/a', 'b@c.us': null });
+  });
 });
 
 describe('WebhooksResource — exact paths', () => {
@@ -176,6 +186,21 @@ describe('WebhooksResource — exact paths', () => {
     await c.webhooks.test('s', 'w1');
     expect(t.lastCall!.url).toContain('/webhooks/w1/test');
   });
+
+  it('create forwards polymorphic filter values (string, string[], boolean) verbatim', async () => {
+    const t = new MockTransport().on('POST', /\/webhooks$/, {
+      body: { id: 'w1', sessionId: 's', url: 'u', events: ['*'], active: true, createdAt: '', updatedAt: '' },
+    });
+    const filters = {
+      conditions: [
+        { field: 'sender', operator: 'is', value: ['123@c.us'] },
+        { field: 'body', operator: 'contains', value: 'invoice', caseSensitive: true },
+        { field: 'isGroup', operator: 'is', value: false },
+      ],
+    };
+    await client(t).webhooks.create('s', { url: 'u', events: ['message.received'], filters });
+    expect(t.lastCall!.body).toEqual({ url: 'u', events: ['message.received'], filters });
+  });
 });
 
 describe('StatusResource — nested media bodies', () => {
@@ -188,6 +213,15 @@ describe('StatusResource — nested media bodies', () => {
     expect(t.lastCall!.body).toEqual({ image: { url: 'http://img' }, recipients: ['a@c.us'], caption: 'hi' });
     await c.status.sendVideo('s', { video: { url: 'http://vid' }, recipients: ['a@c.us'] });
     expect(t.lastCall!.body).toEqual({ video: { url: 'http://vid' }, recipients: ['a@c.us'] });
+  });
+
+  it('media fetches the stored status bytes with their content type', async () => {
+    const t = new MockTransport().on('GET', /\/status\/w1\/media$/, { text: 'PNG_BYTES', contentType: 'image/png' });
+    const res = await client(t).status.media('s', 'w1');
+    expect(t.lastCall!.method).toBe('GET');
+    expect(t.lastCall!.url).toBe('http://x/api/sessions/s/status/w1/media');
+    expect(new TextDecoder().decode(res.data)).toBe('PNG_BYTES');
+    expect(res.contentType).toBe('image/png');
   });
 });
 

--- a/sdk/php/src/Http/HttpExecutor.php
+++ b/sdk/php/src/Http/HttpExecutor.php
@@ -76,6 +76,51 @@ class HttpExecutor
      */
     public function request(string $method, string $path, array $query = [], $body = null)
     {
+        $response = $this->send($method, $path, $query, $body);
+
+        $text = (string) $response->getBody();
+        if ($response->getStatusCode() === 204 || $text === '') {
+            return null;
+        }
+
+        $decoded = json_decode($text, true);
+        return $decoded === null && json_last_error() !== JSON_ERROR_NONE ? $text : $decoded;
+    }
+
+    /**
+     * Perform one request for a non-JSON (binary) 2xx body — e.g. stored
+     * status media — and return it as ['data' => raw bytes, 'contentType' =>
+     * ?string]. A 204/empty body yields empty data and a null content type.
+     *
+     * @param string              $method HTTP method.
+     * @param string              $path   Path beginning with /.
+     * @param array<string,mixed> $query  Query parameters (null values skipped).
+     *
+     * @return array{data: string, contentType: ?string}
+     *
+     * @throws OpenWAApiException  On any non-2xx response (typed subclass).
+     * @throws OpenWATimeoutException On timeout.
+     */
+    public function requestBinary(string $method, string $path, array $query = []): array
+    {
+        $response = $this->send($method, $path, $query, null);
+        if ($response->getStatusCode() === 204) {
+            return ['data' => '', 'contentType' => null];
+        }
+        $contentType = $response->getHeaderLine('Content-Type');
+        return ['data' => (string) $response->getBody(), 'contentType' => $contentType === '' ? null : $contentType];
+    }
+
+    /**
+     * Shared transport for {@see request()} and {@see requestBinary()}:
+     * builds options, performs the Guzzle call, and maps a non-2xx (including
+     * an unfollowed 3xx) to a typed SDK exception.
+     *
+     * @param array<string,mixed> $query
+     * @param mixed|null          $body
+     */
+    private function send(string $method, string $path, array $query, $body): ResponseInterface
+    {
         // Auth/JSON headers are applied per-request so they are correct whether
         // a default or injected client is used (and never leak Guzzle exceptions:
         // http_errors disabled so we translate status into typed SDK exceptions).
@@ -125,14 +170,7 @@ class HttpExecutor
         if ($status >= 300) {
             throw $this->buildApiException($response, $method, $path);
         }
-
-        $text = (string) $response->getBody();
-        if ($status === 204 || $text === '') {
-            return null;
-        }
-
-        $decoded = json_decode($text, true);
-        return $decoded === null && json_last_error() !== JSON_ERROR_NONE ? $text : $decoded;
+        return $response;
     }
 
     private function buildApiException(ResponseInterface $response, string $method, string $path): OpenWAApiException

--- a/sdk/php/src/Resources/ContactsResource.php
+++ b/sdk/php/src/Resources/ContactsResource.php
@@ -47,6 +47,21 @@ class ContactsResource
         return $this->http->request('GET', "/api/sessions/{$this->http->encodeSegment($sessionId)}/contacts/{$this->http->encodeSegment($contactId)}/profile-picture");
     }
 
+    /**
+     * Batch-resolve profile picture URLs for up to 50 contacts in one request.
+     *
+     * @param list<string> $ids
+     * @return array{pictures: array<string,?string>} Map of contact id → URL (null when a lookup fails).
+     */
+    public function profilePictures(string $sessionId, array $ids): array
+    {
+        return $this->http->request(
+            'GET',
+            "/api/sessions/{$this->http->encodeSegment($sessionId)}/contacts/profile-pictures",
+            ['ids' => implode(',', $ids)]
+        );
+    }
+
     /** @return array<string,mixed> */
     public function phone(string $sessionId, string $contactId): array
     {

--- a/sdk/php/src/Resources/MessagesResource.php
+++ b/sdk/php/src/Resources/MessagesResource.php
@@ -101,6 +101,17 @@ class MessagesResource
         return $this->http->request('POST', "/api/sessions/{$this->http->encodeSegment($sessionId)}/messages/send-template", [], $body);
     }
 
+    /**
+     * Send a native WhatsApp poll (2–12 options).
+     *
+     * @param array<string,mixed> $body {chatId, name, options, allowMultipleAnswers?}
+     * @return array<string,mixed>
+     */
+    public function sendPoll(string $sessionId, array $body): array
+    {
+        return $this->http->request('POST', "/api/sessions/{$this->http->encodeSegment($sessionId)}/messages/send-poll", [], $body);
+    }
+
     /** @return array<string,mixed> */
     public function reply(string $sessionId, array $body): array
     {

--- a/sdk/php/src/Resources/StatusResource.php
+++ b/sdk/php/src/Resources/StatusResource.php
@@ -34,6 +34,16 @@ class StatusResource
     }
 
     /**
+     * Fetch the stored media bytes for a status update (404 when there is no stored media).
+     *
+     * @return array{data: string, contentType: ?string}
+     */
+    public function media(string $sessionId, string $statusId): array
+    {
+        return $this->http->requestBinary('GET', "/api/sessions/{$this->http->encodeSegment($sessionId)}/status/{$this->http->encodeSegment($statusId)}/media");
+    }
+
+    /**
      * @param array<string,mixed> $body Body may include a `recipients` key (list<string> of JIDs).
      *                                   Required on the Baileys engine (absent/empty -> 400 there);
      *                                   ignored by whatsapp-web.js — omit it there.

--- a/sdk/php/tests/MessagesTest.php
+++ b/sdk/php/tests/MessagesTest.php
@@ -21,6 +21,36 @@ class MessagesTest extends TestCase
         $this->assertSame(['chatId' => 'a@c.us', 'text' => 'hi'], $call['body']);
     }
 
+    public function testSendTextForwardsMentionsVerbatim(): void
+    {
+        $backend = (new MockBackend())->on(201, ['messageId' => 'm1', 'timestamp' => 1]);
+        $client = $backend->makeClient();
+        $client->messages->sendText('s1', ['chatId' => 'g@g.us', 'text' => 'hi @628123', 'mentions' => ['628123@c.us']]);
+        $this->assertSame(
+            ['chatId' => 'g@g.us', 'text' => 'hi @628123', 'mentions' => ['628123@c.us']],
+            $backend->lastCall()['body']
+        );
+    }
+
+    public function testSendPollUsesSendPollPath(): void
+    {
+        $backend = (new MockBackend())->on(201, ['messageId' => 'm2', 'timestamp' => 2]);
+        $client = $backend->makeClient();
+        $res = $client->messages->sendPoll('s1', [
+            'chatId' => 'a@c.us',
+            'name' => 'Where?',
+            'options' => ['Park', 'Beach'],
+            'allowMultipleAnswers' => true,
+        ]);
+        $call = $backend->lastCall();
+        $this->assertSame('/api/sessions/s1/messages/send-poll', $call['path']);
+        $this->assertSame(
+            ['chatId' => 'a@c.us', 'name' => 'Where?', 'options' => ['Park', 'Beach'], 'allowMultipleAnswers' => true],
+            $call['body']
+        );
+        $this->assertSame('m2', $res['messageId']);
+    }
+
     public function testListReturnsMessagesPageEnvelope(): void
     {
         // The server responds with a {messages, total} page, not a flat array. Pin the shape so a

--- a/sdk/php/tests/MockBackend.php
+++ b/sdk/php/tests/MockBackend.php
@@ -46,6 +46,16 @@ class MockBackend
         return $this;
     }
 
+    /**
+     * Queue a raw (non-JSON) response body for the next matching call — e.g.
+     * the binary stream of a stored status media.
+     */
+    public function onRaw(int $status, string $body, array $headers = []): self
+    {
+        $this->mock->append(new Response($status, $headers, $body));
+        return $this;
+    }
+
     public function httpClient(): GuzzleClient
     {
         // Record at the handler layer (innermost). The handler always sees the

--- a/sdk/php/tests/ResourcesTest.php
+++ b/sdk/php/tests/ResourcesTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenWA\Tests;
 
+use OpenWA\Exceptions\OpenWANotFoundException;
 use PHPUnit\Framework\TestCase;
 
 class ResourcesTest extends TestCase
@@ -158,6 +159,18 @@ class ResourcesTest extends TestCase
         $this->assertSame('DELETE', $backend->calls()[1]['method']);
     }
 
+    public function testProfilePicturesBatchResolvesIdsQuery(): void
+    {
+        $backend = (new MockBackend())->on(200, ['pictures' => ['a@c.us' => 'http://p/a', 'b@c.us' => null]]);
+        $client = $backend->makeClient();
+        $res = $client->contacts->profilePictures('s', ['a@c.us', 'b@c.us']);
+        $call = $backend->lastCall();
+        $this->assertSame('GET', $call['method']);
+        $this->assertSame('/api/sessions/s/contacts/profile-pictures', $call['path']);
+        $this->assertSame('ids=a%40c.us%2Cb%40c.us', $call['query']);
+        $this->assertSame(['a@c.us' => 'http://p/a', 'b@c.us' => null], $res['pictures']);
+    }
+
     // ── Webhooks ──────────────────────────────────────────────────────
 
     public function testWebhookCrudTest(): void
@@ -180,6 +193,26 @@ class ResourcesTest extends TestCase
         $client->webhooks->delete('s', 'w1');
         $client->webhooks->test('s', 'w1');
         $this->assertStringContainsString('/webhooks/w1/test', $backend->calls()[5]['url']);
+    }
+
+    public function testWebhookCreateForwardsPolymorphicFilterValuesVerbatim(): void
+    {
+        $backend = (new MockBackend())->on(201, ['id' => 'w1']);
+        $client = $backend->makeClient();
+        // The filter value is polymorphic on the wire: string (text fields),
+        // string list (id/enum fields), bool (boolean fields) + caseSensitive.
+        $filters = [
+            'conditions' => [
+                ['field' => 'sender', 'operator' => 'is', 'value' => ['123@c.us']],
+                ['field' => 'body', 'operator' => 'contains', 'value' => 'invoice', 'caseSensitive' => true],
+                ['field' => 'isGroup', 'operator' => 'is', 'value' => false],
+            ],
+        ];
+        $client->webhooks->create('s', ['url' => 'u', 'events' => ['message.received'], 'filters' => $filters]);
+        $this->assertSame(
+            ['url' => 'u', 'events' => ['message.received'], 'filters' => $filters],
+            $backend->lastCall()['body']
+        );
     }
 
     // ── Chats & Health ────────────────────────────────────────────────
@@ -218,6 +251,29 @@ class ResourcesTest extends TestCase
         $this->assertSame(['image' => ['url' => 'http://img'], 'recipients' => ['a@c.us'], 'caption' => 'c'], $backend->lastCall()['body']);
         $client->status->sendVideo('s', ['video' => ['url' => 'http://vid'], 'recipients' => ['a@c.us']]);
         $this->assertSame(['video' => ['url' => 'http://vid'], 'recipients' => ['a@c.us']], $backend->lastCall()['body']);
+    }
+
+    public function testStatusMediaReturnsStoredBytes(): void
+    {
+        $backend = (new MockBackend())->onRaw(200, 'PNG_BYTES', ['Content-Type' => 'image/png']);
+        $client = $backend->makeClient();
+        $media = $client->status->media('s', 'w1');
+        $call = $backend->lastCall();
+        $this->assertSame('GET', $call['method']);
+        $this->assertSame('/api/sessions/s/status/w1/media', $call['path']);
+        $this->assertSame('PNG_BYTES', $media['data']);
+        $this->assertSame('image/png', $media['contentType']);
+    }
+
+    public function testStatusMedia404MapsToNotFoundException(): void
+    {
+        $backend = (new MockBackend())->on(404, [
+            'statusCode' => 404,
+            'message' => 'Status media not found or expired',
+            'error' => 'Not Found',
+        ]);
+        $this->expectException(OpenWANotFoundException::class);
+        $backend->makeClient()->status->media('s', 'w1');
     }
 
     public function testHealthAndAuth(): void

--- a/sdk/python/openwa/_http.py
+++ b/sdk/python/openwa/_http.py
@@ -97,6 +97,30 @@ class HttpExecutor:
 
     def request(self, method: HttpMethod, path: str, *, query: Mapping[str, Any] | None = None, body: Any = None) -> Any:
         """Perform one request and return the parsed JSON (or ``None`` for 204)."""
+        res = self._send(method, path, query=query, body=body)
+        if res.status_code == 204 or not res.content:
+            return None
+        try:
+            return res.json()
+        except ValueError:
+            # A 2xx body that isn't JSON surfaces as text rather than a raw
+            # JSONDecodeError (mirrors the JS and PHP transports).
+            return res.text
+
+    def request_bytes(
+        self, method: HttpMethod, path: str, *, query: Mapping[str, Any] | None = None
+    ) -> tuple[bytes, str | None]:
+        """Perform one request for a non-JSON (binary) 2xx body — e.g. stored
+        status media — and return ``(body bytes, content type)``. A 204/empty
+        body yields empty bytes and ``None``."""
+        res = self._send(method, path, query=query, body=None)
+        if res.status_code == 204:
+            return b"", None
+        return res.content, res.headers.get("content-type")
+
+    def _send(self, method: HttpMethod, path: str, *, query: Mapping[str, Any] | None, body: Any) -> httpx.Response:
+        """Shared transport for :meth:`request` and :meth:`request_bytes`: builds
+        the URL, performs the request, and translates a non-2xx into a typed error."""
         url = build_url("", path, query)
         try:
             res = self._client.request(method, url, json=body if body is not None else None)
@@ -108,11 +132,4 @@ class HttpExecutor:
         if res.status_code >= 300:
             context = f"{method} {path}"
             raise OpenWAApiError.from_response(res.status_code, res.text, context)
-        if res.status_code == 204 or not res.content:
-            return None
-        try:
-            return res.json()
-        except ValueError:
-            # A 2xx body that isn't JSON surfaces as text rather than a raw
-            # JSONDecodeError (mirrors the JS and PHP transports).
-            return res.text
+        return res

--- a/sdk/python/openwa/resources/contacts.py
+++ b/sdk/python/openwa/resources/contacts.py
@@ -13,6 +13,7 @@ from ..types import (
     ContactPhoneResponse,
     ContactRecord,
     ProfilePictureResponse,
+    ProfilePicturesResponse,
     SuccessResult,
 )
 
@@ -41,6 +42,13 @@ class ContactsResource:
     def profile_picture(self, session_id: str, contact_id: str) -> ProfilePictureResponse:
         return self._http.request(
             "GET", f"/api/sessions/{quote_segment(session_id)}/contacts/{quote_segment(contact_id)}/profile-picture"
+        )
+
+    def profile_pictures(self, session_id: str, ids: list[str]) -> ProfilePicturesResponse:
+        """Batch-resolve profile picture URLs for up to 50 contacts in one request.
+        Returns a map of contact id → URL (None when a lookup fails)."""
+        return self._http.request(
+            "GET", f"/api/sessions/{quote_segment(session_id)}/contacts/profile-pictures", query={"ids": ",".join(ids)}
         )
 
     def phone(self, session_id: str, contact_id: str) -> ContactPhoneResponse:

--- a/sdk/python/openwa/resources/messages.py
+++ b/sdk/python/openwa/resources/messages.py
@@ -28,6 +28,7 @@ from ..types import (
     SendLocationRequest,
     SendAudioRequest,
     SendMediaRequest,
+    SendPollRequest,
     SendTemplateRequest,
     SendTextRequest,
     SuccessResult,
@@ -73,6 +74,10 @@ class MessagesResource:
 
     def send_template(self, session_id: str, body: SendTemplateRequest) -> MessageResponse:
         return self._http.request("POST", f"/api/sessions/{quote_segment(session_id)}/messages/send-template", body=body)
+
+    def send_poll(self, session_id: str, body: SendPollRequest) -> MessageResponse:
+        """Send a native WhatsApp poll (2–12 options)."""
+        return self._http.request("POST", f"/api/sessions/{quote_segment(session_id)}/messages/send-poll", body=body)
 
     def reply(self, session_id: str, body: ReplyMessageRequest) -> MessageResponse:
         return self._http.request("POST", f"/api/sessions/{quote_segment(session_id)}/messages/reply", body=body)

--- a/sdk/python/openwa/resources/status.py
+++ b/sdk/python/openwa/resources/status.py
@@ -13,6 +13,7 @@ from ..types import (
     SendImageStatusRequest,
     SendTextStatusRequest,
     SendVideoStatusRequest,
+    StatusMedia,
     StatusRecord,
     StatusResult,
 )
@@ -30,6 +31,13 @@ class StatusResource:
 
     def from_contact(self, session_id: str, contact_id: str) -> dict[str, list[StatusRecord]]:
         return self._http.request("GET", f"/api/sessions/{quote_segment(session_id)}/status/{quote_segment(contact_id)}")
+
+    def media(self, session_id: str, status_id: str) -> StatusMedia:
+        """Fetch the stored media bytes for a status update (404 when there is no stored media)."""
+        data, content_type = self._http.request_bytes(
+            "GET", f"/api/sessions/{quote_segment(session_id)}/status/{quote_segment(status_id)}/media"
+        )
+        return {"data": data, "contentType": content_type}
 
     def send_text(self, session_id: str, body: SendTextStatusRequest) -> StatusResult:
         return self._http.request("POST", f"/api/sessions/{quote_segment(session_id)}/status/send-text", body=body)

--- a/sdk/python/openwa/types.py
+++ b/sdk/python/openwa/types.py
@@ -94,9 +94,12 @@ class MessageResponse(TypedDict):
     timestamp: int
 
 
-class SendTextRequest(TypedDict):
+class SendTextRequest(TypedDict, total=False):
+    # chatId/text required; mentions optional.
     chatId: Jid
     text: str
+    # WIDs to @mention (e.g. ["62811@c.us"]). The text must also contain the @<number> token.
+    mentions: list[str]
 
 
 class SendMediaRequest(TypedDict, total=False):
@@ -176,6 +179,16 @@ class SendTemplateRequest(TypedDict, total=False):
     templateId: str
     templateName: str
     vars: dict[str, str]
+
+
+class SendPollRequest(TypedDict, total=False):
+    # chatId/name/options required; allowMultipleAnswers optional (default single choice).
+    chatId: Jid
+    # Poll question / title (max 255 chars).
+    name: str
+    # Options to vote on (WhatsApp allows between 2 and 12).
+    options: list[str]
+    allowMultipleAnswers: bool
 
 
 # ``from`` is a Python keyword, so use the functional TypedDict form.
@@ -385,6 +398,11 @@ class ProfilePictureResponse(TypedDict):
     url: str | None
 
 
+class ProfilePicturesResponse(TypedDict):
+    # Map of contact id → picture URL (None when the lookup failed).
+    pictures: dict[str, str | None]
+
+
 class ContactPhoneResponse(TypedDict):
     contactId: Jid
     phone: str | None
@@ -479,10 +497,14 @@ class SetProfilePictureRequest(TypedDict, total=False):
 # ── Webhook ───────────────────────────────────────────────────────
 
 
-class WebhookFilterCondition(TypedDict):
+class WebhookFilterCondition(TypedDict, total=False):
+    # field/operator/value required; caseSensitive optional (text fields only, default false).
     field: str
     operator: str
-    value: list[str]
+    # Polymorphic per field kind: a single string (text fields), a list of
+    # strings (id/idArray/enum fields), or a bool (boolean fields).
+    value: str | list[str] | bool
+    caseSensitive: bool
 
 
 class WebhookFilters(TypedDict):
@@ -587,6 +609,13 @@ class StatusResult(TypedDict, total=False):
     timestamp: str
     # ISO 8601 expiry timestamp.
     expiresAt: str
+
+
+class StatusMedia(TypedDict):
+    """A stored status media file: raw bytes plus the served content type."""
+
+    data: bytes
+    contentType: str | None
 
 
 class SendTextStatusRequest(TypedDict, total=False):

--- a/sdk/python/tests/test_sdk.py
+++ b/sdk/python/tests/test_sdk.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import httpx
 import pytest
 
 from openwa import OpenWAClient, OpenWAApiError, OpenWANotFoundError
@@ -123,6 +124,22 @@ class TestMessages:
         make_client(backend).messages.send_text("s1", {"chatId": "a@c.us", "text": "hi"})
         assert backend.last_call.url == "http://localhost:2785/api/sessions/s1/messages/send-text"
         assert backend.last_call.body == {"chatId": "a@c.us", "text": "hi"}
+
+    def test_send_text_forwards_mentions_verbatim(self):
+        backend = MockBackend().on("POST", "/send-text", body={"messageId": "m1", "timestamp": 1})
+        make_client(backend).messages.send_text("s1", {"chatId": "g@g.us", "text": "hi @628123", "mentions": ["628123@c.us"]})
+        assert backend.last_call.body == {"chatId": "g@g.us", "text": "hi @628123", "mentions": ["628123@c.us"]}
+
+    def test_send_poll_uses_send_poll_path(self):
+        backend = MockBackend().on("POST", "/send-poll", body={"messageId": "m2", "timestamp": 2})
+        res = make_client(backend).messages.send_poll("s1", {
+            "chatId": "a@c.us", "name": "Where?", "options": ["Park", "Beach"], "allowMultipleAnswers": True,
+        })
+        assert backend.last_call.url == "http://localhost:2785/api/sessions/s1/messages/send-poll"
+        assert backend.last_call.body == {
+            "chatId": "a@c.us", "name": "Where?", "options": ["Park", "Beach"], "allowMultipleAnswers": True,
+        }
+        assert res["messageId"] == "m2"
 
     @pytest.mark.parametrize("method,segment", [
         ("send_image", "send-image"),
@@ -419,6 +436,15 @@ class TestContacts:
         client.contacts.unblock("s", "a@c.us")
         assert backend.calls[-1].method == "DELETE"
 
+    def test_profile_pictures_batch_resolves_ids_query(self):
+        backend = MockBackend().on("GET", "/contacts/profile-pictures", body={
+            "pictures": {"a@c.us": "http://p/a", "b@c.us": None}
+        })
+        res = make_client(backend).contacts.profile_pictures("s", ["a@c.us", "b@c.us"])
+        assert backend.last_call.method == "GET"
+        assert backend.last_call.url == "http://localhost:2785/api/sessions/s/contacts/profile-pictures?ids=a%40c.us%2Cb%40c.us"
+        assert res["pictures"] == {"a@c.us": "http://p/a", "b@c.us": None}
+
 
 class TestWebhooks:
     def test_crud_test(self):
@@ -442,6 +468,18 @@ class TestWebhooks:
         client.webhooks.test("s", "w1")
         assert "/webhooks/w1/test" in backend.calls[-1].url
 
+    def test_create_forwards_polymorphic_filter_values_verbatim(self):
+        backend = MockBackend().on("POST", "/webhooks", body={"id": "w1"})
+        filters = {
+            "conditions": [
+                {"field": "sender", "operator": "is", "value": ["123@c.us"]},
+                {"field": "body", "operator": "contains", "value": "invoice", "caseSensitive": True},
+                {"field": "isGroup", "operator": "is", "value": False},
+            ]
+        }
+        make_client(backend).webhooks.create("s", {"url": "u", "events": ["message.received"], "filters": filters})
+        assert backend.last_call.body == {"url": "u", "events": ["message.received"], "filters": filters}
+
 
 class TestStatus:
     def test_send_image_video_forward_nested_media_body(self):
@@ -455,6 +493,22 @@ class TestStatus:
         assert backend.calls[-1].body == {"image": {"url": "http://img"}, "recipients": ["a@c.us"], "caption": "hi"}
         client.status.send_video("s", {"video": {"url": "http://vid"}, "recipients": ["a@c.us"]})
         assert backend.calls[-1].body == {"video": {"url": "http://vid"}, "recipients": ["a@c.us"]}
+
+    def test_media_fetches_stored_status_bytes(self):
+        backend = MockBackend()
+        backend.fallback = lambda _: httpx.Response(200, content=b"PNG_BYTES", headers={"content-type": "image/png"})
+        res = make_client(backend).status.media("s", "w1")
+        assert backend.last_call.method == "GET"
+        assert backend.last_call.url == "http://localhost:2785/api/sessions/s/status/w1/media"
+        assert res == {"data": b"PNG_BYTES", "contentType": "image/png"}
+
+    def test_media_404_maps_to_not_found_error(self):
+        backend = MockBackend()
+        backend.fallback = lambda _: httpx.Response(
+            404, content=b'{"statusCode": 404, "message": "Status media not found or expired"}'
+        )
+        with pytest.raises(OpenWANotFoundError):
+            make_client(backend).status.media("s", "w1")
 
 
 class TestChatsAndHealth:


### PR DESCRIPTION
## Summary

Four contract gaps between the five hand-written SDKs and the server's actual API surface, verified against `openapi.json` and the server DTOs/controllers. The server itself is untouched (`openapi.json` unchanged); this is SDK-only.

### Gap × SDK matrix

| Gap | JS | Python | Go | PHP | Java |
| --- | --- | --- | --- | --- | --- |
| 1. Webhook filter `value` too narrow (`string[]`-only) + missing `caseSensitive` | **fixed** (was `string[]`) | **fixed** (was `list[str]`) | already correct (`any` + `CaseSensitive`) | n/a (untyped array bodies; contract test added) | **fixed** (was `List<String>`) |
| 2. `mentions` missing on send-text | **fixed** | **fixed** | **fixed** | works already (untyped body; contract test added) | **fixed** |
| 3a. `POST messages/send-poll` unreachable | **added** | **added** | **added** | **added** | **added** |
| 3b. `GET contacts/profile-pictures` (batch) unreachable | **added** | **added** | **added** | **added** | **added** |
| 3c. `GET status/{statusId}/media` (binary) unreachable | **added** | **added** | **added** | **added** | **added** |
| 4. Non-JSON 2xx divergence | reference behavior (raw text / `null` for 204) | reference behavior | **fixed**: `Do` assigns raw body to `*[]byte`, falls back to raw text for `*string` | reference behavior | **fixed**: no more raw Gson exceptions — `String` targets get raw text, typed targets get a tidy `OpenWAError` |

### Details

- **Webhook filters** — the server accepts `value: string | string[] | boolean` plus an optional `caseSensitive` flag (`src/modules/webhook/filters/filter-types.ts`). JS/Python/Java modeled `value` as a string list only, so single-string text filters and boolean filters (e.g. `isGroup`) were inexpressible. Widened to the polymorphic shape; serialization is pass-through, and new tests pin the exact wire body for all three value shapes.
- **`mentions`** — `SendTextMessageDto.mentions?: string[]` is now modeled in every SDK's send-text request and forwarded verbatim (asserted in tests).
- **Three endpoints** — `send-poll` (`{chatId, name, options, allowMultipleAnswers?}` → `MessageResponse`), batch `profile-pictures` (`?ids=a,b` → `{pictures: {id: url|null}}`), and status `media` (raw bytes + `Content-Type`, 404 when none). The media endpoint required a binary path in each transport: JS `requestBytes` (`Uint8Array` + content type), Python `request_bytes` (`bytes` + content type), PHP `requestBinary`, Go `doRaw` (`StatusMedia{Data, ContentType}`), Java `requestBytes` (`BinaryResponse` record); the Java transport now carries the response as `byte[]` end-to-end so binary payloads can't be charset-corrupted.
- **README** — the `sdk/README.md` coverage table now lists `sendPoll`, `profilePictures`, and status `media`; the "all user-facing resources" claim is accurate again.

### How to test (per language)

| SDK | Command | Result |
| --- | --- | --- |
| JavaScript | `cd sdk/javascript && npm ci && npm test && npm run build && npm run smoke` | 58 tests + `tsc --noEmit` gate + dual-format smoke, all green |
| Python | `cd sdk/python && python -m pytest -q` (venv with `pip install -e ".[dev]"`) | 58 passed |
| Go | `cd sdk/go && go test -race ./... && go vet ./...` | ok, race-clean, vet-clean |
| PHP | `cd sdk/php && composer install && ./vendor/bin/phpunit` | OK (58 tests, 184 assertions) |
| Java | `cd sdk/java && mvn -B verify` | 153 tests, BUILD SUCCESS |

New tests everywhere follow the existing mock-transport pattern and assert the exact request URL, method, and body (plus the binary response shape for status media). Root `npm run check:versions` is green; no version numbers were touched.

### Risks

- **Java record signature changes** (additive, back-compatible): `SendTextRequest` and `WebhookFilterCondition` gained components but keep their old constructors as overloads, so existing call sites compile unchanged. `HttpResponseData.body` changed from `String` to `byte[]` — an internal transport type; the public resource surface is unaffected.
- **Go `Do` escape hatch**: a `*string` target now receives raw text instead of an error when a 2xx body isn't JSON, and `*[]byte` always takes the body verbatim. JSON bodies decode exactly as before.
- **Python `SendTextRequest`/`WebhookFilterCondition` TypedDicts** are now `total=False` with required keys documented in comments — the file's existing idiom for mixed required/optional shapes; runtime behavior is unchanged.
- No server changes, no new dependencies, no version bumps.
