### PR TITLE
fix(install): support npm 12 and Windows patching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Native Windows and npm 12 source installs no longer fail during dependency setup.** The
+  whatsapp-web.js backport now normalizes reject-file paths before comparing them, so Windows'
+  `src\structures\Contact.js.rej` is recognized as the same expected, harmless reject as the POSIX
+  path and is cleaned up after verification. The lockfile also resolves `libsignal@6.0.0` from its
+  npm registry tarball (published from the same commit previously fetched over Git SSH), avoiding
+  npm 12's `EALLOWGIT` default without weakening its project security policy.
+
 ## [0.11.1] - 2026-07-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -175,8 +175,8 @@ docker compose -f docker-compose.dev.yml up -d
 git clone https://github.com/rmyndharis/OpenWA.git
 cd OpenWA
 
-# Install dependencies (includes dashboard)
-npm install
+# Install the locked dependencies (includes dashboard)
+npm ci
 
 # Start API + Dashboard (config is auto-generated on first run)
 npm run dev
@@ -186,6 +186,10 @@ npm run dev
 # API: http://localhost:2785/api
 # Swagger: http://localhost:2785/api/docs
 ```
+
+Use `npm install` instead when intentionally changing dependencies. OpenWA's committed lockfile uses
+registry artifacts only, so npm 12 works with its secure default that blocks Git dependencies; do not
+disable that policy globally.
 
 ---
 

--- a/docs/08-development-guidelines.md
+++ b/docs/08-development-guidelines.md
@@ -576,10 +576,14 @@ Add a new one only when the condition is engine-agnostic and recurs; a one-off s
 - pgAdmin or DBeaver
 ```
 
-> `npm install` patches whatsapp-web.js for the WhatsApp Web 2.3000.x message-id rename. It applies
-> the patch with GNU `patch`, falling back to `git apply` — so Git alone is enough, including on
-> Windows outside Git Bash. With neither available the install still succeeds, but the
+> Dependency installation patches whatsapp-web.js for the WhatsApp Web 2.3000.x message-id rename.
+> It applies the patch with GNU `patch`, falling back to `git apply` — so Git alone is enough,
+> including on Windows outside Git Bash. With neither available the install still succeeds, but the
 > whatsapp-web.js engine then fails on every send; see `docs/12-troubleshooting-faq.md`.
+>
+> The committed lockfile resolves dependencies from the npm registry and works with npm 12's default
+> Git-dependency block. Do not work around `EALLOWGIT` by changing npm or Git configuration globally;
+> update to a current lockfile instead.
 
 ### Quick Start
 
@@ -588,12 +592,14 @@ Add a new one only when the condition is engine-agnostic and recurs; a one-off s
 git clone https://github.com/rmyndharis/OpenWA.git
 cd OpenWA
 
