### PR TITLE
fix(api): drop the unreachable 200 on the catalog endpoints, and correct residual documentation details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The published OpenAPI spec no longer advertises a `200` the catalog endpoints never return.**
+  `GET /sessions/{id}/catalog`, `/catalog/products` and `/catalog/products/{productId}` each declared
+  a `200` response described as "always null on whatsapp-web.js", from a time when that engine
+  returned an empty result instead of refusing. Both adapters now throw, so every call answers `501`,
+  and a generated client built against the old snapshot modelled a success case that cannot occur.
+  The stale declarations are removed, the remaining `501` description no longer names only Baileys,
+  and `openapi.json` is regenerated.
+
 - **The documentation set now matches the shipped implementation.** Every numbered document was
   checked claim by claim against source, and the corrections concentrate where following the docs
   could fail silently. Session auth was documented at `./data/.wwebjs_auth` when it lives under

--- a/docs/01-project-overview.md
+++ b/docs/01-project-overview.md
@@ -125,7 +125,7 @@ Phase 2 (Production Ready)
 ├── PostgreSQL support
 ├── Web Dashboard
 ├── Webhook management UI
-├── Message queue (Redis/Bull)
+├── Message queue (Redis/BullMQ)
 ├── Rate limiting
 └── Authentication (API Key)
 
@@ -254,7 +254,7 @@ flowchart TB
 | Browser | Puppeteer/Chrome | Used by default (whatsapp-web.js) engine; not required for baileys engine |
 | Database | SQLite (default) / PostgreSQL | Zero-config default, PostgreSQL for scaling |
 | Cache | Redis | Fast, pub/sub support |
-| Queue | Bull | Reliable job processing |
+| Queue | BullMQ | Reliable job processing |
 | Dashboard | React + Vite | Fast, modern |
 | Styling | Bespoke CSS modules/stylesheets | Lightweight dashboard styling without Tailwind |
 | UI Components | Custom React components + Lucide | Accessible, polished |

--- a/docs/02-requirements-specification.md
+++ b/docs/02-requirements-specification.md
@@ -92,7 +92,7 @@ sequenceDiagram
     
     alt Webhook Failed
         OW->>OW: Queue for Retry
-        OW->>WH: Retry (max 3x)
+        OW->>WH: Retry (up to retryCount attempts in total, default 3)
     end
 ```
 
@@ -100,7 +100,7 @@ sequenceDiagram
 |----|-------------|----------|-------|
 | FR-WH-001 | The system must deliver events to webhook URLs | High | 1 |
 | FR-WH-002 | The system must support multiple webhook URLs | Medium | 2 |
-| FR-WH-003 | The system must retry failed webhooks (max 3x) | Medium | 2 |
+| FR-WH-003 | The system must retry failed webhooks (per-webhook `retryCount`, 0-5, default 3) | Medium | 2 |
 | FR-WH-004 | The system must filter event types per webhook | Medium | 2 |
 | FR-WH-005 | The system must log webhook delivery status | Medium | 2 |
 | FR-WH-006 | The system must support webhook signature verification | Medium | 2 |
@@ -388,7 +388,7 @@ sequenceDiagram
     Engine->>WA: Send via WhatsApp Web
     WA-->>Engine: Message sent
     Engine-->>API: Success response
-    API-->>User: 200 OK {messageId}
+    API-->>User: 201 Created {messageId}
 ```
 
 **Actors**: External application, Developer  
@@ -430,7 +430,7 @@ sequenceDiagram
 4. The webhook endpoint acknowledges
 
 **Alternative Flow**:
-- Webhook failed → Retry 3x
+- Webhook failed → Deliver at most `retryCount` times in **total**, not `retryCount` retries on top of the first try (0-5, default 3 — so the default is one delivery plus two retries, and `retryCount: 1` retries nothing)
 - All retries failed → Log and mark failed
 
 ### UC-003: Create New Session

