### PR TITLE
docs(sdk): cover the session logout endpoint across docs and all five SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   which treats an already-stopped session as a successful no-op). It is additive: the stop, delete,
   and force-kill semantics are unchanged.
 
+- **All five SDKs and the dashboard's API client gain the session logout operation** (#984). The
+  JavaScript, Python, Go, PHP, and Java SDKs each expose a `logout` method mirroring the neighbouring
+  `forceKill`, and the dashboard's `sessionApi` gains a matching `logout(id)`, so every client covers
+  the full session lifecycle again. The reference docs (`docs/06`, the curl collection in `docs/07`,
+  the audit-action enumeration in `docs/05`, the method tables in `docs/18` and `sdk/README.md`) now
+  include the route.
+
 ### Fixed
 
 - **`npm install` from source no longer fails on native Windows, and the whatsapp-web.js backport

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -648,6 +648,7 @@ export const sessionApi = {
   delete: (id: string) => request<void>(`/sessions/${id}`, { method: 'DELETE' }),
   start: (id: string) => request<Session>(`/sessions/${id}/start`, { method: 'POST' }),
   stop: (id: string) => request<Session>(`/sessions/${id}/stop`, { method: 'POST' }),
+  logout: (id: string) => request<Session>(`/sessions/${id}/logout`, { method: 'POST' }),
   forceKill: (id: string) => request<Session>(`/sessions/${id}/force-kill`, { method: 'POST' }),
   getQR: (id: string) => request<{ qrCode: string; status: string }>(`/sessions/${id}/qr`),
   requestPairingCode: (id: string, phoneNumber: string) =>

--- a/docs/05-database-design.md
+++ b/docs/05-database-design.md
@@ -494,7 +494,8 @@ CREATE INDEX "IDX_audit_logs_createdAt" ON audit_logs(created_at);
 **Audit actions** are an enum (`AuditAction`) spanning API-key lifecycle (`api_key_created`,
 `api_key_updated`, `api_key_used`, `api_key_revoked`, `api_key_deleted`, `api_key_auth_failed`), session
 lifecycle (`session_created`, `session_started`, `session_stopped`, `session_force_killed`,
-`session_deleted`, `session_qr_generated`, `session_connected`, `session_disconnected`), messages
+`session_logged_out`, `session_deleted`, `session_qr_generated`, `session_connected`,
+`session_disconnected`), messages
 (`message_sent`, `message_failed`), webhooks (`webhook_created`, `webhook_deleted`,
 `webhook_triggered`, `webhook_failed`), rate-limit enforcement (`rate_limit_exceeded`, sampled to at
 most one row per subject+kind per minute), the queue dashboard (`queue_board_mutated`), integration

--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -502,6 +502,52 @@ Returned via `transformSession`; status typically becomes `disconnected`.
 
 **Errors:** `401` · `403` · `404` not found
 
+#### POST /api/sessions/:id/logout
+
+Log out of WhatsApp — unlinking this device from the account — and tear the session down.
+
+`stop` disconnects while keeping the stored credentials, and `delete` additionally purges the
+on-disk auth directories and the session row, but neither tells WhatsApp anything: the device stays
+listed under the account holder's **Linked Devices** on the phone until they remove it by hand.
+`logout` asks WhatsApp to remove the companion device itself. Both engines perform a real
+protocol-level unlink and clear that session's stored credentials, so a later `start` requires a
+fresh QR scan or pairing code.
+
+The session must be running — the unlink is a network round-trip that needs a live engine, so a
+stopped session is rejected rather than reported as a success that never reached WhatsApp.
+
+**Auth:** API key (OPERATOR)  ·  **Scope:** session-scoped
+
+**Path parameters**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `id` | string | Session UUID |
+
+No request body.
+
+**Response** `200`
+
+```json
+{
+  "id": "8f3c2b1a-9d4e-4c7a-8b2f-1e6d5a4c3b2a",
+  "name": "my-bot",
+  "status": "disconnected",
+  "phone": "6281234567890",
+  "pushName": "My Bot",
+  "connectedAt": null,
+  "lastActive": "2026-06-25T09:01:55.000Z",
+  "createdAt": "2026-06-20T11:30:00.000Z",
+  "updatedAt": "2026-06-25T09:11:00.000Z",
+  "lastError": null
+}
+```
+
+Returned via `transformSession`; status becomes `disconnected`. Recorded in the audit log as
+`session_logged_out`, distinguishing an intentional unlink from a plain stop.
+
+**Errors:** `400` session is not started · `401` · `403` · `404` not found
+
 #### POST /api/sessions/:id/force-kill
 
 Force-kill a stuck session (SIGKILL the wedged engine, then tear it down).

