### PR TITLE
fix(auth): serialize the last-admin check with its mutation to close the lockout race

### DIFF
--- a/src/modules/auth/auth.service.spec.ts
+++ b/src/modules/auth/auth.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { UnauthorizedException, NotFoundException } from '@nestjs/common';
+import { UnauthorizedException, NotFoundException, ConflictException } from '@nestjs/common';
 import { createHash, createHmac } from 'crypto';
 import { AuthService, resolveSeedApiKey, bannerKeyLine } from './auth.service';
 import { ApiKey, ApiKeyRole } from './entities/api-key.entity';
@@ -347,6 +347,105 @@ describe('AuthService', () => {
       await expect(service.revoke('uuid-1')).rejects.toThrow(/last active admin/i);
       expect(repository.save).not.toHaveBeenCalled();
       expect(key.isActive).toBe(true);
+    });
+  });
+
+  // ── last-admin guard under concurrency ─────────────────────────────
+
+  describe('last-admin guard under concurrency', () => {
+    /**
+     * In-memory stand-in for the DB: the set of currently usable admin key ids. count() reports
+     * OTHER usable admins (the guard's query always excludes the target, itself a live usable
+     * admin at check time); save()/remove() apply the capability change synchronously at call
+     * time. Interleaving is then driven purely by promise resolution order, so each scenario
+     * below has a deterministic outcome regardless of which request runs its section first.
+     */
+    function setupLiveAdmins(...ids: string[]): void {
+      const liveAdmins = new Set(ids);
+      const keys = new Map(ids.map(id => [id, createMockApiKey({ id, role: ApiKeyRole.ADMIN })]));
+      (repository.findOne as jest.Mock).mockImplementation((options: { where: { id: string } }) =>
+        Promise.resolve(keys.get(options.where.id) ?? null),
+      );
+      (repository.count as jest.Mock).mockImplementation(() => Promise.resolve(liveAdmins.size - 1));
+      (repository.remove as jest.Mock).mockImplementation((key: ApiKey) => {
+        liveAdmins.delete(key.id);
+        return Promise.resolve(key);
+      });
+      (repository.save as jest.Mock).mockImplementation((key: ApiKey) => {
+        if (key.role === ApiKeyRole.ADMIN && key.isActive) {
+          liveAdmins.add(key.id);
+        } else {
+          liveAdmins.delete(key.id);
+        }
+        return Promise.resolve(key);
+      });
+    }
+
+    const outcomes = (results: PromiseSettledResult<unknown>[]) => ({
+      succeeded: results.filter(r => r.status === 'fulfilled'),
+      conflicts: results.filter(r => r.status === 'rejected' && r.reason instanceof ConflictException),
+    });
+
+    it('rejects exactly one of two concurrent deletes against the last two admins', async () => {
+      setupLiveAdmins('admin-a', 'admin-b');
+
+      // Without serialization both counts run before either remove commits and both deletes pass.
+      const results = await Promise.allSettled([service.delete('admin-a'), service.delete('admin-b')]);
+
+      const { succeeded, conflicts } = outcomes(results);
+      expect(succeeded).toHaveLength(1);
+      expect(conflicts).toHaveLength(1);
+      expect(repository.remove).toHaveBeenCalledTimes(1); // one admin survives — no lockout
+    });
+
+    it('rejects exactly one of a concurrent demote and revoke against the last two admins', async () => {
+      setupLiveAdmins('admin-a', 'admin-b');
+
+      const results = await Promise.allSettled([
+        service.update('admin-a', { role: ApiKeyRole.OPERATOR }),
+        service.revoke('admin-b'),
+      ]);
+
+      const { succeeded, conflicts } = outcomes(results);
+      expect(succeeded).toHaveLength(1);
+      expect(conflicts).toHaveLength(1);
+      // The loser's write never happened: exactly one capability-stripping write in total.
+      const strippingSaves = (repository.save as jest.Mock).mock.calls.filter(
+        ([key]: [ApiKey]) => key.role !== ApiKeyRole.ADMIN || key.isActive === false,
+      );
+      expect((repository.remove as jest.Mock).mock.calls.length + strippingSaves.length).toBe(1);
+    });
+
+    it('lets concurrent deletes proceed when another usable admin remains', async () => {
+      setupLiveAdmins('admin-a', 'admin-b', 'admin-c');
+
+      const results = await Promise.allSettled([service.delete('admin-a'), service.delete('admin-b')]);
+
+      const { succeeded, conflicts } = outcomes(results);
+      expect(succeeded).toHaveLength(2);
+      expect(conflicts).toHaveLength(0);
+      expect(repository.remove).toHaveBeenCalledTimes(2);
+    });
+
+    it('keeps non-admin mutations and benign admin updates off the mutex (no contention)', async () => {
+      const lockRun = jest.spyOn(
+        (service as unknown as { adminCapabilityLock: { run: (...args: unknown[]) => unknown } }).adminCapabilityLock,
+        'run',
+      );
+      const operatorKey = createMockApiKey({ id: 'op-1', role: ApiKeyRole.OPERATOR });
+      const adminKey = createMockApiKey({ id: 'adm-1', role: ApiKeyRole.ADMIN });
+      (repository.findOne as jest.Mock).mockImplementation((options: { where: { id: string } }) =>
+        Promise.resolve(options.where.id === 'op-1' ? operatorKey : adminKey),
+      );
+      (repository.remove as jest.Mock).mockImplementation((key: ApiKey) => Promise.resolve(key));
+      (repository.save as jest.Mock).mockImplementation((key: ApiKey) => Promise.resolve(key));
+
+      await service.delete('op-1'); // non-admin delete
+      await service.revoke('op-1'); // non-admin revoke
+      await service.update('op-1', { role: ApiKeyRole.VIEWER }); // demote of a non-admin
+      await service.update('adm-1', { name: 'renamed' }); // benign update of an admin
+
+      expect(lockRun).not.toHaveBeenCalled();
     });
   });
 

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -12,6 +12,7 @@ import { ApiKey, ApiKeyRole } from './entities/api-key.entity';
 import { CreateApiKeyDto, UpdateApiKeyDto } from './dto';
 import { createLogger } from '../../common/services/logger.service';
 import { EventsGateway, type ApiKeyEvictionReason } from '../events/events.gateway';
