### PR TITLE
fix(bootstrap): exit non-zero when the HTTP bind fails after full init

### DIFF
--- a/src/config/bootstrap-fatal.spec.ts
+++ b/src/config/bootstrap-fatal.spec.ts
@@ -1,0 +1,99 @@
+import { runBootstrapOrExit, BootstrapFatalDeps } from './bootstrap-fatal';
+
+describe('runBootstrapOrExit', () => {
+  const makeDeps = () => {
+    const logs: Array<[string, string | undefined]> = [];
+    const exitCalls: number[] = [];
+    const deps: BootstrapFatalDeps = {
+      logger: {
+        error: (m: string, d?: string) => {
+          logs.push([m, d]);
+        },
+      },
+      exit: (code: number) => {
+        exitCalls.push(code);
+      },
+    };
+    return { deps, logs, exitCalls };
+  };
+
+  it('logs and exits(1) when bootstrap rejects with a bind failure (EADDRINUSE from listen())', async () => {
+    const { deps, logs, exitCalls } = makeDeps();
+    const err = Object.assign(new Error('listen EADDRINUSE: address already in use 0.0.0.0:2785'), {
+      code: 'EADDRINUSE',
+    });
+    const closeApp = jest.fn().mockResolvedValue(undefined);
+
+    await runBootstrapOrExit(() => Promise.reject(err), { ...deps, closeApp });
+
+    expect(exitCalls).toEqual([1]);
+    expect(logs).toHaveLength(1);
+    expect(logs[0][0]).toMatch(/Fatal error during bootstrap/);
+    expect(logs[0][1]).toContain('EADDRINUSE'); // err.stack
+    // Teardown ran BEFORE the exit so sessions/connections don't outlive the process.
+    expect(closeApp).toHaveBeenCalledTimes(1);
+  });
+
+  it('never logs, tears down, or exits on a successful boot', async () => {
+    const { deps, logs, exitCalls } = makeDeps();
+    const closeApp = jest.fn().mockResolvedValue(undefined);
+
+    await runBootstrapOrExit(() => Promise.resolve(), { ...deps, closeApp });
+
+    expect(exitCalls).toEqual([]);
+    expect(logs).toEqual([]);
+    expect(closeApp).not.toHaveBeenCalled();
+  });
+
+  it('still exits(1) when the teardown rejects', async () => {
+    const { deps, exitCalls } = makeDeps();
+    const closeApp = jest.fn().mockRejectedValue(new Error('close wedged'));
+
+    await runBootstrapOrExit(() => Promise.reject(new Error('boom')), { ...deps, closeApp });
+
+    expect(exitCalls).toEqual([1]);
+  });
+
+  it('still exits(1) when the teardown hangs past the bound', async () => {
+    const { deps, exitCalls } = makeDeps();
+    const closeApp = jest.fn(() => new Promise<void>(resolve => setTimeout(resolve, 250)));
+
+    await runBootstrapOrExit(() => Promise.reject(new Error('boom')), { ...deps, closeApp, closeTimeoutMs: 5 });
+
+    expect(exitCalls).toEqual([1]);
+    expect(closeApp).toHaveBeenCalledTimes(1);
+  });
+
+  it('still exits(1) when the logger throws — the exit is the guarantee', async () => {
+    const { deps, exitCalls } = makeDeps();
+    deps.logger = {
+      error: () => {
+        throw new Error('logger is down');
+      },
+    };
+
+    await runBootstrapOrExit(() => Promise.reject(new Error('boom')), deps);
+
+    expect(exitCalls).toEqual([1]);
+  });
+
+  it('stringifies a non-Error rejection without throwing', async () => {
+    const { deps, logs, exitCalls } = makeDeps();
+
+    // Deliberately a non-Error rejection: the handler must stringify it and still exit.
+    // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+    await runBootstrapOrExit(() => Promise.reject('a bare string'), deps);
+
+    expect(exitCalls).toEqual([1]);
+    expect(logs[0][1]).toContain('a bare string');
+  });
+
+  it('skips teardown when no closeApp is provided (failure before app creation)', async () => {
+    const { deps, logs, exitCalls } = makeDeps();
+
+    await runBootstrapOrExit(() => Promise.reject(new Error('bad secrets')), deps);
+
+    expect(exitCalls).toEqual([1]);
+    expect(logs[0][1]).toContain('bad secrets');
+  });
+});

