### PR TITLE
feat(config): declare a templated default server in the OpenAPI spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   connection. Credentials authenticate on the socket itself, so the Chromium first-CONNECT 407
   limitation that can bite the wwjs engine's proxy-auth path does not apply to this engine.
 
+- **The OpenAPI spec now declares a templated default server.** `servers` was empty; it now carries
+  `http://{host}:{port}` with `localhost`/`2785` defaults, so Swagger UI's "Try it" works out of the
+  box and stays usable on real deployments via the host/port variables, and static consumers of the
+  published `openapi.json` get a concrete base URL to display.
+
 ### Fixed
 
 - **A source install without the GNU `patch` binary no longer silently ships an unpatched

--- a/openapi.json
+++ b/openapi.json
@@ -5916,7 +5916,21 @@
       "description": "Health check endpoints"
     }
   ],
-  "servers": [],
+  "servers": [
+    {
+      "url": "http://{host}:{port}",
+      "description": "OpenWA instance",
+      "variables": {
+        "host": {
+          "default": "localhost"
+        },
+        "port": {
+          "default": "2785",
+          "description": "PORT env var"
+        }
+      }
+    }
+  ],
   "components": {
     "securitySchemes": {
       "X-API-Key": {

--- a/src/config/swagger.config.spec.ts
+++ b/src/config/swagger.config.spec.ts
@@ -24,6 +24,16 @@ describe('createSwaggerConfig', () => {
     // requirement would falsely claim every route accepts it.
     expect(config.security).not.toContainEqual({ [METRICS_BEARER_SCHEME]: [] });
   });
+
+  it('declares a templated default server so published specs carry a base URL', () => {
+    const config = createSwaggerConfig();
+
+    expect(config.servers).toHaveLength(1);
+    const [server] = config.servers ?? [];
+    expect(server.url).toBe('http://{host}:{port}');
+    expect(server.variables?.host.default).toBe('localhost');
+    expect(server.variables?.port.default).toBe('2785');
+  });
 });
 
 describe('exemptPublicOperations', () => {

--- a/src/config/swagger.config.ts
+++ b/src/config/swagger.config.ts
@@ -96,6 +96,14 @@ export function createSwaggerConfig(): Omit<OpenAPIObject, 'paths'> {
       .addTag('audit', 'Audit log')
       .addTag('metrics', 'Prometheus metrics')
       .addTag('health', 'Health check endpoints')
+      // Templated server: defaults to the out-of-box local instance, and the {host}/{port}
+      // variables keep Swagger UI "Try it" usable on real deployments (a hardcoded
+      // localhost URL would break Try-it for anyone serving elsewhere). Static consumers
+      // of the spec (the docs site) also get a concrete base URL to display.
+      .addServer('http://{host}:{port}', 'OpenWA instance', {
+        host: { default: 'localhost' },
+        port: { default: '2785', description: 'PORT env var' },
+      })
       .build()
   );
 }


### PR DESCRIPTION
## Summary

The exported OpenAPI spec declared no servers (`"servers": []`), which left Swagger UI's "Try it" with no base URL and gave static consumers of the published `openapi.json` nothing to display as an endpoint.

The spec now declares a single templated server:

```json
{
  "url": "http://{host}:{port}",
  "description": "OpenWA instance",
  "variables": {
    "host": { "default": "localhost" },
    "port": { "default": "2785", "description": "PORT env var" }
  }
}
```

A templated URL rather than a hardcoded `http://localhost:2785`: the defaults make the out-of-box local instance work immediately, while the `{host}`/`{port}` variables keep "Try it" usable on deployments serving anywhere else — a hardcoded URL would have broken exactly those.

## Changes

- `src/config/swagger.config.ts`: `.addServer('http://{host}:{port}', …)` with `localhost`/`2785` defaults.
- `openapi.json`: regenerated (`npm run openapi:export`); the only delta is the populated `servers` array.
- `src/config/swagger.config.spec.ts`: new case asserting the templated server and its variable defaults.
- `CHANGELOG.md`: entry under `[Unreleased]`.

## Testing

- `npm run openapi:check` — no drift between the committed spec and a fresh export.
- Full lint clean; `src/config` suites 178/178.
