### PR TITLE
fix(dashboard): complete i18n catalogs and give modals real dialog semantics

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.test.json",
     "preview": "vite preview",
     "i18n:check": "node scripts/check-i18n-parity.mjs",
+    "test": "node --experimental-strip-types --test \"src/**/*.test.ts\"",
     "test:unit": "node --experimental-strip-types --test \"src/**/*.test.ts\""
   },
   "dependencies": {

--- a/dashboard/src/components/Modal.tsx
+++ b/dashboard/src/components/Modal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useId, useRef, type ReactNode } from 'react';
 import { X } from 'lucide-react';
+import { bindModalA11y } from '../utils/modalA11y.ts';
 
 export interface ModalProps {
   /** Whether the dialog is shown. When false, renders nothing. */
@@ -15,21 +16,36 @@ export interface ModalProps {
   className?: string;
   /** aria-label for the header close button. */
   closeLabel?: string;
+  /** Optional extra header content rendered between the title and the close button (e.g. tab bars). */
+  headerExtra?: ReactNode;
+  /** Optional content rendered between the pinned header and the scrolling body (e.g. a tab row). */
+  subheader?: ReactNode;
+  /** Hide the header close button — for dialogs that must not be dismissed mid-operation. */
+  hideCloseButton?: boolean;
 }
-
-const FOCUSABLE =
-  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 /**
  * Shared accessible modal dialog: role="dialog", aria-modal, Escape/overlay close, body scroll
- * lock, initial focus, and a minimal focus trap. Markup uses the GLOBAL modal styles
- * (.modal-overlay/.modal/.modal-header/.modal-body/.modal-footer from index.css), so the card
- * gets the 90vh cap with pinned header/footer and a scrolling body for free.
+ * lock, initial focus, a minimal focus trap, and focus restore to the trigger on close (wired by
+ * bindModalA11y). Markup uses the GLOBAL modal styles (.modal-overlay/.modal/.modal-header/
+ * .modal-body/.modal-footer from index.css), so the card gets the 90vh cap with pinned
+ * header/footer and a scrolling body for free.
  *
  * Every page previously hand-rolled the overlay+dialog without any dialog semantics; new modals
  * must use this component, and existing ones are being migrated to it.
  */
-export function Modal({ open, onClose, title, children, footer, className, closeLabel = 'Close' }: ModalProps) {
+export function Modal({
+  open,
+  onClose,
+  title,
+  children,
+  footer,
+  className,
+  closeLabel = 'Close',
+  headerExtra,
+  subheader,
+  hideCloseButton = false,
+}: ModalProps) {
   const titleId = useId();
   const cardRef = useRef<HTMLDivElement>(null);
 
@@ -46,50 +62,8 @@ export function Modal({ open, onClose, title, children, footer, className, close
   });
 
   useEffect(() => {
-    if (!open) return undefined;
-
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        // Capture phase: nested widgets (selects, menus) may also listen for Escape — the dialog
-        // owns dismissal while it is open.
-        event.stopPropagation();
-        onCloseRef.current();
-        return;
-      }
-      if (event.key === 'Tab') {
-        const card = cardRef.current;
-        if (!card) return;
-        const focusables = Array.from(card.querySelectorAll<HTMLElement>(FOCUSABLE)).filter(
-          el => el.offsetParent !== null,
-        );
-        if (focusables.length === 0) return;
-        const first = focusables[0];
-        const last = focusables[focusables.length - 1];
-        if (event.shiftKey && document.activeElement === first) {
-          event.preventDefault();
-          last.focus();
-        } else if (!event.shiftKey && document.activeElement === last) {
-          event.preventDefault();
-          first.focus();
-        }
-      }
-    };
-
-    document.addEventListener('keydown', onKeyDown, true);
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-
-    // Initial focus: the first visible focusable in the dialog, else the dialog card itself.
-    // Runs only when `open` flips true (not on parent re-renders) thanks to the `[open]` dep above.
-    const card = cardRef.current;
-    const initial =
-      card && (Array.from(card.querySelectorAll<HTMLElement>(FOCUSABLE)).find(el => el.offsetParent !== null) ?? null);
-    (initial ?? card)?.focus();
-
-    return () => {
-      document.removeEventListener('keydown', onKeyDown, true);
-      document.body.style.overflow = previousOverflow;
-    };
+    if (!open || !cardRef.current) return undefined;
+    return bindModalA11y(document, cardRef.current, () => onCloseRef.current());
   }, [open]);
 
   if (!open) return null;
@@ -113,10 +87,14 @@ export function Modal({ open, onClose, title, children, footer, className, close
       >
         <div className="modal-header">
           <h2 id={titleId}>{title}</h2>
-          <button type="button" className="btn-icon" onClick={onClose} aria-label={closeLabel}>
-            <X size={20} />
-          </button>
+          {headerExtra}
+          {hideCloseButton ? null : (
+            <button type="button" className="btn-icon" onClick={onClose} aria-label={closeLabel}>
+              <X size={20} />
+            </button>
+          )}
         </div>
+        {subheader}
         <div className="modal-body">{children}</div>
         {footer ? <div className="modal-footer">{footer}</div> : null}
       </div>

--- a/dashboard/src/components/PluginInstances.tsx
+++ b/dashboard/src/components/PluginInstances.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Plus, Copy, Check, RefreshCw, Pencil, Trash2, X, Loader2, Power, AlertTriangle } from 'lucide-react';
+import { Plus, Copy, Check, RefreshCw, Pencil, Trash2, Loader2, Power, AlertTriangle } from 'lucide-react';
 import type { InstanceView, MintedInstance } from '../services/api';
 import {
   usePluginInstancesQuery,
@@ -11,6 +11,7 @@ import {
 } from '../hooks/queries';
 import { isValidInstanceId, isValidInstanceSecret, parseInstanceConfig } from '../utils/instanceForm';
 import { copyToClipboard } from '../utils/clipboard';
+import { Modal } from './Modal';
 import { useToast } from './Toast';
 import './PluginInstances.css';
 
@@ -202,162 +203,140 @@ export function PluginInstances({ pluginId }: { pluginId: string }) {
 
       {/* Create modal — form, or the secret-shown-once view after mint */}
       {showForm && (
-        <div className="modal-overlay" onClick={() => setShowForm(false)}>
-          <div className="modal" onClick={e => e.stopPropagation()}>
-            <div className="modal-header">
-              <h2>{t('plugins.instances.create')}</h2>
-              <button className="btn-icon" onClick={() => setShowForm(false)}>
-                <X size={20} />
-              </button>
-            </div>
-            <div className="modal-body plugin-instances">
-              <label>{t('plugins.instances.form.instanceId')}</label>
-              <input
-                type="text"
-                value={form.instanceId}
-                placeholder={t('plugins.instances.form.instanceIdPlaceholder')}
-                onChange={e => setForm({ ...form, instanceId: e.target.value })}
-              />
-              <p className="pi-hint">{t('plugins.instances.form.instanceIdHint')}</p>
-              <label>{t('plugins.instances.form.sessionScope')}</label>
-              <input
-                type="text"
-                value={form.sessionScope}
-                placeholder={t('plugins.instances.form.sessionScopePlaceholder')}
-                onChange={e => setForm({ ...form, sessionScope: e.target.value })}
-              />
-              <label>{t('plugins.instances.form.verifyToken')}</label>
-              <input
-                type="text"
-                value={form.verifyToken}
-                placeholder={t('plugins.instances.form.verifyTokenPlaceholder')}
-                onChange={e => setForm({ ...form, verifyToken: e.target.value })}
-              />
-              <label>{t('plugins.instances.form.secret')}</label>
-              <input
-                type="text"
-                value={form.secret}
-                placeholder={t('plugins.instances.form.secretPlaceholder')}
-                onChange={e => setForm({ ...form, secret: e.target.value })}
-              />
-              <p className="pi-hint">{t('plugins.instances.form.secretHint')}</p>
-              <label>{t('plugins.instances.form.config')}</label>
-              <textarea
-                value={form.config}
-                placeholder={t('plugins.instances.form.configPlaceholder')}
-                onChange={e => setForm({ ...form, config: e.target.value })}
-              />
-              {formError && <p className="pi-error">{formError}</p>}
-            </div>
-            <div className="modal-footer">
+        <Modal
+          open
+          onClose={() => setShowForm(false)}
+          title={t('plugins.instances.create')}
+          closeLabel={t('common.close')}
+          footer={
+            <>
               <button className="btn-secondary" onClick={() => setShowForm(false)}>
                 {t('common.cancel')}
               </button>
               <button className="btn-primary" onClick={() => void submitCreate()} disabled={createM.isPending || !form.instanceId}>
                 {createM.isPending ? <Loader2 className="animate-spin" size={16} /> : t('common.create')}
               </button>
-            </div>
-          </div>
-        </div>
+            </>
+          }
+        >
+          <label>{t('plugins.instances.form.instanceId')}</label>
+          <input
+            type="text"
+            value={form.instanceId}
+            placeholder={t('plugins.instances.form.instanceIdPlaceholder')}
+            onChange={e => setForm({ ...form, instanceId: e.target.value })}
+          />
+          <p className="pi-hint">{t('plugins.instances.form.instanceIdHint')}</p>
+          <label>{t('plugins.instances.form.sessionScope')}</label>
+          <input
+            type="text"
+            value={form.sessionScope}
+            placeholder={t('plugins.instances.form.sessionScopePlaceholder')}
+            onChange={e => setForm({ ...form, sessionScope: e.target.value })}
+          />
+          <label>{t('plugins.instances.form.verifyToken')}</label>
+          <input
+            type="text"
+            value={form.verifyToken}
+            placeholder={t('plugins.instances.form.verifyTokenPlaceholder')}
+            onChange={e => setForm({ ...form, verifyToken: e.target.value })}
+          />
+          <label>{t('plugins.instances.form.secret')}</label>
+          <input
+            type="text"
+            value={form.secret}
+            placeholder={t('plugins.instances.form.secretPlaceholder')}
+            onChange={e => setForm({ ...form, secret: e.target.value })}
+          />
+          <p className="pi-hint">{t('plugins.instances.form.secretHint')}</p>
+          <label>{t('plugins.instances.form.config')}</label>
+          <textarea
+            value={form.config}
+            placeholder={t('plugins.instances.form.configPlaceholder')}
+            onChange={e => setForm({ ...form, config: e.target.value })}
+          />
+          {formError && <p className="pi-error">{formError}</p>}
+        </Modal>
       )}
 
       {/* Secret-shown-once modal (after create or regenerate) */}
       {minted && (
-        <div className="modal-overlay" onClick={() => setMinted(null)}>
-          <div className="modal" onClick={e => e.stopPropagation()}>
-            <div className="modal-header">
-              <h2>
-                {mintedKind === 'regenerated'
-                  ? t('plugins.instances.regenerate.title')
-                  : t('plugins.instances.created.title')}
-              </h2>
-              <button className="btn-icon" onClick={() => setMinted(null)}>
-                <X size={20} />
-              </button>
-            </div>
-            <div className="modal-body plugin-instances">
-              <p className="pi-hint">{t('plugins.instances.created.hint')}</p>
-              <label>{t('plugins.instances.created.secret')}</label>
-              <div className="pi-secret">
-                <code>{minted.secret}</code>
-                <button className="btn-primary" onClick={() => void copy(minted.secret, 'secret')}>
-                  {copied === 'secret' ? <Check size={16} /> : <Copy size={16} />}
-                </button>
-              </div>
-              <label>{t('plugins.instances.created.ingressUrls')}</label>
-              {minted.ingressUrls.map(u => (
-                <div key={u.route} className="pi-secret">
-                  <code>{u.url}</code>
-                  <button className="btn-primary" onClick={() => void copy(u.url, `mint-${u.route}`)}>
-                    {copied === `mint-${u.route}` ? <Check size={16} /> : <Copy size={16} />}
-                  </button>
-                </div>
-              ))}
-            </div>
-            <div className="modal-footer">
-              <button className="btn-secondary" onClick={() => setMinted(null)}>
-                {t('common.close')}
-              </button>
-            </div>
+        <Modal
+          open
+          onClose={() => setMinted(null)}
+          title={mintedKind === 'regenerated' ? t('plugins.instances.regenerate.title') : t('plugins.instances.created.title')}
+          closeLabel={t('common.close')}
+          footer={
+            <button className="btn-secondary" onClick={() => setMinted(null)}>
+              {t('common.close')}
+            </button>
+          }
+        >
+          <p className="pi-hint">{t('plugins.instances.created.hint')}</p>
+          <label>{t('plugins.instances.created.secret')}</label>
+          <div className="pi-secret">
+            <code>{minted.secret}</code>
+            <button className="btn-primary" onClick={() => void copy(minted.secret, 'secret')}>
+              {copied === 'secret' ? <Check size={16} /> : <Copy size={16} />}
+            </button>
           </div>
-        </div>
+          <label>{t('plugins.instances.created.ingressUrls')}</label>
+          {minted.ingressUrls.map(u => (
+            <div key={u.route} className="pi-secret">
+              <code>{u.url}</code>
+              <button className="btn-primary" onClick={() => void copy(u.url, `mint-${u.route}`)}>
+                {copied === `mint-${u.route}` ? <Check size={16} /> : <Copy size={16} />}
+              </button>
+            </div>
+          ))}
+        </Modal>
       )}
 
       {/* Edit modal — sessionScope + config */}
       {editing && (
-        <div className="modal-overlay" onClick={() => setEditing(null)}>
-          <div className="modal" onClick={e => e.stopPropagation()}>
-            <div className="modal-header">
-              <h2>{t('plugins.instances.edit.title', { id: editing.instanceId })}</h2>
-              <button className="btn-icon" onClick={() => setEditing(null)}>
-                <X size={20} />
-              </button>
-            </div>
-            <div className="modal-body plugin-instances">
-              <label>{t('plugins.instances.form.sessionScope')}</label>
-              <input
-                type="text"
-                value={editForm.sessionScope}
-                placeholder={t('plugins.instances.form.sessionScopePlaceholder')}
-                onChange={e => setEditForm({ ...editForm, sessionScope: e.target.value })}
-              />
-              <label>{t('plugins.instances.form.config')}</label>
-              <textarea
-                value={editForm.config}
-                placeholder={t('plugins.instances.form.configPlaceholder')}
-                onChange={e => setEditForm({ ...editForm, config: e.target.value })}
-              />
-              {editError && <p className="pi-error">{editError}</p>}
-            </div>
-            <div className="modal-footer">
+        <Modal
+          open
+          onClose={() => setEditing(null)}
+          title={t('plugins.instances.edit.title', { id: editing.instanceId })}
+          closeLabel={t('common.close')}
+          footer={
+            <>
               <button className="btn-secondary" onClick={() => setEditing(null)}>
                 {t('common.cancel')}
               </button>
               <button className="btn-primary" onClick={() => void submitEdit()} disabled={updateM.isPending}>
                 {updateM.isPending ? <Loader2 className="animate-spin" size={16} /> : t('plugins.instances.actions.save')}
               </button>
-            </div>
-          </div>
-        </div>
+            </>
+          }
+        >
+          <label>{t('plugins.instances.form.sessionScope')}</label>
+          <input
+            type="text"
+            value={editForm.sessionScope}
+            placeholder={t('plugins.instances.form.sessionScopePlaceholder')}
+            onChange={e => setEditForm({ ...editForm, sessionScope: e.target.value })}
+          />
+          <label>{t('plugins.instances.form.config')}</label>
+          <textarea
+            value={editForm.config}
+            placeholder={t('plugins.instances.form.configPlaceholder')}
+            onChange={e => setEditForm({ ...editForm, config: e.target.value })}
+          />
+          {editError && <p className="pi-error">{editError}</p>}
+        </Modal>
       )}
 
       {/* Confirm modal — delete or regenerate */}
       {confirm && (
-        <div className="modal-overlay" onClick={() => setConfirm(null)}>
-          <div className="modal confirm-modal" onClick={e => e.stopPropagation()}>
-            <div className="modal-header">
-              <h2>{t(`plugins.instances.${confirm.type}.title`)}</h2>
-              <button className="btn-icon" onClick={() => setConfirm(null)}>
-                <X size={20} />
-              </button>
-            </div>
-            <div className="modal-body plugin-instances">
-              <div className="pi-confirm-icon">
-                <AlertTriangle size={40} />
-              </div>
-              <p>{t(`plugins.instances.${confirm.type}.confirm`, { id: confirm.inst.instanceId })}</p>
-            </div>
-            <div className="modal-footer">
+        <Modal
+          open
+          onClose={() => setConfirm(null)}
+          title={t(`plugins.instances.${confirm.type}.title`)}
+          className="confirm-modal"
+          closeLabel={t('common.close')}
+          footer={
+            <>
               <button className="btn-secondary" onClick={() => setConfirm(null)}>
                 {t('common.cancel')}
               </button>
@@ -367,9 +346,14 @@ export function PluginInstances({ pluginId }: { pluginId: string }) {
               >
                 {t(`plugins.instances.${confirm.type}.action`)}
               </button>
-            </div>
+            </>
+          }
+        >
+          <div className="pi-confirm-icon">
+            <AlertTriangle size={40} />
           </div>
-        </div>
+          <p>{t(`plugins.instances.${confirm.type}.confirm`, { id: confirm.inst.instanceId })}</p>
+        </Modal>
       )}
     </div>
   );

--- a/dashboard/src/i18n/locales.test.ts
+++ b/dashboard/src/i18n/locales.test.ts
@@ -1,0 +1,108 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import i18next from 'i18next';
+
+// Catalog-level assertions over the real locale files through a real i18next instance — catches
+// missing keys (a component would render the raw key), missing plural forms (a count renders the
+// wrong number form), and interpolation drift that a JSON diff can't see.
+
+const LOCALES_DIR = join(dirname(fileURLToPath(import.meta.url)), 'locales');
+const LOCALE_IDS = readdirSync(LOCALES_DIR)
+  .filter(f => f.endsWith('.json'))
+  .map(f => f.replace('.json', ''))
+  .sort();
+
+const resources = Object.fromEntries(
+  LOCALE_IDS.map(id => [id, { translation: JSON.parse(readFileSync(join(LOCALES_DIR, `${id}.json`), 'utf8')) }]),
+);
+
+// No fallbackLng on purpose: a key missing from a locale must surface as the raw key, not as English.
+const i18n = i18next.createInstance();
+await i18n.init({ lng: 'en', resources, fallbackLng: false, interpolation: { escapeValue: false } });
+
+const NEW_PLUGIN_KEYS = [
+  'plugins.catalog.empty',
+  'plugins.catalog.install',
+  'plugins.catalog.installed',
+  'plugins.catalog.noDownload',
+  'plugins.catalog.noMatch',
+  'plugins.catalog.searchPlaceholder',
+  'plugins.catalog.update',
+  'plugins.catalog.updateAvailable',
+  'plugins.catalog.updated',
+  'plugins.installModal.catalogHint',
+  'plugins.installModal.catalogTeaser',
+  'plugins.installModal.catalogTeaserSuffix',
+  'plugins.installModal.tabCatalog',
+  'plugins.installModal.tabUpload',
+  'plugins.toasts.updateFailed',
+];
+
+test('webhooks.filters.badge: count=1 renders singular, count>1 renders plural (en)', () => {
+  assert.equal(i18n.t('webhooks.filters.badge', { count: 1 }), '1 filter');
+  assert.equal(i18n.t('webhooks.filters.badge', { count: 2 }), '2 filters');
+  assert.equal(i18n.t('webhooks.filters.badge', { count: 5 }), '5 filters');
+});
+
+test('chats.unreadBadge: count=1 renders singular, count>1 renders plural (en)', () => {
+  assert.equal(i18n.t('chats.unreadBadge', { count: 1 }), '1 unread message');
+  assert.equal(i18n.t('chats.unreadBadge', { count: 3 }), '3 unread messages');
+});
+
+test('chats.channels.subscribers: count=1 renders singular, count>1 renders plural (en)', () => {
+  assert.equal(i18n.t('chats.channels.subscribers', { count: 1 }), '1 subscriber');
+  assert.equal(i18n.t('chats.channels.subscribers', { count: 4 }), '4 subscribers');
+});
+
+test('count badges resolve to a non-key, interpolated string in every locale', () => {
+  for (const lng of LOCALE_IDS) {
+    for (const key of ['webhooks.filters.badge', 'chats.unreadBadge', 'chats.channels.subscribers']) {
+      for (const count of [1, 2]) {
+        const value = i18n.t(key, { lng, count });
+        assert.ok(value && !value.startsWith(key), `${lng} ${key} count=${count} did not resolve (got "${value}")`);
+        assert.ok(
+          // Hebrew/Arabic dual forms ("two filters") legitimately drop the numeral.
+          value.includes(String(count)) || (['he', 'ar'].includes(lng) && count === 2),
+          `${lng} ${key} count=${count} lost the count interpolation (got "${value}")`,
+        );
+      }
+    }
+  }
+});
+
+test('Hebrew dual + Arabic plural categories resolve for the filter badge', () => {
+  assert.equal(i18n.t('webhooks.filters.badge', { lng: 'he', count: 2 }), 'שני מסננים');
+  assert.equal(i18n.t('webhooks.filters.badge', { lng: 'he', count: 5 }), '5 מסננים');
+  assert.equal(i18n.t('webhooks.filters.badge', { lng: 'ar', count: 3 }), '3 عوامل تصفية');
+});
+
+test('every new plugins.* key resolves in every locale', () => {
+  for (const lng of LOCALE_IDS) {
+    for (const key of NEW_PLUGIN_KEYS) {
+      const value = i18n.t(key, { lng });
+      assert.ok(value && value !== key, `${lng}: ${key} missing from catalog (component would show a raw fallback)`);
+    }
+  }
+});
+
+test('new plugins.* keys carry the expected English copy', () => {
+  assert.equal(i18n.t('plugins.installModal.tabCatalog'), 'Catalog');
+  assert.equal(i18n.t('plugins.installModal.tabUpload'), 'Upload .zip');
+  assert.equal(i18n.t('plugins.catalog.installed'), 'Installed');
+  assert.equal(i18n.t('plugins.toasts.updateFailed'), 'Update failed');
+});
+
+test('sessionStatus.failed and sessionStatus.authenticating resolve in every locale', () => {
+  for (const lng of LOCALE_IDS) {
+    for (const status of ['failed', 'authenticating']) {
+      const key = `sessionStatus.${status}`;
+      const value = i18n.t(key, { lng });
+      assert.ok(value && value !== key && value !== status, `${lng}: ${key} missing — status pill would render raw "${status}"`);
+    }
+  }
+  assert.equal(i18n.t('sessionStatus.failed'), 'Failed');
+  assert.equal(i18n.t('sessionStatus.authenticating'), 'Authenticating...');
+});

--- a/dashboard/src/i18n/locales/ar.json
+++ b/dashboard/src/i18n/locales/ar.json
@@ -84,7 +84,11 @@
     "loadingChats": "جارٍ تحميل المحادثات...",
     "empty": "لا توجد محادثات",
     "noMessageYet": "لا توجد رسائل بعد",
-    "unreadBadge": "{{count}} رسائل غير مقروءة",
+    "unreadBadge": "{{count}} رسالة غير مقروءة",
+    "unreadBadge_other": "{{count}} رسالة غير مقروءة",
+    "unreadBadge_two": "{{count}} رسالتان غير مقروءتان",
+    "unreadBadge_few": "{{count}} رسائل غير مقروءة",
+    "unreadBadge_many": "{{count}} رسالة غير مقروءة",
     "loadingMessages": "جارٍ تحميل الرسائل...",
     "noMessagesInChat": "لا توجد رسائل بعد. أرسل الرسالة الأولى للبدء!",
     "downloadDocument": "تنزيل المستند",
@@ -152,7 +156,11 @@
       "notSupported": "القنوات غير مدعومة على محرك Baileys.",
       "empty": "أنت غير مشترك في أي قناة حتى الآن.",
       "notReady": "الجلسة ليست جاهزة بعد.",
-      "subscribers": "{{count}} مشترك"
+      "subscribers": "{{count}} مشترك",
+      "subscribers_other": "{{count}} مشترك",
+      "subscribers_two": "{{count}} مشتركان",
+      "subscribers_few": "{{count}} مشتركين",
+      "subscribers_many": "{{count}} مشترك"
     },
     "errors": {
       "loadSessions": "فشل تحميل الجلسات",
@@ -230,7 +238,9 @@
     "connecting": "جارٍ الاتصال...",
     "qr_ready": "امسح رمز QR",
     "ready": "متصل",
-    "disconnected": "غير متصل"
+    "disconnected": "غير متصل",
+    "failed": "فشل",
+    "authenticating": "جارٍ المصادقة..."
   },
   "sessions": {
     "title": "الجلسات",
@@ -358,10 +368,11 @@
     "saveChanges": "حفظ التغييرات",
     "filters": {
       "badge": "{{count}} عامل تصفية",
-      "badge_zero": "بدون عوامل تصفية",
+      "badge_other": "{{count}} عامل تصفية",
       "badge_two": "عاملا تصفية",
       "badge_few": "{{count}} عوامل تصفية",
       "badge_many": "{{count}} عامل تصفية",
+      "badge_zero": "بدون عوامل تصفية",
       "title": "عوامل التصفية (اختياري)",
       "hint": "يتم التفعيل فقط عند تطابق جميع الشروط. ينطبق على أحداث الرسائل.",
       "addCondition": "إضافة شرط",
@@ -799,7 +810,12 @@
       "title": "تثبيت إضافة",
       "hint": "ارفع إضافة معبّأة بصيغة .zip (تحتوي على manifest.json). تعمل في بيئة معزولة بعد تمكينها.",
       "choose": "اختر ملف .zip…",
-      "tooLarge": "يتجاوز الملف الحد الأقصى البالغ 5 MB."
+      "tooLarge": "يتجاوز الملف الحد الأقصى البالغ 5 MB.",
+      "catalogHint": "ثبّت مباشرة من كتالوج إضافات OpenWA. يتم جلب ملف .zip من جانب الخادم عبر حماية SSRF، ثم يُتحقق منه ويُشغَّل في وضع الحماية.",
+      "catalogTeaser": "تبحث عن إضافات؟",
+      "catalogTeaserSuffix": "يتصفح المتجر الرسمي.",
+      "tabCatalog": "الكتالوج",
+      "tabUpload": "رفع .zip"
     },
     "toasts": {
       "errorTitle": "خطأ في الإضافة",
@@ -817,7 +833,8 @@
       "enableFailedTitle": "فشل التفعيل",
       "disableFailedTitle": "فشل التعطيل",
       "configRequiredTitle": "الإعداد مطلوب",
-      "configRequiredDesc": "املأ الحقول المطلوبة قبل التفعيل: {{fields}}"
+      "configRequiredDesc": "املأ الحقول المطلوبة قبل التفعيل: {{fields}}",
+      "updateFailed": "فشل التحديث"
     },
     "sessions": {
       "activationTitle": "التشغيل لـ",
@@ -896,6 +913,17 @@
         "secretRegenerated": "تم إعادة إنشاء المفتاح السري",
         "actionFailed": "فشل الإجراء"
       }
+    },
+    "catalog": {
+      "empty": "لا توجد إضافات في الكتالوج.",
+      "install": "تثبيت",
+      "installed": "مُثبَّت",
+      "noDownload": "لا يحتوي إدخال الكتالوج هذا على عنوان URL للتنزيل.",
+      "noMatch": "لا توجد إضافات تطابق بحثك.",
+      "searchPlaceholder": "ابحث في الإضافات…",
+      "update": "تحديث",
+      "updateAvailable": "يتوفر تحديث",
+      "updated": "تم تحديث الإضافة"
     }
   },
   "search": {

--- a/dashboard/src/i18n/locales/de.json
+++ b/dashboard/src/i18n/locales/de.json
@@ -84,7 +84,8 @@
     "loadingChats": "Chats werden geladen...",
     "empty": "Keine Chats",
     "noMessageYet": "Noch keine Nachrichten",
-    "unreadBadge": "{{count}} ungelesene Nachrichten",
+    "unreadBadge": "{{count}} ungelesene Nachricht",
+    "unreadBadge_other": "{{count}} ungelesene Nachrichten",
     "loadingMessages": "Nachrichten werden geladen...",
     "noMessagesInChat": "Noch keine Nachrichten. Sende die erste Nachricht, um zu beginnen!",
     "downloadDocument": "Dokument herunterladen",
@@ -147,7 +148,8 @@
       "notSupported": "Kanäle werden von der Baileys-Engine nicht unterstützt.",
       "empty": "Du hast noch keine Kanäle abonniert.",
       "notReady": "Die Sitzung ist noch nicht bereit.",
-      "subscribers": "{{count}} Abonnenten"
+      "subscribers": "{{count}} Abonnent",
+      "subscribers_other": "{{count}} Abonnenten"
     },
     "errors": {
       "loadSessions": "Sitzungen konnten nicht geladen werden",
@@ -225,7 +227,9 @@
     "connecting": "Verbindung wird hergestellt...",
     "qr_ready": "QR-Code scannen",
     "ready": "Verbunden",
-    "disconnected": "Getrennt"
+    "disconnected": "Getrennt",
+    "failed": "Fehlgeschlagen",
+    "authenticating": "Wird authentifiziert..."
   },
   "sessions": {
     "title": "Sitzungen",
@@ -355,6 +359,7 @@
       "title": "Filter (optional)",
       "hint": "Wird nur ausgelöst, wenn alle Bedingungen erfüllt sind. Gilt für Nachrichtenereignisse.",
       "badge": "{{count}} Filter",
+      "badge_other": "{{count}} Filter",
       "addCondition": "Bedingung hinzufügen",
       "removeCondition": "Bedingung entfernen",
       "caseSensitive": "Groß-/Kleinschreibung beachten",
@@ -790,7 +795,12 @@
       "title": "Plugin installieren",
       "hint": "Lade ein als ZIP-Datei verpacktes Plugin mit einer manifest.json hoch. Nach der Aktivierung wird es in einer Sandbox ausgeführt.",
       "choose": "ZIP-Datei auswählen…",
-      "tooLarge": "Die Datei überschreitet das Limit von 5 MB."
+      "tooLarge": "Die Datei überschreitet das Limit von 5 MB.",
+      "catalogHint": "Installieren Sie direkt aus dem OpenWA-Plugin-Katalog. Die .zip-Datei wird serverseitig durch den SSRF-Schutz abgerufen, dann validiert und in einer Sandbox ausgeführt.",
+      "catalogTeaser": "Sie suchen Plugins?",
+      "catalogTeaserSuffix": "durchstöbert den offiziellen Marktplatz.",
+      "tabCatalog": "Katalog",
+      "tabUpload": ".zip hochladen"
     },
     "toasts": {
       "errorTitle": "Plugin-Fehler",
@@ -808,7 +818,8 @@
       "enableFailedTitle": "Aktivierung fehlgeschlagen",
       "disableFailedTitle": "Deaktivierung fehlgeschlagen",
       "configRequiredTitle": "Konfiguration erforderlich",
-      "configRequiredDesc": "Fülle vor der Aktivierung die erforderlichen Felder aus: {{fields}}"
+      "configRequiredDesc": "Fülle vor der Aktivierung die erforderlichen Felder aus: {{fields}}",
+      "updateFailed": "Aktualisierung fehlgeschlagen"
     },
     "sessions": {
       "activationTitle": "Ausführen für",
@@ -887,6 +898,17 @@
         "secretRegenerated": "Geheimnis neu erstellt",
         "actionFailed": "Aktion fehlgeschlagen"
       }
+    },
+    "catalog": {
+      "empty": "Keine Plugins im Katalog.",
+      "install": "Installieren",
+      "installed": "Installiert",
+      "noDownload": "Dieser Katalogeintrag hat keine Download-URL.",
+      "noMatch": "Keine Plugins entsprechen Ihrer Suche.",
+      "searchPlaceholder": "Plugins suchen…",
+      "update": "Aktualisieren",
+      "updateAvailable": "Update verfügbar",
+      "updated": "Plugin aktualisiert"
     }
   },
   "search": {

--- a/dashboard/src/i18n/locales/en.json
+++ b/dashboard/src/i18n/locales/en.json
@@ -84,7 +84,8 @@
     "loadingChats": "Loading chats...",
     "empty": "No chats",
     "noMessageYet": "No messages yet",
-    "unreadBadge": "{{count}} unread messages",
+    "unreadBadge": "{{count}} unread message",
+    "unreadBadge_other": "{{count}} unread messages",
     "loadingMessages": "Loading messages...",
     "noMessagesInChat": "No messages yet. Send the first message to get started!",
     "downloadDocument": "Download document",
@@ -147,7 +148,8 @@
       "notSupported": "Channels are not supported on the Baileys engine.",
       "empty": "You are not subscribed to any channels yet.",
       "notReady": "Session is not ready yet.",
-      "subscribers": "{{count}} subscribers"
+      "subscribers": "{{count}} subscriber",
+      "subscribers_other": "{{count}} subscribers"
     },
     "errors": {
       "loadSessions": "Failed to load sessions",
@@ -225,7 +227,9 @@
     "connecting": "Connecting...",
     "qr_ready": "Scan QR",
     "ready": "Connected",
-    "disconnected": "Disconnected"
+    "disconnected": "Disconnected",
+    "failed": "Failed",
+    "authenticating": "Authenticating..."
   },
   "sessions": {
     "title": "Sessions",
@@ -355,6 +359,7 @@
       "title": "Filters (optional)",
       "hint": "Only fire when all conditions match. Applies to message events.",
       "badge": "{{count}} filter",
+      "badge_other": "{{count}} filters",
       "addCondition": "Add condition",
       "removeCondition": "Remove condition",
       "caseSensitive": "Case sensitive",
@@ -790,7 +795,12 @@
       "title": "Install a plugin",
       "hint": "Upload a plugin packaged as a .zip (with a manifest.json). It runs sandboxed once enabled.",
       "choose": "Choose a .zip file…",
-      "tooLarge": "The file exceeds the 5 MB limit."
+      "tooLarge": "The file exceeds the 5 MB limit.",
+      "catalogHint": "Install directly from the OpenWA plugin catalog. The .zip is fetched server-side through the SSRF guard, then validated and sandboxed.",
+      "catalogTeaser": "Looking for plugins?",
+      "catalogTeaserSuffix": "browses the official marketplace.",
+      "tabCatalog": "Catalog",
+      "tabUpload": "Upload .zip"
     },
     "toasts": {
       "errorTitle": "Plugin Error",
@@ -808,7 +818,8 @@
       "enableFailedTitle": "Enable failed",
       "disableFailedTitle": "Disable failed",
       "configRequiredTitle": "Configuration required",
-      "configRequiredDesc": "Fill in the required field(s) before enabling: {{fields}}"
+      "configRequiredDesc": "Fill in the required field(s) before enabling: {{fields}}",
+      "updateFailed": "Update failed"
     },
     "sessions": {
       "activationTitle": "Run for",
@@ -887,6 +898,17 @@
         "secretRegenerated": "Secret regenerated",
         "actionFailed": "Action failed"
       }