-# 2. Install dependencies (also installs dashboard dependencies)
-npm install
+# 2. Install the locked dependencies (also installs dashboard dependencies)
+npm ci
 
 # 3. Start API + dashboard in development mode
 npm run dev
 ```
+
+Use `npm install` only when intentionally changing dependencies and updating the lockfile.
 
 On first boot the API creates `data/.env.generated` with a minimal SQLite/local-storage
 configuration. A project-level `.env` is optional; real process environment variables take precedence

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,8 +81,8 @@
 git clone https://github.com/rmyndharis/OpenWA.git
 cd OpenWA
 
-# Install & configure
-npm install
+# Install the locked dependencies & configure
+npm ci
 cp .env.minimal .env
 
 # Create data directories

--- a/package-lock.json
+++ b/package-lock.json
@@ -10352,7 +10352,8 @@
     },
     "node_modules/libsignal": {
       "version": "6.0.0",
-      "resolved": "git+ssh://git@github.com/whiskeysockets/libsignal-node.git#bcea72df9ec34d9d9140ab30619cf479c7c144c7",
+      "resolved": "https://registry.npmjs.org/libsignal/-/libsignal-6.0.0.tgz",
+      "integrity": "sha512-d/5V3YFtDljbFMufz4ncyUYGYhJl+vzAe+c2EFFBQ6bz1h8Q3IOMEGXYMzlibU60I+e8GagMMpji18iez3P1hA==",
       "license": "GPL-3.0",
       "dependencies": {
         "curve25519-js": "^0.0.4",

--- a/scripts/patch-wwebjs-201832.js
+++ b/scripts/patch-wwebjs-201832.js
@@ -67,6 +67,11 @@ const REQUIRED_SITES = [
 /** Artifacts `patch` can leave behind. `.~N~` are GNU's backup-if-mismatch copies of pre-patch source. */
 const ARTIFACT_RE = /(\.rej|\.orig|~)$/;
 
+/** Keep artifact keys stable across POSIX and Windows for EXPECTED_REJECTS comparisons. */
+function normalizeArtifactPath(rel) {
+  return rel.replaceAll('\\', '/');
+}
+
 /** True once `rel`'s REQUIRED_SITES marker is present in the installed tree. */
 function siteLanded(wwjsDir, rel) {
   const marker = REQUIRED_SITES.find(([r]) => r === rel)[1];
@@ -93,7 +98,7 @@ function findArtifacts(root, dir = root) {
     if (entry.isDirectory()) {
       out.push(...findArtifacts(root, full));
     } else if (ARTIFACT_RE.test(entry.name)) {
-      out.push(path.relative(root, full));
+      out.push(normalizeArtifactPath(path.relative(root, full)));
     }
   }
   return out;
@@ -259,4 +264,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { applyBackport, DEFAULT_WWJS, DEFAULT_PATCH, EXPECTED_REJECTS };
+module.exports = { applyBackport, normalizeArtifactPath, DEFAULT_WWJS, DEFAULT_PATCH, EXPECTED_REJECTS };

--- a/src/engine/adapters/wwebjs-backport-201832.spec.ts
+++ b/src/engine/adapters/wwebjs-backport-201832.spec.ts
@@ -5,9 +5,14 @@ import * as path from 'path';
 
 // The patcher is a CommonJS build script (scripts/*.js); import it with a typed
 // shape so the spec stays under the strict lint rules.
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const { applyBackport, DEFAULT_PATCH: PATCH_FILE } = require('../../../scripts/patch-wwebjs-201832') as {
+const {
+  applyBackport,
+  normalizeArtifactPath,
+  DEFAULT_PATCH: PATCH_FILE,
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+} = require('../../../scripts/patch-wwebjs-201832') as {
   applyBackport: (wwjsDir: string, patchFile?: string) => { skipped: boolean; reason?: string; note?: string };
+  normalizeArtifactPath: (rel: string) => string;
   DEFAULT_PATCH: string;
 };
 
@@ -26,6 +31,10 @@ const SCRIPT = path.join(__dirname, '..', '..', '..', 'scripts', 'patch-wwebjs-2
  */
 describe('patch-wwebjs-201832 (build-time backport of upstream #201832)', () => {
   const tmpDirs: string[] = [];
+
+  it('normalizes Windows reject paths before matching expected artifacts', () => {
+    expect(normalizeArtifactPath('src\\structures\\Contact.js.rej')).toBe('src/structures/Contact.js.rej');
+  });
 
   /**
    * A pristine (unpatched) copy of the installed whatsapp-web.js.


### PR DESCRIPTION
## Summary

- Resolve `libsignal@6.0.0` from the npm registry instead of Git SSH, preserving npm 12's default Git dependency policy.
- Normalize patch artifact paths so the expected `Contact.js.rej` is handled correctly on Windows.
- Update source installation guidance to use `npm ci` for locked dependencies.

## Root cause

The lockfile retained a Git SSH resolution for `libsignal`, while Windows path separators prevented the patcher from matching its expected reject-file allowlist.

## Validation

- Patcher regression tests: 12 passed
- Postinstall tests: 11 passed
- ESLint and TypeScript checks passed
- Version, formatting, and lockfile checks passed
- npm 12 install validation passed with `allow-git=none`
