### PR TITLE
fix(auth): flush pending usage on shutdown and audit the queue-board boundary

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -18,6 +18,7 @@
                 "api_key_deleted",
                 "api_key_auth_failed",
                 "rate_limit_exceeded",
+                "queue_board_mutated",
                 "session_created",
                 "session_started",
                 "session_stopped",

--- a/src/common/security/bull-board-auth.middleware.spec.ts
+++ b/src/common/security/bull-board-auth.middleware.spec.ts
@@ -4,6 +4,8 @@ import { Request, Response } from 'express';
 import { BullBoardAuthMiddleware } from './bull-board-auth.middleware';
 import { AuthService } from '../../modules/auth/auth.service';
 import { ApiKeyRole } from '../../modules/auth/entities/api-key.entity';
+import { AuditService } from '../../modules/audit/audit.service';
+import { AuditAction } from '../../modules/audit/entities/audit-log.entity';
 import { KeyRateLimiter } from '../../modules/mcp/mcp-rate-limit';
 
 const res = {} as Response;
@@ -111,6 +113,7 @@ describe('BullBoardAuthMiddleware pre-auth IP throttle (mirrors MCP createIpThro
     return new BullBoardAuthMiddleware(
       authService as unknown as AuthService,
       configService as unknown as ConfigService,
+      undefined, // no audit service needed for the throttle tests
       new KeyRateLimiter(ipLimit, 60_000),
     );
   };