+    },
+    "catalog": {
+      "empty": "No plugins in the catalog.",
+      "install": "Install",
+      "installed": "Installed",
+      "noDownload": "This catalog entry has no download URL.",
+      "noMatch": "No plugins match your search.",
+      "searchPlaceholder": "Search plugins…",
+      "update": "Update",
+      "updateAvailable": "Update available",
+      "updated": "Plugin updated"
     }
   },
   "search": {

--- a/dashboard/src/i18n/locales/es.json
+++ b/dashboard/src/i18n/locales/es.json
@@ -84,7 +84,8 @@
     "loadingChats": "Cargando chats...",
     "empty": "Sin chats",
     "noMessageYet": "Aún sin mensajes",
-    "unreadBadge": "{{count}} mensajes sin leer",
+    "unreadBadge": "{{count}} mensaje sin leer",
+    "unreadBadge_other": "{{count}} mensajes sin leer",
     "loadingMessages": "Cargando mensajes...",
     "noMessagesInChat": "Aún no hay mensajes. ¡Envía el primero para empezar!",
     "downloadDocument": "Descargar documento",
@@ -147,7 +148,8 @@
       "notSupported": "Los canales no son compatibles con el motor Baileys.",
       "empty": "Aún no estás suscrito a ningún canal.",
       "notReady": "La sesión aún no está lista.",
-      "subscribers": "{{count}} suscriptores"
+      "subscribers": "{{count}} suscriptor",
+      "subscribers_other": "{{count}} suscriptores"
     },
     "errors": {
       "loadSessions": "Error al cargar las sesiones",
@@ -225,7 +227,9 @@
     "connecting": "Conectando...",
     "qr_ready": "Escanear QR",
     "ready": "Conectada",
-    "disconnected": "Desconectada"
+    "disconnected": "Desconectada",
+    "failed": "Fallida",
+    "authenticating": "Autenticando..."
   },
   "sessions": {
     "title": "Sesiones",
@@ -355,6 +359,7 @@
       "title": "Filtros (opcional)",
       "hint": "Activar solo cuando se cumplan todas las condiciones. Se aplica a eventos de mensajes.",
       "badge": "{{count}} filtro",
+      "badge_other": "{{count}} filtros",
       "addCondition": "Añadir condición",
       "removeCondition": "Eliminar condición",
       "caseSensitive": "Distinguir mayúsculas",
@@ -790,7 +795,12 @@
       "title": "Instalar un plugin",
       "hint": "Sube un plugin empaquetado como un .zip (con un manifest.json). Se ejecuta en modo aislado una vez habilitado.",
       "choose": "Elige un archivo .zip…",
-      "tooLarge": "El archivo supera el límite de 5 MB."
+      "tooLarge": "El archivo supera el límite de 5 MB.",
+      "catalogHint": "Instala directamente desde el catálogo de plugins de OpenWA. El .zip se obtiene en el servidor a través de la protección SSRF, luego se valida y se ejecuta en sandbox.",
+      "catalogTeaser": "¿Buscas plugins?",
+      "catalogTeaserSuffix": "explora el marketplace oficial.",
+      "tabCatalog": "Catálogo",
+      "tabUpload": "Subir .zip"
     },
     "toasts": {
       "errorTitle": "Error de plugin",
@@ -808,7 +818,8 @@
       "enableFailedTitle": "Error al activar",
       "disableFailedTitle": "Error al desactivar",
       "configRequiredTitle": "Configuración requerida",
-      "configRequiredDesc": "Completa los campos obligatorios antes de activar: {{fields}}"
+      "configRequiredDesc": "Completa los campos obligatorios antes de activar: {{fields}}",
+      "updateFailed": "Error al actualizar"
     },
     "sessions": {
       "activationTitle": "Ejecutar para",
@@ -887,6 +898,17 @@
         "secretRegenerated": "Secreto regenerado",
         "actionFailed": "La acción falló"
       }
