### PR TITLE
fix(search): scope the FTS probe to the active schema in degraded states

### DIFF
--- a/src/modules/search/providers/builtin-fts.provider.postgres.spec.ts
+++ b/src/modules/search/providers/builtin-fts.provider.postgres.spec.ts
@@ -1,0 +1,125 @@
+import 'reflect-metadata';
+import { Logger, NotImplementedException } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { BuiltInFtsProvider } from './builtin-fts.provider';
+
+/**
+ * Postgres-side probe coverage. A real PG instance isn't available to the unit suite, so the
+ * DataSource is mocked and its query responses scripted the way each schema state would answer —
+ * same pattern as the migration tests in src/database/migrations/__tests__. The focus is the FTS
+ * availability probe: it must inspect the SAME `messages` table the runtime queries resolve through
+ * the session search_path (pinned to `<schema>,public` on a non-public POSTGRES_SCHEMA), and it must
+ * fail closed when the active schema can't be ascertained.
+ */
+
+interface ProbeScript {
+  /** Whether the active schema's `messages` carries the generated `body_ts` column. */
+  bodyTsPresent?: boolean;
+  /** When set, the probe query itself rejects (degraded pool / mid-recovery state). */
+  probeError?: Error;
+  /** When set, the boot-time ensure DDL rejects, leaving the availability cache unprimed. */
+  failEnsure?: boolean;
+}
+
+function makePostgresDataSource(script: ProbeScript) {
+  // Held in an object so a test can flip the script mid-flight (recovery case).
+  const state: ProbeScript = { ...script };
+  const query = jest.fn((sql: string) => {
+    const s = String(sql);
+    if (/to_regclass\('messages'\)/.test(s)) {
+      if (state.probeError) return Promise.reject(state.probeError);
+      return Promise.resolve(state.bodyTsPresent ? [{ attname: 'body_ts' }] : []);
+    }
+    if (/ALTER TABLE "messages" ADD COLUMN|CREATE INDEX IF NOT EXISTS "idx_messages_body_ts"/.test(s)) {
+      return state.failEnsure ? Promise.reject(new Error('simulated ensure failure')) : Promise.resolve([]);
+    }
+    if (/websearch_to_tsquery/.test(s)) return Promise.resolve([]); // search rows / count
+    return Promise.resolve([]);
+  });
+  const ds = { options: { type: 'postgres' }, query } as unknown as DataSource;
+  return { ds, query, state };
+}
+
+const sqlOf = (query: jest.Mock): string[] => query.mock.calls.map(call => String((call as unknown[])[0]));
+
+describe('BuiltInFtsProvider (postgres probe)', () => {
+  // The provider logs through Nest's Logger on the warn/error paths exercised here; keep the test
+  // output quiet without touching the assertions.
+  beforeEach(() => {
+    jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  it('probes via to_regclass (search_path resolution), never an unqualified information_schema scan', async () => {
+    const { ds, query } = makePostgresDataSource({ bodyTsPresent: true });
+    const provider = new BuiltInFtsProvider(ds);
+
+    expect((await provider.health()).ok).toBe(true);
+
+    const calls = sqlOf(query);
+    expect(calls.some(q => /to_regclass\('messages'\)/.test(q))).toBe(true);
+    expect(calls.some(q => /information_schema/i.test(q))).toBe(false);
+  });
+
+  it('sees body_ts on the active-schema messages table (cold cache: probe decides availability)', async () => {
+    const { ds } = makePostgresDataSource({ bodyTsPresent: true });
+    const provider = new BuiltInFtsProvider(ds);
+
+    const res = await provider.search({ q: 'hello' });
+    expect(res.provider).toBe('builtin-fts');
+    expect((await provider.health()).ok).toBe(true);
+  });
+
+  it('does not credit a namesake in another schema: an empty active-schema probe means 501, not "available"', async () => {
+    // A public.messages.body_ts must not make FTS look available when the table the search queries
+    // resolve (active schema) lacks the column. The scripted probe answers for the resolved table
+    // only — empty — so search must take the clean 501 posture.
+    const { ds } = makePostgresDataSource({ bodyTsPresent: false });
+    const provider = new BuiltInFtsProvider(ds);
+
+    await expect(provider.search({ q: 'hello' })).rejects.toBeInstanceOf(NotImplementedException);
+    const health = await provider.health();
+    expect(health.ok).toBe(false);
+    expect(health.detail).toBe('full-text index absent');
+  });
+
+  it('degraded boot (ensure failed) + active schema lacks body_ts → same absent-index posture as normal', async () => {
+    const { ds, query } = makePostgresDataSource({ bodyTsPresent: false, failEnsure: true });
+    const provider = new BuiltInFtsProvider(ds);
+    await provider.onModuleInit(); // ensure throws inside; boot must not fail and cache stays unprimed
+
+    await expect(provider.search({ q: 'hello' })).rejects.toBeInstanceOf(NotImplementedException);
+    expect((await provider.health()).ok).toBe(false);
+    // The probe (not a re-attempted ensure) decided availability after the failed boot.
+    expect(sqlOf(query).some(q => /to_regclass\('messages'\)/.test(q))).toBe(true);
+  });
+
+  it('degraded boot (ensure failed) + active schema HAS body_ts → probe still detects FTS (no false 501)', async () => {
+    // ensure can die on a transient error even though the column already exists (e.g. GIN index
+    // build raced a statement timeout). The probe must read the active schema's real state and keep
+    // search available — same decision a healthy boot would have cached.
+    const { ds } = makePostgresDataSource({ bodyTsPresent: true, failEnsure: true });
+    const provider = new BuiltInFtsProvider(ds);
+    await provider.onModuleInit();
+
+    const res = await provider.search({ q: 'hello' });
+    expect(res.provider).toBe('builtin-fts');
+    expect((await provider.health()).ok).toBe(true);
+  });
+
+  it('a probe error fails closed (501/unhealthy, never a raw 500) and is NOT cached — a later probe recovers', async () => {
+    const { ds, state } = makePostgresDataSource({ probeError: new Error('connection reset') });
+    const provider = new BuiltInFtsProvider(ds);
+
+    await expect(provider.search({ q: 'hello' })).rejects.toBeInstanceOf(NotImplementedException);
+    expect((await provider.health()).ok).toBe(false);
+
+    // Pool recovered: the failed probe was not cached, so availability is re-probed and found.
+    state.probeError = undefined;
+    state.bodyTsPresent = true;
+    expect((await provider.health()).ok).toBe(true);
+    await expect(provider.search({ q: 'hello' })).resolves.toMatchObject({ provider: 'builtin-fts' });
+  });
+});

--- a/src/modules/search/providers/builtin-fts.provider.ts
+++ b/src/modules/search/providers/builtin-fts.provider.ts
@@ -78,16 +78,37 @@ export class BuiltInFtsProvider implements SearchProvider, OnModuleInit {
 
   /**
    * Probes the FTS schema once per instance and caches the result. SQLite: look for the `messages_fts`
-   * virtual table in sqlite_master. Postgres: look for the generated `body_ts` column in
-   * information_schema. Safe to call repeatedly; only the first call hits the DB.
+   * virtual table in sqlite_master. Postgres: look for the generated `body_ts` column on the SAME
+   * `messages` table the search queries resolve — see the to_regclass note below. Safe to call
+   * repeatedly; only the first successful probe hits the DB and caches.
    */
   private async probeFts(): Promise<boolean> {
     if (this.ftsAvailable !== null) return this.ftsAvailable;
     if (this.dataSource.options.type === 'postgres') {
-      const rows: unknown[] = await this.dataSource.query(
-        `SELECT 1 FROM information_schema.columns WHERE table_name='messages' AND column_name='body_ts'`,
-      );
-      this.ftsAvailable = Array.isArray(rows) && rows.length === 1;
+      // to_regclass('messages') resolves the name through the session search_path — the identical
+      // resolution the runtime queries (`FROM messages m`) use, and the data connection pins
+      // search_path to `<schema>,public` when POSTGRES_SCHEMA is non-public (app.module.ts). So the
+      // probe inspects the table search will actually hit, in the active schema. An unqualified
+      // information_schema scan would instead peek across EVERY visible schema and can lie both ways
+      // on a custom-schema deployment: a namesake public.messages.body_ts reports FTS present when
+      // the active schema lacks it, and a >1-row match (both schemas carry the column) reports it
+      // absent. to_regclass returns NULL when `messages` is unresolvable on the path → zero rows →
+      // unavailable, so an undeterminable schema fails closed by construction.
+      // Fail-closed on probe error (degraded state, e.g. boot ensure left the pool mid-recovery):
+      // report unavailable WITHOUT caching, so search() 501s via ensureFts — the same clean posture
+      // as a genuinely absent index, never a raw 500 — and a later call re-probes after recovery.
+      let rows: unknown[];
+      try {
+        rows = await this.dataSource.query(
+          `SELECT a.attname FROM pg_attribute a WHERE a.attrelid = to_regclass('messages') AND a.attname = 'body_ts' AND NOT a.attisdropped`,
+        );
+      } catch (e) {
+        this.logger.warn(
+          `FTS probe failed; treating the index as unavailable: ${e instanceof Error ? e.message : String(e)}`,
+        );
+        return false;
+      }
+      this.ftsAvailable = Array.isArray(rows) && rows.length >= 1;
     } else {
       const rows: unknown[] = await this.dataSource.query(
         `SELECT name FROM sqlite_master WHERE type='table' AND name='messages_fts'`,


### PR DESCRIPTION
## Problem

On PostgreSQL deployments with a non-public `POSTGRES_SCHEMA`, the FTS availability probe in `BuiltInFtsProvider` (`probeFts`) checked for the generated `body_ts` column with an unqualified `information_schema.columns` scan:

```sql
SELECT 1 FROM information_schema.columns WHERE table_name='messages' AND column_name='body_ts'
```

That query has no `table_schema` filter, so it peeks across **every** schema the role can see instead of the schema the data connection actually resolves `messages` to (the session `search_path` is pinned to `<schema>,public` for a custom schema). It could lie in both directions:

- **False positive:** a namesake `public.messages.body_ts` (stale install, another app) made FTS look available when the active schema's `messages` lacks the column — search then failed at query time with a raw missing-column error instead of the clean 501 posture.
- **False negative:** when both `public` and the active schema carried the column, the `rows.length === 1` check failed and FTS looked absent — search 501'd even though the index was there.

The probe only runs when the boot-time `ensureFtsSchema()` didn't cache the outcome — i.e. exactly the degraded/cold-cache states (ensure failed at boot, or `health()`/`search()` hit before the cache was primed) — so deployments were most likely to get the wrong search posture precisely when already degraded.

## Fix

The probe now inspects the **same table the search queries resolve**, via `to_regclass('messages')`:

```sql
SELECT a.attname FROM pg_attribute a
WHERE a.attrelid = to_regclass('messages') AND a.attname = 'body_ts' AND NOT a.attisdropped
```

`to_regclass` resolves the unqualified name through the session `search_path` — the identical name resolution the runtime queries (`FROM messages m`) use — so the probe answers for the active schema's `messages` in every state, including degraded ones. When the name is unresolvable on the path, `to_regclass` returns NULL and the probe reports unavailable: the schema being undeterminable fails closed by construction.

Additionally, if the probe query itself errors (degraded pool, mid-recovery), it now fails closed: it reports FTS unavailable **without caching**, so `search()` returns the same 501 it would for a genuinely absent index (never a raw 500), and a later call re-probes after recovery. Previously a probe error escaped as a 500.

Normal behavior is unchanged: on a healthy boot the migration/ensure creates the column and the probe (or the boot-cached ensure result) detects it exactly as before; the SQLite FTS5 path is untouched.

## Tests

New `builtin-fts.provider.postgres.spec.ts` (mocked DataSource, same pattern as the migration tests) covers:

- Probe SQL resolves via `to_regclass('messages')` and never issues an unqualified `information_schema` scan.
- Cold-cache probe sees `body_ts` on the active-schema table → search runs.
- Empty active-schema probe → 501 / unhealthy (a namesake in another schema is not credited).
- Degraded boot (simulated ensure failure): probe decision matches the active schema's real state — 501 when `body_ts` is absent, search stays available when it exists.
- Probe error fails closed (501, no raw 500), is not cached, and a later probe recovers.

The existing real-SQLite suite (`builtin-fts.provider.spec.ts`, `search-dual-db.spec.ts`) is unchanged and passing, pinning the SQLite path.

## Verification

- `npx jest src/modules/search src/database` — 31 suites, 141 tests passed (5 skipped).
- `npx eslint src/modules/search src/database` — clean.
- `npm run build` — clean.

## Risk

Low. The change is confined to the Postgres branch of the availability probe; query paths, DDL, and the SQLite provider are untouched. The probe SQL uses catalog functions available on all supported PG versions. Worst case on an exotic setup, the probe reports unavailable — which is the safe, already-supported 501 posture rather than a query-time crash.
