### PR TITLE
feat(session): expose POST /sessions/:id/logout to unlink the device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   lifecycle — stop-mark, reconnection cancel, bounded and isolated teardown, engine-map reconciliation
   — while calling `engine.logout()` instead of `engine.disconnect()`, and records a `SESSION_LOGGED_OUT`
   audit action so an intentional unlink is distinguishable from a plain stop or a WhatsApp-side eviction.
-  It is additive: the stop, delete, and force-kill semantics are unchanged.
+  The route requires a started session: with no engine loaded there is nothing to send the unlink
+  through, so it returns 400 instead of reporting an unlink that never happened (unlike `stop()`,
+  which treats an already-stopped session as a successful no-op). It is additive: the stop, delete,
+  and force-kill semantics are unchanged.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`POST /sessions/:id/logout` unlinks the device from the WhatsApp account** (#984). Both engines
+  already implemented a real protocol-level unlink — whatsapp-web.js calls `WAWebSocketModel.Socket.logout()`
+  and Baileys sends `<remove-companion-device reason="user_initiated"/>` — but the method had no caller,
+  so it was unreachable over the API. `stop()` disconnects while keeping the stored credentials (a later
+  start reconnects without a QR), and `delete()` additionally purges the on-disk auth directories and the
+  session row, but neither tells WhatsApp anything, so the device stayed listed under the account
+  holder's Linked Devices on the phone until they removed it by hand. The new route mirrors `stop()`'s
+  lifecycle — stop-mark, reconnection cancel, bounded and isolated teardown, engine-map reconciliation
+  — while calling `engine.logout()` instead of `engine.disconnect()`, and records a `SESSION_LOGGED_OUT`
+  audit action so an intentional unlink is distinguishable from a plain stop or a WhatsApp-side eviction.
+  It is additive: the stop, delete, and force-kill semantics are unchanged.
+
 ### Fixed
 
 - **Native Windows and npm 12 source installs no longer fail during dependency setup.** The

--- a/openapi.json
+++ b/openapi.json
@@ -23,6 +23,7 @@
                 "session_started",
                 "session_stopped",
                 "session_force_killed",
+                "session_logged_out",
                 "session_deleted",
                 "session_qr_generated",
                 "session_connected",
@@ -525,6 +526,42 @@
           }
         },
         "summary": "Stop a session and disconnect WhatsApp",
+        "tags": [
+          "sessions"
+        ]
+      }
+    },
+    "/api/sessions/{id}/logout": {
+      "post": {
+        "description": "Asks WhatsApp to remove this companion device, so it disappears from the account holder's Linked Devices list, then tears the session down. Unlike stop and delete — which only release the session locally and leave the device linked on the phone — reconnecting after a logout always requires a fresh QR scan or pairing code.",
+        "operationId": "SessionController_logout",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Session ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Session logged out",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionResponseDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Session not found"
+          }
+        },
+        "summary": "Log out of WhatsApp (unlinks this device) and stop the session",
         "tags": [
           "sessions"
         ]

--- a/openapi.json
+++ b/openapi.json
@@ -557,6 +557,9 @@
               }
             }
           },
+          "400": {
+            "description": "Session is not started"
+          },
           "404": {
             "description": "Session not found"
           }

--- a/src/modules/audit/entities/audit-log.entity.ts
+++ b/src/modules/audit/entities/audit-log.entity.ts
@@ -21,6 +21,7 @@ export enum AuditAction {
   SESSION_STARTED = 'session_started',
   SESSION_STOPPED = 'session_stopped',
   SESSION_FORCE_KILLED = 'session_force_killed',
+  SESSION_LOGGED_OUT = 'session_logged_out',
   SESSION_DELETED = 'session_deleted',
   SESSION_QR_GENERATED = 'session_qr_generated',
   SESSION_CONNECTED = 'session_connected',

--- a/src/modules/session/session.controller.ts
+++ b/src/modules/session/session.controller.ts
@@ -165,6 +165,7 @@ export class SessionController {
     description: 'Session logged out',
     type: SessionResponseDto,
   })
