### PR TITLE
fix(engine): force document mode on whatsapp-web.js

### DIFF
--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -2635,6 +2635,55 @@ describe('outbound voice note (PTT)', () => {
   });
 });
 
+describe('outbound document mode (#989)', () => {
+  const ready = (client: unknown): WhatsAppWebJsAdapter => {
+    const adapter = new WhatsAppWebJsAdapter({ sessionId: 's', sessionDataPath: './data/sessions', puppeteer: {} });
+    (adapter as unknown as { status: EngineStatus }).status = EngineStatus.READY;
+    (adapter as unknown as { client: unknown }).client = client;
+    return adapter;
+  };
+  const sentMessage = { id: { _serialized: 'OUT1' }, timestamp: 1700000001 };
+  const bytes = Buffer.from([1]).toString('base64');
+
+  // The regression itself: an image mimetype is exactly what WA Web would reclassify into a photo
+  // bubble, so the flag — not the mimetype — has to decide that this is a document.
+  it('sendDocumentMessage forces sendMediaAsDocument even for an image mimetype', async () => {
+    const sendMessage = jest.fn().mockResolvedValue(sentMessage);
+    await ready({ sendMessage }).sendDocumentMessage('628@c.us', {
+      mimetype: 'image/png',
+      data: bytes,
+      filename: 'chart.png',
+    });
+    expect(sendMessage).toHaveBeenCalledWith(
+      '628@c.us',
+      expect.objectContaining({ mimetype: 'image/png', filename: 'chart.png' }),
+      expect.objectContaining({ sendMediaAsDocument: true }),
+    );
+  });
+
+  // whatsapp-web.js returns null for ANY @broadcast recipient once the flag is set, and a null send
+  // throws — so these two must keep taking the unflagged path.
+  it.each(['status@broadcast', '1234567890@broadcast'])('withholds sendMediaAsDocument for %s', async chatId => {
+    const sendMessage = jest.fn().mockResolvedValue(sentMessage);
+    await ready({ sendMessage }).sendDocumentMessage(chatId, {
+      mimetype: 'application/pdf',
+      data: bytes,
+      filename: 'report.pdf',
+    });
+    expect(sendMessage).toHaveBeenCalledWith(
+      chatId,
+      expect.anything(),
+      expect.not.objectContaining({ sendMediaAsDocument: true }),
+    );
+  });
+
+  it('leaves the other media senders off the document path', async () => {
+    const sendMessage = jest.fn().mockResolvedValue(sentMessage);
+    await ready({ sendMessage }).sendImageMessage('628@c.us', { mimetype: 'image/png', data: bytes });
+    expect(sendMessage).toHaveBeenCalledWith('628@c.us', expect.anything(), { caption: undefined });
+  });
+});
+
 describe('LID resolution for individual sends (#573 — WhatsApp @c.us → @lid migration)', () => {
   const ready = (client: unknown): WhatsAppWebJsAdapter => {
     const adapter = new WhatsAppWebJsAdapter({ sessionId: 's', sessionDataPath: './data/sessions', puppeteer: {} });

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -1565,14 +1565,28 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     return this.sendMediaMessage(chatId, media, media.ptt ? { sendAudioAsVoice: true } : undefined);
   }
 
+  /**
+   * Without `sendMediaAsDocument` whatsapp-web.js lets WA Web classify the attachment from its declared
+   * mimetype (`Injected/Utils.js` `processMediaData` -> `prepRawMedia`), so an `image/*`, `video/*` or
+   * `audio/*` payload posted here reached the recipient as a photo/video/audio bubble — re-encoded and
+   * stripped of its filename — instead of a document (#989). Baileys has always forced it via the
+   * explicit `document:` content key, so the two engines disagreed on the same request.
+   *
+   * The flag is withheld for `status@broadcast` and broadcast lists: whatsapp-web.js refuses every
+   * `@broadcast` recipient outright once it is set (`Client.js` returns `null`, which `toMessageResult`
+   * surfaces as a failed send), so setting it there would turn a working send into an error rather than
+   * improve it. Those recipients keep the classification they have today.
+   */
   async sendDocumentMessage(chatId: string, media: MediaInput): Promise<MessageResult> {
-    return this.sendMediaMessage(chatId, media);
+    const kind = chatKind(chatId);
+    const asDocument = kind !== 'status' && kind !== 'broadcast';
+    return this.sendMediaMessage(chatId, media, asDocument ? { sendMediaAsDocument: true } : undefined);
   }
 
   private async sendMediaMessage(
     chatId: string,
     media: MediaInput,
-    extraOptions?: { sendAudioAsVoice?: boolean },
+    extraOptions?: { sendAudioAsVoice?: boolean; sendMediaAsDocument?: boolean },
   ): Promise<MessageResult> {
     this.ensureReady();
     this.ensureNotChannelRecipient(chatId);
@@ -1583,7 +1597,8 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
       this.client!.sendMessage(to, messageMedia, {
         caption: media.caption,
         ...(media.mentions?.length ? { mentions: media.mentions } : {}),
-        // sendAudioAsVoice only for audio; {...undefined} contributes no keys.
+        // sendAudioAsVoice only for audio, sendMediaAsDocument only for documents;
+        // {...undefined} contributes no keys.
         ...extraOptions,
       }),
     );


### PR DESCRIPTION
## Summary

`sendDocumentMessage` did not tell whatsapp-web.js to send as a document, so the library classified the attachment from its declared mimetype: an `image/*`, `video/*` or `audio/*` payload reached the recipient as a re-encoded photo/video/audio bubble stripped of its filename, instead of a document. Baileys has always forced this via the explicit `document:` content key, so the two engines disagreed on the same request (#989).

This passes `sendMediaAsDocument` from `sendDocumentMessage`, mirroring how `sendAudioMessage` drives `sendAudioAsVoice`.

The flag is withheld for `status@broadcast` and broadcast lists. whatsapp-web.js refuses any `@broadcast` recipient outright once the flag is set (`Client.js` returns `null`), and `toMessageResult` surfaces that as a failed send — so setting it there would turn a working send into a 500 rather than improve it. Our own recipient guard is newsletter-only, and the broadcast-list id stays clickable in the dashboard, so the path is reachable without a crafted request.

## Testing

- `whatsapp-web-js.adapter.spec.ts`: 327 passed (323 prior + 4 new), 0 failed.
- `tsc --noEmit` clean.

The new tests cover:
1. an `image/png` mimetype asserting `sendMediaAsDocument: true` — the case that actually regresses (a PDF already arrives as a document without the flag);
2. `status@broadcast` and `<id>@broadcast` asserting the flag is withheld;
3. `sendImageMessage` staying off the document path.

Fixes #989.

Closes #990 — supersedes it with the `@broadcast` guard and a test that exercises the actual regression.