### PR TITLE
docs(env): document the ingress reconciler and webhook shutdown-drain knobs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -253,6 +253,10 @@ WEBHOOK_TIMEOUT=10000               # Timeout in milliseconds
 WEBHOOK_RETRY_DELAY=5000            # Delay between retries in ms
 # WEBHOOK_DISPATCH_CONCURRENCY=16    # max active inline webhook deliveries per process
 # WEBHOOK_DISPATCH_MAX_QUEUED=1000  # max inline deliveries parked behind the concurrency cap
+# WEBHOOK_SHUTDOWN_DRAIN_MS=5000    # on shutdown, in-flight deliveries get this long to finish
+                                   # before they are logged abandoned (parked ones are
+                                   # dead-lettered). Startup warns when this is shorter than
+                                   # WEBHOOK_TIMEOUT — that cross silently truncates deliveries.
 # WEBHOOK_MAX_PER_SESSION=16        # max webhooks registered per session; new registrations at/over
                                    # the cap get 400 (existing ones are grandfathered); 0 = unlimited
 # WEBHOOK_MEDIA_INLINE_MAX_BYTES=1048576  # decoded-byte cap for inline base64 media in webhook
@@ -378,6 +382,16 @@ RATE_LIMIT_MEDIUM_LIMIT=100         # max requests per window
 #                                    # manifest sets no toleranceSec (also the standard-webhooks
 #                                    # fallback). Must be a positive integer; invalid values fall back
 #                                    # to 300.
+
+# Ingress reconciler: replays persisted events whose dispatch never completed (a crash between
+# persist and dispatch, or an enqueue whose outcome was never recorded) using their ORIGINAL
+# delivery id — a replay is idempotent against a job that did get enqueued, and re-checks the
+# instance is still eligible first. Budget exhaustion marks the event failed and files a DLQ
+# row, so recovery continues through the redrive endpoint instead of looping forever.
+# INGRESS_RECONCILE_INTERVAL_MS=60000   # sweep interval; <= 0 disables the reconciler
+# INGRESS_RECONCILE_GRACE_MS=60000      # age a 'pending' row must pass before it counts as stuck
+# INGRESS_RECONCILE_BATCH_SIZE=50       # stale rows replayed per sweep, oldest first
+# INGRESS_RECONCILE_MAX_ATTEMPTS=5      # replays per event before it goes terminal + DLQ (min 1)
 
 # Concurrency of the BullMQ workers that process queued webhooks and ingress events. Only meaningful
 # when QUEUE_ENABLED=true. Ordering within one conversation is preserved by a per-conversation lock,


### PR DESCRIPTION
`.env.example` is the operator-facing single source of truth for configuration, but five v0.11.0 knobs were missing from it. This adds them next to their related blocks with the exact defaults and parse semantics from source:

- `WEBHOOK_SHUTDOWN_DRAIN_MS` (default 5000) — shutdown drain for in-flight deliveries, including the startup warning that fires when it is shorter than `WEBHOOK_TIMEOUT` (the cross that silently truncates in-flight deliveries).
- `INGRESS_RECONCILE_INTERVAL_MS` (default 60000, `<= 0` disables), `_GRACE_MS` (60000), `_BATCH_SIZE` (50), `_MAX_ATTEMPTS` (5, min 1) — the reconciler that replays persisted ingress events whose dispatch never completed, with their original delivery id, retiring to the DLQ after the attempt budget instead of looping forever.

Comments only; no behavior change. Defaults verified against `ingress-reconciler.service.ts` (`resolveIngressReconcilerOptions`) and `configuration.ts` / `webhook.service.ts`.