+    },
+    "catalog": {
+      "empty": "No hay plugins en el catálogo.",
+      "install": "Instalar",
+      "installed": "Instalado",
+      "noDownload": "Esta entrada del catálogo no tiene URL de descarga.",
+      "noMatch": "Ningún plugin coincide con tu búsqueda.",
+      "searchPlaceholder": "Buscar plugins…",
+      "update": "Actualizar",
+      "updateAvailable": "Actualización disponible",
+      "updated": "Plugin actualizado"
     }
   },
   "search": {

--- a/dashboard/src/i18n/locales/fr.json
+++ b/dashboard/src/i18n/locales/fr.json
@@ -84,7 +84,8 @@
     "loadingChats": "Chargement des discussions...",
     "empty": "Aucune discussion",
     "noMessageYet": "Aucun message pour le moment",
-    "unreadBadge": "{{count}} messages non lus",
+    "unreadBadge": "{{count}} message non lu",
+    "unreadBadge_other": "{{count}} messages non lus",
     "loadingMessages": "Chargement des messages...",
     "noMessagesInChat": "Aucun message pour le moment. Envoyez le premier message pour commencer !",
     "downloadDocument": "Télécharger le document",
@@ -147,7 +148,8 @@
       "notSupported": "Les chaînes ne sont pas prises en charge par le moteur Baileys.",
       "empty": "Vous n'êtes abonné à aucune chaîne pour le moment.",
       "notReady": "La session n'est pas encore prête.",
-      "subscribers": "{{count}} abonnés"
+      "subscribers": "{{count}} abonné",
+      "subscribers_other": "{{count}} abonnés"
     },
     "errors": {
       "loadSessions": "Échec du chargement des sessions",
@@ -225,7 +227,9 @@
     "connecting": "Connexion...",
     "qr_ready": "Scanner le QR",
     "ready": "Connecté",
-    "disconnected": "Déconnecté"
+    "disconnected": "Déconnecté",
+    "failed": "Échec",
+    "authenticating": "Authentification..."
   },
   "sessions": {
     "title": "Sessions",
@@ -355,6 +359,7 @@
       "title": "Filtres (facultatif)",
       "hint": "Déclencher uniquement lorsque toutes les conditions sont remplies. S'applique aux événements de message.",
       "badge": "{{count}} filtre",
+      "badge_other": "{{count}} filtres",
       "addCondition": "Ajouter une condition",
       "removeCondition": "Supprimer la condition",
       "caseSensitive": "Sensible à la casse",
@@ -790,7 +795,12 @@
       "title": "Installer un plugin",
       "hint": "Téléversez un plugin empaqueté au format .zip (avec un manifest.json). Il s'exécute en bac à sable une fois activé.",
       "choose": "Choisir un fichier .zip…",
-      "tooLarge": "Le fichier dépasse la limite de 5 MB."
+      "tooLarge": "Le fichier dépasse la limite de 5 MB.",
+      "catalogHint": "Installez directement depuis le catalogue de plugins OpenWA. Le .zip est récupéré côté serveur via la protection SSRF, puis validé et exécuté en sandbox.",
+      "catalogTeaser": "Vous cherchez des plugins ?",
+      "catalogTeaserSuffix": "parcourt la place de marché officielle.",
+      "tabCatalog": "Catalogue",
+      "tabUpload": "Téléverser .zip"
     },
     "toasts": {
       "errorTitle": "Erreur de plugin",
@@ -808,7 +818,8 @@
       "enableFailedTitle": "Échec de l'activation",
       "disableFailedTitle": "Échec de la désactivation",
       "configRequiredTitle": "Configuration requise",
-      "configRequiredDesc": "Renseignez les champs obligatoires avant l'activation : {{fields}}"
+      "configRequiredDesc": "Renseignez les champs obligatoires avant l'activation : {{fields}}",
+      "updateFailed": "Échec de la mise à jour"
     },
     "sessions": {
       "activationTitle": "Exécuter pour",
@@ -887,6 +898,17 @@
         "secretRegenerated": "Secret régénéré",
         "actionFailed": "L'action a échoué"
       }
+    },
+    "catalog": {
+      "empty": "Aucun plugin dans le catalogue.",
+      "install": "Installer",
+      "installed": "Installé",
+      "noDownload": "Cette entrée du catalogue n'a pas d'URL de téléchargement.",
+      "noMatch": "Aucun plugin ne correspond à votre recherche.",
+      "searchPlaceholder": "Rechercher des plugins…",
+      "update": "Mettre à jour",
+      "updateAvailable": "Mise à jour disponible",
+      "updated": "Plugin mis à jour"
     }
   },
   "search": {

--- a/dashboard/src/i18n/locales/he.json
+++ b/dashboard/src/i18n/locales/he.json
@@ -84,7 +84,10 @@
     "loadingChats": "טוען שיחות...",
     "empty": "אין שיחות",
     "noMessageYet": "אין הודעות עדיין",
-    "unreadBadge": "{{count}} הודעות שלא נקראו",
+    "unreadBadge": "{{count}} הודעה שלא נקראה",
+    "unreadBadge_other": "{{count}} הודעות שלא נקראו",
+    "unreadBadge_two": "שתי הודעות שלא נקראו",
+    "unreadBadge_many": "{{count}} הודעות שלא נקראו",
     "loadingMessages": "טוען הודעות...",
     "noMessagesInChat": "אין הודעות עדיין. שלח את ההודעה הראשונה כדי להתחיל!",
     "downloadDocument": "הורדת מסמך",
@@ -150,7 +153,10 @@
       "notSupported": "ערוצים אינם נתמכים במנוע Baileys.",
       "empty": "עדיין אינך רשום/ה לאף ערוץ.",
       "notReady": "הסשן עדיין אינו מוכן.",
-      "subscribers": "{{count}} מנויים"
+      "subscribers": "{{count}} מנוי",
+      "subscribers_other": "{{count}} מנויים",
+      "subscribers_two": "שני מנויים",
+      "subscribers_many": "{{count}} מנויים"
     },
     "errors": {
       "loadSessions": "טעינת הסשנים נכשלה",
@@ -228,7 +234,9 @@
     "connecting": "מתחבר...",
     "qr_ready": "סריקת QR",
     "ready": "מחובר",
-    "disconnected": "מנותק"
+    "disconnected": "מנותק",
+    "failed": "נכשל",
+    "authenticating": "מאמת..."
   },
   "sessions": {
     "title": "Sessions",
@@ -356,6 +364,8 @@
     "saveChanges": "שמירת שינויים",
     "filters": {
       "badge": "{{count}} מסנן",
+      "badge_other": "{{count}} מסננים",
+      "badge_many": "{{count}} מסננים",
       "badge_two": "שני מסננים",
       "title": "מסננים (אופציונלי)",
       "hint": "הפעלה רק כאשר כל התנאים מתקיימים. חל על אירועי הודעות.",
@@ -794,7 +804,12 @@
       "title": "התקנת תוסף",
       "hint": "ניתן להעלות תוסף ארוז כקובץ .zip (הכולל manifest.json). הוא פועל בארגז חול לאחר ההפעלה.",
       "choose": "בחירת קובץ ‎.zip‎…",
-      "tooLarge": "הקובץ חורג מהמגבלה של ‎5 MB‎."
+      "tooLarge": "הקובץ חורג מהמגבלה של ‎5 MB‎.",
+      "catalogHint": "התקינו ישירות מקטלוג התוספים של OpenWA. קובץ ה-.zip נשלף מהשרת דרך מגן ה-SSRF, מאומת ומורץ בארגז חול.",
+      "catalogTeaser": "מחפשים תוספים?",
+      "catalogTeaserSuffix": "סוקר את החנות הרשמית.",
+      "tabCatalog": "קטלוג",
+      "tabUpload": "העלאת .zip"
     },
     "toasts": {
       "errorTitle": "שגיאת תוסף",
@@ -812,7 +827,8 @@
       "enableFailedTitle": "ההפעלה נכשלה",
       "disableFailedTitle": "ההשבתה נכשלה",
       "configRequiredTitle": "נדרשת הגדרה",
-      "configRequiredDesc": "מלא את שדות החובה לפני ההפעלה: {{fields}}"
+      "configRequiredDesc": "מלא את שדות החובה לפני ההפעלה: {{fields}}",
+      "updateFailed": "העדכון נכשל"
     },
     "sessions": {
       "activationTitle": "הפעלה עבור",
@@ -891,6 +907,17 @@
         "secretRegenerated": "הסוד נוצר מחדש",
         "actionFailed": "הפעולה נכשלה"
       }
+    },
+    "catalog": {
+      "empty": "אין תוספים בקטלוג.",
+      "install": "התקנה",
+      "installed": "מותקן",
+      "noDownload": "לערך קטלוג זה אין כתובת הורדה.",
+      "noMatch": "אין תוספים התואמים את החיפוש.",
+      "searchPlaceholder": "חיפוש תוספים…",
+      "update": "עדכון",
+      "updateAvailable": "עדכון זמין",
+      "updated": "התוסף עודכן"
     }
   },
   "search": {

--- a/dashboard/src/i18n/locales/it.json
+++ b/dashboard/src/i18n/locales/it.json
@@ -84,7 +84,8 @@
     "loadingChats": "Caricamento chat...",
     "empty": "Nessuna chat",
     "noMessageYet": "Ancora nessun messaggio",
-    "unreadBadge": "{{count}} messaggi non letti",
+    "unreadBadge": "{{count}} messaggio non letto",
+    "unreadBadge_other": "{{count}} messaggi non letti",
     "loadingMessages": "Caricamento messaggi...",
     "noMessagesInChat": "Ancora nessun messaggio. Invia il primo messaggio per iniziare!",
     "downloadDocument": "Scarica documento",
@@ -147,7 +148,8 @@
       "notSupported": "I canali non sono supportati sul motore Baileys.",
       "empty": "Non sei ancora iscritto a nessun canale.",
       "notReady": "La sessione non è ancora pronta.",
-      "subscribers": "{{count}} iscritti"
+      "subscribers": "{{count}} iscritto",
+      "subscribers_other": "{{count}} iscritti"
     },
     "errors": {
       "loadSessions": "Impossibile caricare le sessioni",
@@ -225,7 +227,9 @@
     "connecting": "Connessione in corso...",
     "qr_ready": "Scansiona QR",
     "ready": "Connesso",
-    "disconnected": "Disconnesso"
+    "disconnected": "Disconnesso",
+    "failed": "Non riuscita",
+    "authenticating": "Autenticazione in corso..."
   },
   "sessions": {
     "title": "Sessioni",
@@ -355,6 +359,7 @@
       "title": "Filtri (opzionale)",
       "hint": "Attiva solo quando tutte le condizioni corrispondono. Si applica agli eventi dei messaggi.",
       "badge": "{{count}} filtro",
+      "badge_other": "{{count}} filtri",
       "addCondition": "Aggiungi condizione",
       "removeCondition": "Rimuovi condizione",
       "caseSensitive": "Distingui maiuscole",
@@ -790,7 +795,12 @@
       "title": "Installa un plugin",
       "hint": "Carica un plugin pacchettizzato come file .zip (con un manifest.json). Viene eseguito in sandbox una volta abilitato.",
       "choose": "Scegli un file .zip…",
-      "tooLarge": "Il file supera il limite di 5 MB."
+      "tooLarge": "Il file supera il limite di 5 MB.",
+      "catalogHint": "Installa direttamente dal catalogo dei plugin di OpenWA. Lo .zip viene recuperato lato server tramite la protezione SSRF, quindi validato ed eseguito in sandbox.",
+      "catalogTeaser": "Cerchi plugin?",
+      "catalogTeaserSuffix": "sfoglia il marketplace ufficiale.",
+      "tabCatalog": "Catalogo",
+      "tabUpload": "Carica .zip"
     },
     "toasts": {
       "errorTitle": "Errore Plugin",
@@ -808,7 +818,8 @@
       "enableFailedTitle": "Attivazione non riuscita",
       "disableFailedTitle": "Disattivazione non riuscita",
       "configRequiredTitle": "Configurazione richiesta",
-      "configRequiredDesc": "Compila i campi obbligatori prima di attivare: {{fields}}"
+      "configRequiredDesc": "Compila i campi obbligatori prima di attivare: {{fields}}",
+      "updateFailed": "Aggiornamento non riuscito"
     },
     "sessions": {
       "activationTitle": "Esegui per",
@@ -887,6 +898,17 @@
         "secretRegenerated": "Segreto rigenerato",
         "actionFailed": "Azione non riuscita"
       }