@@ -185,5 +188,154 @@ describe('BullBoardAuthMiddleware pre-auth IP throttle (mirrors MCP createIpThro
     const next = jest.fn();
     await defaultMw.use(reqFromIp('203.0.113.9', { 'x-api-key': 'admin' }), res, next);
     expect(next).toHaveBeenCalledWith(); // allowed
+  });
+});
+
+// The Bull Board mount is raw Express, so the Nest guard's audit trail never sees it. The middleware
+// now mirrors it at the boundary: 401/403 → WARN API_KEY_AUTH_FAILED; an authenticated non-GET/HEAD
+// request → INFO QUEUE_BOARD_MUTATED. A throttled 429 is NOT audited — the pre-auth IP limiter is the
+// flood bound for both the credential check and the audit table.
+describe('BullBoardAuthMiddleware audit trail', () => {
+  let mw: BullBoardAuthMiddleware;
+  let authService: { validateApiKey: jest.Mock; hasPermission: jest.Mock };
+  let auditService: { logWarn: jest.Mock; logInfo: jest.Mock };
+  const res = {} as Response;
+
+  const adminKey = { id: 'key-1', name: 'Admin', role: ApiKeyRole.ADMIN };
+
+  const reqFor = (
+    method: string,
+    headers: Record<string, unknown> = {},
+    originalUrl = '/api/admin/queues/api/queues/webhookQueue/1/retry',
+  ): Request =>
+    ({
+      headers,
+      query: {},
+      ip: '127.0.0.1',
+      socket: { remoteAddress: '127.0.0.1' },
+      method,
+      originalUrl,
+      url: originalUrl,
+    }) as unknown as Request;
+
+  beforeEach(() => {
+    authService = { validateApiKey: jest.fn(), hasPermission: jest.fn() };
+    auditService = { logWarn: jest.fn(), logInfo: jest.fn() };
+    const configService = { get: jest.fn().mockReturnValue(undefined) };
+    mw = new BullBoardAuthMiddleware(
+      authService as unknown as AuthService,
+      configService as unknown as ConfigService,
+      auditService as unknown as AuditService,
+    );
+  });
+
+  it('audits a 401 (missing key) with IP, method and path', async () => {
+    const next = jest.fn();
+    await mw.use(reqFor('GET', {}, '/api/admin/queues/'), res, next);
+
+    expect(next).toHaveBeenCalledWith(expect.any(UnauthorizedException));
+    expect(auditService.logWarn).toHaveBeenCalledWith(
+      AuditAction.API_KEY_AUTH_FAILED,
+      expect.objectContaining({
+        ipAddress: '127.0.0.1',
+        method: 'GET',
+        path: '/api/admin/queues/',
+        errorMessage: 'API key is required to access the queue dashboard',
+      }),
+    );
+  });
+
+  it('audits a 401 (invalid key) rejection from validateApiKey', async () => {
+    authService.validateApiKey.mockRejectedValue(new UnauthorizedException('Invalid API key'));
+    const next = jest.fn();
+    await mw.use(reqFor('GET', { 'x-api-key': 'bad' }, '/api/admin/queues/'), res, next);
+
+    expect(next).toHaveBeenCalledWith(expect.any(UnauthorizedException));
+    expect(auditService.logWarn).toHaveBeenCalledWith(
+      AuditAction.API_KEY_AUTH_FAILED,
+      expect.objectContaining({ errorMessage: 'Invalid API key' }),
+    );
+  });
+
+  it('audits a 403 (valid non-admin key)', async () => {
+    authService.validateApiKey.mockResolvedValue({ role: ApiKeyRole.OPERATOR });
+    authService.hasPermission.mockReturnValue(false);
+    const next = jest.fn();
+    await mw.use(reqFor('GET', { 'x-api-key': 'op' }, '/api/admin/queues/'), res, next);
+
+    expect(next).toHaveBeenCalledWith(expect.any(ForbiddenException));
+    expect(auditService.logWarn).toHaveBeenCalledWith(
+      AuditAction.API_KEY_AUTH_FAILED,
+      expect.objectContaining({ errorMessage: 'Admin role required to access the queue dashboard' }),
+    );
+  });
+
+  it('strips the query string from the audited path', async () => {
+    const next = jest.fn();
+    await mw.use(reqFor('GET', {}, '/api/admin/queues/?foo=bar'), res, next);
+
+    expect(auditService.logWarn).toHaveBeenCalledWith(
+      AuditAction.API_KEY_AUTH_FAILED,
+      expect.objectContaining({ path: '/api/admin/queues/' }),
+    );
+  });
+
+  it('audits an authenticated non-GET request as a queue-board mutation with the actor key and method+path', async () => {
+    authService.validateApiKey.mockResolvedValue(adminKey);
+    authService.hasPermission.mockReturnValue(true);
+    const next = jest.fn();
+    await mw.use(reqFor('POST', { 'x-api-key': 'admin' }), res, next);
+
+    expect(next).toHaveBeenCalledWith(); // allowed through
+    expect(auditService.logInfo).toHaveBeenCalledWith(
+      AuditAction.QUEUE_BOARD_MUTATED,
+      expect.objectContaining({
+        apiKey: adminKey,
+        ipAddress: '127.0.0.1',
+        method: 'POST',
+        path: '/api/admin/queues/api/queues/webhookQueue/1/retry',
+      }),
+    );
+    expect(auditService.logWarn).not.toHaveBeenCalled();
+  });
+
+  it('does not audit GET or HEAD requests (read/poll traffic)', async () => {
+    authService.validateApiKey.mockResolvedValue(adminKey);
+    authService.hasPermission.mockReturnValue(true);
+
+    await mw.use(reqFor('GET', { 'x-api-key': 'admin' }, '/api/admin/queues/'), res, jest.fn());
+    await mw.use(reqFor('HEAD', { 'x-api-key': 'admin' }, '/api/admin/queues/'), res, jest.fn());
+
+    expect(auditService.logInfo).not.toHaveBeenCalled();
+    expect(auditService.logWarn).not.toHaveBeenCalled();
+  });
+
+  it('does not audit a throttled 429 — the pre-auth IP limiter is the flood bound', async () => {
+    const tightMw = new BullBoardAuthMiddleware(
+      authService as unknown as AuthService,
+      { get: jest.fn().mockReturnValue(undefined) } as unknown as ConfigService,
+      auditService as unknown as AuditService,
+      new KeyRateLimiter(1, 60_000),
+    );
+    authService.validateApiKey.mockResolvedValue(adminKey);
+    authService.hasPermission.mockReturnValue(true);
+
+    await tightMw.use(reqFor('GET', { 'x-api-key': 'admin' }, '/api/admin/queues/'), res, jest.fn()); // consumes the slot
+    const next = jest.fn();
+    await tightMw.use(reqFor('GET', { 'x-api-key': 'admin' }, '/api/admin/queues/'), res, next); // throttled
+
+    expect(next).toHaveBeenCalledWith(expect.any(HttpException));
+    expect(auditService.logWarn).not.toHaveBeenCalled();
+    expect(auditService.logInfo).not.toHaveBeenCalled();
+  });
+
+  it('degrades gracefully when no audit service is provided (rejections still work)', async () => {
+    const noAuditMw = new BullBoardAuthMiddleware(
+      authService as unknown as AuthService,
+      { get: jest.fn().mockReturnValue(undefined) } as unknown as ConfigService,
+    );
+    const next = jest.fn();
+    await noAuditMw.use(reqFor('GET', {}, '/api/admin/queues/'), res, next);
+    expect(next).toHaveBeenCalledWith(expect.any(UnauthorizedException));
   });
 });

--- a/src/common/security/bull-board-auth.middleware.ts
+++ b/src/common/security/bull-board-auth.middleware.ts
@@ -3,6 +3,8 @@ import { ConfigService } from '@nestjs/config';
 import { Request, Response, NextFunction } from 'express';
 import { AuthService } from '../../modules/auth/auth.service';
 import { ApiKeyRole } from '../../modules/auth/entities/api-key.entity';