--- a/docs/08-development-guidelines.md
+++ b/docs/08-development-guidelines.md
@@ -766,7 +766,7 @@ ENABLE_SWAGGER=false
 ### Logging Best Practices
 
 ```typescript
-// Use Logger from NestJS
+// Use createLogger from the shared LoggerService, not console.*
 import { Inject, Scope } from '@nestjs/common';
 import { REQUEST } from '@nestjs/core';
 import { Request } from 'express';

--- a/docs/12-troubleshooting-faq.md
+++ b/docs/12-troubleshooting-faq.md
@@ -210,8 +210,11 @@ curl -H "X-API-Key: $API_KEY" \
 # Check WhatsApp engine logs
 docker compose logs openwa-api 2>&1 | grep -i "whatsapp\|puppeteer\|browser"
 
-# Check auth folder (named after the session NAME, under SESSION_DATA_PATH)
-docker compose exec openwa-api ls -la /app/data/sessions/session-<name>/
+# Check auth folder. Both engines key it on the session NAME, but the location differs:
+#   whatsapp-web.js → SESSION_DATA_PATH (default /app/data/sessions), dir `session-<name>`
+#   baileys         → BAILEYS_AUTH_DIR  (default /app/data/baileys),  dir `<name>` (no prefix)
+docker compose exec openwa-api ls -la /app/data/sessions/session-<name>/   # whatsapp-web.js
+docker compose exec openwa-api ls -la /app/data/baileys/<name>/            # baileys
 ```
 
 **Solutions:**
@@ -225,8 +228,10 @@ docker compose exec openwa-api ls -la /app/data/sessions/session-<name>/
 | WhatsApp blocked | Set a per-session proxy (`proxyUrl`) |
 
 ```bash
-# Clear auth and restart (the profile dir carries the session NAME, not its UUID id)
-docker compose exec openwa-api rm -rf /app/data/sessions/session-<name>
+# Clear auth and restart (the profile dir carries the session NAME, not its UUID id).
+# Remove the one that matches the session's engine — deleting the other path is a silent no-op.
+docker compose exec openwa-api rm -rf /app/data/sessions/session-<name>   # whatsapp-web.js
+docker compose exec openwa-api rm -rf /app/data/baileys/<name>            # baileys
 docker compose restart openwa-api
 ```
 
@@ -1065,7 +1070,7 @@ available_events:
   "event": "message.received",
   "timestamp": "2026-02-02T10:30:00Z",
   "sessionId": "sess_abc123",
