### PR TITLE
fix(engine): force document mode on whatsapp-web.js

### DIFF
--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -2635,6 +2635,32 @@ describe('outbound voice note (PTT)', () => {
   });
 });
 
+describe('outbound document mode', () => {
+  it('sendDocumentMessage forces whatsapp-web.js to preserve the document attachment type', async () => {
+    const sentMessage = { id: { _serialized: 'OUT1' }, timestamp: 1700000001 };
+    const sendMessage = jest.fn().mockResolvedValue(sentMessage);
+    const adapter = new WhatsAppWebJsAdapter({
+      sessionId: 's',
+      sessionDataPath: './data/sessions',
+      puppeteer: {},
+    });
+    (adapter as unknown as { status: EngineStatus }).status = EngineStatus.READY;
+    (adapter as unknown as { client: unknown }).client = { sendMessage };
+
+    await adapter.sendDocumentMessage('628@c.us', {
+      mimetype: 'application/pdf',
+      data: Buffer.from([1]).toString('base64'),
+      filename: 'document.pdf',
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      '628@c.us',
+      expect.any(MessageMedia),
+      expect.objectContaining({ sendMediaAsDocument: true }),
+    );
+  });
+});
+
 describe('LID resolution for individual sends (#573 — WhatsApp @c.us → @lid migration)', () => {
   const ready = (client: unknown): WhatsAppWebJsAdapter => {
     const adapter = new WhatsAppWebJsAdapter({ sessionId: 's', sessionDataPath: './data/sessions', puppeteer: {} });

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -1566,13 +1566,13 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
   }
 
   async sendDocumentMessage(chatId: string, media: MediaInput): Promise<MessageResult> {
-    return this.sendMediaMessage(chatId, media);
+    return this.sendMediaMessage(chatId, media, { sendMediaAsDocument: true });
   }
 
   private async sendMediaMessage(
     chatId: string,
     media: MediaInput,
-    extraOptions?: { sendAudioAsVoice?: boolean },
+    extraOptions?: { sendAudioAsVoice?: boolean; sendMediaAsDocument?: boolean },
   ): Promise<MessageResult> {
     this.ensureReady();
     this.ensureNotChannelRecipient(chatId);


### PR DESCRIPTION
## summary

- force `sendDocumentMessage` to pass `sendMediaAsDocument: true` to whatsapp-web.js
- add a regression test for the forwarded option

## testing

- 324 tests passed in `whatsapp-web-js.adapter.spec.ts`
- a live `send-document` request arrived as a WhatsApp document

Fixes #989