+import { AuditService } from '../../modules/audit/audit.service';
+import { AuditAction } from '../../modules/audit/entities/audit-log.entity';
 import { KeyRateLimiter, readIpRateLimitConfig } from '../../modules/mcp/mcp-rate-limit';
 import { resolveClientIp } from '../utils/ip';
 
@@ -20,6 +22,16 @@ import { resolveClientIp } from '../utils/ip';
  * A pre-auth per-IP throttle (mirroring the MCP mount's createIpThrottle) bounds a credential-probing
  * flood BEFORE it reaches the validateApiKey DB lookup. It uses the same KeyRateLimiter + IP-rate-limit
  * settings as MCP, so the two raw-Express mounts share one generous pre-auth IP-flood policy.
+ *
+ * Audit trail at this boundary (the Nest guard cannot see this mount):
+ *  - 401/403 rejections are recorded as WARN API_KEY_AUTH_FAILED, mirroring the REST guard and the
+ *    MCP mount. The pre-auth IP throttle above is the flood bound — a throttled 429 is NOT audited,
+ *    so a probing flood cannot drown the audit table either.
+ *  - An authenticated non-GET/HEAD request is recorded as INFO QUEUE_BOARD_MUTATED with method+path.
+ *    This is a boundary trace of queue-mutation attempts reaching the Bull Board router (the UI's
+ *    retry/remove/pause actions are POSTs); it deliberately does NOT model Bull Board's internal
+ *    per-action outcomes, which are invisible from middleware.
+ * Both are fire-and-forget: audit logging is best-effort and must never affect the auth decision.
  */
 @Injectable()
 export class BullBoardAuthMiddleware implements NestMiddleware {
@@ -28,6 +40,7 @@ export class BullBoardAuthMiddleware implements NestMiddleware {
   constructor(
     private readonly authService: AuthService,
     private readonly configService: ConfigService,
+    private readonly auditService?: AuditService,
     ipRateLimiter?: KeyRateLimiter,
   ) {
     // Default to MCP's pre-auth per-IP policy (max 120 / 60s) when not supplied. Tests inject a tight
@@ -58,12 +71,41 @@ export class BullBoardAuthMiddleware implements NestMiddleware {
         throw new ForbiddenException('Admin role required to access the queue dashboard');
       }
 
+      // Boundary trace of queue-mutation attempts. GET/HEAD are the UI's read/poll traffic; every
+      // other method reaching the Bull Board router mutates queue state, so record it with the
+      // authenticated key, the resolved client IP, and the method + full path (no query string).
+      if (req.method !== 'GET' && req.method !== 'HEAD') {
+        void this.auditService?.logInfo(AuditAction.QUEUE_BOARD_MUTATED, {
+          apiKey,
+          ipAddress: clientIp,
+          method: req.method,
+          path: this.auditPath(req),
+        });
+      }
+
       next();
     } catch (err) {
+      // Audit the rejected/denied attempt for a forensic trail, like the REST guard and the MCP
+      // mount do. A throttle overrun (HttpException 429) is deliberately NOT audited: the limiter
+      // already rejected it, and logging each throttled hit would let a flood write unbounded rows.
+      if (err instanceof UnauthorizedException || err instanceof ForbiddenException) {
+        void this.auditService?.logWarn(AuditAction.API_KEY_AUTH_FAILED, {
+          ipAddress: this.getClientIp(req),
+          method: req.method,
+          path: this.auditPath(req),
+          errorMessage: err instanceof Error ? err.message : String(err),
+        });
+      }
       // Forward to Nest's exception layer so the response uses the standard format. A throttle overrun
       // surfaces here as an HttpException(429) → rendered as a standard 429 by the global exception filter.
       next(err);
     }
+  }
+
+  /** Full request path (mount prefix included) with any query string stripped. */
+  private auditPath(req: Request): string {
+    const url = req.originalUrl ?? req.url ?? '';
+    return url.split('?')[0];
   }
 
   private extractKey(req: Request): string | undefined {

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,7 @@ import {
 } from './config/bootstrap-security';
 import { BullBoardAuthMiddleware } from './common/security/bull-board-auth.middleware';
 import { AuthService } from './modules/auth/auth.service';
+import { AuditService } from './modules/audit/audit.service';
 import { Request, Response, NextFunction, json, urlencoded } from 'express';
 import { randomBytes } from 'crypto';
 import { readFileSync } from 'fs';
@@ -308,8 +309,13 @@ async function bootstrap() {
   // Protect the Bull Board queue UI (/api/admin/queues). It is mounted by
   // @bull-board/nestjs as raw Express middleware that the global ApiKeyGuard
   // does not cover; registering this before app.listen() ensures it runs ahead
-  // of the Bull Board router. Requires a valid ADMIN API key.
-  const bullBoardAuth = new BullBoardAuthMiddleware(app.get(AuthService), app.get(ConfigService));
+  // of the Bull Board router. Requires a valid ADMIN API key. The middleware also
+  // writes the audit trail for this mount (auth failures + queue mutations).
+  const bullBoardAuth = new BullBoardAuthMiddleware(
+    app.get(AuthService),
+    app.get(ConfigService),
+    app.get(AuditService),
+  );
   app.use('/api/admin/queues', (req: Request, res: Response, next: NextFunction) => {
     void bullBoardAuth.use(req, res, next);
   });

--- a/src/modules/audit/entities/audit-log.entity.ts
+++ b/src/modules/audit/entities/audit-log.entity.ts
@@ -13,6 +13,9 @@ export enum AuditAction {
   // EventsGateway — so enforcing a limit never becomes an audit-write flood of its own).
   RATE_LIMIT_EXCEEDED = 'rate_limit_exceeded',
 
+  // Queue dashboard (Bull Board) events
+  QUEUE_BOARD_MUTATED = 'queue_board_mutated',
+
   // Session events
   SESSION_CREATED = 'session_created',
   SESSION_STARTED = 'session_started',

--- a/src/modules/auth/auth.service.spec.ts
+++ b/src/modules/auth/auth.service.spec.ts
@@ -1,8 +1,13 @@
+// Spread the real fs so every method passes through, but as configurable props the test can spy on
+// (the bare `import * as fs` namespace is non-configurable, so jest.spyOn can't redefine its methods).
+jest.mock('fs', () => ({ __esModule: true, ...jest.requireActual<typeof import('fs')>('fs') }));
+
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { UnauthorizedException, NotFoundException, ConflictException } from '@nestjs/common';
 import { createHash, createHmac } from 'crypto';
+import * as fs from 'fs';
 import { AuthService, resolveSeedApiKey, bannerKeyLine } from './auth.service';
 import { ApiKey, ApiKeyRole } from './entities/api-key.entity';
 
@@ -93,6 +98,7 @@ describe('AuthService', () => {
       create: jest.fn(),
       save: jest.fn(),
       remove: jest.fn(),
+      increment: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -568,6 +574,181 @@ describe('AuthService', () => {
       await expect(service.validateApiKey('sess-restricted', undefined, 'session-B')).rejects.toThrow(
         'API key not authorized for this session',
       );
+    });
+  });
+
+  // ── usage-stat lost-update safety + shutdown flush ────────────────
+
+  describe('usage-stat lost-update safety', () => {
+    it('keeps the accumulated delta when the windowed save fails, and the next flush carries it', async () => {
+      const rawKey = 'flaky-key';
+      // Fresh row per findOne, as TypeORM returns it (no identity map): the DB state never
+      // reflects the failed write, so the delta must survive in the pending map.
+      const freshRow = () =>
+        createMockApiKey({ keyHash: hashKey(rawKey), lastUsedAt: new Date(Date.now() - 5 * 60_000), usageCount: 5 });
+      (repository.findOne as jest.Mock).mockImplementation(() => Promise.resolve(freshRow()));
+      (repository.save as jest.Mock)
+        .mockRejectedValueOnce(new Error('db write failed'))
+        .mockImplementation(k => Promise.resolve(k));
+
+      // The windowed write fails: the request still succeeds (the key is valid) and the delta is kept.
+      const first = await service.validateApiKey(rawKey);
+      expect(first.usageCount).toBe(6);
+
+      // Still due on the next request (DB lastUsedAt was never written) → the retry persists the
+      // failed delta plus this request's increment — nothing is lost.
+      await service.validateApiKey(rawKey);
+      const saves = (repository.save as jest.Mock).mock.calls as Array<[ApiKey]>;
+      expect(saves[1][0].usageCount).toBe(7); // DB 5 + failed delta 1 + this request 1
+
+      // The successful retry drained the accumulator — nothing left for the shutdown flush.
+      await service.onModuleDestroy();
+      expect(repository.increment).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('usage-stat shutdown flush', () => {
+    it('flushes pending deltas on module destroy with an atomic increment, only once', async () => {
+      const rawKey = 'recent-key';
+      (repository.findOne as jest.Mock).mockResolvedValue(
+        createMockApiKey({ keyHash: hashKey(rawKey), lastUsedAt: new Date(), usageCount: 5 }),
+      );
+      (repository.increment as jest.Mock).mockResolvedValue({ affected: 1 });
+
+      await service.validateApiKey(rawKey); // inside the throttle window → coalesced, no DB write
+      expect(repository.save).not.toHaveBeenCalled();
+
+      await service.onModuleDestroy();
+      expect(repository.increment).toHaveBeenCalledWith({ id: 'uuid-1' }, 'usageCount', 1);
+
+      await service.onModuleDestroy(); // idempotent — nothing left pending
+      expect(repository.increment).toHaveBeenCalledTimes(1);
+    });
+
+    it('does nothing on destroy when there is nothing pending', async () => {
+      await service.onModuleDestroy();
+      expect(repository.increment).not.toHaveBeenCalled();
+    });
+
+    it('tolerates a failing flush (destroy still resolves — stats are best-effort)', async () => {
+      const rawKey = 'recent-key';
+      (repository.findOne as jest.Mock).mockResolvedValue(
+        createMockApiKey({ keyHash: hashKey(rawKey), lastUsedAt: new Date(), usageCount: 5 }),
+      );
+      (repository.increment as jest.Mock).mockRejectedValue(new Error('db gone'));
+
+      await service.validateApiKey(rawKey);
+      await expect(service.onModuleDestroy()).resolves.toBeUndefined();
+    });
+  });
+
+  // ── bootstrap API key file (data/.api-key) staleness ─────────────
+
+  describe('bootstrap API key file (data/.api-key)', () => {
+    let existsSpy: jest.SpyInstance;
+    let readSpy: jest.Mock;
+    let unlinkSpy: jest.Mock;
+    let logSpy: jest.SpyInstance;
+
+    const bannerText = (): string => (logSpy.mock.calls as unknown[][]).map(call => String(call[0])).join('\n');
+
+    beforeEach(() => {
+      existsSpy = jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+      readSpy = jest.spyOn(fs, 'readFileSync') as unknown as jest.Mock;
+      readSpy.mockReturnValue('');
+      unlinkSpy = jest.spyOn(fs, 'unlinkSync') as unknown as jest.Mock;
+      unlinkSpy.mockImplementation(() => undefined);
+      logSpy = jest
+        .spyOn((service as unknown as { logger: { log: (...args: unknown[]) => void } }).logger, 'log')
+        .mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('revoke removes the bootstrap key file when it still holds the revoked key', async () => {
+      const key = createMockApiKey({ isActive: true }); // keyHash matches hashKey('test-key')
+      (repository.findOne as jest.Mock).mockResolvedValue(key);
+      (repository.save as jest.Mock).mockImplementation(k => Promise.resolve(k));
+      existsSpy.mockReturnValue(true);
+      readSpy.mockReturnValue('test-key\n');
+
+      await service.revoke('uuid-1');
+
+      expect(unlinkSpy).toHaveBeenCalledWith(expect.stringContaining('.api-key'));
+    });
+
+    it('revoke leaves the file alone when it holds a different (still live) key', async () => {
+      const key = createMockApiKey({ isActive: true });
+      (repository.findOne as jest.Mock).mockResolvedValue(key);
+      (repository.save as jest.Mock).mockImplementation(k => Promise.resolve(k));
+      existsSpy.mockReturnValue(true);
+      readSpy.mockReturnValue('another-key');
+
+      await service.revoke('uuid-1');
+
+      expect(unlinkSpy).not.toHaveBeenCalled();
+    });
+
+    it('delete removes the bootstrap key file when it still holds the deleted key', async () => {
+      const key = createMockApiKey();
+      (repository.findOne as jest.Mock).mockResolvedValue(key);
+      (repository.remove as jest.Mock).mockResolvedValue(key);
+      existsSpy.mockReturnValue(true);
+      readSpy.mockReturnValue('test-key');
+
+      await service.delete('uuid-1');
+
+      expect(unlinkSpy).toHaveBeenCalledWith(expect.stringContaining('.api-key'));
+    });
+
+    it('tolerates a missing file on revoke (nothing to clean up)', async () => {
+      const key = createMockApiKey({ isActive: true });
+      (repository.findOne as jest.Mock).mockResolvedValue(key);
+      (repository.save as jest.Mock).mockImplementation(k => Promise.resolve(k));
+      existsSpy.mockReturnValue(false);
+
+      await service.revoke('uuid-1');
+
+      expect(unlinkSpy).not.toHaveBeenCalled();
+    });
+
+    it('boot removes a stale bootstrap file and the banner no longer advertises the dead key', async () => {
+      (repository.count as jest.Mock).mockResolvedValue(1); // not first boot → the file path is consulted
+      existsSpy.mockReturnValue(true);
+      readSpy.mockReturnValue('owa_k1_deaddeaddead');
+      (repository.findOne as jest.Mock).mockResolvedValue(null); // hash no longer resolves to any key
+
+      await service.onModuleInit();
+
+      expect(unlinkSpy).toHaveBeenCalledWith(expect.stringContaining('.api-key'));
+      expect(bannerText()).toContain('(check dashboard for keys)');
+      expect(bannerText()).not.toContain('owa_k1_d'); // no fingerprint of the dead key
+    });
+
+    it('boot treats a revoked bootstrap key as stale too', async () => {
+      (repository.count as jest.Mock).mockResolvedValue(1);
+      existsSpy.mockReturnValue(true);
+      readSpy.mockReturnValue('test-key');
+      (repository.findOne as jest.Mock).mockResolvedValue(createMockApiKey({ isActive: false }));
+
+      await service.onModuleInit();
+
+      expect(unlinkSpy).toHaveBeenCalled();
+      expect(bannerText()).toContain('(check dashboard for keys)');
+    });
+
+    it('boot keeps a live bootstrap key: file untouched, banner shows the masked fingerprint', async () => {
+      (repository.count as jest.Mock).mockResolvedValue(1);
+      existsSpy.mockReturnValue(true);
+      readSpy.mockReturnValue('test-key');
+      (repository.findOne as jest.Mock).mockResolvedValue(createMockApiKey({ isActive: true }));
+
+      await service.onModuleInit();
+
+      expect(unlinkSpy).not.toHaveBeenCalled();
+      expect(bannerText()).toContain('(full key in data/.api-key');
     });
   });
 

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -1,9 +1,16 @@
-import { ConflictException, Injectable, NotFoundException, UnauthorizedException, OnModuleInit } from '@nestjs/common';
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+  OnModuleInit,
+  OnModuleDestroy,
+} from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import { InjectRepository } from '@nestjs/typeorm';
 import { IsNull, MoreThan, Not, Repository } from 'typeorm';
 import { randomBytes } from 'crypto';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { writeSecretFile } from '../../common/utils/secret-file';
 import { ipMatches } from '../../common/utils/ip';
@@ -47,11 +54,13 @@ export function bannerKeyLine(displayKey: string, isNewKey: boolean): string {
 }
 
 @Injectable()
-export class AuthService implements OnModuleInit {
+export class AuthService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = createLogger('AuthService');
 
   /** Coalesce per-request usage-stat writes to at most one DB write per key per window. */
   private static readonly STAT_FLUSH_INTERVAL_MS = 60_000;
+  /** Upper bound for the best-effort usage-stat flush on shutdown — teardown must not stall on a wedged DB. */
+  private static readonly SHUTDOWN_FLUSH_TIMEOUT_MS = 5_000;
   /** keyId -> usage increments observed but not yet persisted (flushed on the next windowed write). */
   private readonly pendingUsage = new Map<string, number>();
 
@@ -93,17 +102,9 @@ export class AuthService implements OnModuleInit {
         this.logger.warn('Could not save API key file', { error: String(err) });
       }
     } else {
-      // Read saved API key from file if exists
-      if (existsSync(API_KEY_FILE)) {
-        try {
-          displayKey = readFileSync(API_KEY_FILE, 'utf-8').trim();
-        } catch (error) {
-          this.logger.warn(`Failed to read API key file: ${API_KEY_FILE}`, { error: String(error) });
-          displayKey = '(check dashboard for keys)';
-        }
-      } else {
-        displayKey = '(check dashboard for keys)';
-      }
+      // Read the saved bootstrap key from the file — but only while it still resolves to a LIVE
+      // key; a revoked/rotated/deleted key must not be advertised in the banner.
+      displayKey = (await this.readLiveBootstrapKey()) ?? '(check dashboard for keys)';
     }
 
     // Always show the welcome banner on startup
@@ -128,6 +129,97 @@ export class AuthService implements OnModuleInit {
     this.logger.log('');
     this.logger.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
     this.logger.log('');
+  }
+
+  /**
+   * Best-effort flush of the coalesced usage-stat counters on teardown. Nest runs onModuleDestroy
+   * before the TypeORM connection closes (the DataSource is destroyed in onApplicationShutdown, the
+   * last lifecycle hook), so the DB is still writable here. Bounded so a wedged DB cannot stall
+   * shutdown past the grace window; whatever is still unflushed after the bound is dropped — the
+   * counters are advisory statistics, authentication never depends on them.
+   */
+  async onModuleDestroy(): Promise<void> {
+    if (this.pendingUsage.size === 0) return;
+    this.logger.log(`Flushing usage stats for ${this.pendingUsage.size} API key(s) before shutdown`);
+    const timeout = new Promise<'timeout'>(resolve =>
+      setTimeout(() => resolve('timeout'), AuthService.SHUTDOWN_FLUSH_TIMEOUT_MS).unref(),
+    );
+    const result = await Promise.race([this.flushPendingUsage().then(() => 'done' as const), timeout]);
+    if (result === 'timeout') {
+      this.logger.warn('Usage-stat shutdown flush exceeded its time bound; remaining deltas dropped');
+    }
+  }
+
+  /** Persist every accumulated usage delta with an atomic increment; entries that fail stay pending. */
+  private async flushPendingUsage(): Promise<void> {
+    for (const [keyId, delta] of [...this.pendingUsage.entries()]) {
+      if (delta <= 0) {
+        this.pendingUsage.delete(keyId);
+        continue;
+      }
+      try {
+        // Atomic UPDATE ... SET usageCount = usageCount + delta — no read-modify-write race with a
+        // concurrent windowed save, unlike reloading the row and saving it back.
+        await this.apiKeyRepository.increment({ id: keyId }, 'usageCount', delta);
+        this.pendingUsage.delete(keyId);
+      } catch (error) {
+        this.logger.warn('Usage-stat flush failed for a key; delta kept pending', {
+          keyId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  }
+
+  /**
+   * Read the bootstrap key file for the startup banner — only while it still points at a LIVE key.
+   * The file is written once at first boot; when that key is later revoked, rotated, or deleted, the
+   * file (and the banner quoting it) would otherwise keep advertising a dead credential. A stale file
+   * is removed here too, so a backup restore that lost the key self-heals on the next boot.
+   * Returns null when the file is absent, unreadable, empty, or stale.
+   */
+  private async readLiveBootstrapKey(): Promise<string | null> {
+    if (!existsSync(API_KEY_FILE)) return null;
+    let rawKey: string;
+    try {
+      rawKey = readFileSync(API_KEY_FILE, 'utf-8').trim();
+    } catch (error) {
+      this.logger.warn(`Failed to read API key file: ${API_KEY_FILE}`, { error: String(error) });
+      return null;
+    }
+    if (!rawKey) return null;
+    const stored = await this.apiKeyRepository.findOne({ where: { keyHash: this.hashKey(rawKey) } });
+    const live = Boolean(stored && stored.isActive && (!stored.expiresAt || stored.expiresAt > new Date()));
+    if (live) return rawKey;
+    this.removeBootstrapKeyFile('it no longer resolves to an active key');
+    return null;
+  }
+
+  /**
+   * Remove the bootstrap key file when it still holds the key being revoked or deleted, so the next
+   * boot's banner cannot point the operator at a dead credential. The file is an operator
+   * convenience (banner + backup scripts); it is never read for seeding or authentication, so
+   * removing it cannot break first-boot seeding — seeding writes it only when no keys exist.
+   */
+  private removeBootstrapKeyFileIfMatching(apiKey: ApiKey): void {
+    try {
+      if (!existsSync(API_KEY_FILE)) return;
+      const fileKey = readFileSync(API_KEY_FILE, 'utf-8').trim();
+      if (!fileKey || this.hashKey(fileKey) !== apiKey.keyHash) return;
+      this.removeBootstrapKeyFile('its key was revoked or deleted');
+    } catch (error) {
+      this.logger.warn(`Failed to inspect API key file: ${API_KEY_FILE}`, { error: String(error) });
+    }
+  }
+
+  private removeBootstrapKeyFile(reason: string): void {
+    try {
+      unlinkSync(API_KEY_FILE);
+      this.logger.log(`Removed stale bootstrap API key file (${reason}): ${API_KEY_FILE}`);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return; // already gone
+      this.logger.warn(`Failed to remove stale API key file: ${API_KEY_FILE}`, { error: String(error) });
+    }
   }
 
   private async seedApiKey(rawKey: string, name: string, role: ApiKeyRole): Promise<ApiKey> {
@@ -244,6 +336,7 @@ export class AuthService implements OnModuleInit {
       // Drop any un-flushed usage accumulator so a deleted key leaves nothing behind in the Map.
       this.pendingUsage.delete(id);
       await this.apiKeyRepository.remove(apiKey);
+      this.removeBootstrapKeyFileIfMatching(apiKey);
     };
     // A target that is not a usable admin can skip the lock: it is not counted as one, so removing
     // it cannot strand the system — some other usable admin (or none at all) exists independently.
@@ -267,7 +360,9 @@ export class AuthService implements OnModuleInit {
       // drop it here.
       this.pendingUsage.delete(id);
       apiKey.isActive = false;
-      return this.apiKeyRepository.save(apiKey);
+      const saved = await this.apiKeyRepository.save(apiKey);
+      this.removeBootstrapKeyFileIfMatching(apiKey);
+      return saved;
     };
     const saved = AuthService.isUsableAdmin(apiKey)
       ? await this.adminCapabilityLock.run(AuthService.ADMIN_CAPABILITY_LOCK_KEY, revokeKey)
@@ -369,7 +464,19 @@ export class AuthService implements OnModuleInit {
       apiKey.lastUsedAt.getTime() - previousLastUsedAt.getTime() >= AuthService.STAT_FLUSH_INTERVAL_MS;
     if (due) {
       this.pendingUsage.delete(apiKey.id);
-      await this.apiKeyRepository.save(apiKey);
+      try {
+        await this.apiKeyRepository.save(apiKey);
+      } catch (error) {
+        // Lost-update safe: a failed windowed write must not drop the accumulated increments —
+        // merge them back (accumulate, never overwrite, in case a concurrent path re-added a
+        // delta) so the next windowed write or the shutdown flush persists them. Validation
+        // itself succeeded, so a stat-write failure must not fail the request.
+        this.pendingUsage.set(apiKey.id, (this.pendingUsage.get(apiKey.id) ?? 0) + pending);
+        this.logger.warn('Usage-stat write failed; delta kept pending for the next flush', {
+          keyId: apiKey.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     } else {
       this.pendingUsage.set(apiKey.id, pending);
     }


### PR DESCRIPTION
## Summary

Three reliability/observability fixes around API-key usage stats and the queue dashboard boundary.

### 1. Usage-stat counter: lost-update safe + shutdown flush (`src/modules/auth/auth.service.ts`)

Per-request usage stats are coalesced into an in-memory `pendingUsage` map and written at most once per key per 60s window. Two gaps:

- **Lost updates on a failed write**: the windowed flush deleted the accumulated delta from the map *before* `save()`, so a failed write silently dropped every increment since the last flush — and the thrown error also failed an otherwise valid authenticated request. Now the delta is merged back into the map on failure (accumulate, never overwrite), a warning is logged, and the request proceeds; the next windowed write or the shutdown flush persists the accumulated count.
- **No flush on shutdown**: increments accrued inside the final window were lost on every restart/deploy. `onModuleDestroy` now flushes each pending delta with an atomic `increment` (`UPDATE ... SET usageCount = usageCount + n`, no read-modify-write race), bounded by a 5s budget so a wedged database cannot stall teardown. Nest runs `onModuleDestroy` before the TypeORM DataSource closes (`onApplicationShutdown`), so the connection is still writable. Counters are advisory; anything still unflushed after the bound is dropped with a warning.

### 2. Audit trail for the Bull Board mount (`src/common/security/bull-board-auth.middleware.ts`, `src/main.ts`)

Bull Board is raw Express middleware, so the global guard's audit trail never saw it: rejections left no forensic record, and queue mutations via the UI were invisible.

- 401/403 rejections are now recorded as WARN `API_KEY_AUTH_FAILED` (IP, method, path, error) — same pattern as the REST guard and the MCP mount. A throttled 429 is deliberately **not** audited: the pre-auth per-IP limiter is the flood bound for both the credential check and the audit table, so a probing flood cannot write unbounded rows.
- An authenticated non-GET/HEAD request is recorded as INFO `QUEUE_BOARD_MUTATED` (new `AuditAction`) with the actor key, IP, method, and full path (query string stripped). This is a boundary trace of mutation attempts reaching the Bull Board router — it intentionally does not model Bull Board's internal per-action outcomes, which are not visible from middleware.
- `AuditService` is an optional constructor dependency; `main.ts` wires it in. The audit-coverage gate validates the new action is emitted.

### 3. Stale `data/.api-key` after rotate/revoke/delete (`src/modules/auth/auth.service.ts`)

The bootstrap key file is written once at first boot and read afterwards only for the startup banner. After the seeded key was rotated/revoked/deleted, the file — and the banner quoting it — kept advertising a dead credential. Now:

- `revoke()`/`delete()` remove the file when its content still matches that key (hash comparison; a file holding a different, live key is left alone).
- Boot validates the file against the database: if the key no longer resolves to an active, unexpired credential, the file is removed and the banner falls back to the `(check dashboard for keys)` placeholder instead of a dead key's fingerprint. This also self-heals a backup restore that lost the key.

First-boot seeding is unaffected: seeding writes the file only when no keys exist and never reads it; the file is an operator convenience (banner + backup scripts), not an authentication input.

## Tests

- `auth.service.spec.ts`: failed windowed save keeps the delta and the next flush carries the full accumulated count; shutdown flush persists pending deltas via atomic `increment` exactly once and tolerates flush failures; revoke/delete removes the bootstrap file only when it holds that key; boot removes a stale file (missing hash, revoked key) and the banner shows the placeholder, while a live key keeps the file and shows the masked fingerprint.
- `bull-board-auth.middleware.spec.ts`: 401 (missing/invalid key) and 403 audited with IP/method/path; query string stripped from the audited path; authenticated POST audited as `QUEUE_BOARD_MUTATED` with actor + method + path; GET/HEAD not audited; throttled 429 not audited; middleware still works without an audit service.

## Verification

- `npx jest src/modules/auth src/common/security src/config` — 24 suites / 360 tests pass.
- `src/modules/audit` (incl. the audit-coverage gate for the new action) — pass.
- `npx eslint src/modules/auth src/common/security src/config src/main.ts` — clean.
- `npm run build` — clean.

## Risks

- A stat-write failure no longer fails the request (previously a `save()` throw propagated as a 500 on an otherwise valid key). Intentional: usage stats must not gate authentication, and no count is lost now.
- The boot-time liveness check adds one indexed `keyHash` lookup per restart — negligible.
- Removing `data/.api-key` on revoke/delete changes operator-visible behavior only where the file was already pointing at a dead credential; backup/restore of a *live* key is untouched.