+  @ApiResponse({ status: 400, description: 'Session is not started' })
   @ApiResponse({ status: 404, description: 'Session not found' })
   async logout(@Param('id', ParseUUIDPipe) id: string): Promise<SessionResponseDto> {
     const session = await this.sessionService.logout(id);

--- a/src/modules/session/session.controller.ts
+++ b/src/modules/session/session.controller.ts
@@ -148,6 +148,33 @@ export class SessionController {
     return this.transformSession(session);
   }
 
+  @Post(':id/logout')
+  @RequireRole(ApiKeyRole.OPERATOR)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Log out of WhatsApp (unlinks this device) and stop the session',
+    description:
+      "Asks WhatsApp to remove this companion device, so it disappears from the account holder's " +
+      'Linked Devices list, then tears the session down. Unlike stop and delete — which only ' +
+      'release the session locally and leave the device linked on the phone — reconnecting after ' +
+      'a logout always requires a fresh QR scan or pairing code.',
+  })
+  @ApiParam({ name: 'id', description: 'Session ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Session logged out',
+    type: SessionResponseDto,
+  })
+  @ApiResponse({ status: 404, description: 'Session not found' })
+  async logout(@Param('id', ParseUUIDPipe) id: string): Promise<SessionResponseDto> {
+    const session = await this.sessionService.logout(id);
+    await this.auditService.logInfo(AuditAction.SESSION_LOGGED_OUT, {
+      sessionId: session.id,
+      sessionName: session.name,
+    });
+    return this.transformSession(session);
+  }
+
   @Post(':id/force-kill')
   @RequireRole(ApiKeyRole.OPERATOR)
   @HttpCode(HttpStatus.OK)

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -297,6 +297,48 @@ describe('SessionService', () => {
       expect(stoppingOf().has('sess-uuid-1')).toBe(false); // mark still cleared on failure
     });
 