-  "idempotencyKey": "msg_sess_abc123_ABC123_DEF456",
+  "idempotencyKey": "msg_sess_abc123_ABC123_DEF456_f1e2d3c4-b5a6-7890-1234-567890abcdef",
   "deliveryId": "dlv_550e8400-e29b-41d4-a716-446655440000",
   "data": {
     "id": "ABC123_DEF456",

--- a/docs/24-mcp-integration.md
+++ b/docs/24-mcp-integration.md
@@ -152,7 +152,9 @@ only when an agent genuinely needs to send messages / mutate state.
   that carries an `allowedIps` list will be rejected. Use a key without `allowedIps` for
   MCP.
 - **Rate limiting.** A per-key limiter (keyed by the *authenticated* key id) bounds tool
-  calls. Buckets are pruned when idle. This is independent of the REST throttler.
+  calls. The key map is capped (approximate-LRU eviction at 50,000 keys), so a
+  distinct-key flood cannot grow process memory without limit. This is independent of
+  the REST throttler.
   Tune with `MCP_RATE_LIMIT_MAX` (default `60`) and `MCP_RATE_LIMIT_WINDOW_MS`
   (default `60000`). Any missing, blank, non-positive, or non-numeric value falls back
   to the default. A **second, pre-auth per-IP throttle** runs on the `/mcp` mount *before*

--- a/docs/27-plugin-search-providers.md
+++ b/docs/27-plugin-search-providers.md
@@ -1,6 +1,6 @@
 # 27 - Writing a Search-Provider Plugin
 
-> **Status:** The host→plugin search RPC shipped in v0.8.13 (PR #674). A sandboxed plugin can now register
+> **Status:** The host→plugin search RPC shipped in v0.8.14 (PR #674). A sandboxed plugin can now register
 > as a `SearchProvider` and answer `GET /api/search` queries from its own backend (Meilisearch,
 > Elasticsearch, Typesense, OpenSearch, …) while the core stays backend-agnostic. This guide is the
 > plugin-author's contract.

--- a/docs/29-engine-capability-matrix.md
+++ b/docs/29-engine-capability-matrix.md
@@ -35,7 +35,7 @@ The `rootCause`/`evidence` fields are hand-curated from source traces of the ins
 > **Wired.** ✅ `getChannelById`, `subscribeToChannel`, `unsubscribeFromChannel` on Baileys — via `newsletterMetadata('jid'|'invite', …)` → `NewsletterMetadata` mapped to `Channel` (id/name/description/inviteCode/subscriberCount/picture/verified/createdAt), `newsletterFollow` (subscribe, invite→jid bridge), `newsletterUnfollow` (unsubscribe, 1:1). `getChannelById` on Baileys resolves ANY channel by jid (richer than the wwjs subscribed-list lookup).
 - **`subscribeToChannel` (wwjs, adapter-gap).** whatsapp-web.js `Client.subscribeToChannel(channelId)` takes a channel ID and resolves a boolean (`Client.js:2533`) — it cannot satisfy the subscribe-by-invite-code contract on its own. The correct wiring is two-step: `getChannelByInviteCode(inviteCode)` (`Client.js:1707`) → `subscribeToChannel(channel.id)`. The adapter previously passed the invite code straight in and fabricated a `Channel` out of the returned boolean (`{ id: "undefined" }` — a reported success that never subscribed); it now throws an honest `EngineNotSupportedError` (501) until the two-step flow is verified against a live session.
 - **`getChannelMessages` (baileys, adapter-gap).** `sock.newsletterFetchMessages(channelId, limit, 0, 0)` (`Socket/newsletter.d.ts:19`) returns the **raw `BinaryNode`** of `<message_updates>` children (`newsletter.js:149`). The fetch is one line; the real work is walking the children and mapping each to `ChannelMessage{id,body,timestamp,hasMedia}` — no library parser is exposed. Not wired: a hand-written BinaryNode walk can't be verified without a live WhatsApp session, so it stays a documented gap rather than an unverified implementation.
-- **`getSubscribedChannels` (baileys, library-limitation).** No enumerate-subscribed-newsletters query in the library. All 23 `Socket/newsletter.d.ts` exports are per-jid (`newsletterMetadata` requires a key; `newsletterSubscribers(jid)` returns the count of one newsletter). The `newsletter` event surfaces jids opportunistically during live sync, but that is incremental, not a list-all. Would require a raw WMex/app-state hack against an undocumented XWAPath.
+- **`getSubscribedChannels` (baileys, library-limitation).** No enumerate-subscribed-newsletters query in the library. All 19 newsletter members of `Socket/newsletter.d.ts` address a single newsletter — by jid, by invite key, or by creating one (`newsletterMetadata('invite'|'jid', key)` requires a key; `newsletterSubscribers(jid)` returns the count of one newsletter; `newsletterCreate(name, description?)` makes a new one). The `newsletter` event surfaces jids opportunistically during live sync, but that is incremental, not a list-all. Would require a raw WMex/app-state hack against an undocumented XWAPath.
 
 ### Labels (WhatsApp Business)
 
@@ -68,7 +68,7 @@ The `rootCause`/`evidence` fields are hand-curated from source traces of the ins
 ### Status — post / delete
 
 > **Wired.** ✅ `postTextStatus` / `postImageStatus` / `postVideoStatus` + `deleteStatus` on whatsapp-web.js. Posts route via `sendMessage('status@broadcast', …)` (`{ extra: { backgroundColor, fontStyle } }` for text; `{ caption }` for media); `deleteStatus` calls `revokeStatusMessage(statusId)` (own-status only). **Caveat:** whatsapp-web.js has no status-recipient arg, so `StatusPostOptions.recipients` is not honored on this engine (it broadcasts to the account's status-privacy audience; a one-time warning is logged). The Baileys engine honors `recipients` (`statusJidList`).
-- **`deleteStatus` (baileys) caveat.** Marked `supported` (no throw), but the adapter self-describes its `sendMessage(status@broadcast,{delete})` revoke shape as *empirically unverified* (`baileys.adapter.ts:909-911`) — only posting was live-spiked. May need a fallback to `EngineNotSupportedError` if WA rejects the shape.
+- **`deleteStatus` (baileys) caveat.** Marked `supported` (no throw), but the adapter self-describes its `sendMessage(status@broadcast,{delete})` revoke shape as *empirically unverified* (`baileys.adapter.ts`, the `deleteStatus()` doc comment) — only posting was live-spiked. May need a fallback to `EngineNotSupportedError` if WA rejects the shape.
 
 ### Status — read (contact stories)
 
@@ -89,7 +89,7 @@ The `rootCause`/`evidence` fields are hand-curated from source traces of the ins
 | `getMessageReactions` | not-available — **library-limitation** | supported |
 
 - **`getChatHistory` (baileys, library-limitation).** The only history primitive is `fetchMessageHistory(count, oldestMsgKey, oldestMsgTimestamp)` (`Socket/business.d.ts:25`) — it returns a sync-token *string*, not messages; the messages are delivered later via the `messaging-history.set` event. There is no per-chat `fetchMessages(chatId, limit)` on the socket. A synchronous `Promise<IncomingMessage[]>` for one chat would require an OpenWA-side chat-indexed store populated from `messages.upsert` + `messaging-history.set` events.
-- **`getMessageReactions` (baileys, library-limitation).** No on-demand server fetch. Reactions exist only as event-augmented state on `WAMessage.reactions` (`proto.IReaction[]` at `WAProto/index.d.ts:10623`), mutated by `updateMessageWithReaction` and surfaced via the `messages.reaction` event. The adapter already processes `reactionMessage` events (`baileys.adapter.ts:1048-1057`) and emits `onMessageReaction`, but it does **not** persist `.reactions` into its `messageStore` (early-returns at line 1058). A store-backed read would need that persistence added first; even then, only reactions observed since session start are known (no historical backfill).
+- **`getMessageReactions` (baileys, library-limitation).** No on-demand server fetch. Reactions exist only as event-augmented state on `WAMessage.reactions` (`proto.IReaction[]` at `WAProto/index.d.ts:10623`), mutated by `updateMessageWithReaction` and surfaced via the `messages.reaction` event. The adapter already processes `reactionMessage` events (`baileys.adapter.ts`, the `reactionMessage` branch of `processInboundMessage()`) and emits `onMessageReaction`, but it does **not** persist `.reactions` into its `messageStore` (that branch returns before the `messageStore.put`). A store-backed read would need that persistence added first; even then, only reactions observed since session start are known (no historical backfill).
 
 ### Groups — disappearing messages
 
@@ -142,7 +142,7 @@ _All Tier-2 items wired (see progress above). Remaining channel work is Tier 3: 
 These are honestly out of reach of a clean adapter wiring because the installed library exposes no first-class symbol. Listed so operators can plan around them rather than file unactionable bugs.
 
 **baileys (9 cells):**
-- `getSubscribedChannels` — no enumerate-newsletters query; all `Socket/newsletter.d.ts` exports are per-jid. Needs a raw WMex/app-state hack.
+- `getSubscribedChannels` — no enumerate-newsletters query; all 19 newsletter members of `Socket/newsletter.d.ts` address a single newsletter (by jid, by invite key, or by creating one). Needs a raw WMex/app-state hack.
 - `getLabels` / `getLabelById` / `getChatLabels` — no label read symbol; only writes (`Types/Label.d.ts` is types-only). Workaround: capture labels from the `messaging-history.set` app-state event into an in-memory cache (relay hack, no on-demand refresh).
 - `getChatHistory` — only `fetchMessageHistory` (event-delivered sync token); no synchronous per-chat `fetchMessages`. Needs an OpenWA-side chat-indexed store fed from `messages.upsert` + `messaging-history.set`.
 - `getMessageReactions` — no on-demand fetch; reactions only arrive via the `messages.reaction` event. Partial local path: persist each event into the `messageStore`, then read (no historical backfill).
@@ -153,7 +153,7 @@ These are honestly out of reach of a clean adapter wiring because the installed 
 - `getCatalog` / `getProducts` / `getProduct` — no catalog API at all (`index.d.ts` 0 hits; `Product` is inbound-only).
 - `sendProduct` — no outbound product content type.
 - `sendCatalog` — no outbound catalog content type.
-- `setGroupEphemeral` — no disappearing-timer setter in whatsapp-web.js 1.34.7 (`ephemeralDuration` exists only as a createGroup option). Baileys: `groupToggleEphemeral`.
+- `setGroupEphemeral` — no disappearing-timer setter in whatsapp-web.js 1.34.7; the timer is only reachable through the create-time `messageTimer` option (`index.d.ts:870`), which `Client.js` maps to the internal `ephemeralDuration` wire field. Baileys: `groupToggleEphemeral`.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -127,7 +127,7 @@ random `owa_k1_...` admin key is generated on first run in all environments; set
 `ALLOW_DEV_API_KEY=true` to seed the well-known `dev-admin-key` for local
 development only. Use an admin key to create additional keys with
 `POST /api/auth/api-keys` (see
-[API Specification](./06-api-specification.md#api-key-management)).
+[API Specification](./06-api-specification.md#649-api-keys)).
 
 ## API Example
 
@@ -166,7 +166,7 @@ const socket = io('http://localhost:2785/events', {
 socket.on('connect', () => {
   socket.emit('message', {
     type: 'subscribe',
-    sessionId: 'sess_abc123',
+    sessionId: '550e8400-e29b-41d4-a716-446655440000',
     events: ['message.received', 'session.status'],
     requestId: 'req_001',
   });
@@ -195,7 +195,8 @@ socket.on('message', msg => {
 | Rate Limiting                   | Ready                         |
 | Audit Logging                   | Ready                         |
 | Groups / Contacts / Labels API  | Ready                         |
-| Channels / Status / Catalog API | Experimental (engine-limited) |
+| Channels / Status API           | Experimental (engine-limited) |
+| Catalog / Product API           | Endpoints defined; `501` on both engines |
 | Pluggable Engine (wwebjs / Baileys) | Ready (set `ENGINE_TYPE`)  |
 | Plugin Extension System         | Ready                         |
 | Queue-based Webhook Retries     | Optional (QUEUE_ENABLED=true) |

--- a/docs/examples/chat-history-limits.md
+++ b/docs/examples/chat-history-limits.md
@@ -64,7 +64,7 @@ Use the live history endpoint as a bounded recent-history helper, not as a full 
 
 ```bash
 curl -H "X-API-Key: $API_KEY" \
-  "http://localhost:2785/api/sessions/default/messages/628123456789@c.us/history?limit=100"
+  "http://localhost:2785/api/sessions/{sessionId}/messages/628123456789@c.us/history?limit=100"
 ```
 
 Use `limit=100` when you want the maximum single-request live history window currently allowed by OpenWA.

--- a/openapi.json
+++ b/openapi.json
@@ -4487,11 +4487,8 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "Always null on whatsapp-web.js: catalog reads are not implemented on either engine."
-          },
           "501": {
-            "description": "Not supported by the active engine: Baileys does not implement catalog reads."
+            "description": "Not supported: neither engine implements catalog reads."
           }
         },
         "summary": "Get business catalog info (not implemented by any engine)",
@@ -4536,11 +4533,8 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "Always an empty page on whatsapp-web.js: catalog reads are not implemented on either engine."
-          },
           "501": {
-            "description": "Not supported by the active engine: Baileys does not implement catalog reads."
+            "description": "Not supported: neither engine implements catalog reads."
           }
         },
         "summary": "List catalog products (not implemented by any engine)",
@@ -4571,11 +4565,8 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "Always null on whatsapp-web.js: catalog reads are not implemented on either engine."
-          },
           "501": {
-            "description": "Not supported by the active engine: Baileys does not implement catalog reads."
+            "description": "Not supported: neither engine implements catalog reads."
           }
         },
         "summary": "Get a specific product (not implemented by any engine)",

--- a/src/engine/engine-capability-matrix.ts
+++ b/src/engine/engine-capability-matrix.ts
@@ -166,7 +166,7 @@ export const ENGINE_CAPABILITY_MATRIX: Record<string, MethodCapability> = {
     wwjs: { status: 'supported' },
     baileys: { status: 'not-available', rootCause: 'library-limitation' },
     evidence:
-      'baileys no enumerate-newsletters fn; all 23 Socket/newsletter.d.ts exports are per-jid (newsletterMetadata requires a key; newsletterSubscribers returns the count of ONE). Only the newsletter EVENT surfaces jids opportunistically (incremental, not list-all); wwjs Client.getChannels (Client.js:1680)',
+      'baileys no enumerate-newsletters fn; 18 of the 19 Socket/newsletter.d.ts newsletter members are per-jid (only newsletterCreate is not) (newsletterMetadata requires a key; newsletterSubscribers returns the count of ONE). Only the newsletter EVENT surfaces jids opportunistically (incremental, not list-all); wwjs Client.getChannels (Client.js:1680)',
   },
   initialize: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   joinGroupViaInviteCode: {

--- a/src/modules/catalog/catalog.controller.ts
+++ b/src/modules/catalog/catalog.controller.ts
@@ -13,12 +13,8 @@ export class CatalogController {
   @Get('catalog')
   @ApiOperation({ summary: 'Get business catalog info (not implemented by any engine)' })
   @ApiResponse({
-    status: 200,
-    description: 'Always null on whatsapp-web.js: catalog reads are not implemented on either engine.',
-  })
-  @ApiResponse({
     status: 501,
-    description: 'Not supported by the active engine: Baileys does not implement catalog reads.',
+    description: 'Not supported: neither engine implements catalog reads.',
   })
   async getCatalog(@Param('sessionId') sessionId: string) {
     return this.catalogService.getCatalog(sessionId);
@@ -27,12 +23,8 @@ export class CatalogController {
   @Get('catalog/products')
   @ApiOperation({ summary: 'List catalog products (not implemented by any engine)' })
   @ApiResponse({
-    status: 200,
-    description: 'Always an empty page on whatsapp-web.js: catalog reads are not implemented on either engine.',
-  })
-  @ApiResponse({
     status: 501,
-    description: 'Not supported by the active engine: Baileys does not implement catalog reads.',
+    description: 'Not supported: neither engine implements catalog reads.',
   })
   async getProducts(@Param('sessionId') sessionId: string, @Query() query: ProductQueryDto) {
     return this.catalogService.getProducts(sessionId, query.page, query.limit);
@@ -41,12 +33,8 @@ export class CatalogController {
   @Get('catalog/products/:productId')
   @ApiOperation({ summary: 'Get a specific product (not implemented by any engine)' })
   @ApiResponse({
-    status: 200,
-    description: 'Always null on whatsapp-web.js: catalog reads are not implemented on either engine.',
-  })
-  @ApiResponse({
     status: 501,
-    description: 'Not supported by the active engine: Baileys does not implement catalog reads.',
+    description: 'Not supported: neither engine implements catalog reads.',
   })
   async getProduct(@Param('sessionId') sessionId: string, @Param('productId') productId: string) {
     return this.catalogService.getProduct(sessionId, productId);


### PR DESCRIPTION
## Summary

A follow-up pass over the smaller reference details left after #977, plus one correction to a published artifact that the pass turned up.

Most of what was reviewed here had already been resolved by #977 and needed no change. What follows is what survived that check and was verified against source.

## API contract

`GET /sessions/{id}/catalog`, `/catalog/products` and `/catalog/products/{productId}` each declared a `200` response in Swagger, described as returning `null` on whatsapp-web.js. That described an earlier behaviour: both adapters now throw `EngineNotSupportedError`, so the only status these routes can produce is `501`. The published `openapi.json` therefore advertised a success case that cannot occur, and a client generated from it modelled a nullable payload for a call that always fails. The stale declarations are removed, the remaining `501` description no longer attributes the limitation to Baileys alone, and the snapshot is regenerated.

## Documentation

**The webhook retry contract was the most misleading item.** `retryCount` is the total number of delivery attempts, not the number of retries on top of the first one — `if (attempt < webhook.retryCount)` with `attempt` starting at 1, and the queued path hands the same value to BullMQ's `attempts`. The documented "retry 3x" promised one more attempt than the code makes, and `retryCount: 1` retries nothing at all. The requirements flow and the requirement row now state the total-attempts semantics explicitly.

**The troubleshooting auth-folder commands were engine-specific inside a section that is not.** Both the diagnostic and the "clear auth and restart" step used the whatsapp-web.js layout only. On a Baileys session that path does not exist, so the `rm -rf` was a silent no-op while the real credentials sat untouched under `BAILEYS_AUTH_DIR`. Both engines are now shown, with the directory-naming difference called out.

Smaller corrections: the webhook payload sample omitted the per-webhook salt that every delivered `idempotencyKey` carries, so a reader building a parser from it would mis-split the field; the queue is BullMQ rather than Bull; send-message returns `201` rather than `200`; the engine capability matrix cited 23 newsletter members where the pinned library exposes 19, and called all of them per-jid when `newsletterCreate` takes a name; an anchor link and a session-id placeholder pointed at targets that do not resolve; the plugin search-provider status named the wrong release; and the feature table now separates the catalog surface, which answers `501` on both engines, from the channels and status APIs that work.

## Verification

- `npm run openapi:check` confirms the committed snapshot matches what the decorators generate.
- `npx tsc --noEmit -p tsconfig.json` and ESLint pass on the changed sources; the engine parity suite is green (81 tests).
- `npm run check:versions` passes; internal document links resolve and code fences remain balanced across the set.