+import { KeyedAsyncLock } from '../integration/ordering-lock';
 
 const API_KEY_FILE = join(process.cwd(), 'data', '.api-key');
 
@@ -53,6 +54,19 @@ export class AuthService implements OnModuleInit {
   private static readonly STAT_FLUSH_INTERVAL_MS = 60_000;
   /** keyId -> usage increments observed but not yet persisted (flushed on the next windowed write). */
   private readonly pendingUsage = new Map<string, number>();
+
+  /**
+   * Serializes every last-usable-admin check with the mutation it guards, in ONE critical section.
+   * The check is check-then-act across awaits: without serialization, two concurrent requests that
+   * demote/delete/revoke the last two admins both pass the check before either writes — leaving zero
+   * usable admins, a total management lockout (the boot seed only fires on an EMPTY table, not on
+   * zero admins). The guarded invariant is global ("count of OTHER usable admins"), so the lock key
+   * must be a single global key too: keying per target key id would serialize nothing — the racing
+   * requests target DIFFERENT keys. An in-process mutex is sufficient under the single-process
+   * deployment contract.
+   */
+  private readonly adminCapabilityLock = new KeyedAsyncLock();
+  private static readonly ADMIN_CAPABILITY_LOCK_KEY = 'admin-capability';
 
   constructor(
     @InjectRepository(ApiKey, 'main')
@@ -176,50 +190,68 @@ export class AuthService implements OnModuleInit {
     const removesOrSchedulesLastAdmin =
       (dto.role !== undefined && dto.role !== ApiKeyRole.ADMIN) ||
       (dto.expiresAt !== undefined && dto.expiresAt !== null);
-    if (removesOrSchedulesLastAdmin) {
-      await this.assertNotLastUsableAdmin(apiKey);
-    }
 
-    // Capture the authorization-relevant fields BEFORE applying the change. Only a change to role,
-    // allowedIps, allowedSessions, or expiry can widen or restrict what an already-connected WebSocket
-    // socket may see, so only those trigger eviction of live /events sockets — a benign rename must
-    // NOT disconnect clients. REST enforces the new state immediately; without eviction a live socket
-    // keeps streaming events for sessions/IPs the key just lost until it resubscribes or drops.
-    const before = {
-      role: apiKey.role,
-      allowedIps: apiKey.allowedIps,
-      allowedSessions: apiKey.allowedSessions,
-      expiresAt: apiKey.expiresAt,
+    const applyAndSave = async (): Promise<ApiKey> => {
+      if (removesOrSchedulesLastAdmin) {
+        await this.assertNotLastUsableAdmin(apiKey);
+      }
+
+      // Capture the authorization-relevant fields BEFORE applying the change. Only a change to role,
+      // allowedIps, allowedSessions, or expiry can widen or restrict what an already-connected WebSocket
+      // socket may see, so only those trigger eviction of live /events sockets — a benign rename must
+      // NOT disconnect clients. REST enforces the new state immediately; without eviction a live socket
+      // keeps streaming events for sessions/IPs the key just lost until it resubscribes or drops.
+      const before = {
+        role: apiKey.role,
+        allowedIps: apiKey.allowedIps,
+        allowedSessions: apiKey.allowedSessions,
+        expiresAt: apiKey.expiresAt,
+      };
+
+      if (dto.name) apiKey.name = dto.name;
+      if (dto.role) apiKey.role = dto.role;
+      if (dto.allowedIps !== undefined) apiKey.allowedIps = dto.allowedIps;
+      if (dto.allowedSessions !== undefined) apiKey.allowedSessions = dto.allowedSessions;
+      if (dto.expiresAt !== undefined) apiKey.expiresAt = dto.expiresAt ? new Date(dto.expiresAt) : null;
+
+      const saved = await this.apiKeyRepository.save(apiKey);
+
+      // Compare membership, not order: a pure reorder of allowedIps/allowedSessions is a no-op for the
+      // .includes()-based enforcement, so sort before stringify to avoid a spurious eviction on a reorder.
+      const ordered = (v: string[] | null) => (v ? [...v].sort() : v);
+      const authzChanged =
+        saved.role !== before.role ||
+        saved.expiresAt?.getTime() !== before.expiresAt?.getTime() ||
+        JSON.stringify(ordered(saved.allowedIps)) !== JSON.stringify(ordered(before.allowedIps)) ||
+        JSON.stringify(ordered(saved.allowedSessions)) !== JSON.stringify(ordered(before.allowedSessions));
+      if (authzChanged) {
+        this.evictActiveSockets(id, 'authorization_changed');
+      }
+      return saved;
     };
 
-    if (dto.name) apiKey.name = dto.name;
-    if (dto.role) apiKey.role = dto.role;
-    if (dto.allowedIps !== undefined) apiKey.allowedIps = dto.allowedIps;
-    if (dto.allowedSessions !== undefined) apiKey.allowedSessions = dto.allowedSessions;
-    if (dto.expiresAt !== undefined) apiKey.expiresAt = dto.expiresAt ? new Date(dto.expiresAt) : null;
-
-    const saved = await this.apiKeyRepository.save(apiKey);
-
-    // Compare membership, not order: a pure reorder of allowedIps/allowedSessions is a no-op for the
-    // .includes()-based enforcement, so sort before stringify to avoid a spurious eviction on a reorder.
-    const ordered = (v: string[] | null) => (v ? [...v].sort() : v);
-    const authzChanged =
-      saved.role !== before.role ||
-      saved.expiresAt?.getTime() !== before.expiresAt?.getTime() ||
-      JSON.stringify(ordered(saved.allowedIps)) !== JSON.stringify(ordered(before.allowedIps)) ||
-      JSON.stringify(ordered(saved.allowedSessions)) !== JSON.stringify(ordered(before.allowedSessions));
-    if (authzChanged) {
-      this.evictActiveSockets(id, 'authorization_changed');
-    }
-    return saved;
+    // Run check+write inside the shared critical section ONLY when this update can strip the last
+    // usable admin; every other update (rename, promotion, non-admin keys) stays lock-free.
+    return removesOrSchedulesLastAdmin && AuthService.isUsableAdmin(apiKey)
+      ? this.adminCapabilityLock.run(AuthService.ADMIN_CAPABILITY_LOCK_KEY, applyAndSave)
+      : applyAndSave();
   }
 
   async delete(id: string): Promise<void> {
     const apiKey = await this.findOne(id);
-    await this.assertNotLastUsableAdmin(apiKey);
-    // Drop any un-flushed usage accumulator so a deleted key leaves nothing behind in the Map.
-    this.pendingUsage.delete(id);
-    await this.apiKeyRepository.remove(apiKey);
+    const removeKey = async (): Promise<void> => {
+      await this.assertNotLastUsableAdmin(apiKey);
+      // Drop any un-flushed usage accumulator so a deleted key leaves nothing behind in the Map.
+      this.pendingUsage.delete(id);
+      await this.apiKeyRepository.remove(apiKey);
+    };
+    // A target that is not a usable admin can skip the lock: it is not counted as one, so removing
+    // it cannot strand the system — some other usable admin (or none at all) exists independently.
+    if (AuthService.isUsableAdmin(apiKey)) {
+      await this.adminCapabilityLock.run(AuthService.ADMIN_CAPABILITY_LOCK_KEY, removeKey);
+    } else {
+      await removeKey();
+    }
     this.evictActiveSockets(id, 'deleted');
     this.logger.log(`API key deleted: ${apiKey.name}`, {
       keyId: id,
@@ -229,23 +261,30 @@ export class AuthService implements OnModuleInit {
 
   async revoke(id: string): Promise<ApiKey> {
     const apiKey = await this.findOne(id);
-    await this.assertNotLastUsableAdmin(apiKey);
-    // A revoked key fails validation before its next flush, so its accumulator would orphan —
-    // drop it here.
-    this.pendingUsage.delete(id);
-    apiKey.isActive = false;
-    const saved = await this.apiKeyRepository.save(apiKey);
+    const revokeKey = async (): Promise<ApiKey> => {
+      await this.assertNotLastUsableAdmin(apiKey);
+      // A revoked key fails validation before its next flush, so its accumulator would orphan —
+      // drop it here.
+      this.pendingUsage.delete(id);
+      apiKey.isActive = false;
+      return this.apiKeyRepository.save(apiKey);
+    };
+    const saved = AuthService.isUsableAdmin(apiKey)
+      ? await this.adminCapabilityLock.run(AuthService.ADMIN_CAPABILITY_LOCK_KEY, revokeKey)
+      : await revokeKey();
     // Kick any WebSocket connections already authenticated with this key: without this, a revoked
     // key keeps receiving events on already-subscribed sockets until they happen to disconnect.
     this.evictActiveSockets(id, 'revoked');
     return saved;
   }
 
+  private static isUsableAdmin(key: ApiKey, now = new Date()): boolean {
+    return key.role === ApiKeyRole.ADMIN && key.isActive && (!key.expiresAt || key.expiresAt > now);
+  }
+
   private async assertNotLastUsableAdmin(target: ApiKey): Promise<void> {
     const now = new Date();
-    const targetIsUsableAdmin =
-      target.role === ApiKeyRole.ADMIN && target.isActive && (!target.expiresAt || target.expiresAt > now);
-    if (!targetIsUsableAdmin) return;
+    if (!AuthService.isUsableAdmin(target, now)) return;
 
     const otherUsableAdmins = await this.apiKeyRepository.count({
       where: [


### PR DESCRIPTION
## Problem

`AuthService.assertNotLastUsableAdmin` guards every path that strips admin capability (role demotion in `update`, `delete`, `revoke`, scheduling expiry), but it is check-then-act **across an `await`**: the "other usable admins" count and the subsequent write are separate steps. Two concurrent requests that demote/delete/revoke the last two admin keys both run the count before either write commits, both see one remaining admin, both pass, and both write — leaving **zero usable admins**. That is a total management lockout: the first-boot seed only fires when the key table is completely empty, so no new admin is ever minted and every admin-scoped endpoint stays unreachable until manual DB intervention.

## Fix

Serialize the check together with the mutation it guards in one critical section, reusing the existing `KeyedAsyncLock` (`src/modules/integration/ordering-lock.ts`):

- A single `adminCapabilityLock` instance on `AuthService` with one **global** lock key. The guarded invariant is global ("count of OTHER usable admins"), so keying per target key id would serialize nothing — the racing requests target *different* keys. Global keying is the only correct granularity; it is documented on the field.
- `update` runs the guard + field application + `save` inside the lock only when the DTO actually reduces admin capability (demote or scheduling an expiry) **and** the target is currently a usable admin. Renames, promotions, scope changes, and updates to non-admin keys stay lock-free.
- `delete`/`revoke` enter the lock only when the target is a usable admin. A non-usable-admin target can safely skip it: it is not counted as a usable admin, so removing it cannot strand the system — some other usable admin (or none at all) exists independently of it.
- The usability predicate is extracted unchanged into `isUsableAdmin` and shared by the guard and the lock decision. Sequential single-request behavior is byte-for-byte identical: same guard condition, same write order, same eviction and logging side effects.

Why an in-process mutex and not a DB transaction: the deployment contract is single-process, and the main store runs on better-sqlite3 — a synchronous, single-connection driver whose TypeORM query-runner transactions do not give check-then-act atomicity across concurrent async requests (the statements still interleave per-statement). The mutex is the smallest serialization point that actually closes the race, and it carries no DB-level risk.

## Tests

New `last-admin guard under concurrency` block in `auth.service.spec.ts`, driven by an in-memory set of live admins so interleaving is deterministic via promise resolution order:

- two concurrent `delete`s against the last two admins → exactly one succeeds, the other gets 409, `remove` runs once (no lockout);
- concurrent `update` demote + `revoke` against the last two admins → exactly one capability-stripping write total, the loser gets 409;
- two concurrent `delete`s with a third usable admin → both succeed (no over-rejection);
- non-admin delete/revoke/demote and a benign admin rename never touch the mutex (no unnecessary contention).

Negative control: with the service change stashed, the first two tests fail (both requests pass the check) — they discriminate the race.

## Verification

- `npx jest src/modules/auth` — 8 suites, 112 tests, all pass.
- `npx jest --config ./test/jest-e2e.json test/session-scope.e2e-spec.ts` — 14 tests, all pass.
- `npx eslint src/modules/auth` — clean.
- `npm run build` — clean.

## Risks

- The mutex is per-process by design; running multiple API processes against the same DB would re-open the race (already outside the deployment contract, same as the ingress ordering lock).
- Admin-capability mutations now serialize against each other; these are rare management operations, so throughput impact is negligible, and all other auth paths (including every `validateApiKey` call) are untouched.
