### PR TITLE
fix(engine): honour caller media metadata and default nameless documents to file (#989)

### DIFF
--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -2695,6 +2695,16 @@ describe('outbound document mode (#989)', () => {
     );
   });
 
+  it('defaults a nameless document to "file" (WA Web would otherwise label it "undefined")', async () => {
+    const sendMessage = jest.fn().mockResolvedValue(sentMessage);
+    await ready({ sendMessage }).sendDocumentMessage('628@c.us', { mimetype: 'application/pdf', data: bytes });
+    expect(sendMessage).toHaveBeenCalledWith(
+      '628@c.us',
+      expect.objectContaining({ filename: 'file' }),
+      expect.objectContaining({ sendMediaAsDocument: true }),
+    );
+  });
+
   it('leaves the other media senders off the document path', async () => {
     const sendMessage = jest.fn().mockResolvedValue(sentMessage);
     await ready({ sendMessage }).sendImageMessage('628@c.us', { mimetype: 'image/png', data: bytes });

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -1736,6 +1736,11 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
 
     // Build the media once (a remote URL is fetched here); sendResolved may retry the send itself.
     const messageMedia = await this.toMessageMedia(media);
+    // A nameless document reaches WA Web as `new File([blob], undefined)` and is labelled literally
+    // "undefined". Only documents render a filename, so default just this path — as Baileys does.
+    if (extraOptions?.sendMediaAsDocument && !messageMedia.filename) {
+      messageMedia.filename = 'file';
+    }
     const msg = await this.sendResolved(chatId, to =>
       this.client!.sendMessage(to, messageMedia, {
         caption: media.caption,
@@ -1885,17 +1890,7 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     // hits the same channel crash: for a channel wwjs drops the sticker form and runs processMediaData
     // with sendToChannel, which still ends at msg.avParams() (Utils.js:518). Guard it too (#673).
     this.ensureNotChannelRecipient(chatId);
-    let messageMedia: MessageMedia;
-
-    if (typeof media.data === 'string') {
-      if (isHttpUrl(media.data)) {
-        messageMedia = await loadRemoteMedia(media.data);
-      } else {
-        messageMedia = new MessageMedia(media.mimetype, media.data, media.filename);
-      }
-    } else {
-      messageMedia = new MessageMedia(media.mimetype, media.data.toString('base64'), media.filename);
-    }
+    const messageMedia = await this.toMessageMedia(media);
 
     const msg = await this.sendResolved(chatId, to =>
       this.client!.sendMessage(to, messageMedia, {
@@ -2831,11 +2826,22 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
 
   /** Build a MessageMedia from a MediaInput (URL → fetched, base64/Buffer → wrapped). */
   private async toMessageMedia(media: MediaInput): Promise<MessageMedia> {
-    if (typeof media.data === 'string') {
-      if (isHttpUrl(media.data)) return loadRemoteMedia(media.data);
-      return new MessageMedia(media.mimetype, media.data, media.filename);
+    if (typeof media.data === 'string' && isHttpUrl(media.data)) {
+      const fetched = await loadRemoteMedia(media.data);
+      // `loadRemoteMedia` derives both fields from the response (content-type, URL basename) because
+      // that is all it has. The caller usually knows better, so let an explicit `mimetype`/`filename`
+      // win — matching `resolveMediaBuffer` on the Baileys adapter, which already prefers the caller's.
+      // `application/octet-stream` is the DTO's own placeholder, not a statement about the bytes.
+      if (media.mimetype && media.mimetype !== 'application/octet-stream') {
+        fetched.mimetype = media.mimetype;
+      }
+      if (media.filename) {
+        fetched.filename = media.filename;
+      }
+      return fetched;
     }
-    return new MessageMedia(media.mimetype, media.data.toString('base64'), media.filename);
+    const data = typeof media.data === 'string' ? media.data : media.data.toString('base64');
+    return new MessageMedia(media.mimetype, data, media.filename);
   }
 
   /**


### PR DESCRIPTION
Follows up #996, the whatsapp-web.js document-mode fix for #989. The document-mode guard, the `sendMediaAsDocument` signature, and its `@broadcast` withhold landed there; this PR carries the three remaining parts that were parked for it.

## Changes

**`toMessageMedia` honours the caller's `mimetype`/`filename` on http(s) sends.**
`loadRemoteMedia` derives both fields from the HTTP response (content-type, URL basename) because that is all it has. The caller usually knows better, so an explicit `mimetype` or `filename` now wins. `application/octet-stream` is treated as the DTO's own placeholder rather than a statement about the bytes, so it is not allowed to clobber the response-derived type. This matches `resolveMediaBuffer` on the Baileys adapter, which already prefers the caller.

**`sendStickerMessage` folds onto `toMessageMedia`.**
It previously carried its own copy of the same three (url / base64 / Buffer) branches. With the metadata-handling above centralized in `toMessageMedia`, the duplication is dropped and the sticker path inherits the same caller-preference behaviour for free.

**A nameless document defaults its filename to `file`.**
Without a filename, whatsapp-web.js reaches WA Web as `new File([blob], undefined)` and renders the label literally as "undefined". Only documents render a filename, so the default is scoped to the document path via the existing `sendMediaAsDocument` flag — the same behaviour Baileys has, where `media.filename ?? 'file'`.

## Tests
Adds a case asserting a nameless `sendDocumentMessage` lands with `filename: 'file'` and `sendMediaAsDocument: true`. The existing "outbound document mode (#989)" suite (guard + `@broadcast` withhold + image-stays-a-bubble) still passes.

`npx jest src/engine/adapters/whatsapp-web-js.adapter.spec.ts` — 337 passed
`npx eslint` on both files — clean
`npx tsc --noEmit` — clean

Refs #989.