### PR TITLE
test(session): expect logout() to reject 502 when its teardown loses the deadline race

### DIFF
--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -376,7 +376,10 @@ describe('SessionService', () => {
       try {
         const logoutCall = service.logout('sess-uuid-1');
         await jest.advanceTimersByTimeAsync(10_000); // deadline fires; the race is lost
-        await logoutCall;
+        // The deadline loss means the unlink is unconfirmed, so logout() rejects 502 — but the
+        // local teardown already ran and the losing promise is still tracked in pendingTeardowns
+        // (it settles only when releaseLogout() fires below).
+        await expect(logoutCall).rejects.toBeInstanceOf(BadGatewayException);
         expect(pendingTeardownsOf().has('sess-uuid-1')).toBe(true); // still running past the race
 
         const startCall = service.start('sess-uuid-1');
@@ -402,7 +405,9 @@ describe('SessionService', () => {
       try {
         const logoutCall = service.logout('sess-uuid-1');
         await jest.advanceTimersByTimeAsync(10_000);
-        await logoutCall;
+        // The wedged logout never unlinks within the deadline, so it rejects 502; the losing
+        // promise keeps running and start()'s bounded wait eventually gives up on it below.
+        await expect(logoutCall).rejects.toBeInstanceOf(BadGatewayException);
 
         const startCall = service.start('sess-uuid-1');
         await jest.advanceTimersByTimeAsync(10_000); // bounded wait exhausted


### PR DESCRIPTION
Fixes the red `Test` job that has been on `main` since #999 landed on top of #997.

## Root cause
#999 added two teardown-resilience tests that drive `logout()` with a promise hung past the 10s deadline, then `await` the call assuming it resolves. #997 landed first and made `logout()` throw `BadGatewayException` whenever the unlink is unconfirmed — which is exactly the outcome of a lost deadline race. So both tests have failed on `main` since #999 merged: `logout()` rejects with 502 while the tests awaited a resolved promise.

This was a regression-on-merge, not a product change: the two PRs were authored without knowledge of each other, and #999 was never green after #997 merged.

## Fix
Production behaviour from #997 is correct and is already asserted explicitly elsewhere (the test at `logout() rejects with 502 when the unlink is unconfirmed`). This PR changes only the two #999 tests to expect that rejection, while preserving what they actually exercise:
- the losing promise stays registered in `pendingTeardowns`, and
- `start()` still waits for it (bounded) before re-creating the profile.

No production code (`session.service.ts`) is touched.

## Verification
`npx jest src/modules/session/session.service.spec.ts` — 212 passed (was 210 passed / 2 failed)
`npx eslint src/modules/session/session.service.spec.ts` — clean
`npx tsc --noEmit` — clean

Once this is green, the `Test` job on `main` returns to green and the previously-blocked #1000 (document-mode follow-ups) can merge.