+    },
+    "catalog": {
+      "empty": "Nessun plugin nel catalogo.",
+      "install": "Installa",
+      "installed": "Installato",
+      "noDownload": "Questa voce del catalogo non ha un URL di download.",
+      "noMatch": "Nessun plugin corrisponde alla ricerca.",
+      "searchPlaceholder": "Cerca plugin…",
+      "update": "Aggiorna",
+      "updateAvailable": "Aggiornamento disponibile",
+      "updated": "Plugin aggiornato"
     }
   },
   "search": {

--- a/dashboard/src/i18n/locales/ko.json
+++ b/dashboard/src/i18n/locales/ko.json
@@ -85,6 +85,7 @@
     "empty": "채팅 없음",
     "noMessageYet": "아직 메시지 없음",
     "unreadBadge": "읽지 않은 메시지 {{count}}개",
+    "unreadBadge_other": "읽지 않은 메시지 {{count}}개",
     "loadingMessages": "메시지 불러오는 중...",
     "noMessagesInChat": "아직 메시지가 없습니다. 첫 메시지를 보내 대화를 시작하세요!",
     "downloadDocument": "문서 다운로드",
@@ -147,7 +148,8 @@
       "notSupported": "Baileys 엔진에서는 채널을 지원하지 않습니다.",
       "empty": "아직 구독 중인 채널이 없습니다.",
       "notReady": "세션이 아직 준비되지 않았습니다.",
-      "subscribers": "구독자 {{count}}명"
+      "subscribers": "구독자 {{count}}명",
+      "subscribers_other": "구독자 {{count}}명"
     },
     "errors": {
       "loadSessions": "세션을 불러오지 못했습니다",
@@ -225,7 +227,9 @@
     "connecting": "연결하는 중...",
     "qr_ready": "QR 스캔",
     "ready": "연결됨",
-    "disconnected": "연결 끊김"
+    "disconnected": "연결 끊김",
+    "failed": "실패",
+    "authenticating": "인증하는 중..."
   },
   "sessions": {
     "title": "세션",
@@ -355,6 +359,7 @@
       "title": "필터 (선택 사항)",
       "hint": "모든 조건이 일치할 때만 실행됩니다. 메시지 이벤트에 적용됩니다.",
       "badge": "필터 {{count}}개",
+      "badge_other": "필터 {{count}}개",
       "addCondition": "조건 추가",
       "removeCondition": "조건 제거",
       "caseSensitive": "대소문자 구분",
@@ -790,7 +795,12 @@
       "title": "플러그인 설치",
       "hint": "manifest.json이 포함된 .zip으로 패키징된 플러그인을 업로드하세요. 활성화되면 샌드박스에서 실행됩니다.",
       "choose": ".zip 파일 선택…",
-      "tooLarge": "파일이 5MB 제한을 초과합니다."
+      "tooLarge": "파일이 5MB 제한을 초과합니다.",
+      "catalogHint": "OpenWA 플러그인 카탈로그에서 직접 설치하세요. .zip 파일은 SSRF 가드를 통해 서버에서 가져온 후 검증되고 샌드박스에서 실행됩니다.",
+      "catalogTeaser": "플러그인을 찾고 계신가요?",
+      "catalogTeaserSuffix": "공식 마켓플레이스를 둘러봅니다.",
+      "tabCatalog": "카탈로그",
+      "tabUpload": ".zip 업로드"
     },
     "toasts": {
       "errorTitle": "플러그인 오류",
@@ -808,7 +818,8 @@
       "enableFailedTitle": "활성화 실패",
       "disableFailedTitle": "비활성화 실패",
       "configRequiredTitle": "설정 필요",
-      "configRequiredDesc": "활성화하기 전에 필수 항목을 입력하세요: {{fields}}"
+      "configRequiredDesc": "활성화하기 전에 필수 항목을 입력하세요: {{fields}}",
+      "updateFailed": "업데이트 실패"
     },
     "sessions": {
       "activationTitle": "실행 대상",
@@ -887,6 +898,17 @@
         "secretRegenerated": "시크릿이 재생성되었습니다",
         "actionFailed": "작업 실패"
       }
+    },
+    "catalog": {
+      "empty": "카탈로그에 플러그인이 없습니다.",
+      "install": "설치",
+      "installed": "설치됨",
+      "noDownload": "이 카탈로그 항목에는 다운로드 URL이 없습니다.",
+      "noMatch": "검색과 일치하는 플러그인이 없습니다.",
+      "searchPlaceholder": "플러그인 검색…",
+      "update": "업데이트",
+      "updateAvailable": "업데이트 사용 가능",
+      "updated": "플러그인이 업데이트되었습니다"
     }
   },
   "search": {

--- a/dashboard/src/i18n/locales/pt-BR.json
+++ b/dashboard/src/i18n/locales/pt-BR.json
@@ -84,7 +84,8 @@
     "loadingChats": "Carregando chats...",
     "empty": "Sem chats",
     "noMessageYet": "Ainda sem mensagens",
-    "unreadBadge": "{{count}} mensagens não lidas",
+    "unreadBadge": "{{count}} mensagem não lida",
+    "unreadBadge_other": "{{count}} mensagens não lidas",
     "loadingMessages": "Carregando mensagens...",
     "noMessagesInChat": "Ainda não há mensagens. Envie a primeira para começar!",
     "downloadDocument": "Baixar documento",
@@ -147,7 +148,8 @@
       "notSupported": "Os canais não são compatíveis com o mecanismo Baileys.",
       "empty": "Você ainda não está inscrito em nenhum canal.",
       "notReady": "A sessão ainda não está pronta.",
-      "subscribers": "{{count}} inscritos"
+      "subscribers": "{{count}} inscrito",
+      "subscribers_other": "{{count}} inscritos"
     },
     "errors": {
       "loadSessions": "Erro ao carregar as sessões",
@@ -225,7 +227,9 @@
     "connecting": "Conectando...",
     "qr_ready": "Escanear QR",
     "ready": "Conectada",
-    "disconnected": "Desconectada"
+    "disconnected": "Desconectada",
+    "failed": "Falha",
+    "authenticating": "Autenticando..."
   },
   "sessions": {
     "title": "Sessões",
@@ -355,6 +359,7 @@
       "title": "Filtros (opcional)",
       "hint": "Disparar somente quando todas as condições forem atendidas. Aplica-se a eventos de mensagens.",
       "badge": "{{count}} filtro",
+      "badge_other": "{{count}} filtros",
       "addCondition": "Adicionar condição",
       "removeCondition": "Remover condição",
       "caseSensitive": "Diferenciar maiúsculas",
@@ -790,7 +795,12 @@
       "title": "Instalar um plugin",
       "hint": "Envie um plugin empacotado como .zip (com um manifest.json). É executado em modo isolado quando habilitado.",
       "choose": "Escolha um arquivo .zip…",
-      "tooLarge": "O arquivo excede o limite de 5 MB."
+      "tooLarge": "O arquivo excede o limite de 5 MB.",
+      "catalogHint": "Instale diretamente do catálogo de plugins do OpenWA. O .zip é baixado no servidor através da proteção SSRF, depois validado e executado em sandbox.",
+      "catalogTeaser": "Procurando plugins?",
+      "catalogTeaserSuffix": "navega no marketplace oficial.",
+      "tabCatalog": "Catálogo",
+      "tabUpload": "Enviar .zip"
     },
     "toasts": {
       "errorTitle": "Erro de plugin",
@@ -808,7 +818,8 @@
       "enableFailedTitle": "Falha ao ativar",
       "disableFailedTitle": "Falha ao desativar",
       "configRequiredTitle": "Configuração necessária",
-      "configRequiredDesc": "Preencha os campos obrigatórios antes de ativar: {{fields}}"
+      "configRequiredDesc": "Preencha os campos obrigatórios antes de ativar: {{fields}}",
+      "updateFailed": "Falha ao atualizar"
     },
     "sessions": {
       "activationTitle": "Executar para",
@@ -887,6 +898,17 @@
         "secretRegenerated": "Segredo regenerado",
         "actionFailed": "Falha na ação"
       }
+    },
+    "catalog": {
+      "empty": "Não há plugins no catálogo.",
+      "install": "Instalar",
+      "installed": "Instalado",
+      "noDownload": "Esta entrada do catálogo não tem URL de download.",
+      "noMatch": "Nenhum plugin corresponde à sua pesquisa.",
+      "searchPlaceholder": "Pesquisar plugins…",
+      "update": "Atualizar",
+      "updateAvailable": "Atualização disponível",
+      "updated": "Plugin atualizado"
     }
   },
   "search": {

--- a/dashboard/src/i18n/locales/te.json
+++ b/dashboard/src/i18n/locales/te.json
@@ -84,7 +84,8 @@
     "loadingChats": "చాట్‌లను లోడ్ చేస్తోంది...",
     "empty": "చాట్‌లు లేవు",
     "noMessageYet": "ఇంకా సందేశాలు లేవు",
-    "unreadBadge": "{{count}} చదవని సందేశాలు",
+    "unreadBadge": "{{count}} చదవని సందేశం",
+    "unreadBadge_other": "{{count}} చదవని సందేశాలు",
     "loadingMessages": "సందేశాలను లోడ్ చేస్తోంది...",
     "noMessagesInChat": "ఇంకా సందేశాలు లేవు. ప్రారంభించడానికి మొదటి సందేశాన్ని పంపండి!",
     "downloadDocument": "డాక్యుమెంట్‌ను డౌన్‌లోడ్ చేయి",
@@ -147,7 +148,8 @@
       "notSupported": "Channels are not supported on the Baileys engine.",
       "empty": "You are not subscribed to any channels yet.",
       "notReady": "సెషన్ ఇంకా సిద్ధంగా లేదు.",
-      "subscribers": "{{count}} సబ్‌స్క్రైబర్‌లు"
+      "subscribers": "{{count}} సబ్‌స్క్రైబర్",
+      "subscribers_other": "{{count}} సబ్‌స్క్రైబర్‌లు"
     },
     "errors": {
       "loadSessions": "సెషన్లను లోడ్ చేయడం విఫలమైంది",
@@ -225,7 +227,9 @@
     "connecting": "కనెక్ట్ అవుతోంది...",
     "qr_ready": "QR స్కాన్ చేయండి",
     "ready": "కనెక్ట్ అయింది",
-    "disconnected": "డిస్‌కనెక్ట్ అయింది"
+    "disconnected": "డిస్‌కనెక్ట్ అయింది",
+    "failed": "విఫలమైంది",
+    "authenticating": "ప్రామాణీకరిస్తోంది..."
   },
   "sessions": {
     "title": "సెషన్స్",
@@ -355,6 +359,7 @@
       "title": "ఫిల్టర్‌లు (ఐచ్ఛికం)",
       "hint": "అన్ని షరతులు సరిపోలినప్పుడు మాత్రమే ట్రిగ్గర్ అవుతుంది. సందేశ ఈవెంట్‌లకు వర్తిస్తుంది.",
       "badge": "{{count}} ఫిల్టర్",
+      "badge_other": "{{count}} ఫిల్టర్‌లు",
       "addCondition": "షరతును జోడించు",
       "removeCondition": "షరతును తొలగించు",
       "caseSensitive": "కేస్ సెన్సిటివ్",
@@ -790,7 +795,12 @@
       "title": "ఒక ప్లగిన్‌ను ఇన్‌స్టాల్ చేయి",
       "hint": "ఒక .zip గా ప్యాక్ చేయబడిన ప్లగిన్‌ను అప్‌లోడ్ చేయండి (manifest.json తో). ప్రారంభించిన తర్వాత ఇది శాండ్‌బాక్స్‌లో రన్ అవుతుంది.",
       "choose": "ఒక .zip ఫైల్‌ను ఎంచుకోండి…",
-      "tooLarge": "ఫైల్ 5 MB పరిమితిని మించిపోయింది."
+      "tooLarge": "ఫైల్ 5 MB పరిమితిని మించిపోయింది.",
+      "catalogHint": "OpenWA ప్లగిన్ కేటలాగ్ నుండి నేరుగా ఇన్‌స్టాల్ చేయండి. .zip సర్వర్‌లో SSRF గార్డ్ ద్వారా పొందబడి, ఆపై ధృవీకరించబడి శాండ్‌బాక్స్‌లో అమలవుతుంది.",
+      "catalogTeaser": "ప్లగిన్‌ల కోసం చూస్తున్నారా?",
+      "catalogTeaserSuffix": "అధికారిక మార్కెట్‌ప్లేస్‌ను బ్రౌజ్ చేస్తుంది.",
+      "tabCatalog": "కేటలాగ్",
+      "tabUpload": ".zip అప్‌లోడ్ చేయండి"
     },
     "toasts": {
       "errorTitle": "ప్లగిన్ లోపం",
@@ -808,7 +818,8 @@
       "enableFailedTitle": "ప్రారంభించడం విఫలమైంది",
       "disableFailedTitle": "నిలిపివేయడం విఫలమైంది",
       "configRequiredTitle": "కాన్ఫిగరేషన్ అవసరం",
-      "configRequiredDesc": "ప్రారంభించే ముందు అవసరమైన ఫీల్డ్‌లను పూరించండి: {{fields}}"
+      "configRequiredDesc": "ప్రారంభించే ముందు అవసరమైన ఫీల్డ్‌లను పూరించండి: {{fields}}",
+      "updateFailed": "అప్‌డేట్ విఫలమైంది"
     },
     "sessions": {
       "activationTitle": "దీని కోసం రన్ చేయండి",
@@ -887,6 +898,17 @@
         "secretRegenerated": "సీక్రెట్ రీజెనరేట్ చేయబడింది",
         "actionFailed": "చర్య విఫలమైంది"
       }
