### PR TITLE
fix(docker): forward AUTO_START_SESSIONS to the container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   npm registry tarball (published from the same commit previously fetched over Git SSH), avoiding
   npm 12's `EALLOWGIT` default without weakening its project security policy.
 
+- **`AUTO_START_SESSIONS` set in `.env` now reaches the container under the bundled production
+  compose.** `docker-compose.yml` never forwarded the variable — not in any revision of the file — so
+  on a stock Docker Compose deployment the flag was inert: previously authenticated sessions were
+  reset to `disconnected` at boot and left there, and the operator got no error to work from, because
+  nothing was misconfigured from the application's point of view. `.env.example` documents the
+  setting, and `docker-compose.dev.yml` did forward it, which made the omission read as a working
+  feature everywhere except where most deployments run. The forward is blank-defaulted like the
+  neighbouring engine options, so an unset value still resolves to the documented opt-out default and
+  only an explicit `true` starts sessions at boot.
+
 - **A whatsapp-web.js session no longer publishes a QR belonging to the browser it is about to
   replace** (#982). On `LOGOUT`, whatsapp-web.js deletes the auth profile and re-runs its injection
   against the same browser, so the old client keeps serving QR codes while the session lifecycle waits

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -151,6 +151,10 @@ services:
       # low-resource hosts where the QR can time out before WA Web loads. Empty = default; see
       # docs/12-troubleshooting-faq.md. (Without this line the var in .env never reaches the container.)
       - WWEBJS_AUTH_TIMEOUT_MS=${WWEBJS_AUTH_TIMEOUT_MS:-}
+      # Re-start previously authenticated sessions at boot. Opt-in: the app reads the exact string
+      # "true", so a blank forward (nothing set) keeps the default off. Without this line the value in
+      # .env never reaches the container and the flag silently does nothing.
+      - AUTO_START_SESSIONS=${AUTO_START_SESSIONS:-}
       # Storage. Blank-forwarded (see Database note) so a dashboard local↔S3 switch applies; a real
       # host value pins. Credentials use the canonical S3_ACCESS_KEY_ID / S3_SECRET_ACCESS_KEY names the
       # app and dashboard write; the legacy S3_ACCESS_KEY / S3_SECRET_KEY are ALSO forwarded (and read

--- a/src/config/feature-flags.spec.ts
+++ b/src/config/feature-flags.spec.ts
@@ -1,3 +1,5 @@
+import * as fs from 'fs';
+import * as path from 'path';
 import { computeFeatureFlags, resolveFeatureFlags, FeatureFlags } from './feature-flags';
 
 describe('feature-flags', () => {
@@ -68,6 +70,16 @@ describe('feature-flags', () => {
       process.env.AUTO_START_SESSIONS = 'true';
       const configService = { get: jest.fn().mockImplementation((_k: string, def?: unknown) => def) };
       expect(resolveFeatureFlags(configService).autoStartSessions).toBe(true);
+    });
+  });
+
+  // A flag the app reads is useless if the bundled compose never hands it to the container: the
+  // operator sets it in .env, nothing happens, and there is no error to go on. That was the state of
+  // AUTO_START_SESSIONS until this guard landed, so assert the forward exists rather than trusting it.
+  describe('bundled production compose', () => {
+    it('forwards AUTO_START_SESSIONS to the container', () => {
+      const compose = fs.readFileSync(path.join(__dirname, '../../docker-compose.yml'), 'utf8');
+      expect(compose).toMatch(/^\s*- AUTO_START_SESSIONS=\$\{AUTO_START_SESSIONS:-\}$/m);
     });
   });
 });


### PR DESCRIPTION
## Problem

`docker-compose.yml` never forwarded `AUTO_START_SESSIONS` into the `openwa-api` service. Not in the
current file, and not in any revision of it — `git log -S 'AUTO_START_SESSIONS' -- docker-compose.yml`
returns nothing. There is no `env_file:` entry either, and `.dockerignore` excludes `.env*` from the
build context, so there was no path by which the value could reach the process.

On a stock Docker Compose deployment the flag was therefore inert. `SessionService.onModuleInit()`
resets previously authenticated sessions to `disconnected` at boot, and with the flag never arriving,
`onApplicationBootstrap()` returned early and left them there. The operator got no error, because from
the application's point of view nothing was misconfigured — the variable simply was not present.

What made this hard to notice is that every other signal said the feature worked:

- `.env.example:25` documents `AUTO_START_SESSIONS=false` as a setting operators are meant to change.
- `docker-compose.dev.yml:58` does forward it, so it behaves correctly in development.
- The application reads it correctly (`feature-flags.ts`) and validates it at boot (`env.validation.ts`).

Only the production compose file, where most deployments actually run, dropped it.

## Change

One forward added next to the existing engine options, blank-defaulted to match them:

```yaml
- AUTO_START_SESSIONS=${AUTO_START_SESSIONS:-}
```

Blank-defaulting matters for correctness here. `AUTO_START_SESSIONS` is opt-in and read as an exact
string comparison against `"true"`, so an unset value rendering blank resolves to the documented
default of off. Only an explicit `true` starts sessions at boot, which keeps the behaviour of every
existing deployment unchanged.

The key is deliberately **not** added to `BLANK_SHADOWED_ENV_KEYS`. That list exists for keys the
compose file blank-forwards *and* the dashboard writes to `data/.env.generated`, where a blank forward
would shadow a saved dashboard value. `AUTO_START_SESSIONS` is not dashboard-managed, so it follows the
same pattern as `WWEBJS_AUTH_TIMEOUT_MS` and `BODY_SIZE_LIMIT`: forwarded blank, not cleared.

## Verification

Rendered config before and after, with `AUTO_START_SESSIONS=true` present in `.env`:

```
before (main):  docker compose config -> variable absent from the service environment
after:          docker compose config -> AUTO_START_SESSIONS: "true"
```

The feature-flags spec now asserts the forward is present, so the gap cannot silently reopen. The
assertion was checked against a known-negative as well as the current file — it fails both when the
line is removed and when the variable name is misspelled, so it is not a vacuous match.

Full local gate: `format:check`, `lint`, `tsc --noEmit -p tsconfig.json` (including specs), `build`,
and the `src/config` suite (13 files, 182 tests) all pass. `docker compose config -q` parses. No
dashboard files are touched.

## Scope

This is a packaging fix and does not change application behaviour.

It came out of triage on #981, where sessions come back as `qr_ready` after an upgrade, but it is **not
a fix for that issue** — a missing flag leaves sessions idle at `disconnected` rather than presenting a
QR. It is relevant there only because it means the reporter's flag may never have been effective, which
changes how their report should be read. That investigation continues separately.

## Follow-up worth tracking separately

The same audit found that the production compose forwards **none** of the runtime feature flags:
`STORE_EPHEMERAL_MESSAGES`, `RESOLVE_LID_TO_PHONE`, `SIMULATE_TYPING`, `SIMULATE_TYPING_MAX_MS`,
`QUEUE_ENABLED`, `MCP_ENABLED`, `SERVE_DASHBOARD`, `SEARCH_ENABLED` and `SEARCH_PROVIDER` are all
absent as well, and most are documented in `.env.example`.

They are left out of this PR on purpose. Several carry precedence considerations this one does not —
`QUEUE_ENABLED` in particular is written by the dashboard to `data/.env.generated`, so forwarding it
blank without adding it to `BLANK_SHADOWED_ENV_KEYS` would shadow a saved dashboard value and trade one
silent bug for another. Each deserves that judgement made explicitly rather than swept in here.