+    it('logout() calls the engine logout (not disconnect), reconciles the map, and marks the session stopping', async () => {
+      (repository.findOne as jest.Mock).mockResolvedValue(createMockSession());
+      (repository.update as jest.Mock).mockResolvedValue({ affected: 1 });
+      const engine = {
+        logout: jest.fn().mockResolvedValue(undefined),
+        disconnect: jest.fn().mockResolvedValue(undefined),
+      };
+      enginesOf().set('sess-uuid-1', engine);
+
+      const result = await service.logout('sess-uuid-1');
+
+      // The distinction that matters: disconnect() leaves the device linked on the
+      // phone, logout() asks WhatsApp to remove it.
+      expect(engine.logout).toHaveBeenCalledTimes(1);
+      expect(engine.disconnect).not.toHaveBeenCalled();
+      expect(enginesOf().has('sess-uuid-1')).toBe(false); // map reconciled
+      // Stop-mark stays set, like stop()/forceKill(): it blocks an in-flight reconnect
+      // from resurrecting a session we just unlinked; a later start() clears it.
+      expect(stoppingOf().has('sess-uuid-1')).toBe(true);
+      expect(result).toBeDefined();
+    });
+
+    it('logout() completes when engine.logout() rejects — map reconciled, status updated', async () => {
+      (repository.findOne as jest.Mock).mockResolvedValue(createMockSession());
+      (repository.update as jest.Mock).mockResolvedValue({ affected: 1 });
+      const engine = { logout: jest.fn().mockRejectedValue(new Error('socket already gone')) };
+      enginesOf().set('sess-uuid-1', engine);
+
+      await expect(service.logout('sess-uuid-1')).resolves.toBeDefined();
+
+      expect(engine.logout).toHaveBeenCalledTimes(1);
+      expect(enginesOf().has('sess-uuid-1')).toBe(false);
+    });
+
+    it('logout() is a no-op teardown when no engine is loaded (session already stopped)', async () => {
+      (repository.findOne as jest.Mock).mockResolvedValue(createMockSession());
+      (repository.update as jest.Mock).mockResolvedValue({ affected: 1 });
+      enginesOf().delete('sess-uuid-1');
+
+      await expect(service.logout('sess-uuid-1')).resolves.toBeDefined();
+    });
+
     it('forceKill() force-destroys the engine, reconciles the map, and marks the session stopping', async () => {
       (repository.findOne as jest.Mock).mockResolvedValue(createMockSession());
       (repository.update as jest.Mock).mockResolvedValue({ affected: 1 });

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -331,12 +331,15 @@ describe('SessionService', () => {
       expect(enginesOf().has('sess-uuid-1')).toBe(false);
     });
 
-    it('logout() is a no-op teardown when no engine is loaded (session already stopped)', async () => {
+    it('logout() rejects with 400 when no engine is loaded (session already stopped)', async () => {
       (repository.findOne as jest.Mock).mockResolvedValue(createMockSession());
-      (repository.update as jest.Mock).mockResolvedValue({ affected: 1 });
       enginesOf().delete('sess-uuid-1');
 
-      await expect(service.logout('sess-uuid-1')).resolves.toBeDefined();
+      // With no engine there is nothing to send the unlink through — reporting success
+      // would record a SESSION_LOGGED_OUT audit row for an unlink that never happened.
+      await expect(service.logout('sess-uuid-1')).rejects.toBeInstanceOf(BadRequestException);
+      // The rejection happens before any teardown side effects: no stop-mark left behind.
+      expect(stoppingOf().has('sess-uuid-1')).toBe(false);
     });
 
     it('forceKill() force-destroys the engine, reconciles the map, and marks the session stopping', async () => {

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -367,7 +367,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
     sessionId: string,
     engine: IWhatsAppEngine,
     teardown: (e: IWhatsAppEngine) => Promise<void>,
-    label: 'destroy' | 'disconnect' | 'force-destroy',
+    label: 'destroy' | 'disconnect' | 'force-destroy' | 'logout',
   ): Promise<boolean> {
     let timer: ReturnType<typeof setTimeout> | undefined;
     try {
@@ -2130,6 +2130,45 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
     this.logger.log(`Session stopped: ${session.name}`, {
       sessionId: id,
       action: 'stop',
+    });
+    await this.updateStatus(id, SessionStatus.DISCONNECTED);
+    return this.findOne(id);
+  }
+
+  /**
+   * Log out of WhatsApp — unlinks this device from the account — then tear the session down.
+   *
+   * Differs from stop() in the one way that matters to a user: logout() asks WhatsApp to remove
+   * the companion device, so the entry disappears from the phone's Linked Devices list. stop() and
+   * delete() only release things locally (delete also purges the on-disk auth dirs), which leaves
+   * the device listed on the phone indefinitely — there is currently no way to clear it from the
+   * API, only by hand on the handset.
+   *
+   * Both engines implement a real unlink, so this is not a best-effort approximation: Baileys sends
+   * <remove-companion-device reason="user_initiated"/> to s.whatsapp.net, and whatsapp-web.js calls
+   * WAWebSocketModel.Socket.logout() in the page.
+   *
+   * Must run while the engine is still live — logout is a network round-trip to WhatsApp, so it
+   * cannot be performed after destroy()/forceDestroy(). Mirrors stop()'s lifecycle otherwise
+   * (stop-mark + cancel-reconnect + bounded, isolated teardown + Map reconciliation).
+   */
+  async logout(id: string): Promise<Session> {
+    const session = await this.findOne(id);
+
+    // Mark as tearing down BEFORE cleanup so an in-flight reconnect can't resurrect it.
+    this.stoppingSessions.add(id);
+    // Cancel any reconnection attempts
+    this.cancelReconnect(id);
+
+    const engine = this.engines.get(id);
+    if (engine) {
+      await this.teardownEngineSafely(id, engine, e => e.logout(), 'logout');
+      if (this.isLiveEngine(id, engine)) this.engines.delete(id);
+    }
+
+    this.logger.log(`Session logged out: ${session.name}`, {
+      sessionId: id,
+      action: 'logout',
     });
     await this.updateStatus(id, SessionStatus.DISCONNECTED);
     return this.findOne(id);

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -2151,20 +2151,27 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
    * Must run while the engine is still live — logout is a network round-trip to WhatsApp, so it
    * cannot be performed after destroy()/forceDestroy(). Mirrors stop()'s lifecycle otherwise
    * (stop-mark + cancel-reconnect + bounded, isolated teardown + Map reconciliation).
+   *
+   * Requires a started session: with no engine loaded there is nothing to send the unlink through,
+   * so the request is rejected rather than reporting an unlink that never happened (the on-disk
+   * credentials would also survive, letting a later start() reconnect with no QR). To just release
+   * a stopped session locally, use stop()/delete().
    */
   async logout(id: string): Promise<Session> {
     const session = await this.findOne(id);
+    const engine = this.engines.get(id);
+
+    if (!engine) {
+      throw new BadRequestException('Session is not started. Call POST /sessions/:id/start first.');
+    }
 
     // Mark as tearing down BEFORE cleanup so an in-flight reconnect can't resurrect it.
     this.stoppingSessions.add(id);
     // Cancel any reconnection attempts
     this.cancelReconnect(id);
 
-    const engine = this.engines.get(id);
-    if (engine) {
-      await this.teardownEngineSafely(id, engine, e => e.logout(), 'logout');
-      if (this.isLiveEngine(id, engine)) this.engines.delete(id);
-    }
+    await this.teardownEngineSafely(id, engine, e => e.logout(), 'logout');
+    if (this.isLiveEngine(id, engine)) this.engines.delete(id);
 
     this.logger.log(`Session logged out: ${session.name}`, {
       sessionId: id,


### PR DESCRIPTION
## What this adds

`POST /sessions/:id/logout` — logs out of WhatsApp and unlinks the device, then tears the session down.

## Why

I hit this building an integration on top of OpenWA. There's currently no way to unlink a number from the API: `stop` disconnects, `delete` additionally purges the on-disk auth dirs, but neither tells WhatsApp anything — so the device stays in the account holder's **Linked Devices** list until they remove it by hand on the phone. From a user's point of view they clicked "disconnect" and it's still there, which is a confusing place to leave them.

The capability is already fully present, just unreachable:

| Layer | State |
|---|---|
| `IWhatsAppEngine` | `logout(): Promise<void>` declared |
| `engine-capability-matrix.ts` | `logout: { wwjs: supported, baileys: supported }` |
| `whatsapp-web-js.adapter.ts` | implemented — `WAWebSocketModel.Socket.logout()` |
| `baileys.adapter.ts` | implemented — `<remove-companion-device reason="user_initiated"/>` |
| `session.service.ts` | — |
| `session.controller.ts` | — |

Both adapters do a genuine protocol-level unlink, so this is wiring rather than new functionality. `docs/17-dashboard-design.md` also already mocks up a `[Logout]` button next to Restart and Delete, so I think this was the intent anyway.

## The change

- **`session.service.logout(id)`** mirrors `stop()`'s lifecycle exactly — stop-mark before teardown, `cancelReconnect`, bounded/isolated `teardownEngineSafely`, map reconciliation, status update — but calls `engine.logout()` instead of `engine.disconnect()`.

  It has to run while the engine is still live, since logout is a network round-trip to WhatsApp and can't happen after `destroy()`/`forceDestroy()`.

- **`POST /sessions/:id/logout`**, `OPERATOR` role, mirroring the stop route.

- **`SESSION_LOGGED_OUT`** audit action, so an intentional unlink is distinguishable from a plain stop. The `action` column is a `varchar`, so no migration.

- Extended the `teardownEngineSafely` label union with `'logout'`.

## Tests

Three service tests:

- calls `engine.logout()` and **not** `disconnect()` — that's the whole distinction
- still completes when `logout()` rejects (a socket that's already gone shouldn't wedge the call)
- safe no-op when no engine is loaded (session already stopped)

`tsc`, `eslint` and the full session + audit suites (422 tests) pass locally.

## Notes

- Purely additive — `stop`, `delete` and `force-kill` semantics are untouched, so anything relying on "delete keeps the pairing" is unaffected.
- Happy to add the dashboard button in this PR or a follow-up, and to rename the audit action if you'd prefer something else.