+    },
+    "catalog": {
+      "empty": "కేటలాగ్‌లో ప్లగిన్‌లు లేవు.",
+      "install": "ఇన్‌స్టాల్ చేయండి",
+      "installed": "ఇన్‌స్టాల్ చేయబడింది",
+      "noDownload": "ఈ కేటలాగ్ ఎంట్రీకి డౌన్‌లోడ్ URL లేదు.",
+      "noMatch": "మీ శోధనకు సరిపోలే ప్లగిన్‌లు లేవు.",
+      "searchPlaceholder": "ప్లగిన్‌లను శోధించండి…",
+      "update": "అప్‌డేట్ చేయండి",
+      "updateAvailable": "అప్‌డేట్ అందుబాటులో ఉంది",
+      "updated": "ప్లగిన్ అప్‌డేట్ చేయబడింది"
     }
   },
   "search": {

--- a/dashboard/src/i18n/locales/zh-CN.json
+++ b/dashboard/src/i18n/locales/zh-CN.json
@@ -85,6 +85,7 @@
     "empty": "没有聊天",
     "noMessageYet": "暂无消息",
     "unreadBadge": "{{count}} 条未读消息",
+    "unreadBadge_other": "{{count}} 条未读消息",
     "loadingMessages": "正在加载消息...",
     "noMessagesInChat": "暂无消息。发送第一条消息即可开始！",
     "downloadDocument": "下载文档",
@@ -147,7 +148,8 @@
       "notSupported": "Baileys 引擎不支持频道。",
       "empty": "你尚未订阅任何频道。",
       "notReady": "会话尚未就绪。",
-      "subscribers": "{{count}} 位订阅者"
+      "subscribers": "{{count}} 位订阅者",
+      "subscribers_other": "{{count}} 位订阅者"
     },
     "errors": {
       "loadSessions": "加载会话失败",
@@ -225,7 +227,9 @@
     "connecting": "正在连接...",
     "qr_ready": "扫描 QR",
     "ready": "已连接",
-    "disconnected": "已断开"
+    "disconnected": "已断开",
+    "failed": "失败",
+    "authenticating": "正在验证..."
   },
   "sessions": {
     "title": "会话",
@@ -355,6 +359,7 @@
       "title": "筛选条件（可选）",
       "hint": "仅当所有条件都匹配时才触发。适用于消息事件。",
       "badge": "{{count}} 个筛选条件",
+      "badge_other": "{{count}} 个筛选条件",
       "addCondition": "添加条件",
       "removeCondition": "移除条件",
       "caseSensitive": "区分大小写",
@@ -790,7 +795,12 @@
       "title": "安装插件",
       "hint": "上传打包为 .zip 的插件（包含 manifest.json）。启用后将在沙箱中运行。",
       "choose": "选择 .zip 文件…",
-      "tooLarge": "文件超过 5 MB 限制。"
+      "tooLarge": "文件超过 5 MB 限制。",
+      "catalogHint": "直接从 OpenWA 插件目录安装。.zip 文件由服务器通过 SSRF 防护获取，然后经过验证并在沙箱中运行。",
+      "catalogTeaser": "在找插件吗？",
+      "catalogTeaserSuffix": "浏览官方市场。",
+      "tabCatalog": "目录",
+      "tabUpload": "上传 .zip"
     },
     "toasts": {
       "errorTitle": "插件错误",
@@ -808,7 +818,8 @@
       "enableFailedTitle": "启用失败",
       "disableFailedTitle": "停用失败",
       "configRequiredTitle": "需要配置",
-      "configRequiredDesc": "启用前请填写必填项：{{fields}}"
+      "configRequiredDesc": "启用前请填写必填项：{{fields}}",
+      "updateFailed": "更新失败"
     },
     "sessions": {
       "activationTitle": "运行范围",
@@ -887,6 +898,17 @@
         "secretRegenerated": "密钥已重新生成",
         "actionFailed": "操作失败"
       }
+    },
+    "catalog": {
+      "empty": "目录中暂无插件。",
+      "install": "安装",
+      "installed": "已安装",
+      "noDownload": "该目录条目没有下载地址。",
+      "noMatch": "没有符合搜索条件的插件。",
+      "searchPlaceholder": "搜索插件…",
+      "update": "更新",
+      "updateAvailable": "有可用更新",
+      "updated": "插件已更新"
     }
   },
   "search": {

--- a/dashboard/src/i18n/locales/zh-HK.json
+++ b/dashboard/src/i18n/locales/zh-HK.json
@@ -85,6 +85,7 @@
     "empty": "沒有聊天",
     "noMessageYet": "尚無訊息",
     "unreadBadge": "{{count}} 條未讀訊息",
+    "unreadBadge_other": "{{count}} 條未讀訊息",
     "loadingMessages": "正在載入訊息...",
     "noMessagesInChat": "尚無訊息。傳送第一則訊息即可開始！",
     "downloadDocument": "下載文件",
@@ -147,7 +148,8 @@
       "notSupported": "Baileys 引擎不支援頻道。",
       "empty": "你尚未訂閱任何頻道。",
       "notReady": "工作階段尚未就緒。",
-      "subscribers": "{{count}} 位訂閱者"
+      "subscribers": "{{count}} 位訂閱者",
+      "subscribers_other": "{{count}} 位訂閱者"
     },
     "errors": {
       "loadSessions": "載入工作階段失敗",
@@ -225,7 +227,9 @@
     "connecting": "正在連線...",
     "qr_ready": "掃描 QR",
     "ready": "已連線",
-    "disconnected": "已中斷連線"
+    "disconnected": "已中斷連線",
+    "failed": "失敗",
+    "authenticating": "正在驗證..."
   },
   "sessions": {
     "title": "工作階段",
@@ -355,6 +359,7 @@
       "title": "篩選條件（選填）",
       "hint": "僅當所有條件都符合時才觸發。適用於訊息事件。",
       "badge": "{{count}} 個篩選條件",
+      "badge_other": "{{count}} 個篩選條件",
       "addCondition": "新增條件",
       "removeCondition": "移除條件",
       "caseSensitive": "區分大小寫",
@@ -790,7 +795,12 @@
       "title": "安裝外掛",
       "hint": "上載打包成 .zip 的外掛（內含 manifest.json）。啟用後會以沙盒方式執行。",
       "choose": "選擇 .zip 檔案…",
-      "tooLarge": "檔案超出 5 MB 上限。"
+      "tooLarge": "檔案超出 5 MB 上限。",
+      "catalogHint": "直接從 OpenWA 外掛目錄安裝。.zip 檔案由伺服器透過 SSRF 防護取得，然後經過驗證並在沙箱中執行。",
+      "catalogTeaser": "在找外掛嗎？",
+      "catalogTeaserSuffix": "瀏覽官方市場。",
+      "tabCatalog": "目錄",
+      "tabUpload": "上傳 .zip"
     },
     "toasts": {
       "errorTitle": "外掛錯誤",
@@ -808,7 +818,8 @@
       "enableFailedTitle": "啟用失敗",
       "disableFailedTitle": "停用失敗",
       "configRequiredTitle": "需要設定",
-      "configRequiredDesc": "啟用前請填寫必填項：{{fields}}"
+      "configRequiredDesc": "啟用前請填寫必填項：{{fields}}",
+      "updateFailed": "更新失敗"
     },
     "sessions": {
       "activationTitle": "執行對象",
@@ -887,6 +898,17 @@
         "secretRegenerated": "密鑰已重新產生",
         "actionFailed": "操作失敗"
       }