--- a/docs/07-api-collection.md
+++ b/docs/07-api-collection.md
@@ -136,6 +136,16 @@ curl -X POST "$BASE/api/sessions/8f3c2b1a-9d4e-4c7a-8b2f-1e6d5a4c3b2a/stop" \
   -H "X-API-Key: $API_KEY"
 ```
 
+#### POST /api/sessions/:id/logout
+
+Unlink this device from the WhatsApp account and stop the session (OPERATOR). Requires a running
+session; a later start needs a fresh QR scan or pairing code.
+
+```bash
+curl -X POST "$BASE/api/sessions/8f3c2b1a-9d4e-4c7a-8b2f-1e6d5a4c3b2a/logout" \
+  -H "X-API-Key: $API_KEY"
+```
+
 #### POST /api/sessions/:id/force-kill
 
 Force-kill a stuck session (OPERATOR).

--- a/docs/18-sdk-design.md
+++ b/docs/18-sdk-design.md
@@ -28,7 +28,7 @@ All five SDKs expose the same fluent surface:
 
 | Resource | Methods |
 | --- | --- |
-| `sessions` | list, get, create, delete, start, stop, forceKill, getQrCode, requestPairingCode, stats |
+| `sessions` | list, get, create, delete, start, stop, logout, forceKill, getQrCode, requestPairingCode, stats |
 | `messages` | list, sendText, sendImage/Video/Audio/Document/Sticker, sendLocation, sendContact, sendTemplate, sendPoll, reply, forward, react, delete, editMessage, history, reactions, sendBulk, batchStatus, cancelBatch |
 | `contacts` | list, get, check, profilePicture, profilePictures, phone, block, unblock |
 | `groups` | list, get, create, joinGroup, add/remove/promote/demoteParticipants, setSubject, setDescription, getGroupSettings, updateGroupSettings, leave, inviteCode, revokeInviteCode |
@@ -131,6 +131,7 @@ The top-level client also exposes:
 | `delete` | `delete(id)` | Delete a session. **OPERATOR** |
 | `start` | `start(id)` | Start a session and initialize the WhatsApp connection. **OPERATOR** |
 | `stop` | `stop(id)` | Stop a session and disconnect gracefully. **OPERATOR** |
+| `logout` | `logout(id)` | Unlink this device from the WhatsApp account, then stop the session; a later `start` needs a fresh QR. Requires a running session. **OPERATOR** |
 | `forceKill` | `forceKill(id)` | Force-kill a stuck session (SIGKILL + teardown). **OPERATOR** |
 | `getQrCode` | `getQrCode(id)` | Get the current QR code for authentication (live from the engine). **OPERATOR** |
 | `requestPairingCode` | `requestPairingCode(id, body)` | Request an 8-character pairing code for phone-based login. **OPERATOR** |
@@ -456,6 +457,7 @@ Resources are accessed as properties on the client (e.g. `client.messages`). All
 | `delete` | `delete(session_id) -> None` | Delete a session. **OPERATOR** |
 | `start` | `start(session_id) -> SessionResponse` | Start (connect) a session. **OPERATOR** |
 | `stop` | `stop(session_id) -> SessionResponse` | Stop a session. **OPERATOR** |
+| `logout` | `logout(session_id) -> SessionResponse` | Unlink this device from the WhatsApp account, then stop the session. Requires a running session. **OPERATOR** |
 | `force_kill` | `force_kill(session_id) -> SessionResponse` | Force-terminate a session. **OPERATOR** |
 | `get_qr_code` | `get_qr_code(session_id) -> QrCodeResponse` | Fetch the login QR code. **OPERATOR** |
 | `request_pairing_code` | `request_pairing_code(session_id, body) -> PairingCodeResponse` | Request a phone-number pairing code. **OPERATOR** |
@@ -752,6 +754,7 @@ All payloads are associative arrays; all listed methods are synchronous and retu
 | `delete` | `delete(string $id): void` | Delete a session. **OPERATOR** |
 | `start` | `start(string $id): array` | Start a session. **OPERATOR** |
 | `stop` | `stop(string $id): array` | Stop a session. **OPERATOR** |
+| `logout` | `logout(string $id): array` | Unlink this device from the WhatsApp account, then stop the session. Requires a running session. **OPERATOR** |
 | `forceKill` | `forceKill(string $id): array` | Force-kill a session. **OPERATOR** |
 | `getQrCode` | `getQrCode(string $id): array` | Fetch the current QR code. **OPERATOR** |
 | `requestPairingCode` | `requestPairingCode(string $id, array $body): array` | Request a phone-pairing code. **OPERATOR** |

--- a/docs/24-mcp-integration.md
+++ b/docs/24-mcp-integration.md
@@ -127,7 +127,8 @@ declares a `tier` (`read` | `write`) and, for writes, a required role.
 | **Webhook** | list, get (read-only) | — |
 
 **Deliberately excluded from the surface** (not exposed as tools): session lifecycle
-(create/delete/start/stop/force-kill), chat delete, bulk send, message delete, message edit, group
+(create/delete/start/stop/logout/force-kill), chat delete, bulk send, message delete, message edit,
+group
 leave/remove/promote/demote/invite-revoke/join, group settings writes, all own-profile writes
 (name/status/picture), call reject, all API-key management, all plugin management,
 infrastructure import/export/restart, settings writes, and webhook create/update/delete.

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -24,7 +24,7 @@ All five SDKs expose the same fluent resource surface:
 
 | Resource   | Methods                                                                                                                                                                                |
 | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `sessions` | list, get, create, delete, start, stop, forceKill, getQrCode, requestPairingCode, stats                                                                                                |
+| `sessions` | list, get, create, delete, start, stop, logout, forceKill, getQrCode, requestPairingCode, stats                                                                                        |
 | `messages` | list, sendText, sendImage/Video/Audio/Document/Sticker, sendLocation, sendContact, sendTemplate, sendPoll, reply, forward, react, delete, editMessage, history, reactions, sendBulk, batchStatus, cancelBatch |
 | `contacts` | list, get, check, profilePicture, profilePictures, phone, block, unblock                                                                                                                                |
 | `groups`   | list, get, create, joinGroup, add/remove/promote/demoteParticipants, setSubject, setDescription, get/updateGroupSettings, leave, inviteCode, revokeInviteCode                          |

--- a/sdk/go/routing_test.go
+++ b/sdk/go/routing_test.go
@@ -23,6 +23,7 @@ func TestRouting(t *testing.T) {
 		{"Sessions.Delete", func(c *Client) { c.Sessions.Delete(ctx, "s1") }, "DELETE", "/api/sessions/s1"},
 		{"Sessions.Start", func(c *Client) { c.Sessions.Start(ctx, "s1") }, "POST", "/api/sessions/s1/start"},
 		{"Sessions.Stop", func(c *Client) { c.Sessions.Stop(ctx, "s1") }, "POST", "/api/sessions/s1/stop"},
+		{"Sessions.Logout", func(c *Client) { c.Sessions.Logout(ctx, "s1") }, "POST", "/api/sessions/s1/logout"},
 		{"Sessions.ForceKill", func(c *Client) { c.Sessions.ForceKill(ctx, "s1") }, "POST", "/api/sessions/s1/force-kill"},
 		{"Sessions.QRCode", func(c *Client) { c.Sessions.QRCode(ctx, "s1") }, "GET", "/api/sessions/s1/qr"},
 		{"Sessions.RequestPairingCode", func(c *Client) { c.Sessions.RequestPairingCode(ctx, "s1", RequestPairingCodeRequest{}) }, "POST", "/api/sessions/s1/pairing-code"},

--- a/sdk/go/sessions.go
+++ b/sdk/go/sessions.go
@@ -58,6 +58,18 @@ func (s *SessionsService) Stop(ctx context.Context, sessionID string) (*SessionR
 	return &out, nil
 }
 
+// Logout unlinks this device from the WhatsApp account, then tears the session down. Unlike Stop
+// and Delete, it removes the device from the account holder's Linked Devices list, so a later
+// Start requires a fresh QR scan or pairing code. Requires a running session.
+func (s *SessionsService) Logout(ctx context.Context, sessionID string) (*SessionResponse, error) {
+	var out SessionResponse
+	err := s.client.do(ctx, "POST", "/api/sessions/"+pathEscape(sessionID)+"/logout", nil, nil, &out)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
 // ForceKill terminates a stuck session immediately.
 func (s *SessionsService) ForceKill(ctx context.Context, sessionID string) (*SessionResponse, error) {
 	var out SessionResponse

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/resources/SessionsResource.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/resources/SessionsResource.java
@@ -50,6 +50,15 @@ public final class SessionsResource {
         return client.request(HttpMethod.POST, "/api/sessions/" + encodeSegment(id) + "/stop", null, null, SessionResponse.class);
     }
 
+    /**
+     * Unlink this device from the WhatsApp account, then stop the session. Unlike {@code stop} and
+     * {@code delete}, this removes the device from the account holder's Linked Devices list, so a
+     * later {@code start} requires a fresh QR scan or pairing code. Requires a running session.
+     */
+    public SessionResponse logout(String id) {
+        return client.request(HttpMethod.POST, "/api/sessions/" + encodeSegment(id) + "/logout", null, null, SessionResponse.class);
+    }
+
     /** Force-kill a stuck session (SIGKILL + teardown). */
     public SessionResponse forceKill(String id) {
         return client.request(HttpMethod.POST, "/api/sessions/" + encodeSegment(id) + "/force-kill", null, null, SessionResponse.class);

--- a/sdk/java/src/test/java/com/rmyndharis/openwa/resources/SessionsResourceTest.java
+++ b/sdk/java/src/test/java/com/rmyndharis/openwa/resources/SessionsResourceTest.java
@@ -39,6 +39,14 @@ class SessionsResourceTest {
     }
 
     @Test
+    void logoutHitsLogoutPath() {
+        tx.respond(200, "{\"id\":\"s\",\"name\":\"n\",\"status\":\"disconnected\"}");
+        client.sessions.logout("s");
+        assertEquals("http://h/api/sessions/s/logout", tx.lastRequest().url());
+        assertEquals(HttpMethod.POST, tx.lastRequest().method());
+    }
+
+    @Test
     void requestPairingCodeSendsBody() {
         tx.respond(200, "{\"pairingCode\":\"ABCD1234\",\"status\":\"qr_ready\"}");
         client.sessions.requestPairingCode("s", RequestPairingCodeRequest.builder().phoneNumber("628123").build());

--- a/sdk/javascript/src/resources/sessions.ts
+++ b/sdk/javascript/src/resources/sessions.ts
@@ -49,6 +49,15 @@ export class SessionsResource {
     return this.client.request<SessionResponse>({ method: 'POST', path: `/api/sessions/${encodeSegment(id)}/stop` });
   }
 
+  /**
+   * Unlink this device from the WhatsApp account, then stop the session. Unlike `stop` and
+   * `delete`, this removes the device from the account holder's Linked Devices list, so a later
+   * `start` requires a fresh QR scan or pairing code. Requires a running session.
+   */
+  logout(id: string): Promise<SessionResponse> {
+    return this.client.request<SessionResponse>({ method: 'POST', path: `/api/sessions/${encodeSegment(id)}/logout` });
+  }
+
   /** Force-kill a stuck session (SIGKILL + teardown). */
   forceKill(id: string): Promise<SessionResponse> {
     return this.client.request<SessionResponse>({ method: 'POST', path: `/api/sessions/${encodeSegment(id)}/force-kill` });

--- a/sdk/javascript/test/sessions.test.ts
+++ b/sdk/javascript/test/sessions.test.ts
@@ -7,7 +7,7 @@ function client(t: MockTransport): OpenWAClient {
 }
 
 describe('SessionsResource — exact paths', () => {
-  it('list/get/create/delete/start/stop/forceKill', async () => {
+  it('list/get/create/delete/start/stop/logout/forceKill', async () => {
     const t = new MockTransport()
       .on('GET', /\/sessions$/, { body: [] })
       .on('GET', /\/sessions\/s1$/, { body: { id: 's1', name: 'n', status: 'ready' } })
@@ -15,6 +15,7 @@ describe('SessionsResource — exact paths', () => {
       .on('DELETE', /\/sessions\/s1$/, { status: 204 })
       .on('POST', /\/sessions\/s1\/start$/, { body: { id: 's1', name: 'n', status: 'initializing' } })
       .on('POST', /\/sessions\/s1\/stop$/, { body: { id: 's1', name: 'n', status: 'disconnected' } })
+      .on('POST', /\/sessions\/s1\/logout$/, { body: { id: 's1', name: 'n', status: 'disconnected' } })
       .on('POST', /\/sessions\/s1\/force-kill$/, { body: { id: 's1', name: 'n', status: 'disconnected' } });
     const c = client(t);
     await c.sessions.list();
@@ -26,6 +27,8 @@ describe('SessionsResource — exact paths', () => {
     await c.sessions.start('s1');
     expect(t.lastCall!.url).toBe('http://x/api/sessions/s1/start');
     await c.sessions.stop('s1');
+    await c.sessions.logout('s1');
+    expect(t.lastCall!.url).toBe('http://x/api/sessions/s1/logout');
     await c.sessions.forceKill('s1');
     expect(t.lastCall!.url).toBe('http://x/api/sessions/s1/force-kill');
     await c.sessions.delete('s1');

--- a/sdk/php/src/Resources/SessionsResource.php
+++ b/sdk/php/src/Resources/SessionsResource.php
@@ -58,6 +58,18 @@ class SessionsResource
         return $this->http->request('POST', "/api/sessions/{$this->http->encodeSegment($id)}/stop");
     }
 
+    /**
+     * Unlink this device from the WhatsApp account, then stop the session. Unlike stop() and
+     * delete(), this removes the device from the account holder's Linked Devices list, so a later
+     * start() requires a fresh QR scan or pairing code. Requires a running session.
+     *
+     * @return array<string,mixed>
+     */
+    public function logout(string $id): array
+    {
+        return $this->http->request('POST', "/api/sessions/{$this->http->encodeSegment($id)}/logout");
+    }
+
     /** @return array<string,mixed> */
     public function forceKill(string $id): array
     {

--- a/sdk/php/tests/ResourcesTest.php
+++ b/sdk/php/tests/ResourcesTest.php
@@ -14,11 +14,12 @@ class ResourcesTest extends TestCase
     public function testSessionLifecyclePaths(): void
     {
         $backend = new MockBackend();
-        // Queue responses in CALL order: list, get, create, start, stop, forceKill, delete.
+        // Queue responses in CALL order: list, get, create, start, stop, logout, forceKill, delete.
         $backend->on(200, []);
         $backend->on(200, ['id' => 's1', 'name' => 'n', 'status' => 'ready']);
         $backend->on(201, ['id' => 's1', 'name' => 'n', 'status' => 'created']);
         $backend->on(200, ['id' => 's1', 'status' => 'initializing']);
+        $backend->on(200, ['id' => 's1', 'status' => 'disconnected']);
         $backend->on(200, ['id' => 's1', 'status' => 'disconnected']);
         $backend->on(200, ['id' => 's1', 'status' => 'disconnected']);
         $backend->on(204);
@@ -31,6 +32,8 @@ class ResourcesTest extends TestCase
         $client->sessions->start('s1');
         $this->assertStringContainsString('/sessions/s1/start', $backend->lastCall()['path']);
         $client->sessions->stop('s1');
+        $client->sessions->logout('s1');
+        $this->assertStringContainsString('/sessions/s1/logout', $backend->lastCall()['path']);
         $client->sessions->forceKill('s1');
         $this->assertStringContainsString('/sessions/s1/force-kill', $backend->lastCall()['path']);
         $client->sessions->delete('s1');

--- a/sdk/python/openwa/resources/sessions.py
+++ b/sdk/python/openwa/resources/sessions.py
@@ -43,6 +43,9 @@ class SessionsResource:
     def stop(self, session_id: str) -> SessionResponse:
         return self._http.request("POST", f"/api/sessions/{quote_segment(session_id)}/stop")
 
+    def logout(self, session_id: str) -> SessionResponse:
+        return self._http.request("POST", f"/api/sessions/{quote_segment(session_id)}/logout")
+
     def force_kill(self, session_id: str) -> SessionResponse:
         return self._http.request("POST", f"/api/sessions/{quote_segment(session_id)}/force-kill")
 

--- a/sdk/python/tests/test_sdk.py
+++ b/sdk/python/tests/test_sdk.py
@@ -261,6 +261,7 @@ class TestSessions:
         backend.on("DELETE", "/sessions/s1", status=204)
         backend.on("POST", "/start", body={"id": "s1", "status": "initializing"})
         backend.on("POST", "/stop", body={"id": "s1", "status": "disconnected"})
+        backend.on("POST", "/logout", body={"id": "s1", "status": "disconnected"})
         backend.on("POST", "/force-kill", body={"id": "s1", "status": "disconnected"})
         client = make_client(backend)
         client.sessions.list()
@@ -272,6 +273,8 @@ class TestSessions:
         client.sessions.start("s1")
         assert "/sessions/s1/start" in backend.calls[-1].url
         client.sessions.stop("s1")
+        client.sessions.logout("s1")
+        assert "/sessions/s1/logout" in backend.calls[-1].url
         client.sessions.force_kill("s1")
         assert "/sessions/s1/force-kill" in backend.calls[-1].url
         client.sessions.delete("s1")


### PR DESCRIPTION
## Description

Follow-up to #984 (now merged). `POST /sessions/:id/logout` is reachable over REST but was absent from the hand-written reference docs and from every client, leaving each one a session route behind the API. This brings docs, all five SDKs, and the dashboard's API client back in sync.

- **Docs** — new route section in `docs/06` (including the 400 raised for a session that is not running), curl collection entry in `docs/07`, `session_logged_out` added to the `AuditAction` enumeration in `docs/05`, the deliberate-omission list in `docs/24`, and the per-language method tables in `docs/18` and `sdk/README.md`.
- **SDKs** — a `logout` method in the Go, Java, JavaScript, PHP, and Python SDKs, each mirroring the neighbouring `forceKill`, plus a routing test per language asserting the exact path.
- **Dashboard** — `sessionApi.logout(id)` in `dashboard/src/services/api.ts`.
- **CHANGELOG** — entry under `[Unreleased] → Added`.

No runtime behaviour changes; docs/client surface only. `docs/18` documents only the TypeScript, Python, and PHP SDKs — Go and Java have never been covered there, which is left as-is.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist
- [x] Tests added/updated
- [x] Documentation updated
- [x] Lint passes
- [x] Self-reviewed

## Related Issues
Relates to #984