--- a/src/config/bootstrap-fatal.ts
+++ b/src/config/bootstrap-fatal.ts
@@ -1,0 +1,73 @@
+/**
+ * Fatal-bootstrap handling: log, best-effort teardown, then a real exit.
+ *
+ * Extracted from `main.ts` so the failure contract is unit-tested without booting the app.
+ *
+ * Why a real `process.exit(1)` instead of only setting `process.exitCode`: Nest's `listen()` runs the
+ * FULL module init (sessions, Redis, Postgres, Chromium) before binding the port. If the bind then
+ * fails (EADDRINUSE), setting `exitCode` alone leaves the event loop held open by those very handles —
+ * the process becomes a zombie that serves no HTTP yet keeps the WhatsApp sessions running, and Docker's
+ * `restart: unless-stopped` never fires because the container stays "running". Exiting lets the
+ * orchestrator restart us onto a free port (or surface the conflict), and Puppeteer's own `exit`
+ * handlers kill the browser children as the process goes down.
+ */
+
+/** Minimal structured-logger surface (satisfied by createLogger()'s result). */
+export interface BootstrapFatalLogger {
+  error: (message: string, detail?: string) => void;
+}
+
+export interface BootstrapFatalDeps {
+  logger: BootstrapFatalLogger;
+  /**
+   * Best-effort teardown of whatever the app initialised before the failure (engine sessions, Redis/pg
+   * connections). Bounded by `closeTimeoutMs` — a wedged teardown must never block the exit.
+   */
+  closeApp?: () => Promise<unknown>;
+  /** Injectable for tests; defaults to `process.exit`. */
+  exit?: (code: number) => void;
+  /** Bound on `closeApp()`. Defaults to `DEFAULT_BOOTSTRAP_CLOSE_TIMEOUT_MS`. */
+  closeTimeoutMs?: number;
+}
+
+export const DEFAULT_BOOTSTRAP_CLOSE_TIMEOUT_MS = 5000;
+
+/**
+ * Run `bootstrap()`; on ANY rejection (e.g. `listen()` failing with EADDRINUSE after full init), log the
+ * fatal error, run the bounded best-effort teardown, and exit non-zero. A successful boot returns
+ * normally and never touches `exit`.
+ *
+ * Every step is guarded: a throwing logger or teardown degrades to losing that one step while the exit
+ * still proceeds — the exit is the guarantee the orchestrator relies on.
+ */
+export async function runBootstrapOrExit(bootstrap: () => Promise<unknown>, deps: BootstrapFatalDeps): Promise<void> {
+  try {
+    await bootstrap();
+    return;
+  } catch (err) {
+    try {
+      deps.logger.error(
+        'Fatal error during bootstrap — process will exit',
+        err instanceof Error ? err.stack : String(err),
+      );
+    } catch {
+      /* never mask the original fatal error */
+    }
+  }
+
+  if (deps.closeApp) {
+    try {
+      const closeApp = deps.closeApp;
+      await Promise.race([
+        Promise.resolve().then(() => closeApp()),
+        new Promise<void>(resolve => {
+          setTimeout(resolve, deps.closeTimeoutMs ?? DEFAULT_BOOTSTRAP_CLOSE_TIMEOUT_MS).unref();
+        }),
+      ]);
+    } catch {
+      /* best-effort teardown — the exit below is what matters */
+    }
+  }
+
+  (deps.exit ?? ((code: number) => process.exit(code)))(1);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@
 // webhook Worker's @Processor connection) see the configured values rather than pre-dotenv defaults.
 import './config/load-env';
 import { NestFactory } from '@nestjs/core';
-import { ShutdownSignal } from '@nestjs/common';
+import { INestApplication, ShutdownSignal } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { SwaggerModule } from '@nestjs/swagger';
 import helmet from 'helmet';
@@ -12,6 +12,7 @@ import { ShutdownService } from './common/services/shutdown.service';
 import { LoggerService, LogLevel, createLogger } from './common/services/logger.service';
 import { createSwaggerConfig, exemptPublicOperations } from './config/swagger.config';
 import { registerUncaughtExceptionMonitor } from './config/process-error-monitor';
+import { runBootstrapOrExit } from './config/bootstrap-fatal';
 import { applyHttpTimeouts, HttpTimeoutConfig, HttpTimeoutSink } from './config/http-timeouts';
 import { applyGlobalValidation } from './config/app-validation';
 import { requestContextMiddleware } from './common/middleware/request-context.middleware';
@@ -31,6 +32,11 @@ import { Request, Response, NextFunction, json, urlencoded } from 'express';
 import { randomBytes } from 'crypto';
 import { readFileSync } from 'fs';
 import { extname, join } from 'path';
+
+// The created app, exposed at module scope so the fatal handler below can run a best-effort teardown
+// (engine sessions, Redis/pg) when bootstrap fails AFTER NestFactory.create succeeded — notably a
+// listen() bind failure (EADDRINUSE), where full init already ran.
+let appInstance: INestApplication | undefined;
 
 async function bootstrap() {
   // Apply the operator-configured log verbosity (LOG_LEVEL) before anything logs. Unset/invalid → INFO.
@@ -82,6 +88,7 @@ async function bootstrap() {
 
   // Disable Nest's default body parser so we can set an explicit size cap below.
   const app = await NestFactory.create(AppModule, { bodyParser: false });
+  appInstance = app;
 
   // Cap request body size (DoS hardening). Media sends carry base64 in the JSON body,
   // so the default is generous; tune with BODY_SIZE_LIMIT.
@@ -334,7 +341,13 @@ async function bootstrap() {
   }
 }
 
-bootstrap().catch((err: unknown) => {
-  createLogger('Bootstrap').error('Fatal error during bootstrap', err instanceof Error ? err.stack : String(err));
-  process.exitCode = 1;
+// A failed bootstrap MUST terminate the process with a non-zero code, not just set `process.exitCode`:
+// listen() runs the FULL init (sessions, Redis, pg, Chromium) before binding the port, so a bind failure
+// (EADDRINUSE) would otherwise leave a zombie process — no HTTP port, yet still holding the event loop
+// open and running WhatsApp sessions, invisible to Docker's restart policy. runBootstrapOrExit logs the
+// failure, runs a bounded best-effort app.close() teardown, then exits(1); a successful boot returns
+// without touching exit. Puppeteer's own `exit` handlers kill any browser children still up.
+void runBootstrapOrExit(bootstrap, {
+  logger: createLogger('Bootstrap'),
+  closeApp: () => (appInstance ? appInstance.close() : Promise.resolve()),
 });


### PR DESCRIPTION
## Problem

`bootstrap()` in `src/main.ts` ends with a `catch` that only sets `process.exitCode = 1`. That is fine for failures that leave nothing running — but Nest's `listen()` runs the **full** module init (WhatsApp sessions, Redis, Postgres, Chromium) **before** binding the port. When the bind then fails (e.g. `EADDRINUSE` because another instance or a stale process holds the port):

- the rejection reaches the catch, which sets `exitCode` and returns — but `exitCode` only takes effect when the event loop drains, and the handles init just opened (Redis/pg connections, engine sessions, Chromium) keep it alive **forever**;
- the result is a zombie process: no HTTP port is served, yet the WhatsApp sessions keep running, so no health check or orchestrator sees a crash;
- Docker's `restart: unless-stopped` never fires, because the container stays "running" — recovery requires external intervention, and a second instance started manually fails the same way on the same port.

## Fix

Extract the bootstrap failure path into a small, unit-tested helper, `src/config/bootstrap-fatal.ts` (`runBootstrapOrExit`), following the same extraction pattern as the other bootstrap helpers under `src/config/`. On any bootstrap rejection it:

1. logs the fatal error through the structured logger (message + stack, guarded so a broken logger can't mask the original error);
2. runs a **bounded, best-effort `app.close()`** teardown of whatever init already started (engine sessions, Redis/pg) — the timeout (5 s default, injectable) guarantees a wedged teardown can never block the exit; any browser children still up after that are reaped by Puppeteer's own `exit` handlers;
3. calls `process.exit(1)` for real, so the orchestrator's restart policy can recover the instance.

The app reference is exposed at module scope in `main.ts` so the fatal handler can close it when the failure happens after `NestFactory.create` (notably the failed `listen()`).

Explicitly unchanged:

- **Successful boot** — returns normally, `exit` is never touched (covered by a test).
- **Graceful shutdown** — `ShutdownService` and the SIGTERM/SIGINT drain path are untouched.

## Tests

New `src/config/bootstrap-fatal.spec.ts` (7 cases):

- `listen()`-style rejection carrying `EADDRINUSE` → error logged (stack includes the code) and `exit(1)` called, teardown ran before exit;
- successful boot → no log, no teardown, no exit;
- teardown rejects / teardown hangs past the bound → still exits(1);
- logger throws → still exits(1);
- non-Error rejection is stringified without throwing;
- failure before app creation (no `closeApp`) → still exits(1).

## Verification

- `npx jest src/config` — 11 suites / 118 tests pass
- `npx jest --config ./test/jest-e2e.json test/app.e2e-spec.ts` — 5/5 pass
- `npx eslint src/main.ts src/config` — clean
- `npm run build` — no errors

## Risks

- The process now exits immediately on bootstrap failure instead of lingering — that is the intended behavioral change; anything that (incorrectly) relied on the zombie staying up to keep sessions alive will instead see container restarts until the port conflict is resolved, which is exactly the failure visibility we want.
- `app.close()` on a half-initialized app is exercised best-effort and bounded; a hang there degrades to the 5 s delay before exit, never to a blocked exit.