+    },
+    "catalog": {
+      "empty": "目錄中暫無外掛。",
+      "install": "安裝",
+      "installed": "已安裝",
+      "noDownload": "此目錄項目沒有下載地址。",
+      "noMatch": "沒有符合搜尋條件的外掛。",
+      "searchPlaceholder": "搜尋外掛…",
+      "update": "更新",
+      "updateAvailable": "有可用更新",
+      "updated": "外掛已更新"
     }
   },
   "search": {

--- a/dashboard/src/pages/ApiKeys.tsx
+++ b/dashboard/src/pages/ApiKeys.tsx
@@ -15,7 +15,6 @@ import {
   Eye,
   EyeOff,
   Loader2,
-  X,
   Check,
   KeyRound,
   AlertTriangle,
@@ -30,6 +29,7 @@ import {
   useRevokeApiKeyMutation,
 } from '../hooks/queries';
 import { PageHeader } from '../components/PageHeader';
+import { Modal } from '../components/Modal';
 import { useToast } from '../components/Toast';
 import { copyToClipboard } from '../utils/clipboard';
 import './ApiKeys.css';
@@ -246,69 +246,17 @@ export function ApiKeys() {
       )}
 
       {showModal && (
-        <div
-          className="modal-overlay"
-          onClick={() => {
+        <Modal
+          open
+          onClose={() => {
             setShowModal(false);
             setCreatedKey(null);
           }}
-        >
-          <div className="modal" onClick={e => e.stopPropagation()}>
-            <div className="modal-header">
-              <h2>{createdKey ? t('apiKeys.createdTitle') : t('apiKeys.modalTitle')}</h2>
-              <button
-                className="btn-icon"
-                onClick={() => {
-                  setShowModal(false);
-                  setCreatedKey(null);
-                }}
-              >
-                <X size={20} />
-              </button>
-            </div>
-            <div className="modal-body">
-              {createdKey ? (
-                <div>
-                  <p style={{ marginBottom: '1rem', color: 'var(--text-muted)' }}>{t('apiKeys.createdHint')}</p>
-                  <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
-                    <code
-                      style={{
-                        flex: 1,
-                        padding: '0.75rem',
-                        background: 'var(--bg-secondary)',
-                        borderRadius: '6px',
-                        wordBreak: 'break-all',
-                      }}
-                    >
-                      {createdKey}
-                    </code>
-                    <button className="btn-primary" onClick={() => void handleCopy(createdKey, 'modal')}>
-                      {copied === 'modal' ? <Check size={16} /> : <Copy size={16} />}
-                    </button>
-                  </div>
-                </div>
-              ) : (
-                <>
-                  <label>{t('common.name')}</label>
-                  <input
-                    type="text"
-                    placeholder={t('apiKeys.namePlaceholder')}
-                    value={newKey.name}
-                    onChange={e => setNewKey({ ...newKey, name: e.target.value })}
-                  />
-                  <label>{t('common.role')}</label>
-                  <select value={newKey.role} onChange={e => setNewKey({ ...newKey, role: e.target.value })}>
-                    {roleNames.map(r => (
-                      <option key={r} value={r}>
-                        {t(`apiKeys.roles.${r}`)}
-                      </option>
-                    ))}
-                  </select>
-                </>
-              )}
-            </div>
-            {!createdKey && (
-              <div className="modal-footer">
+          title={createdKey ? t('apiKeys.createdTitle') : t('apiKeys.modalTitle')}
+          closeLabel={t('common.close')}
+          footer={
+            !createdKey ? (
+              <>
                 <button className="btn-secondary" onClick={() => setShowModal(false)}>
                   {t('common.cancel')}
                 </button>
@@ -319,10 +267,50 @@ export function ApiKeys() {
                 >
                   {createMutation.isPending ? <Loader2 className="animate-spin" size={16} /> : t('common.create')}
                 </button>
+              </>
+            ) : undefined
+          }
+        >
+          {createdKey ? (
+            <div>
+              <p style={{ marginBottom: '1rem', color: 'var(--text-muted)' }}>{t('apiKeys.createdHint')}</p>
+              <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+                <code
+                  style={{
+                    flex: 1,
+                    padding: '0.75rem',
+                    background: 'var(--bg-secondary)',
+                    borderRadius: '6px',
+                    wordBreak: 'break-all',
+                  }}
+                >
+                  {createdKey}
+                </code>
+                <button className="btn-primary" onClick={() => void handleCopy(createdKey, 'modal')}>
+                  {copied === 'modal' ? <Check size={16} /> : <Copy size={16} />}
+                </button>
               </div>
-            )}
-          </div>
-        </div>
+            </div>
+          ) : (
+            <>
+              <label>{t('common.name')}</label>
+              <input
+                type="text"
+                placeholder={t('apiKeys.namePlaceholder')}
+                value={newKey.name}
+                onChange={e => setNewKey({ ...newKey, name: e.target.value })}
+              />
+              <label>{t('common.role')}</label>
+              <select value={newKey.role} onChange={e => setNewKey({ ...newKey, role: e.target.value })}>
+                {roleNames.map(r => (
+                  <option key={r} value={r}>
+                    {t(`apiKeys.roles.${r}`)}
+                  </option>
+                ))}
+              </select>
+            </>
+          )}
+        </Modal>
       )}
 
       <div className="api-keys-content">
@@ -373,40 +361,34 @@ export function ApiKeys() {
       </div>
 
       {confirmAction && (
-        <div className="modal-overlay" onClick={() => setConfirmAction(null)}>
-          <div className="modal confirm-modal" onClick={e => e.stopPropagation()}>
-            <div className="modal-header">
-              <h2>
-                {confirmAction.type === 'delete' ? t('apiKeys.confirm.deleteTitle') : t('apiKeys.confirm.revokeTitle')}
-              </h2>
-              <button className="btn-icon" onClick={() => setConfirmAction(null)}>
-                <X size={20} />
-              </button>
-            </div>
-            <div className="modal-body">
-              <div className="confirm-icon-wrapper">
-                <AlertTriangle size={48} className="confirm-warning-icon" />
-              </div>
-              <p className="confirm-message">
-                <Trans
-                  i18nKey={
-                    confirmAction.type === 'delete' ? 'apiKeys.confirm.deleteMessage' : 'apiKeys.confirm.revokeMessage'
-                  }
-                  values={{ name: confirmAction.name }}
-                  components={{ strong: <strong /> }}
-                />
-              </p>
-            </div>
-            <div className="modal-footer">
+        <Modal
+          open
+          onClose={() => setConfirmAction(null)}
+          title={confirmAction.type === 'delete' ? t('apiKeys.confirm.deleteTitle') : t('apiKeys.confirm.revokeTitle')}
+          className="confirm-modal"
+          closeLabel={t('common.close')}
+          footer={
+            <>
               <button className="btn-secondary" onClick={() => setConfirmAction(null)}>
                 {t('common.cancel')}
               </button>
               <button className="btn-danger" onClick={confirmAndExecute}>
                 {confirmAction.type === 'delete' ? t('apiKeys.confirm.delete') : t('apiKeys.confirm.revoke')}
               </button>
-            </div>
+            </>
+          }
+        >
+          <div className="confirm-icon-wrapper">
+            <AlertTriangle size={48} className="confirm-warning-icon" />
           </div>
-        </div>
+          <p className="confirm-message">
+            <Trans
+              i18nKey={confirmAction.type === 'delete' ? 'apiKeys.confirm.deleteMessage' : 'apiKeys.confirm.revokeMessage'}
+              values={{ name: confirmAction.name }}
+              components={{ strong: <strong /> }}
+            />
+          </p>
+        </Modal>
       )}
     </div>
   );

--- a/dashboard/src/pages/Infrastructure.css
+++ b/dashboard/src/pages/Infrastructure.css
@@ -677,12 +677,12 @@
   text-align: center;
 }
 
-.infrastructure-page .restart-modal-header {
+.infrastructure-page .restart-modal .modal-header {
   justify-content: center;
   border-bottom: none;
 }
 
-.infrastructure-page .restart-modal-body {
+.infrastructure-page .restart-modal .modal-body {
   padding: 2rem;
 }
 

--- a/dashboard/src/pages/Infrastructure.tsx
+++ b/dashboard/src/pages/Infrastructure.tsx
@@ -18,6 +18,7 @@ import { copyToClipboard } from '../utils/clipboard';
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { useInfraStatusQuery, useInfraConfigQuery, useEnginesQuery, useCurrentEngineQuery } from '../hooks/queries';
 import { PageHeader } from '../components/PageHeader';
+import { Modal } from '../components/Modal';
 import { useToast } from '../components/Toast';
 import './Infrastructure.css';
 
@@ -1069,88 +1070,94 @@ export function Infrastructure() {
       </div>
 
       {showRestartModal && (
-        <div className="modal-overlay">
-          <div className="modal restart-modal">
-            <div className="modal-header restart-modal-header">
-              <h2>
-                {restartStatus === 'idle' && t('infrastructure.restart.idleTitle')}
-                {restartStatus === 'restarting' && t('infrastructure.restart.restartingTitle')}
-                {restartStatus === 'waiting' && t('infrastructure.restart.waitingTitle')}
-                {restartStatus === 'success' && t('infrastructure.restart.successTitle')}
-                {restartStatus === 'error' && t('infrastructure.restart.errorTitle')}
-              </h2>
-            </div>
-            <div className="modal-body restart-modal-body">
-              {restartStatus === 'idle' && (
-                <>
-                  <p className="restart-idle-desc">
-                    <Trans i18nKey="infrastructure.restart.idleDesc" components={{ code: <code />, br: <br /> }} />
-                  </p>
-                  {(dbSwitch || storageSwitch) && (
-                    <div className="migration-warning">
-                      <AlertTriangle size={18} />
-                      <div>
-                        <strong>{t('infrastructure.migration.title')}</strong>
-                        {dbSwitch && <p>{t('infrastructure.migration.dbWarning')}</p>}
-                        {storageSwitch && <p>{t('infrastructure.migration.storageWarning')}</p>}
-                        {dbSwitch && (
-                          <button className="btn-secondary btn-sm" onClick={handleExportBackup} disabled={migrating}>
-                            {migrating ? <Loader2 size={14} className="animate-spin" /> : <Download size={14} />}
-                            {t('infrastructure.migration.downloadBackup')}
-                          </button>
-                        )}
-                      </div>
-                    </div>
-                  )}
-                  <div className="restart-actions">
-                    <button className="btn-secondary" onClick={() => setShowRestartModal(false)}>
-                      {t('infrastructure.restart.later')}
-                    </button>
-                    <button className="btn-primary" onClick={handleRestart}>
-                      {t('infrastructure.restart.now')}
-                    </button>
+        <Modal
+          open
+          onClose={() => {
+            // Dismissal is only offered in the idle state (the "Later" path) — while a restart is
+            // running there is deliberately no way to close the progress view.
+            if (restartStatus === 'idle') setShowRestartModal(false);
+          }}
+          title={
+            <>
+              {restartStatus === 'idle' && t('infrastructure.restart.idleTitle')}
+              {restartStatus === 'restarting' && t('infrastructure.restart.restartingTitle')}
+              {restartStatus === 'waiting' && t('infrastructure.restart.waitingTitle')}
+              {restartStatus === 'success' && t('infrastructure.restart.successTitle')}
+              {restartStatus === 'error' && t('infrastructure.restart.errorTitle')}
+            </>
+          }
+          className="restart-modal"
+          closeLabel={t('common.close')}
+          hideCloseButton
+        >
+          {restartStatus === 'idle' && (
+            <>
+              <p className="restart-idle-desc">
+                <Trans i18nKey="infrastructure.restart.idleDesc" components={{ code: <code />, br: <br /> }} />
+              </p>
+              {(dbSwitch || storageSwitch) && (
+                <div className="migration-warning">
+                  <AlertTriangle size={18} />
+                  <div>
+                    <strong>{t('infrastructure.migration.title')}</strong>
+                    {dbSwitch && <p>{t('infrastructure.migration.dbWarning')}</p>}
+                    {storageSwitch && <p>{t('infrastructure.migration.storageWarning')}</p>}
+                    {dbSwitch && (
+                      <button className="btn-secondary btn-sm" onClick={handleExportBackup} disabled={migrating}>
+                        {migrating ? <Loader2 size={14} className="animate-spin" /> : <Download size={14} />}
+                        {t('infrastructure.migration.downloadBackup')}
+                      </button>
+                    )}
                   </div>
-                </>
+                </div>
               )}
+              <div className="restart-actions">
+                <button className="btn-secondary" onClick={() => setShowRestartModal(false)}>
+                  {t('infrastructure.restart.later')}
+                </button>
+                <button className="btn-primary" onClick={handleRestart}>
+                  {t('infrastructure.restart.now')}
+                </button>
+              </div>
+            </>
+          )}
 
-              {(restartStatus === 'restarting' || restartStatus === 'waiting') && (
-                <>
-                  <div className="restart-countdown">
-                    <Loader2 className="animate-spin restart-status-icon" size={48} />
-                    <p className="restart-countdown-msg">
-                      {restartCountdown > 0
-                        ? t('infrastructure.restart.restartingMsg', { count: restartCountdown })
-                        : t('infrastructure.restart.checking')}
-                    </p>
-                  </div>
-                  <div className="restart-progress-track">
-                    <div
-                      className="restart-progress-fill"
-                      style={{ width: restartCountdown > 0 ? `${((30 - restartCountdown) / 30) * 100}%` : '100%' }}
-                    />
-                  </div>
-                  <p className="restart-dont-close">{t('infrastructure.restart.dontClose')}</p>
-                </>
-              )}
+          {(restartStatus === 'restarting' || restartStatus === 'waiting') && (
+            <>
+              <div className="restart-countdown">
+                <Loader2 className="animate-spin restart-status-icon" size={48} />
+                <p className="restart-countdown-msg">
+                  {restartCountdown > 0
+                    ? t('infrastructure.restart.restartingMsg', { count: restartCountdown })
+                    : t('infrastructure.restart.checking')}
+                </p>
+              </div>
+              <div className="restart-progress-track">
+                <div
+                  className="restart-progress-fill"
+                  style={{ width: restartCountdown > 0 ? `${((30 - restartCountdown) / 30) * 100}%` : '100%' }}
+                />
+              </div>
+              <p className="restart-dont-close">{t('infrastructure.restart.dontClose')}</p>
+            </>
+          )}
 
-              {restartStatus === 'success' && (
-                <>
-                  <CheckCircle size={48} className="restart-status-icon" />
-                  <p className="restart-success-msg">{t('infrastructure.restart.successMsg')}</p>
-                </>
-              )}
+          {restartStatus === 'success' && (
+            <>
+              <CheckCircle size={48} className="restart-status-icon" />
+              <p className="restart-success-msg">{t('infrastructure.restart.successMsg')}</p>
+            </>
+          )}
 
-              {restartStatus === 'error' && (
-                <>
-                  <p className="restart-error-msg">{t('infrastructure.restart.errorMsg')}</p>
-                  <button className="btn-primary" onClick={() => window.location.reload()}>
-                    {t('infrastructure.restart.reload')}
-                  </button>
-                </>
-              )}
-            </div>
-          </div>
-        </div>
+          {restartStatus === 'error' && (
+            <>
+              <p className="restart-error-msg">{t('infrastructure.restart.errorMsg')}</p>
+              <button className="btn-primary" onClick={() => window.location.reload()}>
+                {t('infrastructure.restart.reload')}
+              </button>
+            </>
+          )}
+        </Modal>
       )}
 
       <footer className="page-footer">

--- a/dashboard/src/pages/Plugins.css
+++ b/dashboard/src/pages/Plugins.css
@@ -786,7 +786,7 @@
    horizontal center of the header with absolute positioning — justify-content:space-between only
    centers them approximately because the title (left) and close button (right) have different widths,
    leaving the pill visibly off-center. The header carries position:relative so this is self-contained. */
-.plugins-page .install-modal-header .install-tabs {
+.plugins-page .install-modal .modal-header .install-tabs {
   margin: 0;
   position: absolute;
   left: 50%;
@@ -797,13 +797,13 @@
 /* Three-item header (title + tabs + close). Position:relative anchors the absolutely-centered pill;
    flex-wrap keeps it from overflowing horizontally on a narrow viewport (mobile bottom-sheet width),
    wrapping to a second row instead. */
-.plugins-page .install-modal-header {
+.plugins-page .install-modal .modal-header {
   position: relative;
   flex-wrap: wrap;
   row-gap: 0.75rem;
 }
 
-.plugins-page .install-modal-header h2 {
+.plugins-page .install-modal .modal-header h2 {
   min-width: 0;
   /* Truncate an over-long title rather than collide with the tabs; the modal title is short by
      design ("Install a plugin"), so this only ever bites an unusually long translation. */

--- a/dashboard/src/pages/Plugins.tsx
+++ b/dashboard/src/pages/Plugins.tsx
@@ -17,7 +17,6 @@ import {
   Server,
   Shield,
   Zap,
-  X,
   Upload,
   Trash2,
   Globe,
@@ -31,6 +30,7 @@ import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { useTheme } from '../hooks/useTheme';
 import { usePluginsQuery, useSessionsQuery, queryKeys } from '../hooks/queries';
 import { PageHeader } from '../components/PageHeader';
+import { Modal } from '../components/Modal';
 import { useToast } from '../components/Toast';
 import { PluginInstances } from '../components/PluginInstances';
 import './Plugins.css';
@@ -983,194 +983,192 @@ export default function Plugins() {
       )}
 
       {showInstallModal && (
-        <div className="modal-overlay" onClick={() => setShowInstallModal(false)}>
-          <div className="modal install-modal" onClick={e => e.stopPropagation()}>
-            <div className="modal-header install-modal-header">
-              <h2>{t('plugins.installModal.title', 'Install a plugin')}</h2>
-              <div className="install-tabs">
-                <button
-                  className={`install-tab${installMode === 'upload' ? ' active' : ''}`}
-                  onClick={() => setInstallMode('upload')}
-                >
-                  <Upload size={15} /> {t('plugins.installModal.tabUpload', 'Upload .zip')}
-                </button>
-                <button
-                  className={`install-tab${installMode === 'catalog' ? ' active' : ''}`}
-                  onClick={() => setInstallMode('catalog')}
-                >
-                  <Globe size={15} /> {t('plugins.installModal.tabCatalog', 'Catalog')}
-                </button>
-              </div>
-              <button className="btn-icon" onClick={() => setShowInstallModal(false)}>
-                <X size={20} />
+        <Modal
+          open
+          onClose={() => setShowInstallModal(false)}
+          title={t('plugins.installModal.title', 'Install a plugin')}
+          className="install-modal"
+          closeLabel={t('common.close')}
+          headerExtra={
+            <div className="install-tabs">
+              <button
+                className={`install-tab${installMode === 'upload' ? ' active' : ''}`}
+                onClick={() => setInstallMode('upload')}
+              >
+                <Upload size={15} /> {t('plugins.installModal.tabUpload', 'Upload .zip')}
+              </button>
+              <button
+                className={`install-tab${installMode === 'catalog' ? ' active' : ''}`}
+                onClick={() => setInstallMode('catalog')}
+              >
+                <Globe size={15} /> {t('plugins.installModal.tabCatalog', 'Catalog')}
               </button>
             </div>
-
-            {installMode === 'upload' ? (
+          }
+          footer={
+            installMode === 'upload' ? (
               <>
-                <div className="modal-body">
-                  <p className="install-hint">
-                    {t(
-                      'plugins.installModal.hint',
-                      'Upload a plugin packaged as a .zip (with a manifest.json). It runs sandboxed once enabled.',
-                    )}
-                  </p>
-                  <label className={`install-drop${installFile ? ' has-file' : ''}`}>
-                    <input
-                      type="file"
-                      accept=".zip,application/zip"
-                      hidden
-                      onChange={e => setInstallFile(e.target.files?.[0] ?? null)}
-                    />
-                    <Upload size={28} />
-                    <span className="install-drop-name">
-                      {installFile ? installFile.name : t('plugins.installModal.choose', 'Choose a .zip file…')}
-                    </span>
-                  </label>
-                  {/* Point first-time users at the Catalog tab — otherwise the marketplace is invisible
-                      and an operator only ever discovers plugins by hearing about one out-of-band. */}
-                  <p className="install-hint install-hint-sub">
-                    {t('plugins.installModal.catalogTeaser', 'Looking for plugins?')}{' '}
-                    <button type="button" className="install-inline-link" onClick={() => setInstallMode('catalog')}>
-                      {t('plugins.installModal.tabCatalog', 'Catalog')}
-                    </button>{' '}
-                    {t('plugins.installModal.catalogTeaserSuffix', 'browses the official marketplace.')}
-                  </p>
-                </div>
-                <div className="modal-footer">
-                  <button className="btn-secondary" onClick={() => setShowInstallModal(false)} disabled={installing}>
-                    {t('common.cancel', 'Cancel')}
-                  </button>
-                  <button
-                    className="btn-primary"
-                    onClick={() => void handleInstall()}
-                    disabled={!installFile || installing}
-                  >
-                    {installing ? <Loader2 size={16} className="animate-spin" /> : <Upload size={16} />}
-                    {t('plugins.install', 'Install plugin')}
-                  </button>
-                </div>
+                <button className="btn-secondary" onClick={() => setShowInstallModal(false)} disabled={installing}>
+                  {t('common.cancel', 'Cancel')}
+                </button>
+                <button
+                  className="btn-primary"
+                  onClick={() => void handleInstall()}
+                  disabled={!installFile || installing}
+                >
+                  {installing ? <Loader2 size={16} className="animate-spin" /> : <Upload size={16} />}
+                  {t('plugins.install', 'Install plugin')}
+                </button>
               </>
             ) : (
-              <>
-                <div className="modal-body">
-                  <p className="install-hint">
-                    {t(
-                      'plugins.installModal.catalogHint',
-                      'Install directly from the OpenWA plugin catalog. The .zip is fetched server-side through the SSRF guard, then validated and sandboxed.',
-                    )}
-                  </p>
-                  {catalogLoading ? (
-                    <div className="catalog-empty">
-                      <Loader2 size={20} className="animate-spin" />
-                    </div>
-                  ) : catalogError ? (
-                    <div className="catalog-empty catalog-error">
-                      <AlertCircle size={16} /> {catalogError}
-                      <button className="btn-secondary" onClick={() => void loadCatalog()}>
-                        {t('plugins.refresh', 'Refresh')}
-                      </button>
-                    </div>
-                  ) : catalog.length === 0 ? (
-                    <div className="catalog-empty">{t('plugins.catalog.empty', 'No plugins in the catalog.')}</div>
-                  ) : (
-                    (() => {
-                      const q = catalogSearch.trim().toLowerCase();
-                      const filtered = q
-                        ? catalog.filter(e =>
-                            [e.name, e.description, e.author, e.id].some(f => f?.toLowerCase().includes(q)),
-                          )
-                        : catalog;
-                      return (
-                        <>
-                          <div className="catalog-search">
-                            <Search size={15} />
-                            <input
-                              type="text"
-                              value={catalogSearch}
-                              onChange={e => setCatalogSearch(e.target.value)}
-                              placeholder={t('plugins.catalog.searchPlaceholder', 'Search plugins…')}
-                            />
-                          </div>
-                          {filtered.length === 0 ? (
-                            <div className="catalog-empty">
-                              {t('plugins.catalog.noMatch', 'No plugins match your search.')}
-                            </div>
-                          ) : (
-                            <div className="catalog-list">
-                              {filtered.map(entry => {
-                                const lz = localizePlugin(entry, i18n.language);
-                                return (
-                                  <div className="catalog-row" key={entry.id}>
-                                    <div className="catalog-row-info">
-                                      <div className="catalog-row-name">
-                                        {lz.name} <span className="catalog-row-version">v{entry.version}</span>
-                                      </div>
-                                      {lz.description && <div className="catalog-row-desc">{lz.description}</div>}
-                                      <div className="catalog-row-meta">
-                                        {entry.author && <span className="catalog-row-author">{entry.author}</span>}
-                                        {entry.updateAvailable && (
-                                          <span className="catalog-badge update">
-                                            {t('plugins.catalog.updateAvailable', 'Update available')} (v
-                                            {entry.installedVersion} → v{entry.version})
-                                          </span>
-                                        )}
-                                      </div>
-                                    </div>
-                                    <div className="catalog-row-action">
-                                      {entry.installed ? (
-                                        entry.updateAvailable ? (
-                                          <button
-                                            className="btn-update"
-                                            disabled={installingId !== null || !entry.download}
-                                            onClick={() => void handleUpdateFromCatalog(entry)}
-                                          >
-                                            {installingId === entry.id ? (
-                                              <Loader2 size={15} className="animate-spin" />
-                                            ) : (
-                                              <Download size={15} />
-                                            )}
-                                            {t('plugins.catalog.update', 'Update')}
-                                          </button>
-                                        ) : (
-                                          <span className="catalog-installed">
-                                            <CheckCircle size={15} /> {t('plugins.catalog.installed', 'Installed')}
-                                          </span>
-                                        )
-                                      ) : (
-                                        <button
-                                          className="btn-primary"
-                                          disabled={installingId !== null || !entry.download}
-                                          onClick={() => void handleInstallFromCatalog(entry)}
-                                        >
-                                          {installingId === entry.id ? (
-                                            <Loader2 size={15} className="animate-spin" />
-                                          ) : (
-                                            <Download size={15} />
-                                          )}
-                                          {t('plugins.catalog.install', 'Install')}
-                                        </button>
-                                      )}
-                                    </div>
-                                  </div>
-                                );
-                              })}
-                            </div>
-                          )}
-                        </>
-                      );
-                    })()
-                  )}
+              <button className="btn-secondary" onClick={() => setShowInstallModal(false)}>
+                {t('common.close', 'Close')}
+              </button>
+            )
+          }
+        >
+          {installMode === 'upload' ? (
+            <>
+              <p className="install-hint">
+                {t(
+                  'plugins.installModal.hint',
+                  'Upload a plugin packaged as a .zip (with a manifest.json). It runs sandboxed once enabled.',
+                )}
+              </p>
+              <label className={`install-drop${installFile ? ' has-file' : ''}`}>
+                <input
+                  type="file"
+                  accept=".zip,application/zip"
+                  hidden
+                  onChange={e => setInstallFile(e.target.files?.[0] ?? null)}
+                />
+                <Upload size={28} />
+                <span className="install-drop-name">
+                  {installFile ? installFile.name : t('plugins.installModal.choose', 'Choose a .zip file…')}
+                </span>
+              </label>
+              {/* Point first-time users at the Catalog tab — otherwise the marketplace is invisible
+                  and an operator only ever discovers plugins by hearing about one out-of-band. */}
+              <p className="install-hint install-hint-sub">
+                {t('plugins.installModal.catalogTeaser', 'Looking for plugins?')}{' '}
+                <button type="button" className="install-inline-link" onClick={() => setInstallMode('catalog')}>
+                  {t('plugins.installModal.tabCatalog', 'Catalog')}
+                </button>{' '}
+                {t('plugins.installModal.catalogTeaserSuffix', 'browses the official marketplace.')}
+              </p>
+            </>
+          ) : (
+            <>
+              <p className="install-hint">
+                {t(
+                  'plugins.installModal.catalogHint',
+                  'Install directly from the OpenWA plugin catalog. The .zip is fetched server-side through the SSRF guard, then validated and sandboxed.',
+                )}
+              </p>
+              {catalogLoading ? (
+                <div className="catalog-empty">
+                  <Loader2 size={20} className="animate-spin" />
                 </div>
-                <div className="modal-footer">
-                  <button className="btn-secondary" onClick={() => setShowInstallModal(false)}>
-                    {t('common.close', 'Close')}
+              ) : catalogError ? (
+                <div className="catalog-empty catalog-error">
+                  <AlertCircle size={16} /> {catalogError}
+                  <button className="btn-secondary" onClick={() => void loadCatalog()}>
+                    {t('plugins.refresh', 'Refresh')}
                   </button>
                 </div>
-              </>
-            )}
-          </div>
-        </div>
+              ) : catalog.length === 0 ? (
+                <div className="catalog-empty">{t('plugins.catalog.empty', 'No plugins in the catalog.')}</div>
+              ) : (
+                (() => {
+                  const q = catalogSearch.trim().toLowerCase();
+                  const filtered = q
+                    ? catalog.filter(e =>
+                        [e.name, e.description, e.author, e.id].some(f => f?.toLowerCase().includes(q)),
+                      )
+                    : catalog;
+                  return (
+                    <>
+                      <div className="catalog-search">
+                        <Search size={15} />
+                        <input
+                          type="text"
+                          value={catalogSearch}
+                          onChange={e => setCatalogSearch(e.target.value)}
+                          placeholder={t('plugins.catalog.searchPlaceholder', 'Search plugins…')}
+                        />
+                      </div>
+                      {filtered.length === 0 ? (
+                        <div className="catalog-empty">
+                          {t('plugins.catalog.noMatch', 'No plugins match your search.')}
+                        </div>
+                      ) : (
+                        <div className="catalog-list">
+                          {filtered.map(entry => {
+                            const lz = localizePlugin(entry, i18n.language);
+                            return (
+                              <div className="catalog-row" key={entry.id}>
+                                <div className="catalog-row-info">
+                                  <div className="catalog-row-name">
+                                    {lz.name} <span className="catalog-row-version">v{entry.version}</span>
+                                  </div>
+                                  {lz.description && <div className="catalog-row-desc">{lz.description}</div>}
+                                  <div className="catalog-row-meta">
+                                    {entry.author && <span className="catalog-row-author">{entry.author}</span>}
+                                    {entry.updateAvailable && (
+                                      <span className="catalog-badge update">
+                                        {t('plugins.catalog.updateAvailable', 'Update available')} (v
+                                        {entry.installedVersion} → v{entry.version})
+                                      </span>
+                                    )}
+                                  </div>
+                                </div>
+                                <div className="catalog-row-action">
+                                  {entry.installed ? (
+                                    entry.updateAvailable ? (
+                                      <button
+                                        className="btn-update"
+                                        disabled={installingId !== null || !entry.download}
+                                        onClick={() => void handleUpdateFromCatalog(entry)}
+                                      >
+                                        {installingId === entry.id ? (
+                                          <Loader2 size={15} className="animate-spin" />
+                                        ) : (
+                                          <Download size={15} />
+                                        )}
+                                        {t('plugins.catalog.update', 'Update')}
+                                      </button>
+                                    ) : (
+                                      <span className="catalog-installed">
+                                        <CheckCircle size={15} /> {t('plugins.catalog.installed', 'Installed')}
+                                      </span>
+                                    )
+                                  ) : (
+                                    <button
+                                      className="btn-primary"
+                                      disabled={installingId !== null || !entry.download}
+                                      onClick={() => void handleInstallFromCatalog(entry)}
+                                    >
+                                      {installingId === entry.id ? (
+                                        <Loader2 size={15} className="animate-spin" />
+                                      ) : (
+                                        <Download size={15} />
+                                      )}
+                                      {t('plugins.catalog.install', 'Install')}
+                                    </button>
+                                  )}
+                                </div>
+                              </div>
+                            );
+                          })}
+                        </div>
+                      )}
+                    </>
+                  );
+                })()
+              )}
+            </>
+          )}
+        </Modal>
       )}
 
       {showConfigModal &&
@@ -1181,16 +1179,14 @@ export default function Plugins() {
           // Instances tab. Either (or both) turns the modal into a tabbed view.
           const showTabs = configPlugin.sessionScoped !== false || configPlugin.ingressCapable;
           return (
-            <div className="modal-overlay" onClick={() => setShowConfigModal(false)}>
-              <div className="modal config-modal" onClick={e => e.stopPropagation()}>
-                <div className="modal-header">
-                  <h2>{t('plugins.config.title', { name: lz.name })}</h2>
-                  <button className="btn-icon" onClick={() => setShowConfigModal(false)}>
-                    <X size={20} />
-                  </button>
-                </div>
-
-                {showTabs && (
+            <Modal
+              open
+              onClose={() => setShowConfigModal(false)}
+              title={t('plugins.config.title', { name: lz.name })}
+              className="config-modal"
+              closeLabel={t('common.close')}
+              subheader={
+                showTabs ? (
                   <div className="modal-tabs">
                     <button
                       className={`modal-tab ${configTab === 'config' ? 'active' : ''}`}
@@ -1215,39 +1211,10 @@ export default function Plugins() {
                       </button>
                     )}
                   </div>
-                )}
-
-                <div className="modal-body">
-                  {showTabs && configTab === 'instances' && configPlugin.ingressCapable ? (
-                    <PluginInstances pluginId={configPlugin.id} />
-                  ) : showTabs && configTab === 'sessions' && configPlugin.sessionScoped !== false ? (
-                    <SessionsTab plugin={configPlugin} />
-                  ) : /* A plugin that ships its own editor owns the whole config: rendering the generic
-                         form underneath it too produced a second copy of every field and a second Save
-                         button with different semantics, which is what the Chat Flow modal looked like. */
-                  configPlugin.configUi ? (
-                    <PluginConfigUi plugin={configPlugin} />
-                  ) : lz.configSchema && Object.keys(lz.configSchema.properties).length > 0 ? (
-                    <form ref={schemaFormRef} className="config-form" onSubmit={e => e.preventDefault()}>
-                      {Object.entries(lz.configSchema.properties).map(([key, field]) => (
-                        <ConfigField
-                          key={key}
-                          field={field}
-                          label={field.title || key}
-                          value={schemaConfig[key]}
-                          onChange={v => setSchemaConfig({ ...schemaConfig, [key]: v })}
-                        />
-                      ))}
-                    </form>
-                  ) : (
-                    <div className="no-config">
-                      <Settings size={48} style={{ opacity: 0.3 }} />
-                      <p>{t('plugins.config.noOptions')}</p>
-                    </div>
-                  )}
-                </div>
-
-                <div className="modal-footer">
+                ) : undefined
+              }
+              footer={
+                <>
                   <button className="btn-secondary" onClick={() => setShowConfigModal(false)}>
                     {t('common.close')}
                   </button>
@@ -1261,9 +1228,37 @@ export default function Plugins() {
                       {savingConfig ? <Loader2 size={16} className="animate-spin" /> : t('plugins.config.save')}
                     </button>
                   ) : null}
+                </>
+              }
+            >
+              {showTabs && configTab === 'instances' && configPlugin.ingressCapable ? (
+                <PluginInstances pluginId={configPlugin.id} />
+              ) : showTabs && configTab === 'sessions' && configPlugin.sessionScoped !== false ? (
+                <SessionsTab plugin={configPlugin} />
+              ) : /* A plugin that ships its own editor owns the whole config: rendering the generic
+                     form underneath it too produced a second copy of every field and a second Save
+                     button with different semantics, which is what the Chat Flow modal looked like. */
+              configPlugin.configUi ? (
+                <PluginConfigUi plugin={configPlugin} />
+              ) : lz.configSchema && Object.keys(lz.configSchema.properties).length > 0 ? (
+                <form ref={schemaFormRef} className="config-form" onSubmit={e => e.preventDefault()}>
+                  {Object.entries(lz.configSchema.properties).map(([key, field]) => (
+                    <ConfigField
+                      key={key}
+                      field={field}
+                      label={field.title || key}
+                      value={schemaConfig[key]}
+                      onChange={v => setSchemaConfig({ ...schemaConfig, [key]: v })}
+                    />
+                  ))}
+                </form>
+              ) : (
+                <div className="no-config">
+                  <Settings size={48} style={{ opacity: 0.3 }} />
+                  <p>{t('plugins.config.noOptions')}</p>
                 </div>
-              </div>
-            </div>
+              )}
+            </Modal>
           );
         })()}
     </div>

--- a/dashboard/src/pages/Templates.tsx
+++ b/dashboard/src/pages/Templates.tsx
@@ -12,6 +12,7 @@ import {
   useUpdateTemplateMutation,
 } from '../hooks/queries';
 import { PageHeader } from '../components/PageHeader';
+import { Modal } from '../components/Modal';
 import { copyToClipboard } from '../utils/clipboard';
 import './Templates.css';
 
@@ -407,18 +408,14 @@ export function Templates() {
       )}
 
       {deleteTarget && (
-        <div className="modal-overlay" onClick={() => setDeleteTarget(null)}>
-          <div className="modal modal-sm" onClick={event => event.stopPropagation()}>
-            <div className="modal-header">
-              <h2>{t('templates.deleteTitle')}</h2>
-              <button className="btn-icon" onClick={() => setDeleteTarget(null)}>
-                <X size={20} />
-              </button>
-            </div>
-            <div className="modal-body">
-              <p>{t('templates.deleteConfirm', { name: deleteTarget.name })}</p>
-            </div>
-            <div className="modal-footer">
+        <Modal
+          open
+          onClose={() => setDeleteTarget(null)}
+          title={t('templates.deleteTitle')}
+          className="modal-sm"
+          closeLabel={t('common.close')}
+          footer={
+            <>
               <button className="btn-secondary" onClick={() => setDeleteTarget(null)}>
                 {t('common.cancel')}
               </button>
@@ -426,9 +423,11 @@ export function Templates() {
                 {deleteMutation.isPending ? <Loader2 size={18} className="animate-spin" /> : <Trash2 size={18} />}
                 {t('common.delete')}
               </button>
-            </div>
-          </div>
-        </div>
+            </>
+          }
+        >
+          <p>{t('templates.deleteConfirm', { name: deleteTarget.name })}</p>
+        </Modal>
       )}
     </div>
   );

--- a/dashboard/src/pages/Webhooks.tsx
+++ b/dashboard/src/pages/Webhooks.tsx
@@ -27,6 +27,7 @@ import {
 } from '../hooks/queries';
 import { PageHeader } from '../components/PageHeader';
 import { FilterBuilder } from '../components/FilterBuilder';
+import { Modal } from '../components/Modal';
 import './Webhooks.css';
 
 // Filters only apply to message.* events (the wildcard subscribes to them too).
@@ -311,173 +312,165 @@ export function Webhooks() {
       )}
 
       {showCreateModal && (
-        <div className="modal-overlay" onClick={() => setShowCreateModal(false)}>
-          <div className="modal" onClick={e => e.stopPropagation()}>
-            <div className="modal-header">
-              <h2>{t('webhooks.createTitle')}</h2>
-              <button className="btn-icon" onClick={() => setShowCreateModal(false)}>
-                <X size={20} />
-              </button>
-            </div>
-            <div className="modal-body">
-              <label>{t('webhooks.session')}</label>
-              <select
-                value={newWebhook.sessionId}
-                onChange={e => setNewWebhook({ ...newWebhook, sessionId: e.target.value })}
-              >
-                <option value="">{t('webhooks.selectSession')}</option>
-                {sessions.map(s => (
-                  <option key={s.id} value={s.id}>
-                    {s.name}
-                  </option>
-                ))}
-              </select>
-              <label>{t('common.url')}</label>
-              <input
-                type="url"
-                placeholder="https://..."
-                value={newWebhook.url}
-                onChange={e => setNewWebhook({ ...newWebhook, url: e.target.value })}
-              />
-              <label>{t('webhooks.events')}</label>
-              <div className="event-tags">
-                {availableEventNames.map(name => {
-                  const isSelected = newWebhook.events.includes(name);
-                  return (
-                    <button
-                      key={name}
-                      type="button"
-                      className={`event-tag ${isSelected ? 'selected' : ''}`}
-                      onClick={() => toggleNewEvent(name)}
-                    >
-                      {isSelected && <Check size={12} className="tag-check-icon" />}
-                      {name}
-                    </button>
-                  );
-                })}
-              </div>
-              {supportsFilters(newWebhook.events) && (
-                <FilterBuilder
-                  filters={newWebhook.filters}
-                  onChange={filters => setNewWebhook(prev => ({ ...prev, filters }))}
-                  chats={chats}
-                />
-              )}
-            </div>
-            <div className="modal-footer">
+        <Modal
+          open
+          onClose={() => setShowCreateModal(false)}
+          title={t('webhooks.createTitle')}
+          closeLabel={t('common.close')}
+          footer={
+            <>
               <button className="btn-secondary" onClick={() => setShowCreateModal(false)}>
                 {t('common.cancel')}
               </button>
               <button className="btn-primary" onClick={handleCreate}>
                 {t('common.create')}
               </button>
-            </div>
+            </>
+          }
+        >
+          <label>{t('webhooks.session')}</label>
+          <select
+            value={newWebhook.sessionId}
+            onChange={e => setNewWebhook({ ...newWebhook, sessionId: e.target.value })}
+          >
+            <option value="">{t('webhooks.selectSession')}</option>
+            {sessions.map(s => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+          <label>{t('common.url')}</label>
+          <input
+            type="url"
+            placeholder="https://..."
+            value={newWebhook.url}
+            onChange={e => setNewWebhook({ ...newWebhook, url: e.target.value })}
+          />
+          <label>{t('webhooks.events')}</label>
+          <div className="event-tags">
+            {availableEventNames.map(name => {
+              const isSelected = newWebhook.events.includes(name);
+              return (
+                <button
+                  key={name}
+                  type="button"
+                  className={`event-tag ${isSelected ? 'selected' : ''}`}
+                  onClick={() => toggleNewEvent(name)}
+                >
+                  {isSelected && <Check size={12} className="tag-check-icon" />}
+                  {name}
+                </button>
+              );
+            })}
           </div>
-        </div>
+          {supportsFilters(newWebhook.events) && (
+            <FilterBuilder
+              filters={newWebhook.filters}
+              onChange={filters => setNewWebhook(prev => ({ ...prev, filters }))}
+              chats={chats}
+            />
+          )}
+        </Modal>
       )}
 
       {showEditModal && editWebhook && (
-        <div className="modal-overlay" onClick={() => setShowEditModal(false)}>
-          <div className="modal" onClick={e => e.stopPropagation()}>
-            <div className="modal-header">
-              <h2>{t('webhooks.editTitle')}</h2>
-              <button className="btn-icon" onClick={() => setShowEditModal(false)}>
-                <X size={20} />
-              </button>
-            </div>
-            <div className="modal-body">
-              <label>{t('common.url')}</label>
-              <input
-                type="url"
-                value={editWebhook.url}
-                onChange={e => setEditWebhook({ ...editWebhook, url: e.target.value })}
-              />
-              <label>{t('webhooks.events')}</label>
-              <div className="event-tags">
-                {availableEventNames.map(name => {
-                  const isSelected = editWebhook.events.includes(name);
-                  return (
-                    <button
-                      key={name}
-                      type="button"
-                      className={`event-tag ${isSelected ? 'selected' : ''}`}
-                      onClick={() => toggleEditEvent(name)}
-                    >
-                      {isSelected && <Check size={12} className="tag-check-icon" />}
-                      {name}
-                    </button>
-                  );
-                })}
-              </div>
-              {supportsFilters(editWebhook.events) && (
-                <FilterBuilder
-                  filters={editWebhook.filters}
-                  onChange={filters => setEditWebhook(prev => (prev ? { ...prev, filters } : prev))}
-                  chats={chats}
-                />
-              )}
-              <div className="toggle-group">
-                <span className="toggle-label">{t('common.status')}</span>
-                <label className="toggle-switch">
-                  <input
-                    type="checkbox"
-                    checked={editWebhook.active}
-                    onChange={e => setEditWebhook({ ...editWebhook, active: e.target.checked })}
-                  />
-                  <span className="toggle-slider"></span>
-                </label>
-                <span className={`toggle-status ${editWebhook.active ? 'active' : 'inactive'}`}>
-                  {editWebhook.active ? t('common.active') : t('common.inactive')}
-                </span>
-              </div>
-            </div>
-            <div className="modal-footer">
+        <Modal
+          open
+          onClose={() => setShowEditModal(false)}
+          title={t('webhooks.editTitle')}
+          closeLabel={t('common.close')}
+          footer={
+            <>
               <button className="btn-secondary" onClick={() => setShowEditModal(false)}>
                 {t('common.cancel')}
               </button>
               <button className="btn-primary" onClick={handleEdit}>
                 {t('webhooks.saveChanges')}
               </button>
-            </div>
+            </>
+          }
+        >
+          <label>{t('common.url')}</label>
+          <input
+            type="url"
+            value={editWebhook.url}
+            onChange={e => setEditWebhook({ ...editWebhook, url: e.target.value })}
+          />
+          <label>{t('webhooks.events')}</label>
+          <div className="event-tags">
+            {availableEventNames.map(name => {
+              const isSelected = editWebhook.events.includes(name);
+              return (
+                <button
+                  key={name}
+                  type="button"
+                  className={`event-tag ${isSelected ? 'selected' : ''}`}
+                  onClick={() => toggleEditEvent(name)}
+                >
+                  {isSelected && <Check size={12} className="tag-check-icon" />}
+                  {name}
+                </button>
+              );
+            })}
           </div>
-        </div>
+          {supportsFilters(editWebhook.events) && (
+            <FilterBuilder
+              filters={editWebhook.filters}
+              onChange={filters => setEditWebhook(prev => (prev ? { ...prev, filters } : prev))}
+              chats={chats}
+            />
+          )}
+          <div className="toggle-group">
+            <span className="toggle-label">{t('common.status')}</span>
+            <label className="toggle-switch">
+              <input
+                type="checkbox"
+                checked={editWebhook.active}
+                onChange={e => setEditWebhook({ ...editWebhook, active: e.target.checked })}
+              />
+              <span className="toggle-slider"></span>
+            </label>
+            <span className={`toggle-status ${editWebhook.active ? 'active' : 'inactive'}`}>
+              {editWebhook.active ? t('common.active') : t('common.inactive')}
+            </span>
+          </div>
+        </Modal>
       )}
 
       {showDeleteModal && deleteTarget && (
-        <div className="modal-overlay" onClick={() => setShowDeleteModal(false)}>
-          <div className="modal modal-sm" onClick={e => e.stopPropagation()}>
-            <div className="modal-header">
-              <h2>{t('webhooks.deleteTitle')}</h2>
-              <button className="btn-icon" onClick={() => setShowDeleteModal(false)}>
-                <X size={20} />
-              </button>
-            </div>
-            <div className="modal-body">
-              <p>{t('webhooks.deleteConfirm')}</p>
-              <code
-                style={{
-                  display: 'block',
-                  marginTop: '0.5rem',
-                  padding: '0.5rem',
-                  background: 'var(--color-bg-secondary)',
-                  borderRadius: '4px',
-                  fontSize: '0.85rem',
-                  wordBreak: 'break-all',
-                }}
-              >
-                {deleteTarget.url}
-              </code>
-            </div>
-            <div className="modal-footer">
+        <Modal
+          open
+          onClose={() => setShowDeleteModal(false)}
+          title={t('webhooks.deleteTitle')}
+          className="modal-sm"
+          closeLabel={t('common.close')}
+          footer={
+            <>
               <button className="btn-secondary" onClick={() => setShowDeleteModal(false)}>
                 {t('common.cancel')}
               </button>
               <button className="btn-danger" onClick={handleDelete}>
                 {t('common.delete')}
               </button>
-            </div>
-          </div>
-        </div>
+            </>
+          }
+        >
+          <p>{t('webhooks.deleteConfirm')}</p>
+          <code
+            style={{
+              display: 'block',
+              marginTop: '0.5rem',
+              padding: '0.5rem',
+              background: 'var(--color-bg-secondary)',
+              borderRadius: '4px',
+              fontSize: '0.85rem',
+              wordBreak: 'break-all',
+            }}
+          >
+            {deleteTarget.url}
+          </code>
+        </Modal>
       )}
 
       <div className="webhooks-content">

--- a/dashboard/src/utils/modalA11y.test.ts
+++ b/dashboard/src/utils/modalA11y.test.ts
@@ -1,0 +1,170 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { bindModalA11y } from './modalA11y.ts';
+
+// Minimal DOM doubles — just the surface bindModalA11y touches: event registry, body style,
+// activeElement tracking, contains(), and focusable elements with focus() + offsetParent.
+
+interface FakeEvent {
+  key: string;
+  shiftKey?: boolean;
+  defaultPrevented: boolean;
+  propagationStopped: boolean;
+  preventDefault(): void;
+  stopPropagation(): void;
+}
+
+function makeKeyEvent(key: string, shiftKey = false): FakeEvent {
+  return {
+    key,
+    shiftKey,
+    defaultPrevented: false,
+    propagationStopped: false,
+    preventDefault() {
+      this.defaultPrevented = true;
+    },
+    stopPropagation() {
+      this.propagationStopped = true;
+    },
+  };
+}
+
+function makeWorld(focusableCount = 2) {
+  const keydownListeners = new Set<(e: FakeEvent) => void>();
+  const attached = new Set<object>();
+
+  const doc = {
+    activeElement: null as { focus(): void } | null,
+    body: { style: { overflow: '' } },
+    addEventListener(_type: string, fn: (e: FakeEvent) => void) {
+      keydownListeners.add(fn);
+    },
+    removeEventListener(_type: string, fn: (e: FakeEvent) => void) {
+      keydownListeners.delete(fn);
+    },
+    contains(el: object) {
+      return attached.has(el);
+    },
+    dispatchKey(event: FakeEvent) {
+      for (const fn of [...keydownListeners]) fn(event);
+    },
+    listenerCount() {
+      return keydownListeners.size;
+    },
+  };
+
+  const makeElement = () => {
+    const el = {
+      offsetParent: {} as object | null, // non-null → "visible" for the focusable filter
+      focus() {
+        doc.activeElement = el as never;
+      },
+    };
+    attached.add(el);
+    return el;
+  };
+
+  const focusables = Array.from({ length: focusableCount }, makeElement);
+  const card = {
+    focus() {
+      doc.activeElement = card as never;
+    },
+    querySelectorAll: () => focusables,
+  };
+  attached.add(card);
+
+  return {
+    doc,
+    card,
+    focusables,
+    makeElement,
+    detach(el: object) {
+      attached.delete(el);
+    },
+  };
+}
+
+test('locks background scroll while open and restores the previous value on close', () => {
+  const { doc, card } = makeWorld();
+  assert.equal(doc.body.style.overflow, '');
+  const unbind = bindModalA11y(doc as never, card as never, () => {});
+  assert.equal(doc.body.style.overflow, 'hidden');
+  unbind();
+  assert.equal(doc.body.style.overflow, '');
+});
+
+test('moves initial focus to the first visible focusable in the dialog', () => {
+  const { doc, card, focusables } = makeWorld(3);
+  const unbind = bindModalA11y(doc as never, card as never, () => {});
+  assert.equal(doc.activeElement, focusables[0] as never);
+  unbind();
+});
+
+test('focuses the card itself when the dialog has nothing focusable', () => {
+  const { doc, card } = makeWorld(0);
+  const unbind = bindModalA11y(doc as never, card as never, () => {});
+  assert.equal(doc.activeElement, card as never);
+  unbind();
+});
+
+test('Escape closes the dialog and stops propagation', () => {
+  const { doc, card } = makeWorld();
+  let closed = 0;
+  const unbind = bindModalA11y(doc as never, card as never, () => closed++);
+  const event = makeKeyEvent('Escape');
+  doc.dispatchKey(event);
+  assert.equal(closed, 1);
+  assert.equal(event.propagationStopped, true);
+  unbind();
+});
+
+test('returns focus to the trigger element on close', () => {
+  const { doc, card, focusables, makeElement } = makeWorld();
+  const trigger = makeElement();
+  trigger.focus(); // user was on the trigger when the dialog opened
+  const unbind = bindModalA11y(doc as never, card as never, () => {});
+  assert.equal(doc.activeElement, focusables[0] as never); // focus moved into the dialog
+  unbind();
+  assert.equal(doc.activeElement, trigger as never); // …and back to the trigger on close
+});
+
+test('does not restore focus when the trigger has left the document', () => {
+  const { doc, card, focusables, makeElement, detach } = makeWorld();
+  const trigger = makeElement();
+  trigger.focus();
+  const unbind = bindModalA11y(doc as never, card as never, () => {});
+  // The row that opened the dialog was deleted while it was open.
+  detach(trigger);
+  unbind();
+  assert.equal(doc.activeElement, focusables[0] as never); // focus stays put, no throw
+});
+
+test('Tab on the last focusable wraps to the first; Shift+Tab on the first wraps to the last', () => {
+  const { doc, card, focusables } = makeWorld(3);
+  const unbind = bindModalA11y(doc as never, card as never, () => {});
+  const [first, , last] = focusables;
+
+  last.focus();
+  const forward = makeKeyEvent('Tab');
+  doc.dispatchKey(forward);
+  assert.equal(forward.defaultPrevented, true);
+  assert.equal(doc.activeElement, first as never);
+
+  first.focus();
+  const backward = makeKeyEvent('Tab', true);
+  doc.dispatchKey(backward);
+  assert.equal(backward.defaultPrevented, true);
+  assert.equal(doc.activeElement, last as never);
+  unbind();
+});
+
+test('cleanup removes the keydown listener (no stray closes after unmount)', () => {
+  const { doc, card } = makeWorld();
+  let closed = 0;
+  const unbind = bindModalA11y(doc as never, card as never, () => closed++);
+  assert.equal(doc.listenerCount(), 1);
+  unbind();
+  assert.equal(doc.listenerCount(), 0);
+  doc.dispatchKey(makeKeyEvent('Escape'));
+  assert.equal(closed, 0);
+});

--- a/dashboard/src/utils/modalA11y.ts
+++ b/dashboard/src/utils/modalA11y.ts
@@ -1,0 +1,66 @@
+/**
+ * Accessibility wiring for the shared Modal dialog. Extracted from the component so the behavior
+ * (Escape to close, focus trap, initial focus, focus restore, background scroll lock) is unit-testable
+ * without a DOM renderer — the React effect in Modal.tsx is a thin wrapper around this binder.
+ *
+ * The binder is typed against the real DOM (`Document`/`HTMLElement`); tests pass minimal fakes.
+ */
+
+const FOCUSABLE =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+function visibleFocusables(card: HTMLElement): HTMLElement[] {
+  return Array.from(card.querySelectorAll<HTMLElement>(FOCUSABLE)).filter(el => el.offsetParent !== null);
+}
+
+/**
+ * Wires one open dialog: locks background scroll, moves focus into the dialog, traps Tab inside it,
+ * closes on Escape, and returns a cleanup that restores scroll and focus to the element that was
+ * focused when the dialog opened (the trigger).
+ */
+export function bindModalA11y(doc: Document, card: HTMLElement, onClose: () => void): () => void {
+  const previousOverflow = doc.body.style.overflow;
+  doc.body.style.overflow = 'hidden';
+
+  // Capture before moving focus into the dialog — this is the trigger focus returns to on close.
+  // Guarded structurally (not instanceof) so the binder also runs under non-DOM test doubles.
+  const active = doc.activeElement;
+  const previouslyFocused =
+    active && typeof (active as HTMLElement).focus === 'function' ? (active as HTMLElement) : null;
+
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (event.key === 'Escape') {
+      // Capture phase: nested widgets (selects, menus) may also listen for Escape — the dialog
+      // owns dismissal while it is open.
+      event.stopPropagation();
+      onClose();
+      return;
+    }
+    if (event.key === 'Tab') {
+      const focusables = visibleFocusables(card);
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (event.shiftKey && doc.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && doc.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+  };
+
+  doc.addEventListener('keydown', onKeyDown, true);
+
+  // Initial focus: the first visible focusable in the dialog, else the dialog card itself.
+  (visibleFocusables(card)[0] ?? card).focus();
+
+  return () => {
+    doc.removeEventListener('keydown', onKeyDown, true);
+    doc.body.style.overflow = previousOverflow;
+    // Restore focus to the trigger — unless it left the document while the dialog was open
+    // (e.g. the row that opened it was deleted), in which case focus() would throw/no-op.
+    if (previouslyFocused && doc.contains(previouslyFocused)) previouslyFocused.focus();
+  };
+}


### PR DESCRIPTION
## What

Three dashboard fixes in one batch: incomplete i18n catalogs, broken plural rendering on count badges, and thirteen hand-written modals with no dialog semantics.

### 1. i18n catalog gaps

- `Plugins.tsx` referenced 15 catalog keys (`plugins.catalog.*`, `plugins.installModal.tabCatalog/tabUpload/catalogTeaser/catalogTeaserSuffix/catalogHint`, `plugins.toasts.updateFailed`) that existed in **no** locale file — every non-English UI rendered the raw English `defaultValue` fallback. All 15 are now translated in all 12 locales, following each locale's existing terminology (e.g. 插件 vs 外掛, إضافات, תוספים).
- Count-based labels didn't use i18next plural forms: `webhooks.filters.badge` rendered "{{count}} filter" for any count, and `chats.unreadBadge` / `chats.channels.subscribers` rendered the plural form even at count 1 ("1 unread messages"). Following the catalog's existing convention (base key = singular fallback, suffixed forms per language), each locale now has proper `*_other` forms, with Hebrew (`one/two/many/other`) and Arabic (`zero/two/few/many/other`) category sets where those languages need them — Hebrew and Arabic already had partial plural sets for `chats.status.itemCount` and the filter badge, which are now completed. Pre-existing translations (e.g. the Arabic dual "تحديثان") were kept as-is.
- `sessionStatus.failed` and `sessionStatus.authenticating` were missing from every locale, so both session-status renderers (`Dashboard.tsx`, `Sessions.tsx`) showed the raw status string via `defaultValue: status`. Added to all 12 locales.

### 2. Dialog semantics for all hand-written modals

Thirteen modals across `ApiKeys` (2), `Infrastructure` (1), `Plugins` (2), `Templates` (1), `Webhooks` (3), and `PluginInstances` (4) hand-rolled their own overlay markup with no `role="dialog"`, no focus management, no Escape handling, and no background scroll lock. All thirteen now use the shared `Modal` component (which `Sessions`/`Chats` already used), gaining:

- `role="dialog"` + `aria-modal` + `aria-labelledby`
- initial focus into the dialog, a minimal Tab trap, and **focus restore to the trigger on close** (new — the shared component didn't restore focus before)
- Escape to close, overlay click-to-close (only when the press starts on the overlay), and body scroll lock

Supporting changes:

- The modal behavior (Escape / trap / initial focus / focus restore / scroll lock) is extracted into `src/utils/modalA11y.ts` (`bindModalA11y`) so it is unit-testable under the repo's DOM-less `node --test` setup; the React effect in `Modal.tsx` is a thin wrapper.
- `Modal` gains three optional props used by the migration: `headerExtra` (tab pill inside the header — install modal), `subheader` (tab row between the pinned header and the scrolling body — config modal), and `hideCloseButton` (restart-progress modal, which deliberately offers no dismissal while a restart runs; its `onClose` is guarded to the idle state, matching the previous behavior exactly).
- Modal contents, forms, and per-button handlers are unchanged. Two CSS selectors that targeted hand-written header classes were retargeted to the shared structure (`.restart-modal .modal-header/.modal-body`, `.install-modal .modal-header`), keeping visuals identical.
- Nested modals compose correctly: plugin-instance modals render inside the plugin config modal, and the child's Escape/scroll-lock/focus-restore run before and unwind after the parent's.

Also: `package.json` gains a `test` script alias (the repo only had `test:unit`).

## Tests

- `src/utils/modalA11y.test.ts` (8 tests): scroll lock on/off with previous-value restore, initial focus (first focusable, or the card when empty), Escape closes + stops propagation, focus returns to the trigger on close, no restore when the trigger left the document, Tab/Shift+Tab wrap-around, listener cleanup on unmount.
- `src/i18n/locales.test.ts` (7 tests): filter badge / unread badge / subscribers render singular at count 1 and plural at count n (en exact-match), every count badge resolves interpolated in all 12 locales, Hebrew dual + Arabic few-category spot checks, all 15 new `plugins.*` keys resolve in every locale, `sessionStatus.failed/authenticating` resolve in every locale.
- Full suite: 156/156 pass. `npm run lint` (0 errors), `npm run typecheck`, `npm run build`, and `npm run i18n:check` (739 keys × 12 locales) all green.

## Risks

- **Translations are machine-reviewed, not native-reviewed.** Short technical strings follow each file's existing conventions; Arabic/Hebrew plural-category forms were cross-checked against i18next's plural resolution. A native pass can refine wording later without touching code.
- **Restart modal dismissal is unchanged by design**: no close button, Escape/overlay only work in the idle state — mid-restart there is still no way to dismiss the progress view.
- Focus restore is new behavior for the two pages that already used `Modal` (`Sessions`, `Chats`) — on close, focus now returns to the trigger instead of being lost to `<body>`. This is the intended a11y improvement, but it does change focus order for keyboard users on those pages.
- Other count-bearing strings that are plural-agnostic abbreviations in practice (`common.minAgo`, `search.results`, `templates.count`, …) were left alone; they can get the same treatment separately if desired.
