### PR TITLE
refactor(session): decompose SessionService behind narrow ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The live engine is reachable through its own narrow port instead of through the session lifecycle
+  owner.** Ten feature services (contacts, groups, labels, channels, calls, profile, catalog, status,
+  and both message services) injected the whole 2.9k-line `SessionService` purely to reach its private
+  `engines` map, which coupled every one of them to start/stop/delete/reconnect semantics they never
+  call. The map now lives in `EngineRegistry`, exported from the (already global) `EngineModule`, so
+  those services depend on "give me the running engine for this session" and eight feature modules no
+  longer import `SessionModule` at all. `SessionService` remains the only writer, and the services
+  that genuinely drive the lifecycle (`MessageService` for `findOne`/edit recording, `InfraController`
+  for orphan reaping) still hold it deliberately. No API change: each call site keeps its own error, so
+  contacts/labels/groups/channels/calls/profile still answer 400 `Session is not started`,
+  catalog/status still answer 404 `not found or not connected`, and the two message services keep their
+  distinct wording. `openapi.json` is unchanged, byte for byte.
+
+  The engine-identity rule that guards every lifecycle path — a late callback from a superseded engine
+  must never mutate a session that now belongs to a different one, or to none — was open-coded at
+  around twenty call sites as `isLiveEngine(id, e) && engines.delete(id)`. It is now `isLive` /
+  `deleteIfLive` on the registry, written once.
+
+- **Three self-contained concerns were lifted out of `SessionService`.** Each was previously reachable
+  only by driving the full session lifecycle, so the trickiest logic in the file had the least direct
+  coverage. The `@lid`→phone read-through cache became `SessionLidResolver` (and took an `@Optional`
+  constructor dependency with it); the reconnect backoff *decision* became a pure `decideReconnect()`
+  with injected clock and jitter, leaving the service to apply only the effects; and the per-message
+  serialization chain became a general `KeyedMutationQueue`. Behaviour is unchanged — the existing
+  session specs pass untouched — and the split adds 59 tests over branches that previously needed hours
+  of uptime or live engine callbacks to reach: the FIFO eviction that bounds the lid cache, the
+  stability reset that stops a long-lived session slowly wedging `FAILED` across unrelated transient
+  drops, the loop-alert re-arm after a stable stretch, the non-finite-delay fallback that keeps an
+  operator typo from becoming a relaunch storm, and the mutation-chain reclamation that stops the map
+  growing once per message touched.
+
 ### Fixed
 
 - **The non-root smoke test can actually be run.** `scripts/smoke-test-non-root.sh` carried a UTF-8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the same captured `(id, engine)` the closure did, so the stale-generation identity guards are
   unchanged.
 
+- **The session lifecycle no longer imports the whatsapp-web.js adapter to size a timeout.** The
+  deadline `SessionService` races `engine.initialize()` against is engine-agnostic — it applies to
+  Baileys sessions too — but it was derived inline from `resolveAuthTimeoutMs()`, which the adapter
+  owned, so the lifecycle owner depended on one specific engine's module for a value it applies to
+  all of them. Both the env parse and the derivation now live in `engine/engine-init-timeout.ts`, and
+  the adapter re-exports `resolveAuthTimeoutMs` for the callers that legitimately reach it through
+  the engine they are configuring.
+
+  Pure code motion — the derived deadline is identical, and both
+  `whatsapp-web-js.adapter.spec.ts` and `session.service.spec.ts` pass with no edits. The wwjs-named
+  `WWEBJS_AUTH_TIMEOUT_MS` still feeds the shared floor, which is documented rather than changed: it
+  can only ever raise the deadline above 60s, never lower it, so a Baileys session gets a more
+  generous window and never a shorter one. Splitting the two engines' windows needs its own env var
+  and is a behaviour change, not a move.
+
 ### Fixed
 
 - **A missing dashboard asset returns 404 instead of the SPA shell.** `ServeStaticModule`'s built-in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,18 +27,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   around twenty call sites as `isLiveEngine(id, e) && engines.delete(id)`. It is now `isLive` /
   `deleteIfLive` on the registry, written once.
 
-- **Three self-contained concerns were lifted out of `SessionService`.** Each was previously reachable
+- **Four self-contained concerns were lifted out of `SessionService`.** Each was previously reachable
   only by driving the full session lifecycle, so the trickiest logic in the file had the least direct
   coverage. The `@lid`→phone read-through cache became `SessionLidResolver` (and took an `@Optional`
   constructor dependency with it); the reconnect backoff *decision* became a pure `decideReconnect()`
-  with injected clock and jitter, leaving the service to apply only the effects; and the per-message
-  serialization chain became a general `KeyedMutationQueue`. Behaviour is unchanged — the existing
-  session specs pass untouched — and the split adds 59 tests over branches that previously needed hours
-  of uptime or live engine callbacks to reach: the FIFO eviction that bounds the lid cache, the
-  stability reset that stops a long-lived session slowly wedging `FAILED` across unrelated transient
-  drops, the loop-alert re-arm after a stable stretch, the non-finite-delay fallback that keeps an
-  operator typo from becoming a relaunch storm, and the mutation-chain reclamation that stops the map
-  growing once per message touched.
+  with injected clock and jitter, leaving the service to apply only the effects; the liveness watchdog
+  became `SessionLivenessWatchdog`, which owns its interval and failure counter and reports back
+  through a single `onDead` callback; and the per-message serialization chain became a general
+  `KeyedMutationQueue`. Behaviour is unchanged — the existing session specs pass untouched — and the
+  split adds 77 tests over branches that previously needed hours of uptime or live engine callbacks to
+  reach: the FIFO eviction that bounds the lid cache, the stability reset that stops a long-lived
+  session slowly wedging `FAILED` across unrelated transient drops, the loop-alert re-arm after a
+  stable stretch, the non-finite-delay fallback that keeps an operator typo from becoming a relaunch
+  storm, the watchdog's stale-result guard for an engine superseded mid-probe, and the mutation-chain
+  reclamation that stops the map growing once per message touched.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   storm, the watchdog's stale-result guard for an engine superseded mid-probe, and the mutation-chain
   reclamation that stops the map growing once per message touched.
 
+  The three message-persist paths (live inbound, own-send echo, history backfill) also stop
+  re-deriving their shared row mapping: `buildMessageMetadata()` now states the one deliberate
+  difference between them (inbound trusts the engine's media field; the two paths known to lose media
+  synthesize the omitted marker that keeps a row from rendering as an empty bubble and dropping out of
+  the by-type stats), and `storableWaMessageId()` makes the empty-sentinel chokepoint real rather than
+  a comment repeated at each call site.
+
 ### Fixed
 
 - **The non-root smoke test can actually be run.** `scripts/smoke-test-non-root.sh` carried a UTF-8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `/api/infra`. It had no reference from `package.json`, any workflow, the Dockerfile, either compose
   file, or the documentation.
 
+### Security
+
+- **A sandboxed plugin can no longer serve the gateway's search queries without declaring a permission
+  for it.** `ctx.registerSearchProvider` is installed unconditionally in every worker context, and a
+  plugin declares itself a provider by sending `search-provider-register` over IPC — a path that never
+  passes through the capability router gating `ctx.messages` / `ctx.net` / `ctx.engine`. Nothing between
+  that declaration and the `SearchProviderRegistry` consulted the manifest, and under the shipped default
+  `SEARCH_PROVIDER=auto` a registered provider is also made **active**, superseding `builtin-fts`. A
+  plugin that declared no permissions at all could therefore see every query `GET /api/search` serves.
+
+  Registration now requires the new `search:provide` permission. A plugin without it is refused before
+  the provider reaches the registry, the active provider is left untouched, and the host logs one
+  warning (`sandbox_search_provider_denied`) — bounded to a single line per enable, because
+  `WorkerSearchRegistry` posts the declaration only on the plugin's first call. The check is warned
+  rather than silently dropped (as the ingress-subscribe guard does) because there is no manifest
+  `search` array, so no load-time validation can catch it and an operator would otherwise get no signal.
+  `hasPermission` is a required field of `RegisterPluginSearchProviderDeps`, so the compiler — not
+  reviewer discipline — is what keeps a future call site from re-opening the gap.
+
+  **Action required for search-provider plugins:** add `"permissions": ["search:provide"]` to the
+  manifest. Plugins that do not provide search are unaffected, as are all first-party plugins. No
+  gateway payload changes.
+
 ## [0.12.1] - 2026-07-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,14 +27,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   around twenty call sites as `isLiveEngine(id, e) && engines.delete(id)`. It is now `isLive` /
   `deleteIfLive` on the registry, written once.
 
-- **Four self-contained concerns were lifted out of `SessionService`.** Each was previously reachable
+- **Five self-contained concerns were lifted out of `SessionService`.** Each was previously reachable
   only by driving the full session lifecycle, so the trickiest logic in the file had the least direct
   coverage. The `@lid`→phone read-through cache became `SessionLidResolver` (and took an `@Optional`
   constructor dependency with it); the reconnect backoff *decision* became a pure `decideReconnect()`
   with injected clock and jitter, leaving the service to apply only the effects; the liveness watchdog
   became `SessionLivenessWatchdog`, which owns its interval and failure counter and reports back
-  through a single `onDead` callback; and the per-message serialization chain became a general
-  `KeyedMutationQueue`. Behaviour is unchanged — the existing session specs pass untouched — and the
+  through a single `onDead` callback; the per-message serialization chain became a general
+  `KeyedMutationQueue`; and every path that turns an engine message callback into a persisted row —
+  live inbound, own-send echo, ack reconciliation, revoke, reactions, edits and history backfill —
+  became `MessageProjector`, which owns the one mutation chain that IS the per-message ordering
+  guarantee. Behaviour is unchanged — the existing session specs pass untouched — and the
   split adds 77 tests over branches that previously needed hours of uptime or live engine callbacks to
   reach: the FIFO eviction that bounds the lid cache, the stability reset that stops a long-lived
   session slowly wedging `FAILED` across unrelated transient drops, the loop-alert re-arm after a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the by-type stats), and `storableWaMessageId()` makes the empty-sentinel chokepoint real rather than
   a comment repeated at each call site.
 
+  `initializeEngine` itself drops from 807 lines to 327. Nearly all of it was engine-callback bodies
+  inlined into one object literal, which hid the wiring — which events exist, and in what order —
+  under the handling; the five largest (inbound message, own-send echo, ack, ready, revoke) are now
+  named methods and the function reads as the event table it is. Pure code motion: each method takes
+  the same captured `(id, engine)` the closure did, so the stale-generation identity guards are
+  unchanged.
+
 ### Fixed
 
 - **The non-root smoke test can actually be run.** `scripts/smoke-test-non-root.sh` carried a UTF-8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A missing dashboard asset returns 404 instead of the SPA shell.** `ServeStaticModule`'s built-in
+  fallback answered *every* unmatched GET with `index.html`, so a mistyped or stale `<script src>`
+  came back `200 text/html` and the browser reported a JavaScript syntax error from parsing the HTML
+  shell — pointing at the wrong file and hiding a broken build. `main.ts` already serves dashboard
+  documents (it injects the per-response CSP nonce, so it must own them) and is correctly narrow:
+  it skips `/assets`, and only answers extensionless paths or explicit `text/html` navigations. The
+  module's own catch-all is now disabled so that handler is the single owner. Client-side routes are
+  unaffected.
+
+  This also repairs a deployment shape that was broken outright: when the install path contains a
+  dot-segment (`~/.openwa`, a checkout under `~/.cache`, a `TMPDIR` inside a dotdir), the built-in
+  fallback sent the index by **absolute** path and Express's `send` refuses dot-segments under its
+  default `dotfiles: 'ignore'` — so every client-side route 404'd while `/` and the hashed assets
+  kept working. The e2e lock now runs its whole matrix against both path shapes, with a fixture
+  guard asserting the two really differ (`os.tmpdir()` is not reliably dot-free, and using it
+  blindly collapsed both cases onto one shape and hid exactly this bug).
+
 - **The non-root smoke test can actually be run.** `scripts/smoke-test-non-root.sh` carried a UTF-8
   BOM ahead of its `#!/bin/sh`, and neither it nor `scripts/smoke-test-docker-proxy.sh` had the
   executable bit — so the `./scripts/…` invocation both of them document failed outright. The image

--- a/docs/03-system-architecture.md
+++ b/docs/03-system-architecture.md
@@ -78,7 +78,7 @@ sequenceDiagram
 OpenWA is designed with a **Pluggable Architecture** that allows infrastructure components to be swapped without changing application code. This enables flexible deployments ranging from minimal single-session bots to larger single-node, multi-session installs.
 
 > **Note — single-instance:** the live WhatsApp engine layer is stateful and held in-process
-> (an in-memory `Map` in `SessionService`). OpenWA currently runs as **one API instance per
+> (an in-memory `Map` in `EngineRegistry`). OpenWA currently runs as **one API instance per
 > session-data volume**; horizontal scaling across multiple API replicas is a future design
 > (not implemented). See [13 - Horizontal Scaling](13-horizontal-scaling.md).
 
@@ -438,12 +438,14 @@ src/
 
 The diagram below is conceptual: `SessionManager` is the role played by `SessionService`
 (`src/modules/session/session.service.ts`), which injects the TypeORM `Repository<Session>` directly —
-there is no `SessionRepository` class in the codebase.
+there is no `SessionRepository` class in the codebase. The live-engine map itself lives in
+`EngineRegistry` (`src/engine/engine-registry.service.ts`), the narrow port that capability services
+inject when they only need the running engine for a session; `SessionService` is its only writer.
 
 ```mermaid
 classDiagram
     class SessionManager {
-        -engines: Map~string, IWhatsAppEngine~
+        -engines: EngineRegistry
         -sessionRepository: Repository~Session~
         -engineFactory: EngineFactory
         +createSession(config): Session

--- a/docs/08-development-guidelines.md
+++ b/docs/08-development-guidelines.md
@@ -70,7 +70,8 @@ listed explicitly because TypeScript 6 no longer auto-includes every `@types` pa
 
 The backend uses ESLint flat config in `eslint.config.mjs` with type-aware TypeScript rules,
 Prettier integration, and an architecture guard for controllers. HTTP controllers must call
-capability services; they must not import `IWhatsAppEngine` or call `getEngine()` directly.
+capability services; they must not import `IWhatsAppEngine` or `EngineRegistry`, call `getEngine()`,
+or resolve an engine via `engines.require()` / `engines.get()`.
 
 ```bash
 npm run lint
@@ -197,8 +198,25 @@ export class ExampleController {
 
 Controllers are protected by the global API key guard unless marked with `@Public()`. Keep
 controllers thin: validate transport input through DTOs, delegate behavior to services, and never
-call `SessionService.getEngine()` directly from a controller. Engine-specific details belong behind
-capability services and engine adapters.
+resolve an engine directly from a controller. Engine-specific details belong behind capability
+services and engine adapters.
+
+A capability service reaches the live engine through `EngineRegistry`, the narrow port exported by
+the (global) `EngineModule` — not through `SessionService`, which owns the session *lifecycle*
+(start/stop/delete/reconnect) and should only be injected by code that actually drives it:
+
+```typescript
+@Injectable()
+export class ExampleService {
+  constructor(private readonly engines: EngineRegistry) {}
+
+  // require() throws 400 "Session is not started" by default; pass a factory to keep an
+  // endpoint's own documented status/message.
+  private getEngine(sessionId: string): IWhatsAppEngine {
+    return this.engines.require(sessionId);
+  }
+}
+```
 
 ### Service Template
 

--- a/docs/13-horizontal-scaling.md
+++ b/docs/13-horizontal-scaling.md
@@ -4,7 +4,7 @@
 >
 > **OpenWA is currently a single-process, single-instance application.** Live WhatsApp
 > engine state (browser + WebSocket + reconnect/error state) lives in an in-memory `Map`
-> in `SessionService`; there is **no** DB-backed session registry, **no** node-claim/lease,
+> in `EngineRegistry`; there is **no** DB-backed session registry, **no** node-claim/lease,
 > and **no** Socket.IO Redis adapter.
 >
 > **Supported topology:** exactly **one** API instance per session-data volume. Running

--- a/docs/19-plugin-architecture.md
+++ b/docs/19-plugin-architecture.md
@@ -631,8 +631,9 @@ URL / catalog), not an npm/github source descriptor.
 
 ### Permission model
 
-There are exactly **five** capability permissions, declared in the manifest `permissions` array — four
-enforced at the capability boundary, `webhook:ingress` at load and at route subscription:
+There are exactly **six** capability permissions, declared in the manifest `permissions` array — four
+enforced at the capability boundary, plus two on the worker-declaration bridges: `webhook:ingress` at
+load and at route subscription, and `search:provide` when the provider declaration reaches the host:
 
 ```typescript
 // src/core/plugins/plugin.interfaces.ts (doc comments condensed)
@@ -648,6 +649,9 @@ export const PluginCapabilityPermission = {
   WEBHOOK_INGRESS: 'webhook:ingress',
   /** ctx.conversations.send plus ctx.handover.* and ctx.mappings.* — the normalized outbound surface. */
   CONVERSATION_SEND: 'conversation:send',
+  /** ctx.registerSearchProvider — serve /api/search. Under SEARCH_PROVIDER=auto the provider is also
+   *  made ACTIVE, so an undeclared plugin would see every query the gateway serves. */
+  SEARCH_PROVIDE: 'search:provide',
 } as const;
 ```
 
@@ -673,6 +677,15 @@ two places: at **load**, `validateIngressManifest` throws when a manifest declar
 the permission, so the plugin never loads; and at the **ingress-subscribe guard**, a route claim from a
 worker whose manifest lacks the permission is silently dropped (no `PluginCapabilityError`) and the plugin
 simply owns no routes.
+
+`search:provide` is enforced the same way, and for the same reason: a worker declares itself a search
+provider by sending `search-provider-register` over IPC, which never passes through the capability router
+that gates `ctx.messages` / `ctx.net` / `ctx.engine`. `registerPluginSearchProvider` checks the manifest
+before the provider reaches the registry. Unlike the ingress guard this one **warns**
+(`sandbox_search_provider_denied`) rather than dropping silently: there is no manifest `search` array, so
+no load-time validation can catch it, and an operator would otherwise have no signal at all. The warning
+is bounded to one line per enable — `WorkerSearchRegistry` posts the declaration only on the plugin's
+first `ctx.registerSearchProvider` call.
 
 Two further checks apply on top of the permission:
 

--- a/docs/27-plugin-search-providers.md
+++ b/docs/27-plugin-search-providers.md
@@ -21,6 +21,20 @@ user-facing feature and the built-in DB-FTS default.
 
 ## 27.2 The contract
 
+### Declare the permission
+
+The manifest must declare `search:provide`:
+
+```json
+{ "id": "meili", "name": "Meilisearch", "version": "1.0.0", "type": "extension",
+  "main": "index.cjs", "permissions": ["search:provide"] }
+```
+
+Without it the host ignores the registration and logs one warning
+(`sandbox_search_provider_denied`); the plugin keeps running and the active provider is unchanged.
+The permission is required because under the default `SEARCH_PROVIDER=auto` a registered provider is
+also made **active**, so it sees every query `GET /api/search` serves.
+
 ### Register the handler
 
 In `onEnable`, call `ctx.registerSearchProvider(handler)` with a function that takes a `SearchQuery` and

--- a/docs/30-plugin-sandboxing.md
+++ b/docs/30-plugin-sandboxing.md
@@ -96,8 +96,9 @@ in-process plugin that calls it fails loud rather than silently never firing —
 4. **Declare your permissions.** A capability call is denied unless the manifest declares it:
    `messages:send` for `ctx.messages`, `engine:read` for `ctx.engine`, `net:fetch` for `ctx.net.fetch`
    (plus a `net.allow` host list), `conversation:send` for `ctx.conversations` / `ctx.handover` /
-   `ctx.mappings`, and `webhook:ingress` for `ctx.registerWebhook` (enforced at load and again at route
-   subscription). `ctx.storage` needs no permission — it is already per-plugin scoped. See
+   `ctx.mappings`, `webhook:ingress` for `ctx.registerWebhook` (enforced at load and again at route
+   subscription), and `search:provide` for `ctx.registerSearchProvider` (enforced when the declaration
+   reaches the host). `ctx.storage` needs no permission — it is already per-plugin scoped. See
    [19 — Plugin Architecture](./19-plugin-architecture.md).
 
 Sandboxing was a **breaking change for third-party plugin authoring** when it shipped in v0.6.0.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -36,7 +36,8 @@ export default tseslint.config(
     // Architecture guard: HTTP controllers must go through a per-capability service and
     // never reach for the raw WhatsApp engine. This keeps the "session not started" guard,
     // error mapping, and business rules behind the service boundary instead of leaking into
-    // controllers. `.getEngine(` (not `.getEngines()`) and the `IWhatsAppEngine` type are banned.
+    // controllers. `.getEngine(` (not `.getEngines()`), the EngineRegistry accessors, and the
+    // `IWhatsAppEngine` type are banned.
     files: ['**/*.controller.ts'],
     rules: {
       'no-restricted-syntax': [
@@ -45,6 +46,16 @@ export default tseslint.config(
           selector: "CallExpression[callee.property.name='getEngine']",
           message:
             'Controllers must not call getEngine(). Add a method to the capability service (e.g. GroupService) and call that instead.',
+        },
+        {
+          // EngineRegistry.require()/get() resolve a live engine, so reaching for either from a
+          // controller bypasses the capability service exactly as getEngine() used to. Matches
+          // `this.engines.require(...)` (a MemberExpression callee object) as well as a bare
+          // `engines.require(...)`.
+          selector:
+            "CallExpression[callee.property.name=/^(require|get)$/]:has(MemberExpression[property.name='engines'])",
+          message:
+            'Controllers must not resolve an engine from EngineRegistry. Add a method to the capability service and call that instead.',
         },
       ],
       'no-restricted-imports': [
@@ -58,6 +69,11 @@ export default tseslint.config(
               importNames: ['IWhatsAppEngine'],
               message:
                 'Controllers must not import IWhatsAppEngine. Keep engine types behind a capability service.',
+            },
+            {
+              group: ['**/engine/engine-registry.service'],
+              message:
+                'Controllers must not import EngineRegistry. Keep engine access behind a capability service.',
             },
           ],
         },

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -92,6 +92,19 @@ if (dashboardServingEnabled && dashboardBuildPresent) {
       // Let Nest own these so unknown API/socket routes return real 404s/JSON rather
       // than the SPA index.html fallback (Express 5 / path-to-regexp v8 wildcard syntax).
       exclude: ['/api/{*splat}', '/socket.io/{*splat}', '/mcp', '/mcp/{*splat}'],
+      // Disable this module's OWN catch-all SPA fallback. main.ts already serves dashboard
+      // documents (it injects the per-response CSP nonce, which is why it must own them), and
+      // that handler is correctly narrow: it skips /assets and only answers extensionless paths
+      // or explicit text/html navigations. The built-in fallback here is not narrow — it answers
+      // EVERY unmatched GET with index.html, so a mistyped `<script src>` came back 200 HTML and
+      // the browser reported a JavaScript parse error instead of the real 404, hiding broken
+      // builds behind a confusing symptom. It is also outright broken when the install path
+      // contains a dot-segment (~/.openwa, a checkout under ~/.cache): it sends the index by
+      // ABSOLUTE path and Express's `send` refuses dot-segments, 404ing every client-side route.
+      // Turning it off fixes both, and makes behaviour identical on either path shape.
+      // ServeStaticModule has no explicit off switch, so this is a renderPath literal that no
+      // real request can match.
+      renderPath: '/__openwa_spa_fallback_owned_by_main_ts__',
     }),
   );
 }

--- a/src/common/utils/keyed-mutation-queue.spec.ts
+++ b/src/common/utils/keyed-mutation-queue.spec.ts
@@ -1,0 +1,132 @@
+import { KeyedMutationQueue } from './keyed-mutation-queue';
+
+/**
+ * Lets queued chains drain. Cycles through the macrotask queue as well as microtasks, so work
+ * deferred with setImmediate settles too.
+ */
+const drain = async (): Promise<void> => {
+  for (let i = 0; i < 5; i++) await new Promise(resolve => setImmediate(resolve));
+};
+
+describe('KeyedMutationQueue', () => {
+  it('runs queued work', async () => {
+    const queue = new KeyedMutationQueue();
+    const work = jest.fn().mockResolvedValue(undefined);
+
+    queue.enqueue('k', work);
+    await drain();
+
+    expect(work).toHaveBeenCalledTimes(1);
+  });
+
+  it('serializes work for the same key in arrival order', async () => {
+    const queue = new KeyedMutationQueue();
+    const order: string[] = [];
+    const slow = () =>
+      new Promise<void>(resolve => {
+        setImmediate(() => {
+          order.push('first');
+          resolve();
+        });
+      });
+
+    queue.enqueue('k', slow);
+    queue.enqueue('k', () => {
+      order.push('second');
+      return Promise.resolve();
+    });
+    await drain();
+
+    // Without chaining, the synchronous second would land before the deferred first.
+    expect(order).toEqual(['first', 'second']);
+  });
+
+  it('does not serialize across different keys', async () => {
+    const queue = new KeyedMutationQueue();
+    let releaseA: () => void = () => {};
+    const blocked = new Promise<void>(resolve => {
+      releaseA = resolve;
+    });
+    const bDone = jest.fn().mockResolvedValue(undefined);
+
+    queue.enqueue('a', () => blocked);
+    queue.enqueue('b', bDone);
+    await drain();
+
+    // 'b' must not wait on the still-pending 'a'.
+    expect(bDone).toHaveBeenCalledTimes(1);
+    releaseA();
+    await drain();
+  });
+
+  it('isolates a failure so later work on the same key still runs', async () => {
+    const queue = new KeyedMutationQueue();
+    const after = jest.fn().mockResolvedValue(undefined);
+
+    queue.enqueue('k', () => Promise.reject(new Error('boom')));
+    queue.enqueue('k', after);
+    await drain();
+
+    expect(after).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports an unexpected failure to the handler with its key', async () => {
+    const onUnexpectedError = jest.fn();
+    const queue = new KeyedMutationQueue(onUnexpectedError);
+    const err = new Error('boom');
+
+    queue.enqueue('k', () => Promise.reject(err));
+    await drain();
+
+    expect(onUnexpectedError).toHaveBeenCalledWith('k', err);
+  });
+
+  it('never leaks a rejected fire-and-forget promise', async () => {
+    const unhandled = jest.fn();
+    process.on('unhandledRejection', unhandled);
+    const queue = new KeyedMutationQueue();
+
+    queue.enqueue('k', () => Promise.reject(new Error('boom')));
+    await drain();
+
+    process.off('unhandledRejection', unhandled);
+    expect(unhandled).not.toHaveBeenCalled();
+  });
+
+  it('reclaims the chain once it drains, so memory does not grow per entity touched', async () => {
+    const queue = new KeyedMutationQueue();
+
+    queue.enqueue('k', () => Promise.resolve());
+    expect(queue.size).toBe(1);
+    await drain();
+
+    expect(queue.size).toBe(0);
+  });
+
+  it('reclaims a chain that ended in failure', async () => {
+    const queue = new KeyedMutationQueue();
+
+    queue.enqueue('k', () => Promise.reject(new Error('boom')));
+    await drain();
+
+    expect(queue.size).toBe(0);
+  });
+
+  it('keeps the chain while later work is still pending', async () => {
+    const queue = new KeyedMutationQueue();
+    let release: () => void = () => {};
+    const blocked = new Promise<void>(resolve => {
+      release = resolve;
+    });
+
+    queue.enqueue('k', () => Promise.resolve());
+    queue.enqueue('k', () => blocked);
+    await drain();
+
+    // The first chain settled but must not evict the entry the second one replaced it with.
+    expect(queue.size).toBe(1);
+    release();
+    await drain();
+    expect(queue.size).toBe(0);
+  });
+});

--- a/src/common/utils/keyed-mutation-queue.ts
+++ b/src/common/utils/keyed-mutation-queue.ts
@@ -1,0 +1,44 @@
+/**
+ * Serializes async work per key, so concurrent mutations of the same entity apply in arrival order.
+ *
+ * Extracted from SessionService, where it existed to keep stored-message mutations ordered:
+ * reactions perform a read-modify-write and rapid edits must remain latest-write-wins, and sharing
+ * one chain per message also preserves order when different mutation kinds for the same message
+ * arrive together.
+ *
+ * There is nothing session-specific about it — it is a keyed promise chain — so it lives on its own
+ * where its failure-isolation and memory-reclamation behaviour can be tested directly, rather than
+ * through engine callbacks.
+ */
+export class KeyedMutationQueue {
+  private readonly chains = new Map<string, Promise<void>>();
+
+  /**
+   * @param onUnexpectedError Last-resort handler. Callers' work functions are expected to do their
+   *   own contextual error handling; this exists so a future one cannot leak a rejected
+   *   fire-and-forget promise or permanently block the key's later mutations.
+   */
+  constructor(private readonly onUnexpectedError: (key: string, err: unknown) => void = () => {}) {}
+
+  /** Queue work for `key`. A failed operation is isolated so later work on the same key still runs. */
+  enqueue(key: string, work: () => Promise<void>): void {
+    const prior = this.chains.get(key) ?? Promise.resolve();
+    const next = prior
+      .catch(() => undefined)
+      .then(work)
+      .catch(err => this.onUnexpectedError(key, err));
+    this.chains.set(key, next);
+    // Reclaim the entry once the chain drains, but only if no later work replaced it — otherwise a
+    // long-lived process would accumulate one settled promise per entity touched.
+    void next.finally(() => {
+      if (this.chains.get(key) === next) {
+        this.chains.delete(key);
+      }
+    });
+  }
+
+  /** Number of keys with in-flight work. Exposed for tests and diagnostics. */
+  get size(): number {
+    return this.chains.size;
+  }
+}

--- a/src/core/plugins/plugin-loader.service.spec.ts
+++ b/src/core/plugins/plugin-loader.service.spec.ts
@@ -979,7 +979,15 @@ describe('PluginLoaderService — search-provider worker-crash fallback', () => 
     fs.mkdirSync(path.join(tmpDir, 'ok'), { recursive: true });
     fs.writeFileSync(
       path.join(tmpDir, 'ok', 'manifest.json'),
-      JSON.stringify({ id: 'ok', name: 'OK', version: '1.0.0', type: 'extension', main: 'index.cjs' }),
+      JSON.stringify({
+        id: 'ok',
+        name: 'OK',
+        version: '1.0.0',
+        type: 'extension',
+        main: 'index.cjs',
+        // This suite is about crash fallback, so the fixture must be a plugin the search bridge accepts.
+        permissions: ['search:provide'],
+      }),
     );
     fs.writeFileSync(
       path.join(tmpDir, 'ok', 'index.cjs'),
@@ -1011,6 +1019,38 @@ describe('PluginLoaderService — search-provider worker-crash fallback', () => 
 
     expect(registry.list().map(p => p.id)).not.toContain('plugin:ok');
     expect(registry.active()?.id).toBe('builtin-fts'); // fell back, not pinned to the dead plugin
+  });
+
+  it('never activates a plugin that registers a search provider without declaring search:provide', async () => {
+    // Same fixture, permission removed: ctx.registerSearchProvider is installed in EVERY worker context,
+    // so this is the whole distance between an undeclared plugin and serving every /search query.
+    fs.writeFileSync(
+      path.join(tmpDir, 'ok', 'manifest.json'),
+      JSON.stringify({ id: 'ok', name: 'OK', version: '1.0.0', type: 'extension', main: 'index.cjs' }),
+    );
+    const registry = new SearchProviderRegistry();
+    registry.register({ id: 'builtin-fts', label: 'b', search: jest.fn(), health: jest.fn() });
+    const config = {
+      get: (k: string) =>
+        k === 'search.provider' ? 'auto' : k === 'plugins.dir' || k === 'dataDir' ? tmpDir : undefined,
+    } as unknown as ConfigService;
+    const storage = new PluginStorageService(config);
+    const loader = new CapturingLoader(config, new HookManager(), storage, {
+      get: () => registry,
+    } as unknown as ModuleRef);
+
+    loader.loadPlugin(path.join(tmpDir, 'ok'));
+    await loader.enablePlugin('ok');
+
+    // Assert BEFORE reaping: terminate() runs onWorkerExit -> unregisterPluginSearchProvider, which
+    // drops plugin:ok and restores builtin-fts on its own. Asserting after it would pass whether or
+    // not the permission gate works at all. The finally still reaps, so no worker handle leaks.
+    try {
+      expect(registry.list().map(p => p.id)).not.toContain('plugin:ok');
+      expect(registry.active()?.id).toBe('builtin-fts'); // auto mode must NOT hand the gateway to it
+    } finally {
+      await loader.lastHost!.terminate();
+    }
   });
 });
 

--- a/src/core/plugins/plugin-loader.service.ts
+++ b/src/core/plugins/plugin-loader.service.ts
@@ -1314,7 +1314,9 @@ export class PluginLoaderService implements OnModuleInit, OnApplicationBootstrap
     // When the worker declares itself a search provider (ctx.registerSearchProvider →
     // search-provider-register), register a PluginSearchProvider in the SearchProviderRegistry. The host
     // is in sandboxHosts by the time registration fires (during onLoad/onEnable), so look it up lazily
-    // like onHookSubscribe. Search disabled (no registry, or SEARCH_PROVIDER=none) → the util skips.
+    // like onHookSubscribe. Search disabled (no registry, or SEARCH_PROVIDER=none) → the util skips, and
+    // a manifest without 'search:provide' is denied there — the wire declaration is untrusted input, and
+    // this bridge bypasses the capability router that gates the ctx.* capabilities.
     const onSearchProviderRegister = (): void => {
       const liveHost = this.sandboxHosts.get(pluginId);
       if (!liveHost) return;
@@ -1325,6 +1327,8 @@ export class PluginLoaderService implements OnModuleInit, OnApplicationBootstrap
         timeoutMs: SANDBOX_SEARCH_TIMEOUT_MS,
         registry: this.getSearchRegistry(),
         mode: this.configService.get<string>('search.provider', 'auto'),
+        hasPermission: (plugin.manifest.permissions ?? []).includes(PluginCapabilityPermission.SEARCH_PROVIDE),
+        warn: (message, meta) => this.logger.warn(message, meta),
       });
     };
 

--- a/src/core/plugins/plugin.interfaces.ts
+++ b/src/core/plugins/plugin.interfaces.ts
@@ -170,6 +170,12 @@ export const PluginCapabilityPermission = {
   WEBHOOK_INGRESS: 'webhook:ingress',
   /** `ctx.conversations.send` — normalized outbound send translated to MessageService. */
   CONVERSATION_SEND: 'conversation:send',
+  /**
+   * `ctx.registerSearchProvider` — serve the gateway's /search queries. Under the default
+   * SEARCH_PROVIDER=auto a registered provider is also made ACTIVE, superseding builtin-fts, so an
+   * undeclared plugin would otherwise see every search query the gateway serves.
+   */
+  SEARCH_PROVIDE: 'search:provide',
 } as const;
 export type PluginCapabilityPermission = (typeof PluginCapabilityPermission)[keyof typeof PluginCapabilityPermission];
 

--- a/src/core/plugins/search-provider-registration.spec.ts
+++ b/src/core/plugins/search-provider-registration.spec.ts
@@ -11,6 +11,8 @@ const deps = (overrides: Partial<Parameters<typeof registerPluginSearchProvider>
   timeoutMs: 10000,
   registry: new SearchProviderRegistry(),
   mode: 'auto',
+  hasPermission: true,
+  warn: jest.fn(),
   ...overrides,
 });
 
@@ -26,6 +28,18 @@ describe('registerPluginSearchProvider', () => {
 
     expect(registry.list().map(p => p.id)).toContain('plugin:meili');
     expect(registry.active()?.id).toBe('plugin:meili');
+  });
+
+  it('denies a plugin that never declared the search:provide permission, even in auto mode', () => {
+    const registry = new SearchProviderRegistry();
+    registry.register(builtin());
+    const warn = jest.fn();
+
+    registerPluginSearchProvider(deps({ registry, hasPermission: false, warn }));
+
+    expect(registry.list().map(p => p.id)).not.toContain('plugin:meili');
+    expect(registry.active()?.id).toBe('builtin-fts');
+    expect(warn).toHaveBeenCalledTimes(1);
   });
 
   it('builtin-fts mode registers the plugin but leaves builtin active', () => {

--- a/src/core/plugins/search-provider-registration.util.ts
+++ b/src/core/plugins/search-provider-registration.util.ts
@@ -11,12 +11,21 @@ export interface RegisterPluginSearchProviderDeps {
   registry: SearchProviderRegistry | undefined;
   /** Resolved SEARCH_PROVIDER mode: 'auto' | 'builtin-fts' | 'none'. */
   mode: string;
+  /** manifest declares search:provide */
+  hasPermission: boolean;
+  warn: (message: string, meta: Record<string, unknown>) => void;
 }
 
 /**
  * Register a sandboxed plugin as a SearchProvider when it declares itself one (search-provider-register).
  * Pure policy, extracted from the loader so it is unit-testable without constructing PluginLoaderService:
  *
+ * - no search:provide  → deny + warn. Checked FIRST, and warned even when search is off, because an
+ *                        undeclared plugin reaching here is a privilege claim, not a config question:
+ *                        `ctx.registerSearchProvider` is installed unconditionally in every worker
+ *                        context, and this is the only gate between it and the registry (the
+ *                        declaration arrives as an IPC message, so it never passes through the
+ *                        capability router that gates `ctx.messages`/`ctx.net`/`ctx.engine`).
  * - registry undefined → search module not loaded (SEARCH_ENABLED=false); skip silently.
  * - mode 'none'        → operator disabled search; skip.
  * - mode 'auto'        → register AND setActive, superseding builtin-fts (the documented auto behavior).
@@ -25,6 +34,15 @@ export interface RegisterPluginSearchProviderDeps {
  * Last-registered plugin wins in 'auto' if multiple register (Part 1 limitation).
  */
 export function registerPluginSearchProvider(deps: RegisterPluginSearchProviderDeps): void {
+  if (!deps.hasPermission) {
+    // Bounded without a latch: WorkerSearchRegistry posts `search-provider-register` only on the
+    // plugin's FIRST ctx.registerSearchProvider call, so this is at most one line per enable.
+    deps.warn(`Sandboxed plugin ${deps.pluginId} declared a search provider without 'search:provide'; ignoring`, {
+      pluginId: deps.pluginId,
+      action: 'sandbox_search_provider_denied',
+    });
+    return;
+  }
   if (!deps.registry) return;
   if (deps.mode === 'none') return;
   const provider = new PluginSearchProvider(deps.pluginId, deps.label, deps.transport, deps.timeoutMs);

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -50,6 +50,7 @@ import {
   IncomingCallEvent,
 } from '../interfaces/whatsapp-engine.interface';
 import { resolveWebVersionPin } from '../wa-web-version';
+import { resolveAuthTimeoutMs } from '../engine-init-timeout';
 import { chatKind, isChannelJid, userPart } from '../identity/wa-id';
 import { LidMappingStore } from '../identity/lid-mapping-store.service';
 import { ChatLabelsUnsupportedError } from '../../common/errors/chat-labels-unsupported.error';
@@ -390,23 +391,11 @@ export function probeOnboardingModal(options?: { labels?: string[]; headingOptio
 // status can import it without loading whatsapp-web.js (engine lazy-loading). The adapter imports
 // resolveWebVersionPin above for use in initialize().
 
-/**
- * Optional override for whatsapp-web.js's initial boot/inject wait (#353). On slow first boots
- * (e.g. WSL2 or low-resource containers) the default 30s `authTimeoutMs` can expire before WhatsApp
- * Web finishes loading, aborting QR generation. Set WWEBJS_AUTH_TIMEOUT_MS to a larger value in
- * milliseconds (e.g. 120000) to extend it. Unset, or a value that is not a positive safe integer,
- * keeps the whatsapp-web.js default (30000ms).
- */
-export function resolveAuthTimeoutMs(): number | undefined {
-  const raw = process.env.WWEBJS_AUTH_TIMEOUT_MS?.trim();
-  if (!raw || !/^\d+$/.test(raw)) {
-    return undefined;
-  }
-  const ms = Number(raw);
-  // Number.isSafeInteger rejects Infinity (from huge digit strings) and >2^53 unsafe integers — both
-  // pass the /^\d+$/ shape check but would make whatsapp-web.js's inject loop wait effectively forever.
-  return Number.isSafeInteger(ms) && ms > 0 ? ms : undefined;
-}
+// resolveAuthTimeoutMs now lives in ../engine-init-timeout, next to the outer init deadline derived
+// from it: that deadline is engine-agnostic, so deriving it here made the session lifecycle import
+// this adapter just to size a timeout. Re-exported because callers still reach it through the engine
+// they are configuring.
+export { resolveAuthTimeoutMs };
 
 /**
  * Extracts the JID of the parent community a group is linked to, if any.

--- a/src/engine/engine-init-timeout.ts
+++ b/src/engine/engine-init-timeout.ts
@@ -1,0 +1,45 @@
+/**
+ * The deadline the session lifecycle races `engine.initialize()` against, and the whatsapp-web.js
+ * auth window it is derived from.
+ *
+ * These live outside the adapters because the OUTER deadline is engine-agnostic — SessionService
+ * applies it to every engine — while the value it must clear is set by whatsapp-web.js. Deriving it
+ * inside `session.service.ts` meant the lifecycle owner imported the wwjs adapter just to size a
+ * timeout, which is why this pair now has one home instead of a cross-layer import.
+ */
+
+/**
+ * Optional override for whatsapp-web.js's initial boot/inject wait (#353). On slow first boots
+ * (e.g. WSL2 or low-resource containers) the default 30s `authTimeoutMs` can expire before WhatsApp
+ * Web finishes loading, aborting QR generation. Set WWEBJS_AUTH_TIMEOUT_MS to a larger value in
+ * milliseconds (e.g. 120000) to extend it. Unset, or a value that is not a positive safe integer,
+ * keeps the whatsapp-web.js default (30000ms).
+ */
+export function resolveAuthTimeoutMs(): number | undefined {
+  const raw = process.env.WWEBJS_AUTH_TIMEOUT_MS?.trim();
+  if (!raw || !/^\d+$/.test(raw)) {
+    return undefined;
+  }
+  const ms = Number(raw);
+  // Number.isSafeInteger rejects Infinity (from huge digit strings) and >2^53 unsafe integers — both
+  // pass the /^\d+$/ shape check but would make whatsapp-web.js's inject loop wait effectively forever.
+  return Number.isSafeInteger(ms) && ms > 0 ? ms : undefined;
+}
+
+/**
+ * How long a session waits for `engine.initialize()` before treating it as wedged.
+ *
+ * The deadline MUST exceed the auth wait whatsapp-web.js runs INSIDE engine.initialize()
+ * (authTimeoutMs — the inject() poll for WA Web's JS to bootstrap, raisable via
+ * WWEBJS_AUTH_TIMEOUT_MS for slow first boots). A shorter outer deadline would SIGKILL a legitimate
+ * slow init mid-auth. Floor 60s for the hang case; otherwise the configured auth window plus 30s for
+ * launch/navigation/post-inject overhead.
+ *
+ * WWEBJS_AUTH_TIMEOUT_MS can only ever RAISE this above the 60s floor, never lower it, so a
+ * Baileys session whose operator set it for whatsapp-web.js gets a more generous deadline — never a
+ * shorter one. Giving the two engines separate windows would need its own env var and is a
+ * behaviour change, not part of moving this out of the adapter.
+ */
+export function resolveEngineInitTimeoutMs(): number {
+  return Math.max(60_000, (resolveAuthTimeoutMs() ?? 30_000) + 30_000);
+}

--- a/src/engine/engine-registry.service.spec.ts
+++ b/src/engine/engine-registry.service.spec.ts
@@ -117,9 +117,9 @@ describe('EngineRegistry', () => {
     });
 
     it('throws the caller-supplied error so each API keeps its documented status', () => {
-      expect(() => registry.require('s1', () => new NotFoundException('Session s1 not found or not connected'))).toThrow(
-        NotFoundException,
-      );
+      expect(() =>
+        registry.require('s1', () => new NotFoundException('Session s1 not found or not connected')),
+      ).toThrow(NotFoundException);
     });
 
     it('does not build the error when the engine is present', () => {

--- a/src/engine/engine-registry.service.spec.ts
+++ b/src/engine/engine-registry.service.spec.ts
@@ -1,0 +1,166 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { EngineRegistry } from './engine-registry.service';
+import type { IWhatsAppEngine } from './interfaces/whatsapp-engine.interface';
+
+const engineStub = (tag: string): IWhatsAppEngine => ({ tag }) as unknown as IWhatsAppEngine;
+
+describe('EngineRegistry', () => {
+  let registry: EngineRegistry;
+
+  beforeEach(() => {
+    registry = new EngineRegistry();
+  });
+
+  describe('registration', () => {
+    it('stores and returns the engine registered for a session', () => {
+      const engine = engineStub('a');
+      registry.set('s1', engine);
+
+      expect(registry.get('s1')).toBe(engine);
+      expect(registry.has('s1')).toBe(true);
+      expect(registry.size).toBe(1);
+    });
+
+    it('reports an unregistered session as absent', () => {
+      expect(registry.get('missing')).toBeUndefined();
+      expect(registry.has('missing')).toBe(false);
+    });
+
+    it('replaces the engine on re-registration (reconnect installs a new generation)', () => {
+      const first = engineStub('first');
+      const second = engineStub('second');
+      registry.set('s1', first);
+      registry.set('s1', second);
+
+      expect(registry.get('s1')).toBe(second);
+      expect(registry.size).toBe(1);
+    });
+
+    it('clear() drops every engine', () => {
+      registry.set('s1', engineStub('a'));
+      registry.set('s2', engineStub('b'));
+
+      registry.clear();
+
+      expect(registry.size).toBe(0);
+      expect(registry.entries()).toEqual([]);
+    });
+
+    it('entries() snapshots the map so callers can tear down while it mutates', () => {
+      const a = engineStub('a');
+      registry.set('s1', a);
+
+      const snapshot = registry.entries();
+      registry.delete('s1');
+
+      expect(snapshot).toEqual([['s1', a]]);
+      expect(registry.size).toBe(0);
+    });
+  });
+
+  describe('liveness by identity', () => {
+    it('isLive() is true only for the currently registered instance', () => {
+      const engine = engineStub('a');
+      registry.set('s1', engine);
+
+      expect(registry.isLive('s1', engine)).toBe(true);
+    });
+
+    it('isLive() is false for a superseded generation (reconnect replaced it)', () => {
+      const stale = engineStub('stale');
+      const fresh = engineStub('fresh');
+      registry.set('s1', stale);
+      registry.set('s1', fresh);
+
+      expect(registry.isLive('s1', stale)).toBe(false);
+      expect(registry.isLive('s1', fresh)).toBe(true);
+    });
+
+    it('isLive() is false after the session is stopped', () => {
+      const engine = engineStub('a');
+      registry.set('s1', engine);
+      registry.delete('s1');
+
+      expect(registry.isLive('s1', engine)).toBe(false);
+    });
+
+    it('deleteIfLive() reconciles the map for the live engine', () => {
+      const engine = engineStub('a');
+      registry.set('s1', engine);
+
+      expect(registry.deleteIfLive('s1', engine)).toBe(true);
+      expect(registry.has('s1')).toBe(false);
+    });
+
+    it('deleteIfLive() refuses to evict a live replacement on behalf of a stale engine', () => {
+      const stale = engineStub('stale');
+      const fresh = engineStub('fresh');
+      registry.set('s1', stale);
+      registry.set('s1', fresh);
+
+      expect(registry.deleteIfLive('s1', stale)).toBe(false);
+      expect(registry.get('s1')).toBe(fresh);
+    });
+  });
+
+  describe('require()', () => {
+    it('returns the engine when the session is started', () => {
+      const engine = engineStub('a');
+      registry.set('s1', engine);
+
+      expect(registry.require('s1')).toBe(engine);
+    });
+
+    it('throws a 400 "not started" by default', () => {
+      expect(() => registry.require('s1')).toThrow(BadRequestException);
+      expect(() => registry.require('s1')).toThrow('Session is not started');
+    });
+
+    it('throws the caller-supplied error so each API keeps its documented status', () => {
+      expect(() => registry.require('s1', () => new NotFoundException('Session s1 not found or not connected'))).toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('does not build the error when the engine is present', () => {
+      const onMissing = jest.fn(() => new BadRequestException('nope'));
+      registry.set('s1', engineStub('a'));
+
+      registry.require('s1', onMissing);
+
+      expect(onMissing).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('initialization reservations', () => {
+    it('counts a reserved-but-unregistered session as active', () => {
+      registry.initializing.add('s1');
+
+      expect(registry.activeIds()).toEqual(['s1']);
+      // Not yet a live engine: only the reservation exists.
+      expect(registry.has('s1')).toBe(false);
+      expect(registry.size).toBe(0);
+    });
+
+    it('does not double-count a session that is both reserved and registered', () => {
+      registry.initializing.add('s1');
+      registry.set('s1', engineStub('a'));
+
+      expect(registry.activeIds()).toEqual(['s1']);
+    });
+
+    it('releases the reservation', () => {
+      registry.initializing.add('s1');
+      registry.initializing.delete('s1');
+
+      expect(registry.activeIds()).toEqual([]);
+    });
+
+    it('reports registered and initializing sessions together', () => {
+      registry.set('running', engineStub('a'));
+      registry.initializing.add('starting');
+
+      expect(registry.activeIds().sort()).toEqual(['running', 'starting']);
+    });
+  });
+});

--- a/src/engine/engine-registry.service.ts
+++ b/src/engine/engine-registry.service.ts
@@ -1,0 +1,128 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import type { IWhatsAppEngine } from './interfaces/whatsapp-engine.interface';
+
+/**
+ * The single source of truth for which engine instance is live for a session.
+ *
+ * This is the narrow port between session *lifecycle* (SessionService, which creates, retires and
+ * reconnects engines) and the ~10 feature services that only ever need "give me the running engine
+ * for this session". Those consumers previously injected the whole SessionService — a 2.9k-line
+ * lifecycle owner — purely to reach its private `engines` map, which coupled every feature module to
+ * start/stop/delete/reconnect semantics they never call.
+ *
+ * Identity, not just presence, is the invariant that matters. Each engine callback captures its own
+ * engine instance; once a session is stopped (engine removed) or restarted/reconnected (engine
+ * replaced), a late callback from the superseded engine must not mutate the session that now belongs
+ * to a different — or no — engine. `isLive`/`deleteIfLive` exist so that check is written once here
+ * rather than re-derived at each of its ~20 call sites.
+ */
+@Injectable()
+export class EngineRegistry {
+  /** Live engines by session (DB) id. Presence here means "started"; identity means "not superseded". */
+  private readonly engines = new Map<string, IWhatsAppEngine>();
+
+  /**
+   * Sessions whose engine is being constructed but is not in `engines` yet. Held so concurrency
+   * accounting and the infra import pre-flight can see a session that is starting but not yet
+   * registered, which would otherwise look idle and be orphaned or double-started.
+   *
+   * Exposed directly (rather than behind add/remove wrappers) because the lifecycle owner needs the
+   * full Set surface — including `clear()` — and this is a reservation ledger, not an invariant that
+   * benefits from being funnelled through methods the way engine identity is.
+   */
+  readonly initializing = new Set<string>();
+
+  // ── Map-compatible surface (used by the lifecycle owner) ──────────────
+
+  get(id: string): IWhatsAppEngine | undefined {
+    return this.engines.get(id);
+  }
+
+  set(id: string, engine: IWhatsAppEngine): void {
+    this.engines.set(id, engine);
+  }
+
+  has(id: string): boolean {
+    return this.engines.has(id);
+  }
+
+  delete(id: string): boolean {
+    return this.engines.delete(id);
+  }
+
+  clear(): void {
+    this.engines.clear();
+  }
+
+  get size(): number {
+    return this.engines.size;
+  }
+
+  keys(): IterableIterator<string> {
+    return this.engines.keys();
+  }
+
+  entries(): Array<[string, IWhatsAppEngine]> {
+    return [...this.engines];
+  }
+
+  /**
+   * Iterates a *snapshot* of the live entries. Every caller here tears engines down while iterating,
+   * which would otherwise mutate the map mid-iteration.
+   */
+  [Symbol.iterator](): IterableIterator<[string, IWhatsAppEngine]> {
+    return this.entries()[Symbol.iterator]();
+  }
+
+  // ── Liveness (identity) ───────────────────────────────────────────────
+
+  /**
+   * True only while `engine` is still the live engine registered for `id`. Identity comparison closes
+   * both the post-stop and the stale-generation (stop→start / reconnect-replace) windows that a bare
+   * presence check does not cover.
+   */
+  isLive(id: string, engine: IWhatsAppEngine): boolean {
+    return this.engines.get(id) === engine;
+  }
+
+  /**
+   * Reconcile the map only if `engine` is still the registered one. Guards against a teardown of a
+   * superseded engine evicting its live replacement — the single most repeated invariant in the
+   * lifecycle paths.
+   */
+  deleteIfLive(id: string, engine: IWhatsAppEngine): boolean {
+    if (!this.isLive(id, engine)) {
+      return false;
+    }
+    return this.engines.delete(id);
+  }
+
+  // ── Consumer-facing accessor ──────────────────────────────────────────
+
+  /**
+   * The running engine for `id`, or throw. Callers pass their own error so each API surface keeps the
+   * exact status/message it already documented (some report 400 "not started", others 404 "not
+   * connected"); the default matches the most common existing guard.
+   */
+  require(
+    id: string,
+    onMissing: () => Error = () => new BadRequestException('Session is not started'),
+  ): IWhatsAppEngine {
+    const engine = this.engines.get(id);
+    if (!engine) {
+      throw onMissing();
+    }
+    return engine;
+  }
+
+  // ── Initialization reservations ───────────────────────────────────────
+
+  /**
+   * Ids of every session with a live engine — including ones mid-initialization (their engine is not
+   * in `engines` yet but will register when start() completes). The infra import pre-flight uses this
+   * to refuse a full-replace restore that would orphan a running engine.
+   */
+  activeIds(): string[] {
+    return [...new Set([...this.engines.keys(), ...this.initializing])];
+  }
+}

--- a/src/engine/engine.module.ts
+++ b/src/engine/engine.module.ts
@@ -5,11 +5,15 @@ import { BaileysStoredMessage } from './adapters/baileys-stored-message.entity';
 import { BaileysMessageStoreService } from './adapters/baileys-message-store.service';
 import { LidMapping } from './identity/lid-mapping.entity';
 import { LidMappingStoreService } from './identity/lid-mapping-store.service';
+import { EngineRegistry } from './engine-registry.service';
 
 @Global()
 @Module({
   imports: [TypeOrmModule.forFeature([BaileysStoredMessage, LidMapping], 'data')],
-  providers: [EngineFactory, BaileysMessageStoreService, LidMappingStoreService],
-  exports: [EngineFactory, LidMappingStoreService],
+  // EngineRegistry is exported from this @Global module so the feature services that only need a
+  // live engine can inject it directly, instead of importing SessionModule to reach the lifecycle
+  // owner. It is a singleton by DI, which is what makes it a safe single source of truth.
+  providers: [EngineFactory, BaileysMessageStoreService, LidMappingStoreService, EngineRegistry],
+  exports: [EngineFactory, LidMappingStoreService, EngineRegistry],
 })
 export class EngineModule {}

--- a/src/modules/call/call.module.ts
+++ b/src/modules/call/call.module.ts
@@ -1,10 +1,8 @@
 import { Module } from '@nestjs/common';
 import { CallController } from './call.controller';
 import { CallService } from './call.service';
-import { SessionModule } from '../session/session.module';
 
 @Module({
-  imports: [SessionModule],
   controllers: [CallController],
   providers: [CallService],
   exports: [CallService],

--- a/src/modules/call/call.service.spec.ts
+++ b/src/modules/call/call.service.spec.ts
@@ -1,13 +1,14 @@
 import { BadRequestException } from '@nestjs/common';
 import { CallService } from './call.service';
-import { SessionService } from '../session/session.service';
+import { EngineRegistry } from '../../engine/engine-registry.service';
 import { IWhatsAppEngine } from '../../engine/interfaces/whatsapp-engine.interface';
 import { CallNotFoundError } from '../../common/errors/call-not-found.error';
 
 describe('CallService', () => {
   const makeService = (engine: Partial<IWhatsAppEngine> | undefined) => {
-    const sessionService = { getEngine: jest.fn().mockReturnValue(engine) } as unknown as SessionService;
-    return new CallService(sessionService);
+    const engines = new EngineRegistry();
+    if (engine) engines.set('s1', engine as IWhatsAppEngine);
+    return new CallService(engines);
   };
 
   it('throws 400 "Session is not started" when the engine is missing (guard preserved)', () => {

--- a/src/modules/call/call.service.ts
+++ b/src/modules/call/call.service.ts
@@ -1,5 +1,5 @@
-import { Injectable, BadRequestException } from '@nestjs/common';
-import { SessionService } from '../session/session.service';
+import { Injectable } from '@nestjs/common';
+import { EngineRegistry } from '../../engine/engine-registry.service';
 import { IWhatsAppEngine } from '../../engine/interfaces/whatsapp-engine.interface';
 
 /**
@@ -9,14 +9,11 @@ import { IWhatsAppEngine } from '../../engine/interfaces/whatsapp-engine.interfa
  */
 @Injectable()
 export class CallService {
-  constructor(private readonly sessionService: SessionService) {}
+  constructor(private readonly engines: EngineRegistry) {}
 
   private getEngine(sessionId: string): IWhatsAppEngine {
-    const engine = this.sessionService.getEngine(sessionId);
-    if (!engine) {
-      throw new BadRequestException('Session is not started');
-    }
-    return engine;
+    // EngineRegistry.require()'s default is this exact 400 "Session is not started".
+    return this.engines.require(sessionId);
   }
 
   /**

--- a/src/modules/catalog/catalog.module.ts
+++ b/src/modules/catalog/catalog.module.ts
@@ -1,10 +1,8 @@
 import { Module } from '@nestjs/common';
 import { CatalogController } from './catalog.controller';
 import { CatalogService } from './catalog.service';
-import { SessionModule } from '../session/session.module';
 
 @Module({
-  imports: [SessionModule],
   controllers: [CatalogController],
   providers: [CatalogService],
   exports: [CatalogService],

--- a/src/modules/catalog/catalog.service.ts
+++ b/src/modules/catalog/catalog.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { SessionService } from '../session/session.service';
+import { EngineRegistry } from '../../engine/engine-registry.service';
 import type {
   Catalog,
   Product,
@@ -9,45 +9,45 @@ import type {
 
 @Injectable()
 export class CatalogService {
-  constructor(private readonly sessionService: SessionService) {}
+  constructor(private readonly engines: EngineRegistry) {}
 
   async getCatalog(sessionId: string): Promise<Catalog | null> {
-    const engine = this.sessionService.getEngine(sessionId);
-    if (!engine) {
-      throw new NotFoundException(`Session ${sessionId} not found or not connected`);
-    }
+    const engine = this.engines.require(
+      sessionId,
+      () => new NotFoundException(`Session ${sessionId} not found or not connected`),
+    );
     return engine.getCatalog();
   }
 
   async getProducts(sessionId: string, page = 1, limit = 20): Promise<PaginatedProducts> {
-    const engine = this.sessionService.getEngine(sessionId);
-    if (!engine) {
-      throw new NotFoundException(`Session ${sessionId} not found or not connected`);
-    }
+    const engine = this.engines.require(
+      sessionId,
+      () => new NotFoundException(`Session ${sessionId} not found or not connected`),
+    );
     return engine.getProducts({ page, limit });
   }
 
   async getProduct(sessionId: string, productId: string): Promise<Product | null> {
-    const engine = this.sessionService.getEngine(sessionId);
-    if (!engine) {
-      throw new NotFoundException(`Session ${sessionId} not found or not connected`);
-    }
+    const engine = this.engines.require(
+      sessionId,
+      () => new NotFoundException(`Session ${sessionId} not found or not connected`),
+    );
     return engine.getProduct(productId);
   }
 
   async sendProduct(sessionId: string, chatId: string, productId: string, body?: string): Promise<MessageResult> {
-    const engine = this.sessionService.getEngine(sessionId);
-    if (!engine) {
-      throw new NotFoundException(`Session ${sessionId} not found or not connected`);
-    }
+    const engine = this.engines.require(
+      sessionId,
+      () => new NotFoundException(`Session ${sessionId} not found or not connected`),
+    );
     return engine.sendProduct(chatId, productId, body);
   }
 
   async sendCatalog(sessionId: string, chatId: string, body?: string): Promise<MessageResult> {
-    const engine = this.sessionService.getEngine(sessionId);
-    if (!engine) {
-      throw new NotFoundException(`Session ${sessionId} not found or not connected`);
-    }
+    const engine = this.engines.require(
+      sessionId,
+      () => new NotFoundException(`Session ${sessionId} not found or not connected`),
+    );
     return engine.sendCatalog(chatId, body);
   }
 }

--- a/src/modules/channel/channel.module.ts
+++ b/src/modules/channel/channel.module.ts
@@ -1,10 +1,8 @@
 import { Module } from '@nestjs/common';
 import { ChannelController } from './channel.controller';
 import { ChannelService } from './channel.service';
-import { SessionModule } from '../session/session.module';
 
 @Module({
-  imports: [SessionModule],
   controllers: [ChannelController],
   providers: [ChannelService],
 })

--- a/src/modules/channel/channel.service.spec.ts
+++ b/src/modules/channel/channel.service.spec.ts
@@ -1,12 +1,13 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { ChannelService } from './channel.service';
-import { SessionService } from '../session/session.service';
+import { EngineRegistry } from '../../engine/engine-registry.service';
 import { IWhatsAppEngine } from '../../engine/interfaces/whatsapp-engine.interface';
 
 describe('ChannelService', () => {
   const makeService = (engine: Partial<IWhatsAppEngine> | undefined) => {
-    const sessionService = { getEngine: jest.fn().mockReturnValue(engine) } as unknown as SessionService;
-    return new ChannelService(sessionService);
+    const engines = new EngineRegistry();
+    if (engine) engines.set('s1', engine as IWhatsAppEngine);
+    return new ChannelService(engines);
   };
 
   it('throws 400 when the session is not started', () => {

--- a/src/modules/channel/channel.service.ts
+++ b/src/modules/channel/channel.service.ts
@@ -1,5 +1,5 @@
-import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
-import { SessionService } from '../session/session.service';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { EngineRegistry } from '../../engine/engine-registry.service';
 import { IWhatsAppEngine } from '../../engine/interfaces/whatsapp-engine.interface';
 
 /**
@@ -10,14 +10,11 @@ import { IWhatsAppEngine } from '../../engine/interfaces/whatsapp-engine.interfa
 export class ChannelService {
   private static readonly MAX_CHANNEL_HISTORY_LIMIT = 100;
 
-  constructor(private readonly sessionService: SessionService) {}
+  constructor(private readonly engines: EngineRegistry) {}
 
   private getEngine(sessionId: string): IWhatsAppEngine {
-    const engine = this.sessionService.getEngine(sessionId);
-    if (!engine) {
-      throw new BadRequestException('Session is not started');
-    }
-    return engine;
+    // EngineRegistry.require()'s default is this exact 400 "Session is not started".
+    return this.engines.require(sessionId);
   }
 
   getSubscribedChannels(sessionId: string) {

--- a/src/modules/contact/contact.module.ts
+++ b/src/modules/contact/contact.module.ts
@@ -1,10 +1,8 @@
 import { Module } from '@nestjs/common';
 import { ContactController } from './contact.controller';
 import { ContactService } from './contact.service';
-import { SessionModule } from '../session/session.module';
 
 @Module({
-  imports: [SessionModule],
   controllers: [ContactController],
   providers: [ContactService],
   exports: [ContactService],

--- a/src/modules/contact/contact.service.spec.ts
+++ b/src/modules/contact/contact.service.spec.ts
@@ -1,12 +1,13 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { ContactService } from './contact.service';
-import { SessionService } from '../session/session.service';
+import { EngineRegistry } from '../../engine/engine-registry.service';
 import { IWhatsAppEngine } from '../../engine/interfaces/whatsapp-engine.interface';
 
 describe('ContactService', () => {
   const makeService = (engine: Partial<IWhatsAppEngine> | undefined) => {
-    const sessionService = { getEngine: jest.fn().mockReturnValue(engine) } as unknown as SessionService;
-    return new ContactService(sessionService);
+    const engines = new EngineRegistry();
+    if (engine) engines.set('s1', engine as IWhatsAppEngine);
+    return new ContactService(engines);
   };
 
   it('throws 400 when the session is not started', () => {

--- a/src/modules/contact/contact.service.ts
+++ b/src/modules/contact/contact.service.ts
@@ -1,5 +1,5 @@
-import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
-import { SessionService } from '../session/session.service';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { EngineRegistry } from '../../engine/engine-registry.service';
 import { IWhatsAppEngine } from '../../engine/interfaces/whatsapp-engine.interface';
 import { paginate, ListOptions } from '../../common/utils/paginate';
 
@@ -9,14 +9,11 @@ import { paginate, ListOptions } from '../../common/utils/paginate';
  */
 @Injectable()
 export class ContactService {
-  constructor(private readonly sessionService: SessionService) {}
+  constructor(private readonly engines: EngineRegistry) {}
 
   private getEngine(sessionId: string): IWhatsAppEngine {
-    const engine = this.sessionService.getEngine(sessionId);
-    if (!engine) {
-      throw new BadRequestException('Session is not started');
-    }
-    return engine;
+    // EngineRegistry.require()'s default is this exact 400 "Session is not started".
+    return this.engines.require(sessionId);
   }
 
   getContacts(sessionId: string, opts: ListOptions = {}) {

--- a/src/modules/group/group.module.ts
+++ b/src/modules/group/group.module.ts
@@ -1,10 +1,8 @@
 import { Module } from '@nestjs/common';
 import { GroupController } from './group.controller';
 import { GroupService } from './group.service';
-import { SessionModule } from '../session/session.module';
 
 @Module({
-  imports: [SessionModule],
   controllers: [GroupController],
   providers: [GroupService],
   exports: [GroupService],

--- a/src/modules/group/group.service.spec.ts
+++ b/src/modules/group/group.service.spec.ts
@@ -1,14 +1,15 @@
 import { BadRequestException, HttpException, NotFoundException } from '@nestjs/common';
 import { GroupService } from './group.service';
-import { SessionService } from '../session/session.service';
+import { EngineRegistry } from '../../engine/engine-registry.service';
 import { IWhatsAppEngine } from '../../engine/interfaces/whatsapp-engine.interface';
 import { EngineNotSupportedError } from '../../common/errors/engine-not-supported.error';
 import { EngineRefusedError } from '../../common/errors/engine-refused.error';
 
 describe('GroupService', () => {
   const makeService = (engine: Partial<IWhatsAppEngine> | undefined) => {
-    const sessionService = { getEngine: jest.fn().mockReturnValue(engine) } as unknown as SessionService;
-    return new GroupService(sessionService);
+    const engines = new EngineRegistry();
+    if (engine) engines.set('s1', engine as IWhatsAppEngine);
+    return new GroupService(engines);
   };
 
   it('throws 400 "Session is not started" when the engine is missing (guard preserved)', () => {

--- a/src/modules/group/group.service.ts
+++ b/src/modules/group/group.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, BadRequestException, HttpException, HttpStatus, NotFoundException } from '@nestjs/common';
-import { SessionService } from '../session/session.service';
+import { EngineRegistry } from '../../engine/engine-registry.service';
 import { IWhatsAppEngine } from '../../engine/interfaces/whatsapp-engine.interface';
 import { paginate, ListOptions } from '../../common/utils/paginate';
 
@@ -10,14 +10,11 @@ import { paginate, ListOptions } from '../../common/utils/paginate';
  */
 @Injectable()
 export class GroupService {
-  constructor(private readonly sessionService: SessionService) {}
+  constructor(private readonly engines: EngineRegistry) {}
 
   private getEngine(sessionId: string): IWhatsAppEngine {
-    const engine = this.sessionService.getEngine(sessionId);
-    if (!engine) {
-      throw new BadRequestException('Session is not started');
-    }
-    return engine;
+    // EngineRegistry.require()'s default is this exact 400 "Session is not started".
+    return this.engines.require(sessionId);
   }
 
   getGroups(sessionId: string, opts: ListOptions = {}) {

--- a/src/modules/label/label.module.ts
+++ b/src/modules/label/label.module.ts
@@ -1,10 +1,8 @@
 import { Module } from '@nestjs/common';
 import { LabelController } from './label.controller';
 import { LabelService } from './label.service';
-import { SessionModule } from '../session/session.module';
 
 @Module({
-  imports: [SessionModule],
   controllers: [LabelController],
   providers: [LabelService],
 })

--- a/src/modules/label/label.service.spec.ts
+++ b/src/modules/label/label.service.spec.ts
@@ -1,12 +1,13 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { LabelService } from './label.service';
-import { SessionService } from '../session/session.service';
+import { EngineRegistry } from '../../engine/engine-registry.service';
 import { IWhatsAppEngine } from '../../engine/interfaces/whatsapp-engine.interface';
 
 describe('LabelService', () => {
   const makeService = (engine: Partial<IWhatsAppEngine> | undefined) => {
-    const sessionService = { getEngine: jest.fn().mockReturnValue(engine) } as unknown as SessionService;
-    return new LabelService(sessionService);
+    const engines = new EngineRegistry();
+    if (engine) engines.set('s1', engine as IWhatsAppEngine);
+    return new LabelService(engines);
   };
 
   it('throws 400 when the session is not started', () => {

--- a/src/modules/label/label.service.ts
+++ b/src/modules/label/label.service.ts
@@ -1,5 +1,5 @@
-import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
-import { SessionService } from '../session/session.service';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { EngineRegistry } from '../../engine/engine-registry.service';
 import { IWhatsAppEngine } from '../../engine/interfaces/whatsapp-engine.interface';
 
 /**
@@ -8,14 +8,11 @@ import { IWhatsAppEngine } from '../../engine/interfaces/whatsapp-engine.interfa
  */
 @Injectable()
 export class LabelService {
-  constructor(private readonly sessionService: SessionService) {}
+  constructor(private readonly engines: EngineRegistry) {}
 
   private getEngine(sessionId: string): IWhatsAppEngine {
-    const engine = this.sessionService.getEngine(sessionId);
-    if (!engine) {
-      throw new BadRequestException('Session is not started');
-    }
-    return engine;
+    // EngineRegistry.require()'s default is this exact 400 "Session is not started".
+    return this.engines.require(sessionId);
   }
 
   getLabels(sessionId: string) {

--- a/src/modules/message/bulk-message.service.spec.ts
+++ b/src/modules/message/bulk-message.service.spec.ts
@@ -11,7 +11,8 @@ import {
 import { MessageBatch, BatchStatus, BatchMessageStatus, BatchMessageResult } from './entities/message-batch.entity';
 import { MessageStatus } from './entities/message.entity';
 import { SendBulkMessageDto } from './dto/bulk-message.dto';
-import { SessionService } from '../session/session.service';
+import { EngineRegistry } from '../../engine/engine-registry.service';
+import type { IWhatsAppEngine } from '../../engine/interfaces/whatsapp-engine.interface';
 import { MessageService } from './message.service';
 import { HookManager } from '../../core/hooks';
 import { SsrfBlockedError } from '../../common/security/ssrf-guard';
@@ -67,7 +68,7 @@ describe('BulkMessageService.onApplicationBootstrap', () => {
       providers: [
         BulkMessageService,
         { provide: getRepositoryToken(MessageBatch, 'data'), useValue: repo },
-        { provide: SessionService, useValue: { getEngine: jest.fn() } },
+        EngineRegistry,
         { provide: MessageService, useValue: { saveOutgoingMessage: jest.fn() } },
         {
           provide: HookManager,
@@ -126,7 +127,7 @@ describe('BulkMessageService.processBatch', () => {
     sendVideoMessage?: jest.Mock;
     sendAudioMessage?: jest.Mock;
   };
-  let sessionService: { getEngine: jest.Mock; findOne: jest.Mock };
+  let engines: EngineRegistry;
   let hookManager: { execute: jest.Mock };
 
   const makeBatch = (messageCount: number): MessageBatch =>
@@ -148,10 +149,8 @@ describe('BulkMessageService.processBatch', () => {
 
   beforeEach(async () => {
     engine = { sendTextMessage: jest.fn().mockResolvedValue({ id: 'wa1', timestamp: 111 }) };
-    sessionService = {
-      getEngine: jest.fn().mockReturnValue(engine),
-      findOne: jest.fn().mockResolvedValue({ phone: '628' }),
-    };
+    engines = new EngineRegistry();
+    engines.set('s1', engine as unknown as IWhatsAppEngine);
     messageService = { saveOutgoingMessage: jest.fn().mockResolvedValue(undefined) };
     hookManager = {
       execute: jest.fn().mockImplementation((_e: string, data: unknown) => Promise.resolve({ continue: true, data })),
@@ -166,7 +165,7 @@ describe('BulkMessageService.processBatch', () => {
       providers: [
         BulkMessageService,
         { provide: getRepositoryToken(MessageBatch, 'data'), useValue: repo },
-        { provide: SessionService, useValue: sessionService },
+        { provide: EngineRegistry, useValue: engines },
         { provide: MessageService, useValue: messageService },
         { provide: HookManager, useValue: hookManager },
       ],
@@ -197,7 +196,7 @@ describe('BulkMessageService.processBatch', () => {
 
   it('releases the in-flight marker when the engine is missing (no processingBatches leak)', async () => {
     repo.findOne.mockResolvedValue(makeBatch(1));
-    sessionService.getEngine.mockReturnValue(undefined); // engine-not-found → early-return path
+    engines.delete('s1'); // engine-not-found → early-return path
 
     await runProcessBatch();
 
@@ -578,7 +577,7 @@ describe('BulkMessageService.cancelBatch', () => {
       providers: [
         BulkMessageService,
         { provide: getRepositoryToken(MessageBatch, 'data'), useValue: repo },
-        { provide: SessionService, useValue: {} },
+        EngineRegistry,
         { provide: MessageService, useValue: {} },
         { provide: HookManager, useValue: { execute: jest.fn() } },
       ],
@@ -634,7 +633,7 @@ describe('BulkMessageService.cancelBatch', () => {
 describe('BulkMessageService.createBatch base64 media cap', () => {
   let service: BulkMessageService;
   let repo: { findOne: jest.Mock; save: jest.Mock; create: jest.Mock; update: jest.Mock };
-  let sessionService: { getEngine: jest.Mock };
+  let engines: EngineRegistry;
   let messageService: { saveOutgoingMessage: jest.Mock };
 
   beforeEach(async () => {
@@ -644,13 +643,16 @@ describe('BulkMessageService.createBatch base64 media cap', () => {
       create: jest.fn().mockImplementation((b: MessageBatch) => Object.assign({ id: 'b1' }, b)),
       update: jest.fn().mockResolvedValue({ affected: 1 }),
     };
-    sessionService = { getEngine: jest.fn().mockReturnValue({}) };
+    engines = new EngineRegistry();
+    // These suites exercise batch bookkeeping across several session ids, so every session is
+    // "started" here; the engine itself is never called.
+    for (const id of ['s1', 's2']) engines.set(id, {} as IWhatsAppEngine);
     messageService = { saveOutgoingMessage: jest.fn().mockResolvedValue(undefined) };
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         BulkMessageService,
         { provide: getRepositoryToken(MessageBatch, 'data'), useValue: repo },
-        { provide: SessionService, useValue: sessionService },
+        { provide: EngineRegistry, useValue: engines },
         { provide: MessageService, useValue: messageService },
         {
           provide: HookManager,
@@ -787,7 +789,7 @@ describe('BulkMessageService.createBatch base64 media cap', () => {
 
   it('runs the engine once per exact duplicate entry across the full create→process path', async () => {
     const engine = { sendTextMessage: jest.fn().mockResolvedValue({ id: 'wa', timestamp: 1 }) };
-    sessionService.getEngine.mockReturnValue(engine);
+    engines.set('s1', engine as unknown as IWhatsAppEngine);
     const dto = {
       messages: [
         { chatId: 'a@c.us', type: 'text' as const, content: { text: 'first' } },
@@ -813,7 +815,7 @@ describe('BulkMessageService.createBatch base64 media cap', () => {
       sendTextMessage: jest.fn().mockResolvedValue({ id: 'wa-t', timestamp: 1 }),
       sendImageMessage: jest.fn().mockResolvedValue({ id: 'wa-i', timestamp: 2 }),
     };
-    sessionService.getEngine.mockReturnValue(engine);
+    engines.set('s1', engine as unknown as IWhatsAppEngine);
     const dto = {
       messages: [
         { chatId: 'a@c.us', type: 'text' as const, content: { text: 'part 1' } },

--- a/src/modules/message/bulk-message.service.ts
+++ b/src/modules/message/bulk-message.service.ts
@@ -11,7 +11,7 @@ import {
 } from './entities/message-batch.entity';
 import { SendBulkMessageDto } from './dto/bulk-message.dto';
 import { MessageStatus } from './entities/message.entity';
-import { SessionService } from '../session/session.service';
+import { EngineRegistry } from '../../engine/engine-registry.service';
 import { MessageService } from './message.service';
 import { HookManager } from '../../core/hooks';
 import { assertBase64WithinMediaCap, stripBase64DataUri } from './media-cap.util';
@@ -79,7 +79,7 @@ export class BulkMessageService implements OnApplicationBootstrap {
   constructor(
     @InjectRepository(MessageBatch, 'data')
     private readonly batchRepository: Repository<MessageBatch>,
-    private readonly sessionService: SessionService,
+    private readonly engines: EngineRegistry,
     private readonly messageService: MessageService,
     private readonly hookManager: HookManager,
   ) {}
@@ -105,11 +105,8 @@ export class BulkMessageService implements OnApplicationBootstrap {
   }
 
   async createBatch(sessionId: string, dto: SendBulkMessageDto): Promise<MessageBatch> {
-    // Validate session exists
-    const engine = this.sessionService.getEngine(sessionId);
-    if (!engine) {
-      throw new BadRequestException(`Session '${sessionId}' is not active`);
-    }
+    // Validate the session is started (guard only — the batch is sent later, by drainBatch).
+    this.engines.require(sessionId, () => new BadRequestException(`Session '${sessionId}' is not active`));
 
     // Collapse exact duplicate entries — same chatId, type, content, and variables; first
     // occurrence wins, order preserved. A true repeat would only re-run the engine (and the
@@ -300,7 +297,7 @@ export class BulkMessageService implements OnApplicationBootstrap {
       return;
     }
 
-    const engine = this.sessionService.getEngine(batch.sessionId);
+    const engine = this.engines.get(batch.sessionId);
     if (!engine) {
       batch.status = BatchStatus.FAILED;
       batch.completedAt = new Date();

--- a/src/modules/message/message.service.spec.ts
+++ b/src/modules/message/message.service.spec.ts
@@ -6,6 +6,7 @@ import { MessageService } from './message.service';
 import { Message, MessageDirection, MessageStatus } from './entities/message.entity';
 import { SessionService } from '../session/session.service';
 import { EngineRegistry } from '../../engine/engine-registry.service';
+import { MessageProjector } from '../session/message-projector.service';
 import type { IWhatsAppEngine } from '../../engine/interfaces/whatsapp-engine.interface';
 import { HookManager } from '../../core/hooks';
 import { TemplateService } from '../template/template.service';
@@ -42,6 +43,7 @@ describe('MessageService', () => {
   let repository: jest.Mocked<Partial<Repository<Message>>>;
   let sessionService: jest.Mocked<Partial<SessionService>>;
   let engines: EngineRegistry;
+  let messageProjector: { recordOutboundMessageEdit: jest.Mock };
   let hookManager: jest.Mocked<Partial<HookManager>>;
   let templateService: jest.Mocked<Partial<TemplateService>>;
   let lidMappingStore: { lidsForPhone: jest.Mock; getCached: jest.Mock };
@@ -71,8 +73,9 @@ describe('MessageService', () => {
 
     sessionService = {
       findOne: jest.fn().mockResolvedValue({ id: 'sess-1', phone: '628123456789' }),
-      recordOutboundMessageEdit: jest.fn().mockResolvedValue(undefined),
     };
+
+    messageProjector = { recordOutboundMessageEdit: jest.fn().mockResolvedValue(undefined) };
 
     engines = new EngineRegistry();
     engines.set('sess-1', mockEngine as unknown as IWhatsAppEngine);
@@ -97,6 +100,7 @@ describe('MessageService', () => {
         { provide: getRepositoryToken(Message, 'data'), useValue: repository },
         { provide: SessionService, useValue: sessionService },
         { provide: EngineRegistry, useValue: engines },
+        { provide: MessageProjector, useValue: messageProjector },
         { provide: HookManager, useValue: hookManager },
         { provide: TemplateService, useValue: templateService },
         { provide: LidMappingStoreService, useValue: lidMappingStore },
@@ -395,11 +399,12 @@ describe('MessageService', () => {
     it('honors a configured template.renderMaxChars override', async () => {
       const configService = {
         get: (key: string, fallback: unknown) => (key === 'template.renderMaxChars' ? 10 : fallback),
-      } as unknown as ConstructorParameters<typeof MessageService>[6];
+      } as unknown as ConstructorParameters<typeof MessageService>[7];
       const capped = new MessageService(
         repository as Repository<Message>,
         sessionService as unknown as SessionService,
         engines,
+        messageProjector as unknown as MessageProjector,
         hookManager as HookManager,
         templateService as unknown as TemplateService,
         lidMappingStore as unknown as LidMappingStoreService,
@@ -1288,7 +1293,7 @@ describe('MessageService', () => {
       expect(mockEngine.editMessage).toHaveBeenCalledWith('test@c.us', 'wa-msg-1', 'edited');
       // Persistence is delegated to the session's per-message mutation queue (serialized with the
       // inbound edit path) — the service no longer writes the row directly.
-      expect(sessionService.recordOutboundMessageEdit).toHaveBeenCalledWith('sess-1', 'wa-msg-1', 'edited');
+      expect(messageProjector.recordOutboundMessageEdit).toHaveBeenCalledWith('sess-1', 'wa-msg-1', 'edited');
       expect(repository.update).not.toHaveBeenCalled();
       expect(res).toEqual({ messageId: 'wa-msg-1', timestamp: 1706868000 });
     });
@@ -1306,7 +1311,7 @@ describe('MessageService', () => {
       await expect(
         service.editMessage('sess-1', { chatId: 'test@c.us', messageId: 'wa-msg-1', body: 'edited' }),
       ).rejects.toBeInstanceOf(NotFoundException);
-      expect(sessionService.recordOutboundMessageEdit).not.toHaveBeenCalled();
+      expect(messageProjector.recordOutboundMessageEdit).not.toHaveBeenCalled();
     });
 
     it('throws BadRequestException when the session is not started', async () => {
@@ -1337,7 +1342,7 @@ describe('MessageService', () => {
       ).rejects.toThrow('Message sending blocked by plugin');
 
       expect(mockEngine.editMessage).not.toHaveBeenCalled();
-      expect(sessionService.recordOutboundMessageEdit).not.toHaveBeenCalled();
+      expect(messageProjector.recordOutboundMessageEdit).not.toHaveBeenCalled();
     });
 
     it('threads a plugin-rewritten edit body through to the engine and the stored row', async () => {
@@ -1349,7 +1354,7 @@ describe('MessageService', () => {
       await service.editMessage('sess-1', { chatId: 'test@c.us', messageId: 'wa-msg-1', body: 'secret' });
 
       expect(mockEngine.editMessage).toHaveBeenCalledWith('test@c.us', 'wa-msg-1', 'redacted');
-      expect(sessionService.recordOutboundMessageEdit).toHaveBeenCalledWith('sess-1', 'wa-msg-1', 'redacted');
+      expect(messageProjector.recordOutboundMessageEdit).toHaveBeenCalledWith('sess-1', 'wa-msg-1', 'redacted');
     });
   });
 

--- a/src/modules/message/message.service.spec.ts
+++ b/src/modules/message/message.service.spec.ts
@@ -5,6 +5,8 @@ import { BadRequestException, NotFoundException, PayloadTooLargeException } from
 import { MessageService } from './message.service';
 import { Message, MessageDirection, MessageStatus } from './entities/message.entity';
 import { SessionService } from '../session/session.service';
+import { EngineRegistry } from '../../engine/engine-registry.service';
+import type { IWhatsAppEngine } from '../../engine/interfaces/whatsapp-engine.interface';
 import { HookManager } from '../../core/hooks';
 import { TemplateService } from '../template/template.service';
 import { Template } from '../template/entities/template.entity';
@@ -39,6 +41,7 @@ describe('MessageService', () => {
   let service: MessageService;
   let repository: jest.Mocked<Partial<Repository<Message>>>;
   let sessionService: jest.Mocked<Partial<SessionService>>;
+  let engines: EngineRegistry;
   let hookManager: jest.Mocked<Partial<HookManager>>;
   let templateService: jest.Mocked<Partial<TemplateService>>;
   let lidMappingStore: { lidsForPhone: jest.Mock; getCached: jest.Mock };
@@ -67,10 +70,12 @@ describe('MessageService', () => {
     mockEngine = createMockEngine();
 
     sessionService = {
-      getEngine: jest.fn().mockReturnValue(mockEngine),
       findOne: jest.fn().mockResolvedValue({ id: 'sess-1', phone: '628123456789' }),
       recordOutboundMessageEdit: jest.fn().mockResolvedValue(undefined),
     };
+
+    engines = new EngineRegistry();
+    engines.set('sess-1', mockEngine as unknown as IWhatsAppEngine);
 
     hookManager = {
       // Echo the input straight back so the message:sending gate is a pass-through by default; specific
@@ -91,6 +96,7 @@ describe('MessageService', () => {
         MessageService,
         { provide: getRepositoryToken(Message, 'data'), useValue: repository },
         { provide: SessionService, useValue: sessionService },
+        { provide: EngineRegistry, useValue: engines },
         { provide: HookManager, useValue: hookManager },
         { provide: TemplateService, useValue: templateService },
         { provide: LidMappingStoreService, useValue: lidMappingStore },
@@ -268,7 +274,7 @@ describe('MessageService', () => {
     });
 
     it('should throw BadRequestException if session is not active', async () => {
-      (sessionService.getEngine as jest.Mock).mockReturnValue(undefined);
+      engines.delete('sess-1');
 
       await expect(service.sendText('inactive', { chatId: 'test@c.us', text: 'hello' })).rejects.toThrow(
         BadRequestException,
@@ -389,10 +395,11 @@ describe('MessageService', () => {
     it('honors a configured template.renderMaxChars override', async () => {
       const configService = {
         get: (key: string, fallback: unknown) => (key === 'template.renderMaxChars' ? 10 : fallback),
-      } as unknown as ConstructorParameters<typeof MessageService>[5];
+      } as unknown as ConstructorParameters<typeof MessageService>[6];
       const capped = new MessageService(
         repository as Repository<Message>,
         sessionService as unknown as SessionService,
+        engines,
         hookManager as HookManager,
         templateService as unknown as TemplateService,
         lidMappingStore as unknown as LidMappingStoreService,
@@ -1303,7 +1310,7 @@ describe('MessageService', () => {
     });
 
     it('throws BadRequestException when the session is not started', async () => {
-      (sessionService.getEngine as jest.Mock).mockReturnValue(undefined);
+      engines.delete('sess-1');
       await expect(
         service.editMessage('sess-1', { chatId: 'test@c.us', messageId: 'wa-msg-1', body: 'edited' }),
       ).rejects.toBeInstanceOf(BadRequestException);

--- a/src/modules/message/message.service.ts
+++ b/src/modules/message/message.service.ts
@@ -5,6 +5,7 @@ import { Repository } from 'typeorm';
 import { QueryDeepPartialEntity } from 'typeorm';
 import { SessionService } from '../session/session.service';
 import { EngineRegistry } from '../../engine/engine-registry.service';
+import { MessageProjector } from '../session/message-projector.service';
 import { SendTextMessageDto, SendMediaMessageDto, SendAudioMessageDto, MessageResponseDto } from './dto';
 import { SendTemplateMessageDto } from './dto/send-template.dto';
 import { assertBase64WithinMediaCap, stripBase64DataUri } from './media-cap.util';
@@ -55,6 +56,7 @@ export class MessageService {
     private readonly messageRepository: Repository<Message>,
     private readonly sessionService: SessionService,
     private readonly engines: EngineRegistry,
+    private readonly messageProjector: MessageProjector,
     private readonly hookManager: HookManager,
     private readonly templateService: TemplateService,
     private readonly lidMappingStore: LidMappingStoreService,
@@ -762,7 +764,7 @@ export class MessageService {
     // Best-effort: reflect the new body in the stored copy (mirrors deleteMessage's revoked flag),
     // serialized with the inbound edit/reaction writers through the session's per-message mutation
     // queue. A missing row must not fail the request — the engine edit already succeeded.
-    await this.sessionService.recordOutboundMessageEdit(sessionId, finalDto.messageId, finalDto.body);
+    await this.messageProjector.recordOutboundMessageEdit(sessionId, finalDto.messageId, finalDto.body);
     return { messageId: result.id, timestamp: result.timestamp };
   }
 

--- a/src/modules/message/message.service.ts
+++ b/src/modules/message/message.service.ts
@@ -4,6 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { QueryDeepPartialEntity } from 'typeorm';
 import { SessionService } from '../session/session.service';
+import { EngineRegistry } from '../../engine/engine-registry.service';
 import { SendTextMessageDto, SendMediaMessageDto, SendAudioMessageDto, MessageResponseDto } from './dto';
 import { SendTemplateMessageDto } from './dto/send-template.dto';
 import { assertBase64WithinMediaCap, stripBase64DataUri } from './media-cap.util';
@@ -53,6 +54,7 @@ export class MessageService {
     @InjectRepository(Message, 'data')
     private readonly messageRepository: Repository<Message>,
     private readonly sessionService: SessionService,
+    private readonly engines: EngineRegistry,
     private readonly hookManager: HookManager,
     private readonly templateService: TemplateService,
     private readonly lidMappingStore: LidMappingStoreService,
@@ -765,11 +767,10 @@ export class MessageService {
   }
 
   private getEngine(sessionId: string) {
-    const engine = this.sessionService.getEngine(sessionId);
-    if (!engine) {
-      throw new BadRequestException(`Session '${sessionId}' is not active. Start the session first.`);
-    }
-    return engine;
+    return this.engines.require(
+      sessionId,
+      () => new BadRequestException(`Session '${sessionId}' is not active. Start the session first.`),
+    );
   }
 
   /**

--- a/src/modules/profile/profile.module.ts
+++ b/src/modules/profile/profile.module.ts
@@ -1,10 +1,8 @@
 import { Module } from '@nestjs/common';
 import { ProfileController } from './profile.controller';
 import { ProfileService } from './profile.service';
-import { SessionModule } from '../session/session.module';
 
 @Module({
-  imports: [SessionModule],
   controllers: [ProfileController],
   providers: [ProfileService],
   exports: [ProfileService],

--- a/src/modules/profile/profile.service.spec.ts
+++ b/src/modules/profile/profile.service.spec.ts
@@ -1,12 +1,13 @@
 import { BadRequestException } from '@nestjs/common';
 import { ProfileService } from './profile.service';
-import { SessionService } from '../session/session.service';
+import { EngineRegistry } from '../../engine/engine-registry.service';
 import { IWhatsAppEngine, MediaInput } from '../../engine/interfaces/whatsapp-engine.interface';
 
 describe('ProfileService', () => {
   const makeService = (engine: Partial<IWhatsAppEngine> | undefined) => {
-    const sessionService = { getEngine: jest.fn().mockReturnValue(engine) } as unknown as SessionService;
-    return new ProfileService(sessionService);
+    const engines = new EngineRegistry();
+    if (engine) engines.set('s1', engine as IWhatsAppEngine);
+    return new ProfileService(engines);
   };
 
   it('throws 400 "Session is not started" when the engine is missing (guard preserved)', () => {

--- a/src/modules/profile/profile.service.ts
+++ b/src/modules/profile/profile.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, BadRequestException } from '@nestjs/common';
-import { SessionService } from '../session/session.service';
+import { EngineRegistry } from '../../engine/engine-registry.service';
 import { IWhatsAppEngine, MediaInput } from '../../engine/interfaces/whatsapp-engine.interface';
 import { assertBase64WithinMediaCap, stripBase64DataUri } from '../message/media-cap.util';
 import { SetProfilePictureDto } from './dto/profile.dto';
@@ -10,14 +10,11 @@ import { SetProfilePictureDto } from './dto/profile.dto';
  */
 @Injectable()
 export class ProfileService {
-  constructor(private readonly sessionService: SessionService) {}
+  constructor(private readonly engines: EngineRegistry) {}
 
   private getEngine(sessionId: string): IWhatsAppEngine {
-    const engine = this.sessionService.getEngine(sessionId);
-    if (!engine) {
-      throw new BadRequestException('Session is not started');
-    }
-    return engine;
+    // EngineRegistry.require()'s default is this exact 400 "Session is not started".
+    return this.engines.require(sessionId);
   }
 
   setProfileName(sessionId: string, name: string) {

--- a/src/modules/session/logout-teardown-race.spec.ts
+++ b/src/modules/session/logout-teardown-race.spec.ts
@@ -10,6 +10,7 @@ import { EngineFactory } from '../../engine/engine.factory';
 import { EngineRegistry } from '../../engine/engine-registry.service';
 import { SessionLidResolver } from './session-lid-resolver.service';
 import { SessionLivenessWatchdog } from './session-liveness-watchdog.service';
+import { MessageProjector } from './message-projector.service';
 import { LidMappingStoreService } from '../../engine/identity/lid-mapping-store.service';
 import { EventsGateway } from '../events/events.gateway';
 import { WebhookService } from '../webhook/webhook.service';
@@ -96,6 +97,7 @@ describe('SessionService logout() name-scoped teardown fence', () => {
         EngineRegistry,
         SessionLidResolver,
         SessionLivenessWatchdog,
+        MessageProjector,
         {
           provide: EventsGateway,
           useValue: { emitSessionStatus: jest.fn(), emitSessionDisconnected: jest.fn(), emitQRCode: jest.fn() },

--- a/src/modules/session/logout-teardown-race.spec.ts
+++ b/src/modules/session/logout-teardown-race.spec.ts
@@ -8,6 +8,7 @@ import { Session, SessionStatus } from './entities/session.entity';
 import { Message } from '../message/entities/message.entity';
 import { EngineFactory } from '../../engine/engine.factory';
 import { EngineRegistry } from '../../engine/engine-registry.service';
+import { SessionLidResolver } from './session-lid-resolver.service';
 import { LidMappingStoreService } from '../../engine/identity/lid-mapping-store.service';
 import { EventsGateway } from '../events/events.gateway';
 import { WebhookService } from '../webhook/webhook.service';
@@ -92,6 +93,7 @@ describe('SessionService logout() name-scoped teardown fence', () => {
         { provide: EngineFactory, useValue: engineFactory },
         // Real registry: this suite asserts on engine map state across the teardown fence.
         EngineRegistry,
+        SessionLidResolver,
         {
           provide: EventsGateway,
           useValue: { emitSessionStatus: jest.fn(), emitSessionDisconnected: jest.fn(), emitQRCode: jest.fn() },

--- a/src/modules/session/logout-teardown-race.spec.ts
+++ b/src/modules/session/logout-teardown-race.spec.ts
@@ -7,6 +7,7 @@ import { SessionService } from './session.service';
 import { Session, SessionStatus } from './entities/session.entity';
 import { Message } from '../message/entities/message.entity';
 import { EngineFactory } from '../../engine/engine.factory';
+import { EngineRegistry } from '../../engine/engine-registry.service';
 import { LidMappingStoreService } from '../../engine/identity/lid-mapping-store.service';
 import { EventsGateway } from '../events/events.gateway';
 import { WebhookService } from '../webhook/webhook.service';
@@ -89,6 +90,8 @@ describe('SessionService logout() name-scoped teardown fence', () => {
         { provide: getRepositoryToken(Message, 'data'), useValue: messageRepository },
         { provide: getDataSourceToken('data'), useValue: dataSource },
         { provide: EngineFactory, useValue: engineFactory },
+        // Real registry: this suite asserts on engine map state across the teardown fence.
+        EngineRegistry,
         {
           provide: EventsGateway,
           useValue: { emitSessionStatus: jest.fn(), emitSessionDisconnected: jest.fn(), emitQRCode: jest.fn() },

--- a/src/modules/session/logout-teardown-race.spec.ts
+++ b/src/modules/session/logout-teardown-race.spec.ts
@@ -9,6 +9,7 @@ import { Message } from '../message/entities/message.entity';
 import { EngineFactory } from '../../engine/engine.factory';
 import { EngineRegistry } from '../../engine/engine-registry.service';
 import { SessionLidResolver } from './session-lid-resolver.service';
+import { SessionLivenessWatchdog } from './session-liveness-watchdog.service';
 import { LidMappingStoreService } from '../../engine/identity/lid-mapping-store.service';
 import { EventsGateway } from '../events/events.gateway';
 import { WebhookService } from '../webhook/webhook.service';
@@ -94,6 +95,7 @@ describe('SessionService logout() name-scoped teardown fence', () => {
         // Real registry: this suite asserts on engine map state across the teardown fence.
         EngineRegistry,
         SessionLidResolver,
+        SessionLivenessWatchdog,
         {
           provide: EventsGateway,
           useValue: { emitSessionStatus: jest.fn(), emitSessionDisconnected: jest.fn(), emitQRCode: jest.fn() },

--- a/src/modules/session/message-projector.service.ts
+++ b/src/modules/session/message-projector.service.ts
@@ -1,0 +1,686 @@
+import { Injectable, Optional } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, In } from 'typeorm';
+import { QueryDeepPartialEntity } from 'typeorm';
+import { Session } from './entities/session.entity';
+import { Message, MessageDirection, MessageStatus } from '../message/entities/message.entity';
+import { EngineRegistry } from '../../engine/engine-registry.service';
+import { KeyedMutationQueue } from '../../common/utils/keyed-mutation-queue';
+import { SessionLidResolver } from './session-lid-resolver.service';
+import { buildMessageMetadata, storableWaMessageId } from './message-row.mapper';
+import { isUniqueConstraintError } from '../../common/utils/unique-constraint.util';
+import { resolveFeatureFlags } from '../../config/feature-flags';
+import { StatusStoreService } from '../status-store/status-store.service';
+import { buildIncomingStatus } from '../status-store/incoming-status';
+import type { StatusUpdate } from '../status-store/entities/status-update.entity';
+import {
+  IWhatsAppEngine,
+  DeliveryStatus,
+  IncomingMessage,
+  ReactionEvent,
+  EditedMessage,
+  RevokedMessage,
+} from '../../engine/interfaces/whatsapp-engine.interface';
+import { createLogger } from '../../common/services/logger.service';
+import { EventsGateway } from '../events/events.gateway';
+import { WebhookService } from '../webhook/webhook.service';
+import { HookManager } from '../../core/hooks';
+import {
+  deliveryStatusToMessageStatus,
+  deliveryStatusToAck,
+  ackStatusTransitionFrom,
+} from '../message/message-status.util';
+
+/**
+ * Projects engine message events into the `messages` table and out to webhooks/WebSocket.
+ *
+ * This is the data path for messages: inbound arrivals, own-send echoes, delivery acks, revokes,
+ * reactions, edits, and the pre-connection history backfill. It is deliberately separate from
+ * SessionService, which owns the session *lifecycle* (start/stop/delete/reconnect). The two share
+ * only the engine identity guard — a late event from a superseded engine must never mutate a
+ * session that now belongs to a different one, or to none — which both read from EngineRegistry.
+ *
+ * Every entry point takes the captured `(sessionId, engine)` pair its engine callback closed over,
+ * so those staleness checks behave exactly as they did while this code sat inline in
+ * initializeEngine.
+ */
+/**
+ * Delay before retrying an ack UPDATE that matched 0 rows. A fast delivered/read ack can arrive before
+ * the send's 2nd save (which writes waMessageId) has committed, so the first UPDATE finds no row. One
+ * retry after this delay closes that race; the forward-only transition guard keeps it idempotent.
+ */
+export const ACK_RECONCILE_DELAY_MS = 750;
+
+@Injectable()
+export class MessageProjector {
+  private readonly logger = createLogger('MessageProjector');
+
+  // Serializes stored-message mutations per `${sessionId}:${waMessageId}`. Reactions perform a
+  // read-modify-write and rapid edits must remain latest-write-wins; sharing one chain also preserves
+  // order when different mutation kinds for the same message arrive together.
+  private readonly messageMutations = new KeyedMutationQueue((key, err) => {
+    // Both current mutation implementations contain their own contextual error handling. Keep a
+    // final guard here so a future implementation cannot leak a rejected fire-and-forget promise
+    // or permanently block the message's later mutations.
+    this.logger.error(`Unexpected failure applying message mutation: ${key}`, String(err));
+  });
+
+  constructor(
+    @InjectRepository(Message, 'data')
+    private readonly messageRepository: Repository<Message>,
+    @InjectRepository(Session, 'data')
+    private readonly sessionRepository: Repository<Session>,
+    private readonly engines: EngineRegistry,
+    private readonly eventsGateway: EventsGateway,
+    private readonly webhookService: WebhookService,
+    private readonly hookManager: HookManager,
+    private readonly statusStore: StatusStoreService,
+    private readonly lidResolver: SessionLidResolver,
+    @Optional()
+    private readonly configService?: ConfigService,
+  ) {}
+
+  /** Engine callback body, lifted out of initializeEngine so the wiring table stays readable. */
+  handleInboundMessage(id: string, engine: IWhatsAppEngine, message: IncomingMessage): void {
+    if (!this.engines.isLive(id, engine)) return;
+    // Status/Story posts arrive via the inbound path for some engines; ingest them into the
+    // status store instead of the message pipeline. Mirrors the isStatusBroadcast guard in
+    // onMessageCreate below: an own-send echo (fromMe) stays a plain drop — never ingested,
+    // never dispatched — so a status you posted never re-appears in your own webhooks/API as
+    // if a contact had posted it.
+    if (message.isStatusBroadcast) {
+      if (message.fromMe) return;
+      const status = buildIncomingStatus(message);
+      if (status) {
+        void this.statusStore
+          .ingest(id, status)
+          // Dispatch only on a fresh insert: ingest also resolves with the pre-existing row
+          // for a duplicate delivery (or the winner's row after a lost insert race), and the
+          // webhook must fire once per status, not once per (re)delivery.
+          .then(({ row, created }) => {
+            // The ingest awaited; a stop()/delete() can retire this engine mid-flight — don't
+            // dispatch for a session that no longer exists (mirrors message.received's re-check).
+            if (!this.engines.isLive(id, engine)) return;
+            if (created) this.dispatchStatusReceived(id, row);
+          })
+          .catch(err =>
+            this.logger.warn('Status ingest failed', {
+              sessionId: id,
+              error: err instanceof Error ? err.message : String(err),
+            }),
+          );
+      }
+      return;
+    }
+    // Ephemeral/disappearing messages: skip persist + dispatch when the operator opted out.
+    // A message is ephemeral when its chat has a disappearing-messages timer (ephemeralDuration > 0).
+    if (
+      !resolveFeatureFlags(this.configService).storeEphemeralMessages &&
+      message.ephemeralDuration &&
+      message.ephemeralDuration > 0
+    ) {
+      this.logger.debug('Skipping ephemeral message', {
+        sessionId: id,
+        messageId: message.id,
+        chatId: message.chatId,
+        ephemeralDuration: message.ephemeralDuration,
+      });
+      return;
+    }
+    this.logger.debug(`Message received from ${message.from}`, {
+      sessionId: id,
+      messageId: message.id,
+      from: message.from,
+      action: 'message_received',
+    });
+    // Update last active timestamp
+    void this.sessionRepository.update(id, { lastActiveAt: new Date() }).catch(() => undefined);
+    // Convert IncomingMessage to plain object for dispatch
+    const messageData = { ...message };
+
+    // Execute hook for message received - plugins can modify or stop processing
+    void this.hookManager
+      .execute('message:received', messageData, {
+        sessionId: id,
+        source: 'Engine',
+      })
+      .then(async ({ data: finalMessage }) => {
+        // `continue: false` is deliberately NOT read here. It means "stop the handler chain", which
+        // HookManager has already done — the plugins after the one that returned it never ran. It
+        // does not mean "this message never happened".
+        //
+        // Honouring it here used to skip everything below: the message was never written to the
+        // messages table, never dispatched to webhooks, and never emitted over the websocket. An
+        // auto-reply plugin returning `false` for its ordinary purpose — keeping other bots from
+        // answering the same message — silently erased the customer's message from the operator's
+        // own history, leaving a thread of bot replies answering nothing. Nothing in the hook
+        // contract (`HookResult.continue`, docs/19) or the webhook contract (`message.received`
+        // fires when "an inbound message arrives", docs/06) hinted at that, and a sandboxed
+        // marketplace plugin could swallow a session's entire inbound traffic with no audit trail.
+        //
+        // The message has already arrived at WhatsApp. A plugin can stop other plugins from acting
+        // on it; it cannot make the gateway forget it. Pre-action hooks are where a veto belongs —
+        // `message:sending` blocks a send that has not happened yet (core/hooks/sending-gate.ts).
+
+        // Persist the incoming message so the dashboard chats view can render history.
+        const incoming: IncomingMessage = finalMessage;
+
+        // Inline @lid -> phone resolution (#263), opt-in via RESOLVE_LID_TO_PHONE. Best-effort:
+        // attaches senderPhone (digits or null) before persist/dispatch so webhook/ws consumers
+        // get it in a single pass. Only for privacy-id senders, so no lookup for normal numbers.
+        if (resolveFeatureFlags(this.configService).resolveLidToPhone && incoming.isLidSender && !incoming.fromMe) {
+          incoming.senderPhone = await this.lidResolver.resolveSenderPhone(id, incoming.author ?? incoming.from);
+        }
+
+        const metadata = buildMessageMetadata(incoming);
+
+        const chatName = incoming.contact?.pushName ?? incoming.contact?.name ?? undefined;
+
+        const dbMessage = this.messageRepository.create({
+          sessionId: id,
+          waMessageId: storableWaMessageId(incoming.id),
+          chatId: incoming.chatId,
+          chatName,
+          // Group poster (participant JID) — `from` is the group JID, so this is the stable
+          // sender identity the chat view keys attribution runs/colors on. Undefined for 1:1.
+          author: incoming.author,
+          from: incoming.from,
+          to: incoming.to,
+          body: incoming.body,
+          type: incoming.type,
+          direction: incoming.fromMe ? MessageDirection.OUTGOING : MessageDirection.INCOMING,
+          timestamp: incoming.timestamp,
+          status: MessageStatus.SENT,
+          metadata,
+        });
+
+        // The hook chain above is async; a delete()/teardown can retire this engine while it
+        // awaits. Re-check liveness so a late continuation can't persist an orphan messages row
+        // (the row has no FK, so a session-delete cleanup would never reap it) or dispatch for a
+        // session that no longer exists. Mirrors the synchronous isLiveEngine gate at entry.
+        if (!this.engines.isLive(id, engine)) return;
+
+        // De-duplicate at the source: the engine can re-fire `message` for one inbound message
+        // (#464). UNIQUE(sessionId, waMessageId) makes the insert the atomic dedup oracle — a
+        // near-simultaneous re-fire loses the race and is skipped here, so persist + webhook + WS
+        // happen exactly once. Fail-open: a non-conflict DB error still dispatches, so a real
+        // message is never dropped by a transient DB failure.
+        let isNewMessage = true;
+        let persisted = false;
+        try {
+          // `insert()` (not `save()`) is load-bearing: the UNIQUE(sessionId, waMessageId) constraint
+          // makes a duplicate insert throw, which is the atomic dedup oracle for #464 re-fires.
+          // Unlike `save()`, `insert()` does NOT merge DB-generated columns (@PrimaryGeneratedColumn,
+          // @CreateDateColumn) back onto the entity instance — so merge them explicitly here, before
+          // the `message:persisted` emit. `identifiers[0]` always carries the PK on both SQLite and
+          // Postgres; `generatedMaps[0]` adds createdAt where the driver returns it (Postgres yes;
+          // SQLite historically does not — acceptable; the PK is the load-bearing field for plugins).
+          const result = await this.messageRepository.insert(dbMessage as unknown as QueryDeepPartialEntity<Message>);
+          Object.assign(dbMessage, result.identifiers[0] ?? {}, result.generatedMaps?.[0] ?? {});
+          persisted = true;
+        } catch (err) {
+          if (isUniqueConstraintError(err)) {
+            isNewMessage = false;
+          } else {
+            this.logger.error(`Failed to save incoming message ${incoming.id} to database`, String(err));
+          }
+        }
+        if (!isNewMessage) {
+          return; // duplicate re-fire — the original already persisted and dispatched
+        }
+
+        // Fire-and-forget: a plugin handler must never break the receive path. Both engine adapters
+        // (wwjs `message` and Baileys `upsert`) converge on this persist, so one emit covers inbound.
+        // The built-in FTS search provider is DB-synced and does NOT consume this; it exists for
+        // plugin providers (Spec 2) + general use.
+        // Gate ONLY the hook on `persisted`: on a non-unique insert error (transient SQLITE_BUSY /
+        // lock-timeout / connection drop) the row was never stored and `dbMessage.id` is undefined,
+        // so emitting `message:persisted` would hand plugins an id-less payload for a row that isn't
+        // in the DB. The webhook/WS dispatch below stays fail-open — a real inbound message must
+        // never be dropped on a transient DB failure; only the hook requires a durable row.
+        if (persisted) {
+          void this.hookManager
+            .execute(
+              'message:persisted',
+              { sessionId: id, message: dbMessage },
+              { sessionId: id, source: 'SessionService' },
+            )
+            .catch(() => undefined);
+        }
+
+        // Dispatch to webhooks with potentially modified message
+        void this.webhookService.dispatch(id, 'message.received', finalMessage);
+        // Emit real-time event to WebSocket clients
+        this.eventsGateway.emitMessage(id, finalMessage);
+      })
+      .catch(err => this.logger.error(`onMessage handler failed for ${id}`, String(err)));
+  }
+
+  /** Engine callback body, lifted out of initializeEngine so the wiring table stays readable. */
+  handleOwnSendEcho(id: string, engine: IWhatsAppEngine, message: IncomingMessage): void {
+    if (!this.engines.isLive(id, engine)) return;
+    // `message_create` fires for every message the account creates, including sends composed on a
+    // linked phone — which the `message`/`onMessage` event never delivers. Incoming messages are
+    // already handled by `onMessage`, so only outgoing (`fromMe`) ones produce `message.sent` here.
+    if (!message.fromMe) {
+      return;
+    }
+
+    // Status/Story posts are account-created but not real conversations; don't emit `message.sent`
+    // for them. The adapter flags these (the engine-specific pseudo-JID stays out of this layer).
+    if (message.isStatusBroadcast) {
+      return;
+    }
+
+    this.logger.debug(`Message sent to ${message.to}`, {
+      sessionId: id,
+      messageId: message.id,
+      to: message.to,
+      action: 'message_sent',
+    });
+    // Update last active timestamp
+    void this.sessionRepository.update(id, { lastActiveAt: new Date() }).catch(() => undefined);
+    const messageData = { ...message };
+
+    // Execute hook for message sent - plugins can modify or stop processing
+    void this.hookManager
+      .execute('message:sent', messageData, {
+        sessionId: id,
+        source: 'Engine',
+      })
+      .then(async ({ data: finalMessage }) => {
+        // `continue: false` is not read here, for the same reason as the message:received path
+        // above: the send has already happened, so a plugin can stop the handler chain but cannot
+        // un-send it. Skipping the persist below dropped the operator's own outgoing message from
+        // history and from `message.sent` webhooks.
+
+        // Persist the outgoing message so local history reflects sends composed on a linked phone
+        // (message_create is the ONLY event those produce). It also fires for API-originated sends,
+        // which the REST send path persists itself — the UNIQUE(sessionId, waMessageId) index is
+        // the atomic dedup oracle between the two writers: the loser skips its insert, and
+        // persistSentState additionally drops its redundant PENDING row when the echo won. The
+        // webhook/WS dispatch below is identical whether the insert won, lost, or failed — the
+        // message.sent contract is unchanged.
+        const outgoing: IncomingMessage = finalMessage;
+        const metadata = buildMessageMetadata(outgoing, true);
+
+        // The ephemeral opt-out gates STORAGE only (mirrors onMessage); the live dispatch below
+        // is today's contract and stays.
+        const mayPersist =
+          resolveFeatureFlags(this.configService).storeEphemeralMessages ||
+          !(outgoing.ephemeralDuration && outgoing.ephemeralDuration > 0);
+
+        if (mayPersist) {
+          const dbMessage = this.messageRepository.create({
+            sessionId: id,
+            waMessageId: storableWaMessageId(outgoing.id),
+            chatId: outgoing.chatId,
+            from: outgoing.from,
+            to: outgoing.to,
+            body: outgoing.body,
+            type: outgoing.type,
+            direction: MessageDirection.OUTGOING,
+            timestamp: outgoing.timestamp,
+            status: MessageStatus.SENT,
+            metadata,
+          });
+          // The hook chain above is async; a delete()/teardown can retire this engine while it
+          // awaits. Re-check liveness so a late continuation can't persist an orphan row
+          // (mirrors onMessage).
+          if (!this.engines.isLive(id, engine)) return;
+          let persisted = false;
+          try {
+            const result = await this.messageRepository.insert(dbMessage as unknown as QueryDeepPartialEntity<Message>);
+            Object.assign(dbMessage, result.identifiers[0] ?? {}, result.generatedMaps?.[0] ?? {});
+            persisted = true;
+          } catch (err) {
+            // Unique violation = the REST send path already persisted this API-originated send —
+            // the dedup oracle working as intended, not an error. Anything else is a real DB
+            // failure; fail open so a real send is never dropped on a transient DB fault.
+            if (!isUniqueConstraintError(err)) {
+              this.logger.error(`Failed to save outgoing message ${outgoing.id} to database`, String(err));
+            }
+          }
+          if (persisted) {
+            // Fire-and-forget, mirroring onMessage: plugin providers (search etc.) see phone-
+            // composed sends exactly like API sends.
+            void this.hookManager
+              .execute(
+                'message:persisted',
+                { sessionId: id, message: dbMessage },
+                { sessionId: id, source: 'SessionService' },
+              )
+              .catch(() => undefined);
+          }
+        }
+
+        void this.webhookService.dispatch(id, 'message.sent', finalMessage);
+        // Emit real-time event to WebSocket clients (as message.sent, not message.received)
+        this.eventsGateway.emitMessageSent(id, finalMessage);
+      })
+      .catch(err => this.logger.error(`onMessageCreate handler failed for ${id}`, String(err)));
+  }
+
+  /** Engine callback body, lifted out of initializeEngine so the wiring table stays readable. */
+  handleMessageAck(id: string, engine: IWhatsAppEngine, messageId: string, status: DeliveryStatus): void {
+    if (!this.engines.isLive(id, engine)) return;
+    this.logger.debug(`Message ack: ${messageId} -> ${status}`, {
+      sessionId: id,
+      messageId,
+      status,
+      action: 'message_ack',
+    });
+
+    // Reflect real delivery state on the stored message (#220): delivered/read/failed advance the
+    // stored status; pending/sent carry no upgrade (it's already SENT — visibly "not delivered").
+    // The UPDATE is guarded to the allowed prior statuses so delivery state only ADVANCES: an
+    // out-of-order/late ack cannot downgrade a higher status, which also makes these
+    // fire-and-forget writes race-safe at the DB level.
+    const messageStatus = deliveryStatusToMessageStatus(status);
+    if (messageStatus) {
+      // Scope by sessionId: waMessageId is unique per account/chat, not global — an ack on one
+      // session must never advance a same-id row in another session. The In() guard makes the
+      // UPDATE forward-only (a late/out-of-order ack can't downgrade) and idempotent on retry.
+      const advanceAck = (): Promise<number> =>
+        this.messageRepository
+          .update(
+            { sessionId: id, waMessageId: messageId, status: In(ackStatusTransitionFrom(messageStatus)) },
+            { status: messageStatus },
+          )
+          .then(result => result.affected ?? 0);
+
+      const logNoop = (): void =>
+        this.logger.debug(`Message ack ${messageId}: no status row advanced to ${messageStatus} (${status})`, {
+          sessionId: id,
+          messageId,
+          status,
+          action: 'message_ack_noop',
+        });
+
+      const onAckError = (err: unknown): void =>
+        this.logger.error(`Failed to advance ack for ${messageId}`, String(err));
+
+      void advanceAck()
+        .then(affected => {
+          if (affected > 0) return;
+          // affected:0 — most likely the send's 2nd save (which writes waMessageId) hasn't committed
+          // yet, so the row isn't matchable. Each ack is one-shot (WhatsApp won't necessarily resend),
+          // so retry ONCE after a short delay to close that race rather than leave it stuck at SENT.
+          const timer = setTimeout(() => {
+            void advanceAck()
+              .then(retried => {
+                if (retried === 0) logNoop();
+              })
+              .catch(onAckError);
+          }, ACK_RECONCILE_DELAY_MS);
+          timer.unref?.();
+        })
+        .catch(onAckError);
+    }
+
+    // One ack payload, emitted identically over the socket and the webhook so a client coded
+    // against either channel sees the same shape. `id` mirrors the field every other message.*
+    // event carries (and the idempotency-key resolver reads). `ack` is a deprecated legacy field
+    // kept for backward compatibility — new consumers should read the neutral `status`.
+    const ackPayload = { id: messageId, messageId, status, ack: deliveryStatusToAck(status) };
+
+    // Push the live delivery/read tick to the dashboard over the websocket.
+    this.eventsGateway.emitMessageAck(id, ackPayload);
+
+    // Dispatch the delivery/read receipt to webhooks (#155). Outgoing `message.sent` is handled
+    // solely by `onMessageCreate`, so the ack path deliberately does NOT emit `message.sent`.
+    void this.webhookService.dispatch(id, 'message.ack', ackPayload);
+
+    // Surface delivery failures actively so consumers don't have to poll for them (#220). Use a
+    // distinct object (not the shared ackPayload) so this separate event can't be perturbed by an
+    // in-place payload mutation in the concurrent message.ack dispatch's webhook:before hook.
+    if (status === 'failed') {
+      void this.webhookService.dispatch(id, 'message.failed', { ...ackPayload });
+    }
+
+    // Notify plugins of the delivery/read receipt. The `message:ack` hook event was declared in
+    // the HookEvent union but never emitted, so any plugin registered for it silently never fired.
+    // Fire-and-forget: an ack is a notification with nothing downstream to cancel, so the hook's
+    // `continue` flag is moot. Delivery failures surface here as status `failed` — `message:failed`
+    // stays reserved for send-time send failures, which carry a distinct `{ error, input }` payload.
+    void this.hookManager.execute(
+      'message:ack',
+      { messageId, status, ack: deliveryStatusToAck(status) },
+      { sessionId: id, source: 'Engine' },
+    );
+  }
+
+  /** Engine callback body, lifted out of initializeEngine so the wiring table stays readable. */
+  handleMessageRevoked(id: string, engine: IWhatsAppEngine, message: RevokedMessage): void {
+    if (!this.engines.isLive(id, engine)) return;
+    this.logger.debug(`Message revoked: ${message.id}`, {
+      sessionId: id,
+      messageId: message.id,
+      action: 'message_revoked',
+    });
+
+    // Flag the stored message as revoked (best-effort; the message may not be in the
+    // DB). The dashboard renders the localized "message deleted" text, so no display
+    // string is persisted here.
+    //
+    // Match on `revokedId` (the ORIGINAL deleted message's id) when present: on wwebjs
+    // `message.id` is the revocation notification, which never matches a stored row.
+    // `revokedId` falls back to `id` (Baileys, where the two are the same).
+    const revokedWaMessageId = message.revokedId ?? message.id;
+    void this.messageRepository
+      .update({ sessionId: id, waMessageId: revokedWaMessageId }, { body: '', type: 'revoked' })
+      .catch(err => {
+        this.logger.error(`Failed to update revoked message: ${revokedWaMessageId}`, String(err));
+      });
+
+    // Notify consumers regardless of whether the row existed: webhook (message.revoked
+    // is a declared event) + the real-time dashboard stream.
+    const revokedPayload = message as unknown as Record<string, unknown>;
+    void this.webhookService.dispatch(id, 'message.revoked', revokedPayload);
+    this.eventsGateway.emitMessageRevoked(id, revokedPayload);
+  }
+
+  /**
+   * Persist pre-connection history into the `messages` table for the chat view, without webhook/hook/ws
+   * dispatch (it predates the live session). De-duplicated by `waMessageId` so re-syncs never duplicate.
+   */
+  async persistHistoryMessages(id: string, messages: IncomingMessage[]): Promise<void> {
+    const storeEphemeralMessages = resolveFeatureFlags(this.configService).storeEphemeralMessages;
+    const byId = new Map<string, IncomingMessage>();
+    for (const m of messages) {
+      // Need an id to de-dup; chatId/from/to are NOT NULL; status/story posts aren't chats.
+      if (!m.id || m.isStatusBroadcast || !m.chatId || !m.from || !m.to) {
+        continue;
+      }
+      // Mirror the live onMessage guard: skip disappearing messages when the operator opted out, so a
+      // history backfill can't bypass STORE_EPHEMERAL_MESSAGES=false. No-op when the flag is at its
+      // default (true); only a message with a positive timer is dropped, never a regular one.
+      if (!storeEphemeralMessages && (m.ephemeralDuration ?? 0) > 0) {
+        continue;
+      }
+      byId.set(m.id, m);
+    }
+    if (byId.size === 0) {
+      return;
+    }
+    // Chunk the dedup query: a batch can be thousands, past SQLite's bound-variable limit for IN (...).
+    const ids = [...byId.keys()];
+    const CHUNK = 400;
+    let inserted = 0;
+    for (let i = 0; i < ids.length; i += CHUNK) {
+      const chunkIds = ids.slice(i, i + CHUNK);
+      const existing = await this.messageRepository.find({
+        where: { sessionId: id, waMessageId: In(chunkIds) },
+        select: { waMessageId: true },
+      });
+      const seen = new Set(existing.map(r => r.waMessageId));
+      const rows = chunkIds
+        .filter(x => !seen.has(x))
+        .map(x => {
+          const m = byId.get(x)!;
+          const metadata = buildMessageMetadata(m, true);
+          const row = this.messageRepository.create({
+            sessionId: id,
+            waMessageId: m.id,
+            chatId: m.chatId,
+            // Group poster for inbound rows only — the account's own backfilled group messages must
+            // not carry author (the column's contract is "null on outgoing echoes").
+            author: m.fromMe ? undefined : m.author,
+            from: m.from,
+            to: m.to,
+            body: m.body,
+            type: m.type,
+            direction: m.fromMe ? MessageDirection.OUTGOING : MessageDirection.INCOMING,
+            timestamp: m.timestamp,
+            status: MessageStatus.SENT,
+            metadata,
+          });
+          // The chat panel orders by createdAt; stamp the real time so history sorts correctly.
+          if (m.timestamp) {
+            row.createdAt = new Date(m.timestamp * 1000);
+          }
+          return row;
+        });
+      if (rows.length) {
+        // Insert-or-ignore: a live onMessage insert can land between the `seen` SELECT above and this
+        // write, colliding on UNIQUE(sessionId, waMessageId). orIgnore skips the collision instead of
+        // throwing and aborting the whole batch (history is best-effort, persist-never-dispatch).
+        await this.messageRepository
+          .createQueryBuilder()
+          .insert()
+          .values(rows as unknown as QueryDeepPartialEntity<Message>[])
+          .orIgnore()
+          .execute();
+        inserted += rows.length;
+      }
+    }
+    if (inserted) {
+      this.logger.log(`Persisted ${inserted} history message(s)`, {
+        sessionId: id,
+        inserted,
+        action: 'history_messages_persisted',
+      });
+    }
+  }
+
+  /**
+   * Queue a reaction apply. Reactions read-modify-write the metadata column, so they must be
+   * serialized per message; the caller only knows it has an event to apply.
+   */
+  applyReactionQueued(id: string, event: ReactionEvent): void {
+    this.enqueueMessageMutation(id, event.messageId, () => this.applyReaction(id, event));
+  }
+
+  /**
+   * Queue an edit apply. Shares the reaction chain so rapid edit-vs-reaction on the same message
+   * stays ordered rather than racing.
+   */
+  applyMessageEditQueued(id: string, message: EditedMessage): void {
+    this.enqueueMessageMutation(id, message.messageId, () => this.applyMessageEdit(id, message));
+  }
+
+  /** Queue a message-scoped mutation. A failed operation is isolated so later events still run. */
+  enqueueMessageMutation(id: string, messageId: string, work: () => Promise<void>): void {
+    this.messageMutations.enqueue(`${id}:${messageId}`, work);
+  }
+
+  private async applyReaction(id: string, event: ReactionEvent): Promise<void> {
+    try {
+      // Guard the lookup key before it reaches TypeORM: `findOne` DROPS an undefined condition from
+      // the where-clause rather than matching nothing, so an engine that couldn't resolve the reacted
+      // message's id would silently match an arbitrary row and clobber/emit its reactions. `!msg` is
+      // no protection against that — the row it finds is real, just the wrong one.
+      if (!event.messageId) return;
+
+      const msg = await this.messageRepository.findOne({ where: { sessionId: id, waMessageId: event.messageId } });
+      if (!msg) return;
+
+      const metadata = msg.metadata || {};
+      const reactions = (metadata.reactions as Record<string, string>) || {};
+      if (!event.reaction) {
+        delete reactions[event.senderId];
+      } else {
+        reactions[event.senderId] = event.reaction;
+      }
+      metadata.reactions = reactions;
+      // Scoped update of ONLY the metadata column. A full-row save(msg) would re-persist the `status`
+      // read at findOne time, clobbering a concurrent ack UPDATE (SENT→DELIVERED/READ) that committed in
+      // the window between this findOne and the write — the mutation chain serializes reaction-vs-reaction
+      // but NOT reaction-vs-ack, so scoping the write to metadata is what keeps delivery state monotonic
+      // (#220). Other metadata fields are carried through untouched (they were read into `metadata`).
+      await this.messageRepository.update({ sessionId: id, waMessageId: event.messageId }, {
+        metadata,
+      } as QueryDeepPartialEntity<Message>);
+
+      this.eventsGateway.emitMessageReaction(id, { ...event, reactions });
+      // Webhook parity with the WebSocket broadcast: same payload (event + post-apply snapshot), so a
+      // webhook-only consumer observes reactions too. Idempotency for this event is salted per dispatch.
+      void this.webhookService.dispatch(id, 'message.reaction', { ...event, reactions });
+    } catch (err) {
+      this.logger.error(`Failed to update message reaction: ${event.messageId}`, String(err));
+    }
+  }
+
+  /** Persist an edit before notifying consumers, while still surfacing the occurrence if storage fails. */
+  private async applyMessageEdit(id: string, message: EditedMessage): Promise<void> {
+    try {
+      await this.messageRepository.update({ sessionId: id, waMessageId: message.messageId }, { body: message.body });
+    } catch (err) {
+      this.logger.error(`Failed to update edited message: ${message.messageId}`, String(err));
+    }
+
+    const editedPayload = message as unknown as Record<string, unknown>;
+    this.eventsGateway.emitMessageEdited(id, editedPayload);
+    void this.webhookService.dispatch(id, 'message.edited', editedPayload);
+  }
+
+  /**
+   * Reflect an OUTBOUND edit (REST MessageService.editMessage) in the stored row, routed through the
+   * same per-message mutation queue as the inbound edit/reaction paths so the two writers cannot
+   * interleave (latest-write-wins holds across both directions). Same best-effort semantics as
+   * applyMessageEdit: a missing row or a failed write must not fail the request — the engine edit
+   * already succeeded. Resolves once the queued write has run.
+   */
+  async recordOutboundMessageEdit(sessionId: string, messageId: string, body: string): Promise<void> {
+    await new Promise<void>(resolve => {
+      this.enqueueMessageMutation(sessionId, messageId, async () => {
+        try {
+          await this.messageRepository.update({ sessionId, waMessageId: messageId }, { body });
+        } catch (err) {
+          this.logger.warn(`Failed to update stored body of edited message ${messageId}`, { error: String(err) });
+        } finally {
+          resolve();
+        }
+      });
+    });
+  }
+
+  /**
+   * Dispatches the opt-in `status.received` webhook once an inbound status row is ingested, and
+   * mirrors it over the websocket so the dashboard's statuses view refreshes live instead of
+   * waiting for a focus refetch. `WebhookService.dispatch` already filters delivery to webhooks
+   * whose `events` array includes `status.received`, so no extra gating is needed here. No media
+   * bytes are included in the payload — consumers fetch media via the status media endpoint.
+   */
+  private dispatchStatusReceived(sessionId: string, row: StatusUpdate): void {
+    const payload = {
+      sessionId,
+      statusId: row.waStatusId,
+      contact: {
+        id: row.contactJid,
+        ...(row.contactName ? { name: row.contactName } : {}),
+        ...(row.contactPushName ? { pushName: row.contactPushName } : {}),
+      },
+      type: row.type,
+      ...(row.caption ? { caption: row.caption } : {}),
+      hasMedia: Boolean(row.mediaPath) && !row.mediaOmitted,
+      mediaOmitted: row.mediaOmitted,
+      ...(row.omitReason ? { omitReason: row.omitReason } : {}),
+      postedAt: row.postedAt,
+      expiresAt: row.expiresAt,
+    };
+    void this.webhookService.dispatch(sessionId, 'status.received', payload);
+    this.eventsGateway.emitStatusReceived(sessionId, payload);
+  }
+}

--- a/src/modules/session/message-row.mapper.spec.ts
+++ b/src/modules/session/message-row.mapper.spec.ts
@@ -1,0 +1,89 @@
+import { buildMessageMetadata, storableWaMessageId, MEDIA_MESSAGE_TYPES } from './message-row.mapper';
+import type { IncomingMessage, MessageType } from '../../engine/interfaces/whatsapp-engine.interface';
+
+const msg = (over: Partial<IncomingMessage> = {}): IncomingMessage => ({ type: 'chat', ...over }) as IncomingMessage;
+
+describe('buildMessageMetadata', () => {
+  it('returns undefined when there is nothing to store (the column is nullable)', () => {
+    expect(buildMessageMetadata(msg())).toBeUndefined();
+  });
+
+  it('stores the engine-supplied media as-is', () => {
+    const media = { mimetype: 'image/png', data: 'x' };
+
+    expect(buildMessageMetadata(msg({ type: 'image', media }))).toEqual({ media });
+  });
+
+  it('stores a quoted message', () => {
+    const quotedMessage = { id: 'q1' };
+
+    expect(buildMessageMetadata(msg({ quotedMessage } as Partial<IncomingMessage>))).toEqual({ quotedMessage });
+  });
+
+  it('stores call metadata', () => {
+    const call = { video: false, missed: false };
+
+    expect(buildMessageMetadata(msg({ call }))).toEqual({ call });
+  });
+
+  it('stores every present field together', () => {
+    const built = buildMessageMetadata(
+      msg({
+        type: 'image',
+        media: { mimetype: 'image/png' },
+        quotedMessage: { id: 'q' },
+        call: { video: false, missed: false },
+      } as Partial<IncomingMessage>),
+    );
+
+    expect(Object.keys(built!).sort()).toEqual(['call', 'media', 'quotedMessage']);
+  });
+
+  describe('omitted-media synthesis', () => {
+    // The wwjs own-send echo and the history backfill both lose the media payload; without a marker
+    // the row renders as an empty bubble and drops out of the by-type stats.
+    it.each([...MEDIA_MESSAGE_TYPES])('synthesizes a placeholder for a media-typed %s when asked', type => {
+      expect(buildMessageMetadata(msg({ type: type as MessageType }), true)).toEqual({
+        media: { mimetype: '', omitted: true },
+      });
+    });
+
+    it('does NOT synthesize for the live inbound path, where absent media means no media', () => {
+      // This is the one deliberate difference between the three persist paths.
+      expect(buildMessageMetadata(msg({ type: 'image' }))).toBeUndefined();
+    });
+
+    it('does not synthesize for a non-media type', () => {
+      expect(buildMessageMetadata(msg({ type: 'chat' as MessageType }), true)).toBeUndefined();
+    });
+
+    it('prefers real media over the placeholder', () => {
+      const media = { mimetype: 'image/png' };
+
+      expect(buildMessageMetadata(msg({ type: 'image', media }), true)).toEqual({ media });
+    });
+
+    it('returns a fresh placeholder each time, so callers cannot mutate a shared object', () => {
+      const a = buildMessageMetadata(msg({ type: 'image' }), true)!;
+      const b = buildMessageMetadata(msg({ type: 'image' }), true)!;
+
+      expect(a.media).not.toBe(b.media);
+    });
+  });
+});
+
+describe('storableWaMessageId', () => {
+  it('passes a real id through', () => {
+    expect(storableWaMessageId('wa-1')).toBe('wa-1');
+  });
+
+  it('maps the empty sentinel to undefined so the row stores NULL', () => {
+    // `''` would collide the second unreadable-id message on the (sessionId, waMessageId) unique
+    // index and lose the row; NULL is what that index exempts.
+    expect(storableWaMessageId('')).toBeUndefined();
+  });
+
+  it('maps undefined to undefined', () => {
+    expect(storableWaMessageId(undefined)).toBeUndefined();
+  });
+});

--- a/src/modules/session/message-row.mapper.ts
+++ b/src/modules/session/message-row.mapper.ts
@@ -1,0 +1,59 @@
+import type { IncomingMessage } from '../../engine/interfaces/whatsapp-engine.interface';
+
+/**
+ * Message types whose rows must show a media placeholder even when the payload carried none.
+ *
+ * The wwjs own-send echo carries no media field at all (Baileys emits an omitted marker), and the
+ * history sync maps messages media-free to keep its footprint down. Without the marker such a row
+ * renders as an empty bubble — the DB copy wins over the engine-history placeholder in the dashboard
+ * merge — and the by-type stats filter would skip it.
+ */
+export const MEDIA_MESSAGE_TYPES = new Set(['image', 'video', 'audio', 'voice', 'sticker', 'document']);
+
+/** The synthesized stand-in for a media payload the engine did not deliver. */
+export const OMITTED_MEDIA = { mimetype: '', omitted: true } as const;
+
+/**
+ * Builds the `metadata` JSON column for a persisted message row.
+ *
+ * The three persist paths (live inbound `onMessage`, own-send echo `onMessageCreate`, and the
+ * pre-connection history backfill) each assembled this inline, with one deliberate difference:
+ * inbound trusts the engine's media field as-is, while the two paths that are known to lose media
+ * synthesize a placeholder. Keeping both rules in one function makes that difference explicit
+ * instead of something to re-derive at each site.
+ *
+ * @param synthesizeOmittedMedia When true, a media-typed message with no media payload gets the
+ *   omitted marker. False for live inbound, where absent media genuinely means "no media".
+ * @returns The metadata object, or undefined when there is nothing to store (the column is nullable
+ *   and an empty object would be noise).
+ */
+export function buildMessageMetadata(
+  message: Pick<IncomingMessage, 'media' | 'quotedMessage' | 'call' | 'type'>,
+  synthesizeOmittedMedia = false,
+): Record<string, unknown> | undefined {
+  const metadata: Record<string, unknown> = {};
+  if (message.media) {
+    metadata.media = message.media;
+  } else if (synthesizeOmittedMedia && MEDIA_MESSAGE_TYPES.has(message.type)) {
+    metadata.media = { ...OMITTED_MEDIA };
+  }
+  if (message.quotedMessage) {
+    metadata.quotedMessage = message.quotedMessage;
+  }
+  if (message.call) {
+    metadata.call = message.call;
+  }
+  return Object.keys(metadata).length > 0 ? metadata : undefined;
+}
+
+/**
+ * The `waMessageId` to store for a message.
+ *
+ * An engine that received a message but could not read its id back reports the empty sentinel, and
+ * NULL is what the non-partial `(sessionId, waMessageId)` unique index exempts — storing `''` would
+ * collide the second such message and lose the row. Every persist path funnels through here so that
+ * chokepoint cannot be forgotten at a new one.
+ */
+export function storableWaMessageId(id: string | undefined): string | undefined {
+  return id || undefined;
+}

--- a/src/modules/session/reconnect-policy.spec.ts
+++ b/src/modules/session/reconnect-policy.spec.ts
@@ -1,0 +1,203 @@
+import {
+  decideReconnect,
+  clampReconnectDelay,
+  RECONNECT_STABILITY_RESET_MS,
+  RECONNECT_LOOP_ALERT_INTERVAL_ATTEMPTS,
+  RECONNECT_DELAY_CAP_MS,
+  type ReconnectAttemptState,
+} from './reconnect-policy';
+
+const state = (over: Partial<ReconnectAttemptState> = {}): ReconnectAttemptState => ({
+  attempts: 0,
+  maxAttempts: Number.POSITIVE_INFINITY,
+  baseDelay: 5000,
+  ...over,
+});
+
+// Jitter is injected so the delay assertions are exact rather than ranged.
+const NO_JITTER = 0;
+
+describe('decideReconnect', () => {
+  describe('exponential backoff', () => {
+    it('schedules the first attempt at baseDelay', () => {
+      const s = state();
+
+      const d = decideReconnect(s, 1_000, NO_JITTER);
+
+      expect(d).toMatchObject({ kind: 'schedule', delayMs: 5000, attempt: 1 });
+    });
+
+    it('doubles the delay per consecutive attempt', () => {
+      const s = state();
+      const delays: number[] = [];
+
+      for (let i = 0; i < 4; i++) {
+        const d = decideReconnect(s, 1_000, NO_JITTER);
+        if (d.kind === 'schedule') delays.push(d.delayMs);
+      }
+
+      expect(delays).toEqual([5000, 10000, 20000, 40000]);
+    });
+
+    it('adds the supplied jitter before clamping', () => {
+      const s = state();
+
+      const d = decideReconnect(s, 1_000, 777);
+
+      expect(d).toMatchObject({ delayMs: 5777 });
+    });
+
+    it('parks at the cap once the exponent outgrows it (unlimited budget never overflows setTimeout)', () => {
+      const s = state({ attempts: 40 });
+
+      const d = decideReconnect(s, 1_000, NO_JITTER);
+
+      expect(d).toMatchObject({ delayMs: RECONNECT_DELAY_CAP_MS });
+    });
+
+    it('advances the caller-owned attempt counter', () => {
+      const s = state();
+
+      decideReconnect(s, 1_000, NO_JITTER);
+      decideReconnect(s, 1_000, NO_JITTER);
+
+      expect(s.attempts).toBe(2);
+    });
+
+    it('records when the attempt was scheduled', () => {
+      const s = state();
+
+      decideReconnect(s, 12_345, NO_JITTER);
+
+      expect(s.lastAttemptAt).toBe(12_345);
+    });
+  });
+
+  describe('budget exhaustion', () => {
+    it('reports exhausted once attempts reach the cap', () => {
+      const s = state({ attempts: 3, maxAttempts: 3 });
+
+      const d = decideReconnect(s, 1_000, NO_JITTER);
+
+      expect(d).toEqual({
+        kind: 'exhausted',
+        reason: 'Reconnection failed after 3 attempts — restart the session.',
+      });
+    });
+
+    it('distinguishes "auto-reconnect disabled" from "N attempts failed"', () => {
+      const s = state({ attempts: 0, maxAttempts: 0 });
+
+      const d = decideReconnect(s, 1_000, NO_JITTER);
+
+      // maxAttempts:0 means disabled outright; "failed after 0 attempts" would be misleading.
+      expect(d).toEqual({
+        kind: 'exhausted',
+        reason:
+          'Auto-reconnect is disabled (max attempts set to 0); the session was left disconnected — restart it manually.',
+      });
+    });
+
+    it('does not advance the counter once exhausted', () => {
+      const s = state({ attempts: 3, maxAttempts: 3 });
+
+      decideReconnect(s, 1_000, NO_JITTER);
+
+      expect(s.attempts).toBe(3);
+    });
+
+    it('never exhausts on the default unlimited budget', () => {
+      const s = state({ attempts: 10_000 });
+
+      expect(decideReconnect(s, 1_000, NO_JITTER).kind).toBe('schedule');
+    });
+  });
+
+  describe('stability reset', () => {
+    it('resets the budget when the session stayed up past the stability window', () => {
+      const s = state({ attempts: 4, maxAttempts: 5, lastAttemptAt: 1_000 });
+
+      const d = decideReconnect(s, 1_000 + RECONNECT_STABILITY_RESET_MS, NO_JITTER);
+
+      // Budget restarts, so this is attempt 1 at baseDelay rather than a 5th attempt.
+      expect(d).toMatchObject({ kind: 'schedule', attempt: 1, delayMs: 5000, stabilityReset: true });
+    });
+
+    it('keeps accruing inside the stability window', () => {
+      const s = state({ attempts: 4, maxAttempts: 5, lastAttemptAt: 1_000 });
+
+      const d = decideReconnect(s, 1_000 + RECONNECT_STABILITY_RESET_MS - 1, NO_JITTER);
+
+      expect(d).toMatchObject({ attempt: 5, stabilityReset: false });
+    });
+
+    it('rescues a session that would otherwise wedge FAILED after unrelated transient drops', () => {
+      const s = state({ attempts: 5, maxAttempts: 5, lastAttemptAt: 1_000 });
+
+      // Without the reset this is exhausted; with it the session gets a fresh budget.
+      const d = decideReconnect(s, 1_000 + RECONNECT_STABILITY_RESET_MS, NO_JITTER);
+
+      expect(d.kind).toBe('schedule');
+    });
+
+    it('does not reset on the very first attempt (no prior timestamp)', () => {
+      const s = state();
+
+      expect(decideReconnect(s, 10 ** 12, NO_JITTER)).toMatchObject({ stabilityReset: false });
+    });
+  });
+
+  describe('loop alerting', () => {
+    it(`flags every ${RECONNECT_LOOP_ALERT_INTERVAL_ATTEMPTS}th consecutive attempt`, () => {
+      const s = state();
+      const alerts: number[] = [];
+
+      for (let i = 0; i < 12; i++) {
+        const d = decideReconnect(s, 1_000, NO_JITTER);
+        if (d.kind === 'schedule' && d.loopAlert) alerts.push(d.attempt);
+      }
+
+      expect(alerts).toEqual([5, 10]);
+    });
+
+    it('does not alert on the first attempt of an episode', () => {
+      expect(decideReconnect(state(), 1_000, NO_JITTER)).toMatchObject({ loopAlert: false });
+    });
+
+    it('re-arms from attempt 5 again after a stability reset (new episode, not a continuing cadence)', () => {
+      const s = state({ attempts: 4, lastAttemptAt: 1_000 });
+
+      // A stable stretch resets the streak, so the next attempt is #1 and must not alert.
+      const first = decideReconnect(s, 1_000 + RECONNECT_STABILITY_RESET_MS, NO_JITTER);
+      expect(first).toMatchObject({ attempt: 1, loopAlert: false });
+
+      const alerts: number[] = [];
+      for (let i = 0; i < 5; i++) {
+        const d = decideReconnect(s, 1_000 + RECONNECT_STABILITY_RESET_MS, NO_JITTER);
+        if (d.kind === 'schedule' && d.loopAlert) alerts.push(d.attempt);
+      }
+      expect(alerts).toEqual([5]);
+    });
+  });
+});
+
+describe('clampReconnectDelay', () => {
+  it('passes a normal delay through', () => {
+    expect(clampReconnectDelay(8000, 5000)).toBe(8000);
+  });
+
+  it('floors a negative delay at 0', () => {
+    expect(clampReconnectDelay(-1, 5000)).toBe(0);
+  });
+
+  it('caps a huge delay so setTimeout cannot overflow and fire immediately', () => {
+    expect(clampReconnectDelay(Number.MAX_SAFE_INTEGER, 5000)).toBe(RECONNECT_DELAY_CAP_MS);
+  });
+
+  it('falls back to baseDelay when the computed delay is not finite', () => {
+    // An operator-supplied non-numeric config would otherwise yield NaN → setTimeout fires at 0.
+    // Infinity is likewise not finite, so it takes the same fallback rather than the cap.
+    expect(clampReconnectDelay(NaN, 5000)).toBe(5000);
+    expect(clampReconnectDelay(Number.POSITIVE_INFINITY, 5000)).toBe(5000);
+  });
+});

--- a/src/modules/session/reconnect-policy.ts
+++ b/src/modules/session/reconnect-policy.ts
@@ -1,0 +1,124 @@
+/**
+ * The reconnect backoff *decision*, separated from its effects.
+ *
+ * `SessionService.scheduleReconnect` interleaves four rules (stability reset, budget exhaustion,
+ * exponential backoff with jitter, periodic loop alerting) with the side effects they trigger
+ * (status writes, engine eviction, webhooks, timers). The rules are the subtle part and the effects
+ * are the untestable part, so the rules live here as a pure function over explicit state.
+ *
+ * Pure by construction: no timers, no I/O, and `now`/`jitter` are injected, so every branch —
+ * including the ones that only occur after hours of uptime — is directly reachable in a test.
+ */
+
+/** Mutable per-session backoff state. Owned by the caller; this module only reads and derives. */
+export interface ReconnectAttemptState {
+  attempts: number;
+  maxAttempts: number;
+  baseDelay: number;
+  /** When the last attempt was scheduled (epoch ms) — feeds the stability reset. */
+  lastAttemptAt?: number;
+}
+
+/** Give up: the attempt budget is spent (or auto-reconnect was disabled outright). */
+export interface ReconnectExhausted {
+  kind: 'exhausted';
+  /** Operator-facing reason, surfaced via `lastError`. */
+  reason: string;
+}
+
+/** Schedule attempt `attempt` after `delayMs`. */
+export interface ReconnectScheduled {
+  kind: 'schedule';
+  delayMs: number;
+  /** 1-based number of the attempt being scheduled. */
+  attempt: number;
+  /** True when this attempt completes a loop-alert interval. */
+  loopAlert: boolean;
+  /** The attempt counter reset because the session had been stable. */
+  stabilityReset: boolean;
+}
+
+export type ReconnectDecision = ReconnectExhausted | ReconnectScheduled;
+
+/**
+ * A reconnect-attempt budget covers one CONTINUOUS bad stretch: once this much time has passed
+ * since the last scheduled attempt the session demonstrably stayed up, so `attempts` resets to 0.
+ * Without it a long-lived session would slowly accrue attempts toward an explicit cap across
+ * unrelated transient drops and one day wedge FAILED for no current reason.
+ */
+export const RECONNECT_STABILITY_RESET_MS = 300_000;
+
+/**
+ * A reconnect-loop alert fires once per this many CONSECUTIVE attempts of a session — one signal per
+ * ongoing episode, not spam per attempt. A broken-forever setup retries without limit (by design), so
+ * the 5th/10th/15th… scheduled attempt is the operator-facing tell; the streak resets via the
+ * stability window above (or onReady), so a later episode re-arms the alert from attempt 5 again.
+ */
+export const RECONNECT_LOOP_ALERT_INTERVAL_ATTEMPTS = 5;
+
+/** Upper bound on a computed backoff delay (see clampReconnectDelay). */
+export const RECONNECT_DELAY_CAP_MS = 3_600_000;
+
+function clampNumber(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * Clamp a computed backoff delay finite and within setTimeout's safe range (a huge value would
+ * overflow its 32-bit ms field and fire immediately).
+ */
+export function clampReconnectDelay(rawDelay: number, baseDelay: number): number {
+  return clampNumber(Number.isFinite(rawDelay) ? rawDelay : baseDelay, 0, RECONNECT_DELAY_CAP_MS);
+}
+
+/**
+ * Decide what should happen for the next reconnect of a session, and advance `state` accordingly.
+ *
+ * MUTATES `state` (attempts / lastAttemptAt) exactly as the original inline code did, so the caller
+ * keeps a single source of truth for the session's streak across calls.
+ *
+ * @param now     Injected clock (epoch ms).
+ * @param jitter  Injected jitter in ms, added before clamping (production passes `Math.random() * 1000`).
+ */
+export function decideReconnect(
+  state: ReconnectAttemptState,
+  now: number = Date.now(),
+  jitter: number = Math.random() * 1000,
+): ReconnectDecision {
+  // Stability reset: the attempt budget covers one CONTINUOUS bad stretch. When the session stayed
+  // up ≥5 min since the last scheduled attempt it demonstrably recovered, so the next drop
+  // restarts the budget — unrelated transient drops must not accrue toward an explicit cap over
+  // the session's lifetime.
+  let stabilityReset = false;
+  if (state.lastAttemptAt !== undefined && now - state.lastAttemptAt >= RECONNECT_STABILITY_RESET_MS) {
+    state.attempts = 0;
+    stabilityReset = true;
+  }
+
+  if (state.attempts >= state.maxAttempts) {
+    // maxAttempts:0 means auto-reconnect is disabled, not that N attempts were tried and failed — say
+    // so instead of the misleading "failed after 0 attempts".
+    return {
+      kind: 'exhausted',
+      reason:
+        state.maxAttempts === 0
+          ? 'Auto-reconnect is disabled (max attempts set to 0); the session was left disconnected — restart it manually.'
+          : `Reconnection failed after ${state.attempts} attempts — restart the session.`,
+    };
+  }
+
+  // Exponential backoff: baseDelay * 2^attempts (with jitter), clamped finite + within
+  // setTimeout's safe range so the timer can't overflow and fire immediately. With the default
+  // unlimited budget the delay parks at RECONNECT_DELAY_CAP_MS once the exponent outgrows it.
+  const delayMs = clampReconnectDelay(state.baseDelay * Math.pow(2, state.attempts) + jitter, state.baseDelay);
+  state.attempts++;
+  state.lastAttemptAt = now;
+
+  return {
+    kind: 'schedule',
+    delayMs,
+    attempt: state.attempts,
+    loopAlert: state.attempts > 0 && state.attempts % RECONNECT_LOOP_ALERT_INTERVAL_ATTEMPTS === 0,
+    stabilityReset,
+  };
+}

--- a/src/modules/session/session-lid-resolver.service.spec.ts
+++ b/src/modules/session/session-lid-resolver.service.spec.ts
@@ -1,0 +1,108 @@
+import { SessionLidResolver } from './session-lid-resolver.service';
+import { EngineRegistry } from '../../engine/engine-registry.service';
+import type { IWhatsAppEngine } from '../../engine/interfaces/whatsapp-engine.interface';
+import type { LidMappingStoreService } from '../../engine/identity/lid-mapping-store.service';
+
+describe('SessionLidResolver', () => {
+  let engines: EngineRegistry;
+  let resolveContactPhone: jest.Mock;
+  let remember: jest.Mock;
+  let resolver: SessionLidResolver;
+
+  beforeEach(() => {
+    engines = new EngineRegistry();
+    resolveContactPhone = jest.fn().mockResolvedValue('628111222333');
+    engines.set('s1', { resolveContactPhone } as unknown as IWhatsAppEngine);
+    remember = jest.fn().mockResolvedValue(undefined);
+    resolver = new SessionLidResolver(engines, { remember } as unknown as LidMappingStoreService);
+  });
+
+  it('resolves a phone through the engine', async () => {
+    await expect(resolver.resolveSenderPhone('s1', '111@lid')).resolves.toBe('628111222333');
+    expect(resolveContactPhone).toHaveBeenCalledWith('111@lid');
+  });
+
+  it('caches a hit so a chatty sender is queried once', async () => {
+    await resolver.resolveSenderPhone('s1', '111@lid');
+    await resolver.resolveSenderPhone('s1', '111@lid');
+
+    expect(resolveContactPhone).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches a miss too, so an unmapped sender does not re-query every message', async () => {
+    resolveContactPhone.mockResolvedValue(null);
+
+    await expect(resolver.resolveSenderPhone('s1', '404@lid')).resolves.toBeNull();
+    await expect(resolver.resolveSenderPhone('s1', '404@lid')).resolves.toBeNull();
+
+    expect(resolveContactPhone).toHaveBeenCalledTimes(1);
+  });
+
+  it('keys the cache per session, so two sessions resolve independently', async () => {
+    engines.set('s2', { resolveContactPhone } as unknown as IWhatsAppEngine);
+
+    await resolver.resolveSenderPhone('s1', '111@lid');
+    await resolver.resolveSenderPhone('s2', '111@lid');
+
+    expect(resolveContactPhone).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns null (never throws) when the engine rejects', async () => {
+    resolveContactPhone.mockRejectedValue(new Error('socket closed'));
+
+    await expect(resolver.resolveSenderPhone('s1', '111@lid')).resolves.toBeNull();
+  });
+
+  it('returns null when the session has no live engine', async () => {
+    await expect(resolver.resolveSenderPhone('not-started', '111@lid')).resolves.toBeNull();
+  });
+
+  it('persists a real resolution to the shared lid mapping store', async () => {
+    await resolver.resolveSenderPhone('s1', '111@lid');
+
+    expect(remember).toHaveBeenCalledWith('111', '628111222333', 's1');
+  });
+
+  it('does not persist a miss', async () => {
+    resolveContactPhone.mockResolvedValue(null);
+
+    await resolver.resolveSenderPhone('s1', '404@lid');
+
+    expect(remember).not.toHaveBeenCalled();
+  });
+
+  it('never rejects when the mapping store write fails (fire-and-forget)', async () => {
+    remember.mockRejectedValue(new Error('db down'));
+
+    await expect(resolver.resolveSenderPhone('s1', '111@lid')).resolves.toBe('628111222333');
+  });
+
+  it('works without a mapping store at all (optional dependency)', async () => {
+    const bare = new SessionLidResolver(engines);
+
+    await expect(bare.resolveSenderPhone('s1', '111@lid')).resolves.toBe('628111222333');
+  });
+
+  it('evicts the oldest entry once the cache is full, bounding memory', async () => {
+    const max = 5000;
+    // Fill past the cap; the first key inserted must be the one evicted (FIFO).
+    for (let i = 0; i < max; i++) {
+      resolveContactPhone.mockResolvedValue(`phone-${i}`);
+      await resolver.resolveSenderPhone('s1', `${i}@lid`);
+    }
+    expect(resolveContactPhone).toHaveBeenCalledTimes(max);
+
+    // One more insert evicts the oldest ('0@lid').
+    resolveContactPhone.mockResolvedValue('phone-new');
+    await resolver.resolveSenderPhone('s1', 'new@lid');
+
+    // The evicted key must be re-queried; a still-cached one must not be.
+    resolveContactPhone.mockClear();
+    await resolver.resolveSenderPhone('s1', '0@lid');
+    expect(resolveContactPhone).toHaveBeenCalledTimes(1);
+
+    resolveContactPhone.mockClear();
+    await resolver.resolveSenderPhone('s1', `${max - 1}@lid`);
+    expect(resolveContactPhone).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/session/session-lid-resolver.service.ts
+++ b/src/modules/session/session-lid-resolver.service.ts
@@ -1,0 +1,65 @@
+import { Injectable, Optional } from '@nestjs/common';
+import { EngineRegistry } from '../../engine/engine-registry.service';
+import { LidMappingStoreService } from '../../engine/identity/lid-mapping-store.service';
+import { userPart } from '../../engine/identity/wa-id';
+
+/**
+ * Resolves a privacy-id sender (`@lid`) to a phone number for inline attachment on incoming
+ * messages (#263).
+ *
+ * Split out of SessionService because it is a self-contained read-through cache over the engine: it
+ * has no lifecycle state, cannot fail the message path, and its only collaborators are the engine
+ * registry and the shared lid<->phone table. Keeping it here means the eviction policy and the
+ * fire-and-forget persistence are testable without standing up the whole session lifecycle.
+ */
+@Injectable()
+export class SessionLidResolver {
+  /**
+   * Bounded cache keyed `${sessionId}:${lid}`. Caches misses (null) too, so a chatty unmapped sender
+   * isn't re-queried on every message (which also reduces engine rate-limit pressure). Best-effort
+   * feature, so staleness is acceptable.
+   */
+  private readonly cache = new Map<string, string | null>();
+  private static readonly CACHE_MAX = 5000;
+
+  constructor(
+    private readonly engines: EngineRegistry,
+    // Shared lid<->phone table (global). Used to persist an inbound @lid sender's resolved phone so
+    // an inbound-only migrated contact's `@lid` and `@c.us` rows bridge in the read-path (#583 R3 Ph2).
+    @Optional()
+    private readonly lidMappingStore?: LidMappingStoreService,
+  ) {}
+
+  /**
+   * Best-effort resolution, cached per session (incl. misses). Never throws — returns null on any
+   * failure or when the engine isn't available. Gated by the caller on `RESOLVE_LID_TO_PHONE`.
+   */
+  async resolveSenderPhone(sessionId: string, contactId: string): Promise<string | null> {
+    const key = `${sessionId}:${contactId}`;
+    const cached = this.cache.get(key);
+    if (cached !== undefined) {
+      return cached;
+    }
+    let phone: string | null;
+    try {
+      phone = (await this.engines.get(sessionId)?.resolveContactPhone(contactId)) ?? null;
+    } catch {
+      phone = null;
+    }
+    // Bounded FIFO eviction: Map preserves insertion order, so the first key is the oldest.
+    if (this.cache.size >= SessionLidResolver.CACHE_MAX) {
+      for (const oldest of this.cache.keys()) {
+        this.cache.delete(oldest);
+        break;
+      }
+    }
+    this.cache.set(key, phone);
+    // Persist a real @lid -> phone resolution so the read-path can bridge this contact's `@lid` and
+    // `@c.us` rows even when the operator never sent to them (#583 R3 Phase 2). Reuses the resolution
+    // above — no extra network call — and is fire-and-forget so dispatch never blocks/fails on it.
+    if (phone) {
+      void this.lidMappingStore?.remember(userPart(contactId), phone, sessionId)?.catch(() => {});
+    }
+    return phone;
+  }
+}

--- a/src/modules/session/session-liveness-watchdog.service.spec.ts
+++ b/src/modules/session/session-liveness-watchdog.service.spec.ts
@@ -1,0 +1,292 @@
+import {
+  SessionLivenessWatchdog,
+  SESSION_WATCHDOG_INTERVAL_MS,
+  SESSION_WATCHDOG_MAX_FAILURES,
+  SESSION_WATCHDOG_PROBE_TIMEOUT_MS,
+} from './session-liveness-watchdog.service';
+import { EngineRegistry } from '../../engine/engine-registry.service';
+import { EngineStatus, IWhatsAppEngine } from '../../engine/interfaces/whatsapp-engine.interface';
+import type { ShutdownService } from '../../common/services/shutdown.service';
+
+type FakeEngine = {
+  getStatus: jest.Mock;
+  probeLiveness?: jest.Mock;
+};
+
+const engineOf = (status: EngineStatus, probe?: jest.Mock): FakeEngine => ({
+  getStatus: jest.fn().mockReturnValue(status),
+  ...(probe ? { probeLiveness: probe } : {}),
+});
+
+describe('SessionLivenessWatchdog', () => {
+  let engines: EngineRegistry;
+  let onDead: jest.Mock;
+  let watchdog: SessionLivenessWatchdog;
+
+  const failuresOf = (w: SessionLivenessWatchdog): Map<string, number> =>
+    (w as unknown as { failures: Map<string, number> }).failures;
+
+  beforeEach(() => {
+    engines = new EngineRegistry();
+    onDead = jest.fn().mockResolvedValue(undefined);
+    watchdog = new SessionLivenessWatchdog(engines);
+  });
+
+  afterEach(() => {
+    watchdog.stop();
+  });
+
+  describe('probe eligibility', () => {
+    it('treats a READY engine that answers as alive', async () => {
+      const probe = jest.fn().mockResolvedValue(true);
+      const engine = engineOf(EngineStatus.READY, probe);
+      engines.set('s1', engine as unknown as IWhatsAppEngine);
+      watchdog.start(onDead);
+
+      await watchdog.probe('s1', engine as unknown as IWhatsAppEngine);
+
+      expect(probe).toHaveBeenCalled();
+      expect(onDead).not.toHaveBeenCalled();
+    });
+
+    it('skips a non-READY engine entirely (owned by the QR/reconnect flows)', async () => {
+      const probe = jest.fn().mockResolvedValue(false);
+      const engine = engineOf(EngineStatus.INITIALIZING, probe);
+      engines.set('s1', engine as unknown as IWhatsAppEngine);
+
+      await watchdog.probe('s1', engine as unknown as IWhatsAppEngine);
+
+      expect(probe).not.toHaveBeenCalled();
+    });
+
+    it('clears failures accrued in a previous READY stretch when the status leaves READY', async () => {
+      const engine = engineOf(EngineStatus.READY, jest.fn().mockResolvedValue(false));
+      engines.set('s1', engine as unknown as IWhatsAppEngine);
+      await watchdog.probe('s1', engine as unknown as IWhatsAppEngine);
+      expect(failuresOf(watchdog).get('s1')).toBe(1);
+
+      engine.getStatus.mockReturnValue(EngineStatus.DISCONNECTED);
+      await watchdog.probe('s1', engine as unknown as IWhatsAppEngine);
+
+      expect(failuresOf(watchdog).has('s1')).toBe(false);
+    });
+
+    it('skips an engine without probeLiveness (relies on engine events alone)', async () => {
+      const engine = engineOf(EngineStatus.READY);
+      engines.set('s1', engine as unknown as IWhatsAppEngine);
+      watchdog.start(onDead);
+
+      await watchdog.probe('s1', engine as unknown as IWhatsAppEngine);
+
+      expect(onDead).not.toHaveBeenCalled();
+      expect(failuresOf(watchdog).has('s1')).toBe(false);
+    });
+  });
+
+  describe('failure threshold', () => {
+    it(`treats the session as dead after ${SESSION_WATCHDOG_MAX_FAILURES} consecutive failures`, async () => {
+      const engine = engineOf(EngineStatus.READY, jest.fn().mockResolvedValue(false));
+      engines.set('s1', engine as unknown as IWhatsAppEngine);
+      watchdog.start(onDead);
+
+      for (let i = 0; i < SESSION_WATCHDOG_MAX_FAILURES; i++) {
+        await watchdog.probe('s1', engine as unknown as IWhatsAppEngine);
+      }
+
+      expect(onDead).toHaveBeenCalledTimes(1);
+      expect(onDead).toHaveBeenCalledWith('s1', engine, 'liveness probe failed (watchdog)');
+    });
+
+    it('does not act on a single failure', async () => {
+      const engine = engineOf(EngineStatus.READY, jest.fn().mockResolvedValue(false));
+      engines.set('s1', engine as unknown as IWhatsAppEngine);
+      watchdog.start(onDead);
+
+      await watchdog.probe('s1', engine as unknown as IWhatsAppEngine);
+
+      expect(onDead).not.toHaveBeenCalled();
+      expect(failuresOf(watchdog).get('s1')).toBe(1);
+    });
+
+    it('resets the streak on a successful probe, so failures must be CONSECUTIVE', async () => {
+      const probe = jest.fn().mockResolvedValue(false);
+      const engine = engineOf(EngineStatus.READY, probe);
+      engines.set('s1', engine as unknown as IWhatsAppEngine);
+      watchdog.start(onDead);
+
+      await watchdog.probe('s1', engine as unknown as IWhatsAppEngine);
+      probe.mockResolvedValue(true);
+      await watchdog.probe('s1', engine as unknown as IWhatsAppEngine);
+      probe.mockResolvedValue(false);
+      await watchdog.probe('s1', engine as unknown as IWhatsAppEngine);
+
+      expect(onDead).not.toHaveBeenCalled();
+    });
+
+    it('counts a probe that rejects as a failure', async () => {
+      const engine = engineOf(EngineStatus.READY, jest.fn().mockRejectedValue(new Error('socket gone')));
+      engines.set('s1', engine as unknown as IWhatsAppEngine);
+      watchdog.start(onDead);
+
+      await watchdog.probe('s1', engine as unknown as IWhatsAppEngine);
+
+      expect(failuresOf(watchdog).get('s1')).toBe(1);
+    });
+
+    it('counts a hung probe as a failure once the deadline passes', async () => {
+      jest.useFakeTimers();
+      try {
+        // A wedged connection can hang the probe itself; without the race the tick would stall.
+        const engine = engineOf(EngineStatus.READY, jest.fn().mockReturnValue(new Promise<boolean>(() => {})));
+        engines.set('s1', engine as unknown as IWhatsAppEngine);
+        watchdog.start(onDead);
+
+        const pending = watchdog.probe('s1', engine as unknown as IWhatsAppEngine);
+        await jest.advanceTimersByTimeAsync(SESSION_WATCHDOG_PROBE_TIMEOUT_MS);
+        await pending;
+
+        expect(failuresOf(watchdog).get('s1')).toBe(1);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+  });
+
+  describe('ACTION_REQUIRED is observe-only', () => {
+    it('probes the engine but never acts on a failure (the status is operator-owned)', async () => {
+      const probe = jest.fn().mockResolvedValue(false);
+      const engine = engineOf(EngineStatus.ACTION_REQUIRED, probe);
+      engines.set('s1', engine as unknown as IWhatsAppEngine);
+      watchdog.start(onDead);
+
+      for (let i = 0; i < SESSION_WATCHDOG_MAX_FAILURES + 3; i++) {
+        await watchdog.probe('s1', engine as unknown as IWhatsAppEngine);
+      }
+
+      expect(probe).toHaveBeenCalled();
+      // Acting here would silently drop the very status asking for attention.
+      expect(onDead).not.toHaveBeenCalled();
+      expect(failuresOf(watchdog).get('s1')).toBeGreaterThan(SESSION_WATCHDOG_MAX_FAILURES);
+    });
+
+    it('clears the observe-only count when the probe answers again', async () => {
+      const probe = jest.fn().mockResolvedValue(false);
+      const engine = engineOf(EngineStatus.ACTION_REQUIRED, probe);
+      engines.set('s1', engine as unknown as IWhatsAppEngine);
+      watchdog.start(onDead);
+
+      await watchdog.probe('s1', engine as unknown as IWhatsAppEngine);
+      probe.mockResolvedValue(true);
+      await watchdog.probe('s1', engine as unknown as IWhatsAppEngine);
+
+      expect(failuresOf(watchdog).has('s1')).toBe(false);
+    });
+  });
+
+  describe('stale results', () => {
+    it('ignores a probe result for an engine superseded while it was in flight', async () => {
+      const engine = engineOf(EngineStatus.READY, jest.fn().mockResolvedValue(false));
+      engines.set('s1', engine as unknown as IWhatsAppEngine);
+      watchdog.start(onDead);
+      failuresOf(watchdog).set('s1', SESSION_WATCHDOG_MAX_FAILURES - 1);
+
+      // A stop()/restart replaces the engine before the probe settles.
+      engines.set('s1', engineOf(EngineStatus.READY) as unknown as IWhatsAppEngine);
+      await watchdog.probe('s1', engine as unknown as IWhatsAppEngine);
+
+      expect(onDead).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('probes every live engine on each tick', async () => {
+      jest.useFakeTimers();
+      try {
+        const a = engineOf(EngineStatus.READY, jest.fn().mockResolvedValue(true));
+        const b = engineOf(EngineStatus.READY, jest.fn().mockResolvedValue(true));
+        engines.set('a', a as unknown as IWhatsAppEngine);
+        engines.set('b', b as unknown as IWhatsAppEngine);
+        watchdog.start(onDead);
+
+        await jest.advanceTimersByTimeAsync(SESSION_WATCHDOG_INTERVAL_MS);
+
+        expect(a.probeLiveness).toHaveBeenCalled();
+        expect(b.probeLiveness).toHaveBeenCalled();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('is idempotent: a second start does not add a second interval', () => {
+      jest.useFakeTimers();
+      try {
+        watchdog.start(onDead);
+        watchdog.start(onDead);
+
+        expect(jest.getTimerCount()).toBe(1);
+      } finally {
+        watchdog.stop();
+        jest.useRealTimers();
+      }
+    });
+
+    it('stop() clears the interval and the accrued failures, and is safe to call twice', () => {
+      jest.useFakeTimers();
+      try {
+        watchdog.start(onDead);
+        failuresOf(watchdog).set('s1', 1);
+
+        watchdog.stop();
+        watchdog.stop();
+
+        expect(jest.getTimerCount()).toBe(0);
+        expect(failuresOf(watchdog).size).toBe(0);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('skips the whole tick while shutting down (a reconnect would race teardown)', async () => {
+      jest.useFakeTimers();
+      const shutdown = { isShuttingDown: () => true } as unknown as ShutdownService;
+      const draining = new SessionLivenessWatchdog(engines, shutdown);
+      try {
+        const engine = engineOf(EngineStatus.READY, jest.fn().mockResolvedValue(false));
+        engines.set('s1', engine as unknown as IWhatsAppEngine);
+        draining.start(onDead);
+
+        await jest.advanceTimersByTimeAsync(SESSION_WATCHDOG_INTERVAL_MS);
+
+        expect(engine.probeLiveness).not.toHaveBeenCalled();
+      } finally {
+        draining.stop();
+        jest.useRealTimers();
+      }
+    });
+
+    it('clear() forgets one session without disturbing another', () => {
+      failuresOf(watchdog).set('s1', 1);
+      failuresOf(watchdog).set('s2', 1);
+
+      watchdog.clear('s1');
+
+      expect(failuresOf(watchdog).has('s1')).toBe(false);
+      expect(failuresOf(watchdog).get('s2')).toBe(1);
+    });
+
+    it('a failing probe never throws into the timer', async () => {
+      jest.useFakeTimers();
+      try {
+        const engine = engineOf(EngineStatus.READY, jest.fn().mockResolvedValue(false));
+        engines.set('s1', engine as unknown as IWhatsAppEngine);
+        watchdog.start(() => Promise.reject(new Error('disconnect handler blew up')));
+
+        await expect(
+          jest.advanceTimersByTimeAsync(SESSION_WATCHDOG_INTERVAL_MS * (SESSION_WATCHDOG_MAX_FAILURES + 1)),
+        ).resolves.not.toThrow();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+  });
+});

--- a/src/modules/session/session-liveness-watchdog.service.ts
+++ b/src/modules/session/session-liveness-watchdog.service.ts
@@ -1,0 +1,190 @@
+import { Injectable, Optional } from '@nestjs/common';
+import { EngineRegistry } from '../../engine/engine-registry.service';
+import { EngineStatus, IWhatsAppEngine } from '../../engine/interfaces/whatsapp-engine.interface';
+import { createLogger } from '../../common/services/logger.service';
+import { ShutdownService } from '../../common/services/shutdown.service';
+
+/**
+ * Session liveness watchdog. The engine layer is event-driven, so an engine that dies WITHOUT
+ * emitting a disconnect (a killed Chromium, a silently wedged socket) would otherwise sit READY
+ * forever. This actively probes every live engine on an interval and, after repeated failures,
+ * hands the session to the caller's disconnect path.
+ *
+ * Split out of SessionService because it is a self-contained supervisor: one timer, one failure
+ * counter, and exactly one outward effect (`onDead`). Keeping it separate means the probe timeout,
+ * the failure threshold, and the observe-only ACTION_REQUIRED rules are testable with a fake clock
+ * instead of a live engine.
+ */
+@Injectable()
+export class SessionLivenessWatchdog {
+  private readonly logger = createLogger('SessionLivenessWatchdog');
+
+  /** Consecutive failed liveness probes per session id. Cleared on recovery or on a status change. */
+  private readonly failures = new Map<string, number>();
+  private timer: NodeJS.Timeout | null = null;
+
+  /** Invoked when a session has failed enough consecutive probes to be treated as disconnected. */
+  private onDead: (id: string, engine: IWhatsAppEngine, reason: string) => Promise<void> = () => Promise.resolve();
+
+  constructor(
+    private readonly engines: EngineRegistry,
+    @Optional()
+    private readonly shutdownService?: ShutdownService,
+  ) {}
+
+  /**
+   * Start the watchdog (idempotent). One unref'd interval probes every registered engine.
+   *
+   * @param onDead Called after MAX_FAILURES consecutive failures, to treat the session exactly like
+   *   an engine-reported disconnect.
+   */
+  start(
+    onDead: (id: string, engine: IWhatsAppEngine, reason: string) => Promise<void>,
+    intervalMs = SESSION_WATCHDOG_INTERVAL_MS,
+  ): void {
+    this.onDead = onDead;
+    if (this.timer) return;
+    this.timer = setInterval(() => {
+      // allSettled inside the tick keeps a failing session from ever throwing into the timer.
+      void this.tick();
+    }, intervalMs);
+    // The watchdog must never keep the process alive on its own.
+    this.timer.unref();
+  }
+
+  /** Stop the watchdog and forget all accrued failures. */
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    this.failures.clear();
+  }
+
+  /** Forget a session's accrued failures (e.g. it just reported ready). */
+  clear(id: string): void {
+    this.failures.delete(id);
+  }
+
+  /** Probe all live engines in parallel; a slow/failed probe must not delay or abort the others. */
+  async tick(): Promise<void> {
+    // Mid-shutdown the disconnect path would schedule a reconnect racing onModuleDestroy's teardown
+    // (same guard as scheduleReconnect) — leave the sessions to the drain instead.
+    if (this.shutdownService?.isShuttingDown()) {
+      return;
+    }
+    await Promise.allSettled([...this.engines].map(([id, engine]) => this.probe(id, engine)));
+  }
+
+  /**
+   * Actively probe one engine. Only READY sessions are expected to answer (anything else is owned by
+   * the QR/reconnect flows); engines without `probeLiveness` keep relying on engine events alone.
+   * MAX_FAILURES consecutive failures treat the session exactly like an engine-reported disconnect.
+   *
+   * ACTION_REQUIRED is probed too, but OBSERVE-ONLY: the engine is still running and a human has to
+   * act, and clearing that status is theirs to do (stop, then start). Acting on a failed probe would
+   * hand the session to the reconnect path and silently drop the very status that asked for
+   * attention — so the probe result only reaches the log. Without probing at all, a page that dies
+   * while waiting for the operator left no trace anywhere, which is what this closes.
+   */
+  async probe(id: string, engine: IWhatsAppEngine): Promise<void> {
+    const status = engine.getStatus();
+    const observeOnly = status === EngineStatus.ACTION_REQUIRED;
+    if (status !== EngineStatus.READY && !observeOnly) {
+      // Not expected to answer right now — and any accrued failures belong to a previous READY
+      // stretch, so the next one starts clean. This also self-cleans the observe-only counter below:
+      // every path out of ACTION_REQUIRED passes through a status that lands here (or through
+      // onReady, which clears it), so an observe-only count can never be inherited by a READY
+      // stretch and push it over MAX_FAILURES early.
+      this.failures.delete(id);
+      return;
+    }
+    // Feature-detect: an engine whose transport already self-detects death may skip the probe.
+    if (typeof engine.probeLiveness !== 'function') {
+      return;
+    }
+
+    // A wedged connection can hang the probe itself, so race it against a timeout; a timeout or a
+    // probe error both count as "not proven alive".
+    let alive: boolean;
+    let probeTimer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      alive = await Promise.race([
+        engine.probeLiveness(),
+        new Promise<never>((_, reject) => {
+          probeTimer = setTimeout(
+            () => reject(new Error('liveness probe timed out')),
+            SESSION_WATCHDOG_PROBE_TIMEOUT_MS,
+          );
+        }),
+      ]);
+    } catch {
+      alive = false;
+    } finally {
+      if (probeTimer) clearTimeout(probeTimer);
+    }
+
+    // The session may have been stopped/restarted (engine superseded) while the probe was in flight;
+    // a stale result must not touch it (mirrors the isLive gate on engine callbacks).
+    if (!this.engines.isLive(id, engine)) {
+      return;
+    }
+
+    if (alive) {
+      // Note a recovery on the observe-only path, so the log shows the page came back rather than
+      // leaving the earlier warning as the last word.
+      if (observeOnly && this.failures.has(id)) {
+        this.logger.log('Liveness probe answering again while the session awaits operator action', {
+          sessionId: id,
+          action: 'watchdog_probe_recovered',
+        });
+      }
+      this.failures.delete(id);
+      return;
+    }
+
+    const failures = (this.failures.get(id) ?? 0) + 1;
+    if (observeOnly) {
+      this.failures.set(id, failures);
+      // One warning per unresponsive stretch, not one per tick: a session can sit in
+      // ACTION_REQUIRED until a human gets to it, and at a 60s interval an unbounded log would bury
+      // everything else. The count keeps rising so the recovery branch above can tell it happened.
+      if (failures === 1) {
+        this.logger.warn(
+          'Liveness probe failed while the session awaits operator action; not reconnecting it — ' +
+            'the status is operator-owned. If the page is gone, stop and start the session.',
+          { sessionId: id, action: 'watchdog_probe_failed_observe_only' },
+        );
+      }
+      return;
+    }
+
+    if (failures < SESSION_WATCHDOG_MAX_FAILURES) {
+      this.failures.set(id, failures);
+      this.logger.warn('Liveness probe failed; will treat the session as dead after repeated failures', {
+        sessionId: id,
+        failures,
+        action: 'watchdog_probe_failed',
+      });
+      return;
+    }
+
+    this.failures.delete(id);
+    this.logger.warn('Liveness probe failed repeatedly; handling the session as disconnected', {
+      sessionId: id,
+      failures,
+      action: 'watchdog_disconnect',
+    });
+    await this.onDead(id, engine, 'liveness probe failed (watchdog)');
+  }
+}
+
+/**
+ * Session liveness watchdog cadence. The engine layer is event-driven, so an engine that dies
+ * WITHOUT emitting a disconnect would otherwise sit READY forever.
+ */
+export const SESSION_WATCHDOG_INTERVAL_MS = 60_000;
+/** A wedged connection can hang the probe itself, so each probe is raced against this deadline. */
+export const SESSION_WATCHDOG_PROBE_TIMEOUT_MS = 15_000;
+/** Consecutive failed probes before a session is treated as disconnected. */
+export const SESSION_WATCHDOG_MAX_FAILURES = 2;

--- a/src/modules/session/session.module.ts
+++ b/src/modules/session/session.module.ts
@@ -5,6 +5,7 @@ import { Message } from '../message/entities/message.entity';
 import { SessionService } from './session.service';
 import { SessionLidResolver } from './session-lid-resolver.service';
 import { SessionLivenessWatchdog } from './session-liveness-watchdog.service';
+import { MessageProjector } from './message-projector.service';
 import { SessionController } from './session.controller';
 import { WebhookModule } from '../webhook/webhook.module';
 import { StatusStoreModule } from '../status-store/status-store.module';
@@ -14,7 +15,7 @@ import { StatusStoreModule } from '../status-store/status-store.module';
   // one-directional — no forwardRef() needed.
   imports: [TypeOrmModule.forFeature([Session, Message], 'data'), WebhookModule, StatusStoreModule],
   controllers: [SessionController],
-  providers: [SessionService, SessionLidResolver, SessionLivenessWatchdog],
-  exports: [SessionService],
+  providers: [SessionService, SessionLidResolver, SessionLivenessWatchdog, MessageProjector],
+  exports: [SessionService, MessageProjector],
 })
 export class SessionModule {}

--- a/src/modules/session/session.module.ts
+++ b/src/modules/session/session.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Session } from './entities/session.entity';
 import { Message } from '../message/entities/message.entity';
 import { SessionService } from './session.service';
+import { SessionLidResolver } from './session-lid-resolver.service';
 import { SessionController } from './session.controller';
 import { WebhookModule } from '../webhook/webhook.module';
 import { StatusStoreModule } from '../status-store/status-store.module';
@@ -12,7 +13,7 @@ import { StatusStoreModule } from '../status-store/status-store.module';
   // one-directional — no forwardRef() needed.
   imports: [TypeOrmModule.forFeature([Session, Message], 'data'), WebhookModule, StatusStoreModule],
   controllers: [SessionController],
-  providers: [SessionService],
+  providers: [SessionService, SessionLidResolver],
   exports: [SessionService],
 })
 export class SessionModule {}

--- a/src/modules/session/session.module.ts
+++ b/src/modules/session/session.module.ts
@@ -4,6 +4,7 @@ import { Session } from './entities/session.entity';
 import { Message } from '../message/entities/message.entity';
 import { SessionService } from './session.service';
 import { SessionLidResolver } from './session-lid-resolver.service';
+import { SessionLivenessWatchdog } from './session-liveness-watchdog.service';
 import { SessionController } from './session.controller';
 import { WebhookModule } from '../webhook/webhook.module';
 import { StatusStoreModule } from '../status-store/status-store.module';
@@ -13,7 +14,7 @@ import { StatusStoreModule } from '../status-store/status-store.module';
   // one-directional — no forwardRef() needed.
   imports: [TypeOrmModule.forFeature([Session, Message], 'data'), WebhookModule, StatusStoreModule],
   controllers: [SessionController],
-  providers: [SessionService, SessionLidResolver],
+  providers: [SessionService, SessionLidResolver, SessionLivenessWatchdog],
   exports: [SessionService],
 })
 export class SessionModule {}

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -24,6 +24,7 @@ import { Webhook } from '../webhook/entities/webhook.entity';
 import { Template } from '../template/entities/template.entity';
 import { BaileysStoredMessage } from '../../engine/adapters/baileys-stored-message.entity';
 import { EngineFactory } from '../../engine/engine.factory';
+import { EngineRegistry } from '../../engine/engine-registry.service';
 import { LidMappingStoreService } from '../../engine/identity/lid-mapping-store.service';
 import { EventsGateway } from '../events/events.gateway';
 import { WebhookService } from '../webhook/webhook.service';
@@ -197,6 +198,10 @@ describe('SessionService', () => {
           useValue: dataSource,
         },
         { provide: EngineFactory, useValue: engineFactory },
+        // Real EngineRegistry, not a mock: it is the live-engine source of truth this service reads
+        // and writes on every lifecycle path, and the identity semantics (isLive/deleteIfLive) are
+        // exactly what the stale-callback tests below exercise. Its own unit tests cover it directly.
+        EngineRegistry,
         { provide: EventsGateway, useValue: eventsGateway },
         { provide: WebhookService, useValue: webhookService },
         { provide: HookManager, useValue: hookManager },

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -25,6 +25,7 @@ import { Template } from '../template/entities/template.entity';
 import { BaileysStoredMessage } from '../../engine/adapters/baileys-stored-message.entity';
 import { EngineFactory } from '../../engine/engine.factory';
 import { EngineRegistry } from '../../engine/engine-registry.service';
+import type { KeyedMutationQueue } from '../../common/utils/keyed-mutation-queue';
 import { SessionLidResolver } from './session-lid-resolver.service';
 import { LidMappingStoreService } from '../../engine/identity/lid-mapping-store.service';
 import { EventsGateway } from '../events/events.gateway';
@@ -2913,7 +2914,7 @@ describe('SessionService', () => {
 
       for (let i = 0; i < 3; i++) await flush();
 
-      const chains = (service as unknown as { messageMutationChains: Map<string, unknown> }).messageMutationChains;
+      const chains = (service as unknown as { messageMutations: KeyedMutationQueue }).messageMutations;
       expect(chains.size).toBe(0);
     });
 

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -25,6 +25,7 @@ import { Template } from '../template/entities/template.entity';
 import { BaileysStoredMessage } from '../../engine/adapters/baileys-stored-message.entity';
 import { EngineFactory } from '../../engine/engine.factory';
 import { EngineRegistry } from '../../engine/engine-registry.service';
+import { SessionLidResolver } from './session-lid-resolver.service';
 import { LidMappingStoreService } from '../../engine/identity/lid-mapping-store.service';
 import { EventsGateway } from '../events/events.gateway';
 import { WebhookService } from '../webhook/webhook.service';
@@ -202,6 +203,7 @@ describe('SessionService', () => {
         // and writes on every lifecycle path, and the identity semantics (isLive/deleteIfLive) are
         // exactly what the stale-callback tests below exercise. Its own unit tests cover it directly.
         EngineRegistry,
+        SessionLidResolver,
         { provide: EventsGateway, useValue: eventsGateway },
         { provide: WebhookService, useValue: webhookService },
         { provide: HookManager, useValue: hookManager },

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -28,6 +28,7 @@ import { EngineRegistry } from '../../engine/engine-registry.service';
 import type { KeyedMutationQueue } from '../../common/utils/keyed-mutation-queue';
 import { SessionLidResolver } from './session-lid-resolver.service';
 import { SessionLivenessWatchdog } from './session-liveness-watchdog.service';
+import { MessageProjector } from './message-projector.service';
 import { LidMappingStoreService } from '../../engine/identity/lid-mapping-store.service';
 import { EventsGateway } from '../events/events.gateway';
 import { WebhookService } from '../webhook/webhook.service';
@@ -207,6 +208,7 @@ describe('SessionService', () => {
         EngineRegistry,
         SessionLidResolver,
         SessionLivenessWatchdog,
+        MessageProjector,
         { provide: EventsGateway, useValue: eventsGateway },
         { provide: WebhookService, useValue: webhookService },
         { provide: HookManager, useValue: hookManager },
@@ -2921,7 +2923,10 @@ describe('SessionService', () => {
 
       for (let i = 0; i < 3; i++) await flush();
 
-      const chains = (service as unknown as { messageMutations: KeyedMutationQueue }).messageMutations;
+      // The queue lives on the projector now; reach the instance SessionService delegates to so
+      // this still asserts the real chain drained rather than an object that no longer exists.
+      const chains = (service as unknown as { messages: { messageMutations: KeyedMutationQueue } }).messages
+        .messageMutations;
       expect(chains.size).toBe(0);
     });
 
@@ -4622,7 +4627,11 @@ describe('SessionService', () => {
       // The inbound edit lands first; the REST outbound edit for the same message must queue BEHIND
       // it instead of racing the row directly (latest-write-wins across both directions).
       onMessageEdited(inboundEdit);
-      const outbound = service.recordOutboundMessageEdit('sess-uuid-1', 'WA_MSG_EDIT_1', 'outbound edit');
+      const outbound = (service as unknown as { messages: MessageProjector }).messages.recordOutboundMessageEdit(
+        'sess-uuid-1',
+        'WA_MSG_EDIT_1',
+        'outbound edit',
+      );
       await new Promise(resolve => setImmediate(resolve));
 
       expect(messageRepository.update).toHaveBeenCalledTimes(1); // only the inbound write started
@@ -4644,7 +4653,13 @@ describe('SessionService', () => {
     it('is best-effort: a missing row / failed write does not reject the request', async () => {
       (messageRepository.update as jest.Mock).mockRejectedValueOnce(new Error('db down'));
 
-      await expect(service.recordOutboundMessageEdit('sess-uuid-1', 'GONE', 'x')).resolves.toBeUndefined();
+      await expect(
+        (service as unknown as { messages: MessageProjector }).messages.recordOutboundMessageEdit(
+          'sess-uuid-1',
+          'GONE',
+          'x',
+        ),
+      ).resolves.toBeUndefined();
     });
   });
 

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -27,6 +27,7 @@ import { EngineFactory } from '../../engine/engine.factory';
 import { EngineRegistry } from '../../engine/engine-registry.service';
 import type { KeyedMutationQueue } from '../../common/utils/keyed-mutation-queue';
 import { SessionLidResolver } from './session-lid-resolver.service';
+import { SessionLivenessWatchdog } from './session-liveness-watchdog.service';
 import { LidMappingStoreService } from '../../engine/identity/lid-mapping-store.service';
 import { EventsGateway } from '../events/events.gateway';
 import { WebhookService } from '../webhook/webhook.service';
@@ -205,6 +206,7 @@ describe('SessionService', () => {
         // exactly what the stale-callback tests below exercise. Its own unit tests cover it directly.
         EngineRegistry,
         SessionLidResolver,
+        SessionLivenessWatchdog,
         { provide: EventsGateway, useValue: eventsGateway },
         { provide: WebhookService, useValue: webhookService },
         { provide: HookManager, useValue: hookManager },
@@ -1637,11 +1639,14 @@ describe('SessionService', () => {
         string,
         { attempts: number; timer: NodeJS.Timeout | null; maxAttempts: number; baseDelay: number }
       >;
-      livenessFailures: Map<string, number>;
-      watchdogTimer: NodeJS.Timeout | null;
+      // The probe cadence and failure counting now live in SessionLivenessWatchdog; these tests
+      // still drive them end-to-end through SessionService, so they reach the collaborator's state
+      // rather than the service's own.
+      watchdog: { failures: Map<string, number>; timer: NodeJS.Timeout | null };
       scheduleReconnect: (id: string, session: Session) => void;
     };
     const internals = (): WatchdogInternals => service as unknown as WatchdogInternals;
+    const livenessFailures = (): Map<string, number> => internals().watchdog.failures;
 
     // Auto-start is OFF in these tests — the watchdog must start regardless.
     const originalFlag = process.env.AUTO_START_SESSIONS;
@@ -1790,7 +1795,7 @@ describe('SessionService', () => {
           expect.objectContaining({ status: SessionStatus.DISCONNECTED }),
         );
         // The count keeps rising so a later recovery can be distinguished from "never failed".
-        expect(internals().livenessFailures.get('sess-uuid-1')).toBeGreaterThan(SESSION_WATCHDOG_MAX_FAILURES);
+        expect(livenessFailures().get('sess-uuid-1')).toBeGreaterThan(SESSION_WATCHDOG_MAX_FAILURES);
       } finally {
         jest.clearAllTimers();
         jest.useRealTimers();
@@ -1807,8 +1812,10 @@ describe('SessionService', () => {
           probeLiveness: jest.fn().mockResolvedValue(false),
         };
         seedReadySession(engine);
+        // The observe-only warning is emitted by the watchdog collaborator, which carries its own
+        // logger; the behaviour under test (one warning per stretch) is unchanged.
         const warnSpy = jest.spyOn(
-          (service as unknown as { logger: { warn: (...a: unknown[]) => void } }).logger,
+          (internals().watchdog as unknown as { logger: { warn: (...a: unknown[]) => void } }).logger,
           'warn',
         );
 
@@ -1839,12 +1846,12 @@ describe('SessionService', () => {
 
         await service.onApplicationBootstrap();
         await jest.advanceTimersByTimeAsync(SESSION_WATCHDOG_INTERVAL_MS); // tick 1: probe hangs
-        expect(internals().livenessFailures.get('sess-uuid-1')).toBeUndefined(); // not counted yet
+        expect(livenessFailures().get('sess-uuid-1')).toBeUndefined(); // not counted yet
         await jest.advanceTimersByTimeAsync(SESSION_WATCHDOG_PROBE_TIMEOUT_MS); // 15s → timeout failure
-        expect(internals().livenessFailures.get('sess-uuid-1')).toBe(1);
+        expect(livenessFailures().get('sess-uuid-1')).toBe(1);
 
         await jest.advanceTimersByTimeAsync(SESSION_WATCHDOG_INTERVAL_MS); // tick 2: success
-        expect(internals().livenessFailures.get('sess-uuid-1')).toBeUndefined(); // counter reset
+        expect(livenessFailures().get('sess-uuid-1')).toBeUndefined(); // counter reset
       } finally {
         jest.clearAllTimers();
         jest.useRealTimers();
@@ -1855,11 +1862,11 @@ describe('SessionService', () => {
       jest.useFakeTimers();
       try {
         await service.onApplicationBootstrap();
-        expect(internals().watchdogTimer).not.toBeNull();
+        expect(internals().watchdog.timer).not.toBeNull();
         expect(jest.getTimerCount()).toBe(1); // the interval itself
 
         await service.onModuleDestroy();
-        expect(internals().watchdogTimer).toBeNull();
+        expect(internals().watchdog.timer).toBeNull();
         expect(jest.getTimerCount()).toBe(0);
 
         await expect(service.onModuleDestroy()).resolves.toBeUndefined(); // safe to call twice

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -27,7 +27,7 @@ import { decideReconnect, type ReconnectAttemptState } from './reconnect-policy'
 import { SessionLidResolver } from './session-lid-resolver.service';
 import { SessionLivenessWatchdog } from './session-liveness-watchdog.service';
 import { MessageProjector } from './message-projector.service';
-import { resolveAuthTimeoutMs } from '../../engine/adapters/whatsapp-web-js.adapter';
+import { resolveEngineInitTimeoutMs } from '../../engine/engine-init-timeout';
 import { paginate, ListOptions, resolveListWindow } from '../../common/utils/paginate';
 import { isUniqueConstraintError } from '../../common/utils/unique-constraint.util';
 import { resolveFeatureFlags } from '../../config/feature-flags';
@@ -1181,12 +1181,9 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
     // propagate untouched so start()'s catch keeps owning FAILED+reason (the diagnosability #600/#631
     // added) — pre-deleting the engine and writing DISCONNECTED here would make start()'s
     // `engines.get(id)` return undefined, skip its FAILED write, and hide the failure reason.
-    // The deadline MUST exceed the auth wait whatsapp-web.js runs INSIDE engine.initialize()
-    // (authTimeoutMs — the inject() poll for WA Web's JS to bootstrap, raisable via
-    // WWEBJS_AUTH_TIMEOUT_MS for slow first boots, e.g. WSL2/low-resource containers). A shorter
-    // outer deadline would SIGKILL a legitimate slow init mid-auth. Floor 60s for the hang case;
-    // otherwise give the configured auth window + 30s for launch/navigation/post-inject overhead.
-    const engineInitTimeoutMs = Math.max(60_000, (resolveAuthTimeoutMs() ?? 30_000) + 30_000);
+    // The deadline must clear the auth wait an engine runs INSIDE initialize(), or it would SIGKILL a
+    // legitimately slow init mid-auth — see resolveEngineInitTimeoutMs for the derivation.
+    const engineInitTimeoutMs = resolveEngineInitTimeoutMs();
     // Promise.race can't cancel the losing promise, so swallow a late rejection from initPromise.
     initPromise.catch(() => undefined);
 

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -14,9 +14,8 @@ import {
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository, InjectDataSource } from '@nestjs/typeorm';
 import { Repository, In, Not, IsNull, DataSource, FindManyOptions } from 'typeorm';
-import { QueryDeepPartialEntity } from 'typeorm';
 import { Session, SessionStatus } from './entities/session.entity';
-import { Message, MessageDirection, MessageStatus } from '../message/entities/message.entity';
+import { Message } from '../message/entities/message.entity';
 import { MessageBatch } from '../message/entities/message-batch.entity';
 import { Webhook } from '../webhook/entities/webhook.entity';
 import { Template } from '../template/entities/template.entity';
@@ -24,28 +23,21 @@ import { BaileysStoredMessage } from '../../engine/adapters/baileys-stored-messa
 import { CreateSessionDto } from './dto';
 import { EngineFactory } from '../../engine/engine.factory';
 import { EngineRegistry } from '../../engine/engine-registry.service';
-import { KeyedMutationQueue } from '../../common/utils/keyed-mutation-queue';
 import { decideReconnect, type ReconnectAttemptState } from './reconnect-policy';
 import { SessionLidResolver } from './session-lid-resolver.service';
-import { buildMessageMetadata, storableWaMessageId } from './message-row.mapper';
 import { SessionLivenessWatchdog } from './session-liveness-watchdog.service';
+import { MessageProjector } from './message-projector.service';
 import { resolveAuthTimeoutMs } from '../../engine/adapters/whatsapp-web-js.adapter';
 import { paginate, ListOptions, resolveListWindow } from '../../common/utils/paginate';
 import { isUniqueConstraintError } from '../../common/utils/unique-constraint.util';
 import { resolveFeatureFlags } from '../../config/feature-flags';
 import { DEFAULT_MEDIA_MAX_BYTES, STATUS_TTL_MS, StatusStoreService } from '../status-store/status-store.service';
 import { buildIncomingStatus } from '../status-store/incoming-status';
-import type { StatusUpdate } from '../status-store/entities/status-update.entity';
 import {
   IWhatsAppEngine,
   EngineStatus,
   ChatSummary,
   ChatState,
-  DeliveryStatus,
-  IncomingMessage,
-  ReactionEvent,
-  EditedMessage,
-  RevokedMessage,
   GroupEvent,
   IncomingCallEvent,
 } from '../../engine/interfaces/whatsapp-engine.interface';
@@ -58,11 +50,6 @@ import {
 import { EventsGateway } from '../events/events.gateway';
 import { WebhookService } from '../webhook/webhook.service';
 import { HookManager } from '../../core/hooks';
-import {
-  deliveryStatusToMessageStatus,
-  deliveryStatusToAck,
-  ackStatusTransitionFrom,
-} from '../message/message-status.util';
 
 // Message types that carry downloadable media. Any persisted row of these types must have a media
 // marker in metadata — never NULL — or the dashboard renders an empty bubble (no placeholder) and the
@@ -86,12 +73,6 @@ interface ReconnectState extends ReconnectAttemptState {
 const RECONNECT_BASE_DELAY_MIN_MS = 1000;
 const RECONNECT_BASE_DELAY_MAX_MS = 300_000;
 const RECONNECT_MAX_ATTEMPTS_CAP = 20;
-/**
- * Delay before retrying an ack UPDATE that matched 0 rows. A fast delivered/read ack can arrive before
- * the send's 2nd save (which writes waMessageId) has committed, so the first UPDATE finds no row. One
- * retry after this delay closes that race; the forward-only transition guard keeps it idempotent.
- */
-export const ACK_RECONCILE_DELAY_MS = 750;
 
 const clampNumber = (n: number, min: number, max: number): number => Math.min(Math.max(n, min), max);
 
@@ -117,6 +98,7 @@ export function resolveReconnectConfig(
 
 // Re-exported so the existing spec import paths keep working after these moved out.
 export { clampReconnectDelay } from './reconnect-policy';
+export { ACK_RECONCILE_DELAY_MS } from './message-projector.service';
 export {
   SESSION_WATCHDOG_INTERVAL_MS,
   SESSION_WATCHDOG_PROBE_TIMEOUT_MS,
@@ -199,16 +181,6 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
     return this.engineRegistry.initializing;
   }
 
-  // Serializes stored-message mutations per `${sessionId}:${waMessageId}`. Reactions perform a
-  // read-modify-write and rapid edits must remain latest-write-wins; sharing one chain also preserves
-  // order when different mutation kinds for the same message arrive together.
-  private readonly messageMutations = new KeyedMutationQueue((key, err) => {
-    // Both current mutation implementations contain their own contextual error handling. Keep a
-    // final guard here so a future implementation cannot leak a rejected fire-and-forget promise
-    // or permanently block the message's later mutations.
-    this.logger.error(`Unexpected failure applying message mutation: ${key}`, String(err));
-  });
-
   // Destructive credential-teardown promises (logout rms of the session's on-disk WhatsApp auth
   // dir), keyed by session NAME — the on-disk auth-dir key (EngineFactory.wwjsAuthDir/baileysAuthDir
   // and adapter clearLocalAuth all build the path from Session.name), NOT the UUID. A losing
@@ -256,6 +228,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
     private readonly engineRegistry: EngineRegistry,
     private readonly lidResolver: SessionLidResolver,
     private readonly watchdog: SessionLivenessWatchdog,
+    private readonly messages: MessageProjector,
     private readonly eventsGateway: EventsGateway,
     private readonly webhookService: WebhookService,
     private readonly hookManager: HookManager,
@@ -944,117 +917,6 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
     }
   }
 
-  /**
-   * Dispatches the opt-in `status.received` webhook once an inbound status row is ingested, and
-   * mirrors it over the websocket so the dashboard's statuses view refreshes live instead of
-   * waiting for a focus refetch. `WebhookService.dispatch` already filters delivery to webhooks
-   * whose `events` array includes `status.received`, so no extra gating is needed here. No media
-   * bytes are included in the payload — consumers fetch media via the status media endpoint.
-   */
-  private dispatchStatusReceived(sessionId: string, row: StatusUpdate): void {
-    const payload = {
-      sessionId,
-      statusId: row.waStatusId,
-      contact: {
-        id: row.contactJid,
-        ...(row.contactName ? { name: row.contactName } : {}),
-        ...(row.contactPushName ? { pushName: row.contactPushName } : {}),
-      },
-      type: row.type,
-      ...(row.caption ? { caption: row.caption } : {}),
-      hasMedia: Boolean(row.mediaPath) && !row.mediaOmitted,
-      mediaOmitted: row.mediaOmitted,
-      ...(row.omitReason ? { omitReason: row.omitReason } : {}),
-      postedAt: row.postedAt,
-      expiresAt: row.expiresAt,
-    };
-    void this.webhookService.dispatch(sessionId, 'status.received', payload);
-    this.eventsGateway.emitStatusReceived(sessionId, payload);
-  }
-
-  /**
-   * Persist pre-connection history into the `messages` table for the chat view, without webhook/hook/ws
-   * dispatch (it predates the live session). De-duplicated by `waMessageId` so re-syncs never duplicate.
-   */
-  private async persistHistoryMessages(id: string, messages: IncomingMessage[]): Promise<void> {
-    const storeEphemeralMessages = resolveFeatureFlags(this.configService).storeEphemeralMessages;
-    const byId = new Map<string, IncomingMessage>();
-    for (const m of messages) {
-      // Need an id to de-dup; chatId/from/to are NOT NULL; status/story posts aren't chats.
-      if (!m.id || m.isStatusBroadcast || !m.chatId || !m.from || !m.to) {
-        continue;
-      }
-      // Mirror the live onMessage guard: skip disappearing messages when the operator opted out, so a
-      // history backfill can't bypass STORE_EPHEMERAL_MESSAGES=false. No-op when the flag is at its
-      // default (true); only a message with a positive timer is dropped, never a regular one.
-      if (!storeEphemeralMessages && (m.ephemeralDuration ?? 0) > 0) {
-        continue;
-      }
-      byId.set(m.id, m);
-    }
-    if (byId.size === 0) {
-      return;
-    }
-    // Chunk the dedup query: a batch can be thousands, past SQLite's bound-variable limit for IN (...).
-    const ids = [...byId.keys()];
-    const CHUNK = 400;
-    let inserted = 0;
-    for (let i = 0; i < ids.length; i += CHUNK) {
-      const chunkIds = ids.slice(i, i + CHUNK);
-      const existing = await this.messageRepository.find({
-        where: { sessionId: id, waMessageId: In(chunkIds) },
-        select: { waMessageId: true },
-      });
-      const seen = new Set(existing.map(r => r.waMessageId));
-      const rows = chunkIds
-        .filter(x => !seen.has(x))
-        .map(x => {
-          const m = byId.get(x)!;
-          const metadata = buildMessageMetadata(m, true);
-          const row = this.messageRepository.create({
-            sessionId: id,
-            waMessageId: m.id,
-            chatId: m.chatId,
-            // Group poster for inbound rows only — the account's own backfilled group messages must
-            // not carry author (the column's contract is "null on outgoing echoes").
-            author: m.fromMe ? undefined : m.author,
-            from: m.from,
-            to: m.to,
-            body: m.body,
-            type: m.type,
-            direction: m.fromMe ? MessageDirection.OUTGOING : MessageDirection.INCOMING,
-            timestamp: m.timestamp,
-            status: MessageStatus.SENT,
-            metadata,
-          });
-          // The chat panel orders by createdAt; stamp the real time so history sorts correctly.
-          if (m.timestamp) {
-            row.createdAt = new Date(m.timestamp * 1000);
-          }
-          return row;
-        });
-      if (rows.length) {
-        // Insert-or-ignore: a live onMessage insert can land between the `seen` SELECT above and this
-        // write, colliding on UNIQUE(sessionId, waMessageId). orIgnore skips the collision instead of
-        // throwing and aborting the whole batch (history is best-effort, persist-never-dispatch).
-        await this.messageRepository
-          .createQueryBuilder()
-          .insert()
-          .values(rows as unknown as QueryDeepPartialEntity<Message>[])
-          .orIgnore()
-          .execute();
-        inserted += rows.length;
-      }
-    }
-    if (inserted) {
-      this.logger.log(`Persisted ${inserted} history message(s)`, {
-        sessionId: id,
-        inserted,
-        action: 'history_messages_persisted',
-      });
-    }
-  }
-
   private async initializeEngine(id: string, session: Session): Promise<void> {
     this.logger.log(`Initializing engine for session: ${session.name}`, {
       sessionId: id,
@@ -1139,17 +1001,17 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
         void this.updateStatus(id, SessionStatus.QR_READY);
       },
       onReady: (phone, pushName): void => this.handleEngineReady(id, engine, phone, pushName),
-      onMessage: (message): void => this.handleInboundMessage(id, engine, message),
+      onMessage: (message): void => this.messages.handleInboundMessage(id, engine, message),
       onHistoryMessages: (messages): void => {
         if (!this.isLiveEngine(id, engine)) return;
         // Persist for the chat view only; no dispatch (these predate the live session).
-        void this.persistHistoryMessages(id, messages).catch(err =>
-          this.logger.error(`Failed to persist history messages for ${id}`, String(err)),
-        );
+        void this.messages
+          .persistHistoryMessages(id, messages)
+          .catch(err => this.logger.error(`Failed to persist history messages for ${id}`, String(err)));
       },
-      onMessageCreate: (message): void => this.handleOwnSendEcho(id, engine, message),
-      onMessageAck: (messageId, status): void => this.handleMessageAck(id, engine, messageId, status),
-      onMessageRevoked: (message): void => this.handleMessageRevoked(id, engine, message),
+      onMessageCreate: (message): void => this.messages.handleOwnSendEcho(id, engine, message),
+      onMessageAck: (messageId, status): void => this.messages.handleMessageAck(id, engine, messageId, status),
+      onMessageRevoked: (message): void => this.messages.handleMessageRevoked(id, engine, message),
       onMessageReaction: (event): void => {
         if (!this.isLiveEngine(id, engine)) return;
         if (!event.messageId) {
@@ -1165,7 +1027,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
           action: 'message_reaction_received',
         });
 
-        this.enqueueMessageMutation(id, event.messageId, () => this.applyReaction(id, event));
+        this.messages.applyReactionQueued(id, event);
       },
       onMessageEdited: (message): void => {
         if (!this.isLiveEngine(id, engine)) return;
@@ -1182,7 +1044,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
           action: 'message_edited',
         });
 
-        this.enqueueMessageMutation(id, message.messageId, () => this.applyMessageEdit(id, message));
+        this.messages.applyMessageEditQueued(id, message);
       },
       onGroupEvent: (event): void => {
         if (!this.isLiveEngine(id, engine)) return;
@@ -1389,376 +1251,6 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
    * reactions on the same message run sequentially and don't clobber each other.
    */
   /** Engine callback body, lifted out of initializeEngine so the wiring table stays readable. */
-  private handleInboundMessage(id: string, engine: IWhatsAppEngine, message: IncomingMessage): void {
-    if (!this.isLiveEngine(id, engine)) return;
-    // Status/Story posts arrive via the inbound path for some engines; ingest them into the
-    // status store instead of the message pipeline. Mirrors the isStatusBroadcast guard in
-    // onMessageCreate below: an own-send echo (fromMe) stays a plain drop — never ingested,
-    // never dispatched — so a status you posted never re-appears in your own webhooks/API as
-    // if a contact had posted it.
-    if (message.isStatusBroadcast) {
-      if (message.fromMe) return;
-      const status = buildIncomingStatus(message);
-      if (status) {
-        void this.statusStore
-          .ingest(id, status)
-          // Dispatch only on a fresh insert: ingest also resolves with the pre-existing row
-          // for a duplicate delivery (or the winner's row after a lost insert race), and the
-          // webhook must fire once per status, not once per (re)delivery.
-          .then(({ row, created }) => {
-            // The ingest awaited; a stop()/delete() can retire this engine mid-flight — don't
-            // dispatch for a session that no longer exists (mirrors message.received's re-check).
-            if (!this.isLiveEngine(id, engine)) return;
-            if (created) this.dispatchStatusReceived(id, row);
-          })
-          .catch(err =>
-            this.logger.warn('Status ingest failed', {
-              sessionId: id,
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-      }
-      return;
-    }
-    // Ephemeral/disappearing messages: skip persist + dispatch when the operator opted out.
-    // A message is ephemeral when its chat has a disappearing-messages timer (ephemeralDuration > 0).
-    if (
-      !resolveFeatureFlags(this.configService).storeEphemeralMessages &&
-      message.ephemeralDuration &&
-      message.ephemeralDuration > 0
-    ) {
-      this.logger.debug('Skipping ephemeral message', {
-        sessionId: id,
-        messageId: message.id,
-        chatId: message.chatId,
-        ephemeralDuration: message.ephemeralDuration,
-      });
-      return;
-    }
-    this.logger.debug(`Message received from ${message.from}`, {
-      sessionId: id,
-      messageId: message.id,
-      from: message.from,
-      action: 'message_received',
-    });
-    // Update last active timestamp
-    void this.sessionRepository.update(id, { lastActiveAt: new Date() }).catch(() => undefined);
-    // Convert IncomingMessage to plain object for dispatch
-    const messageData = { ...message };
-
-    // Execute hook for message received - plugins can modify or stop processing
-    void this.hookManager
-      .execute('message:received', messageData, {
-        sessionId: id,
-        source: 'Engine',
-      })
-      .then(async ({ data: finalMessage }) => {
-        // `continue: false` is deliberately NOT read here. It means "stop the handler chain", which
-        // HookManager has already done — the plugins after the one that returned it never ran. It
-        // does not mean "this message never happened".
-        //
-        // Honouring it here used to skip everything below: the message was never written to the
-        // messages table, never dispatched to webhooks, and never emitted over the websocket. An
-        // auto-reply plugin returning `false` for its ordinary purpose — keeping other bots from
-        // answering the same message — silently erased the customer's message from the operator's
-        // own history, leaving a thread of bot replies answering nothing. Nothing in the hook
-        // contract (`HookResult.continue`, docs/19) or the webhook contract (`message.received`
-        // fires when "an inbound message arrives", docs/06) hinted at that, and a sandboxed
-        // marketplace plugin could swallow a session's entire inbound traffic with no audit trail.
-        //
-        // The message has already arrived at WhatsApp. A plugin can stop other plugins from acting
-        // on it; it cannot make the gateway forget it. Pre-action hooks are where a veto belongs —
-        // `message:sending` blocks a send that has not happened yet (core/hooks/sending-gate.ts).
-
-        // Persist the incoming message so the dashboard chats view can render history.
-        const incoming: IncomingMessage = finalMessage;
-
-        // Inline @lid -> phone resolution (#263), opt-in via RESOLVE_LID_TO_PHONE. Best-effort:
-        // attaches senderPhone (digits or null) before persist/dispatch so webhook/ws consumers
-        // get it in a single pass. Only for privacy-id senders, so no lookup for normal numbers.
-        if (resolveFeatureFlags(this.configService).resolveLidToPhone && incoming.isLidSender && !incoming.fromMe) {
-          incoming.senderPhone = await this.lidResolver.resolveSenderPhone(id, incoming.author ?? incoming.from);
-        }
-
-        const metadata = buildMessageMetadata(incoming);
-
-        const chatName = incoming.contact?.pushName ?? incoming.contact?.name ?? undefined;
-
-        const dbMessage = this.messageRepository.create({
-          sessionId: id,
-          waMessageId: storableWaMessageId(incoming.id),
-          chatId: incoming.chatId,
-          chatName,
-          // Group poster (participant JID) — `from` is the group JID, so this is the stable
-          // sender identity the chat view keys attribution runs/colors on. Undefined for 1:1.
-          author: incoming.author,
-          from: incoming.from,
-          to: incoming.to,
-          body: incoming.body,
-          type: incoming.type,
-          direction: incoming.fromMe ? MessageDirection.OUTGOING : MessageDirection.INCOMING,
-          timestamp: incoming.timestamp,
-          status: MessageStatus.SENT,
-          metadata,
-        });
-
-        // The hook chain above is async; a delete()/teardown can retire this engine while it
-        // awaits. Re-check liveness so a late continuation can't persist an orphan messages row
-        // (the row has no FK, so a session-delete cleanup would never reap it) or dispatch for a
-        // session that no longer exists. Mirrors the synchronous isLiveEngine gate at entry.
-        if (!this.isLiveEngine(id, engine)) return;
-
-        // De-duplicate at the source: the engine can re-fire `message` for one inbound message
-        // (#464). UNIQUE(sessionId, waMessageId) makes the insert the atomic dedup oracle — a
-        // near-simultaneous re-fire loses the race and is skipped here, so persist + webhook + WS
-        // happen exactly once. Fail-open: a non-conflict DB error still dispatches, so a real
-        // message is never dropped by a transient DB failure.
-        let isNewMessage = true;
-        let persisted = false;
-        try {
-          // `insert()` (not `save()`) is load-bearing: the UNIQUE(sessionId, waMessageId) constraint
-          // makes a duplicate insert throw, which is the atomic dedup oracle for #464 re-fires.
-          // Unlike `save()`, `insert()` does NOT merge DB-generated columns (@PrimaryGeneratedColumn,
-          // @CreateDateColumn) back onto the entity instance — so merge them explicitly here, before
-          // the `message:persisted` emit. `identifiers[0]` always carries the PK on both SQLite and
-          // Postgres; `generatedMaps[0]` adds createdAt where the driver returns it (Postgres yes;
-          // SQLite historically does not — acceptable; the PK is the load-bearing field for plugins).
-          const result = await this.messageRepository.insert(dbMessage as unknown as QueryDeepPartialEntity<Message>);
-          Object.assign(dbMessage, result.identifiers[0] ?? {}, result.generatedMaps?.[0] ?? {});
-          persisted = true;
-        } catch (err) {
-          if (isUniqueConstraintError(err)) {
-            isNewMessage = false;
-          } else {
-            this.logger.error(`Failed to save incoming message ${incoming.id} to database`, String(err));
-          }
-        }
-        if (!isNewMessage) {
-          return; // duplicate re-fire — the original already persisted and dispatched
-        }
-
-        // Fire-and-forget: a plugin handler must never break the receive path. Both engine adapters
-        // (wwjs `message` and Baileys `upsert`) converge on this persist, so one emit covers inbound.
-        // The built-in FTS search provider is DB-synced and does NOT consume this; it exists for
-        // plugin providers (Spec 2) + general use.
-        // Gate ONLY the hook on `persisted`: on a non-unique insert error (transient SQLITE_BUSY /
-        // lock-timeout / connection drop) the row was never stored and `dbMessage.id` is undefined,
-        // so emitting `message:persisted` would hand plugins an id-less payload for a row that isn't
-        // in the DB. The webhook/WS dispatch below stays fail-open — a real inbound message must
-        // never be dropped on a transient DB failure; only the hook requires a durable row.
-        if (persisted) {
-          void this.hookManager
-            .execute(
-              'message:persisted',
-              { sessionId: id, message: dbMessage },
-              { sessionId: id, source: 'SessionService' },
-            )
-            .catch(() => undefined);
-        }
-
-        // Dispatch to webhooks with potentially modified message
-        void this.webhookService.dispatch(id, 'message.received', finalMessage);
-        // Emit real-time event to WebSocket clients
-        this.eventsGateway.emitMessage(id, finalMessage);
-      })
-      .catch(err => this.logger.error(`onMessage handler failed for ${id}`, String(err)));
-  }
-
-  /** Engine callback body, lifted out of initializeEngine so the wiring table stays readable. */
-  private handleOwnSendEcho(id: string, engine: IWhatsAppEngine, message: IncomingMessage): void {
-    if (!this.isLiveEngine(id, engine)) return;
-    // `message_create` fires for every message the account creates, including sends composed on a
-    // linked phone — which the `message`/`onMessage` event never delivers. Incoming messages are
-    // already handled by `onMessage`, so only outgoing (`fromMe`) ones produce `message.sent` here.
-    if (!message.fromMe) {
-      return;
-    }
-
-    // Status/Story posts are account-created but not real conversations; don't emit `message.sent`
-    // for them. The adapter flags these (the engine-specific pseudo-JID stays out of this layer).
-    if (message.isStatusBroadcast) {
-      return;
-    }
-
-    this.logger.debug(`Message sent to ${message.to}`, {
-      sessionId: id,
-      messageId: message.id,
-      to: message.to,
-      action: 'message_sent',
-    });
-    // Update last active timestamp
-    void this.sessionRepository.update(id, { lastActiveAt: new Date() }).catch(() => undefined);
-    const messageData = { ...message };
-
-    // Execute hook for message sent - plugins can modify or stop processing
-    void this.hookManager
-      .execute('message:sent', messageData, {
-        sessionId: id,
-        source: 'Engine',
-      })
-      .then(async ({ data: finalMessage }) => {
-        // `continue: false` is not read here, for the same reason as the message:received path
-        // above: the send has already happened, so a plugin can stop the handler chain but cannot
-        // un-send it. Skipping the persist below dropped the operator's own outgoing message from
-        // history and from `message.sent` webhooks.
-
-        // Persist the outgoing message so local history reflects sends composed on a linked phone
-        // (message_create is the ONLY event those produce). It also fires for API-originated sends,
-        // which the REST send path persists itself — the UNIQUE(sessionId, waMessageId) index is
-        // the atomic dedup oracle between the two writers: the loser skips its insert, and
-        // persistSentState additionally drops its redundant PENDING row when the echo won. The
-        // webhook/WS dispatch below is identical whether the insert won, lost, or failed — the
-        // message.sent contract is unchanged.
-        const outgoing: IncomingMessage = finalMessage;
-        const metadata = buildMessageMetadata(outgoing, true);
-
-        // The ephemeral opt-out gates STORAGE only (mirrors onMessage); the live dispatch below
-        // is today's contract and stays.
-        const mayPersist =
-          resolveFeatureFlags(this.configService).storeEphemeralMessages ||
-          !(outgoing.ephemeralDuration && outgoing.ephemeralDuration > 0);
-
-        if (mayPersist) {
-          const dbMessage = this.messageRepository.create({
-            sessionId: id,
-            waMessageId: storableWaMessageId(outgoing.id),
-            chatId: outgoing.chatId,
-            from: outgoing.from,
-            to: outgoing.to,
-            body: outgoing.body,
-            type: outgoing.type,
-            direction: MessageDirection.OUTGOING,
-            timestamp: outgoing.timestamp,
-            status: MessageStatus.SENT,
-            metadata,
-          });
-          // The hook chain above is async; a delete()/teardown can retire this engine while it
-          // awaits. Re-check liveness so a late continuation can't persist an orphan row
-          // (mirrors onMessage).
-          if (!this.isLiveEngine(id, engine)) return;
-          let persisted = false;
-          try {
-            const result = await this.messageRepository.insert(dbMessage as unknown as QueryDeepPartialEntity<Message>);
-            Object.assign(dbMessage, result.identifiers[0] ?? {}, result.generatedMaps?.[0] ?? {});
-            persisted = true;
-          } catch (err) {
-            // Unique violation = the REST send path already persisted this API-originated send —
-            // the dedup oracle working as intended, not an error. Anything else is a real DB
-            // failure; fail open so a real send is never dropped on a transient DB fault.
-            if (!isUniqueConstraintError(err)) {
-              this.logger.error(`Failed to save outgoing message ${outgoing.id} to database`, String(err));
-            }
-          }
-          if (persisted) {
-            // Fire-and-forget, mirroring onMessage: plugin providers (search etc.) see phone-
-            // composed sends exactly like API sends.
-            void this.hookManager
-              .execute(
-                'message:persisted',
-                { sessionId: id, message: dbMessage },
-                { sessionId: id, source: 'SessionService' },
-              )
-              .catch(() => undefined);
-          }
-        }
-
-        void this.webhookService.dispatch(id, 'message.sent', finalMessage);
-        // Emit real-time event to WebSocket clients (as message.sent, not message.received)
-        this.eventsGateway.emitMessageSent(id, finalMessage);
-      })
-      .catch(err => this.logger.error(`onMessageCreate handler failed for ${id}`, String(err)));
-  }
-
-  /** Engine callback body, lifted out of initializeEngine so the wiring table stays readable. */
-  private handleMessageAck(id: string, engine: IWhatsAppEngine, messageId: string, status: DeliveryStatus): void {
-    if (!this.isLiveEngine(id, engine)) return;
-    this.logger.debug(`Message ack: ${messageId} -> ${status}`, {
-      sessionId: id,
-      messageId,
-      status,
-      action: 'message_ack',
-    });
-
-    // Reflect real delivery state on the stored message (#220): delivered/read/failed advance the
-    // stored status; pending/sent carry no upgrade (it's already SENT — visibly "not delivered").
-    // The UPDATE is guarded to the allowed prior statuses so delivery state only ADVANCES: an
-    // out-of-order/late ack cannot downgrade a higher status, which also makes these
-    // fire-and-forget writes race-safe at the DB level.
-    const messageStatus = deliveryStatusToMessageStatus(status);
-    if (messageStatus) {
-      // Scope by sessionId: waMessageId is unique per account/chat, not global — an ack on one
-      // session must never advance a same-id row in another session. The In() guard makes the
-      // UPDATE forward-only (a late/out-of-order ack can't downgrade) and idempotent on retry.
-      const advanceAck = (): Promise<number> =>
-        this.messageRepository
-          .update(
-            { sessionId: id, waMessageId: messageId, status: In(ackStatusTransitionFrom(messageStatus)) },
-            { status: messageStatus },
-          )
-          .then(result => result.affected ?? 0);
-
-      const logNoop = (): void =>
-        this.logger.debug(`Message ack ${messageId}: no status row advanced to ${messageStatus} (${status})`, {
-          sessionId: id,
-          messageId,
-          status,
-          action: 'message_ack_noop',
-        });
-
-      const onAckError = (err: unknown): void =>
-        this.logger.error(`Failed to advance ack for ${messageId}`, String(err));
-
-      void advanceAck()
-        .then(affected => {
-          if (affected > 0) return;
-          // affected:0 — most likely the send's 2nd save (which writes waMessageId) hasn't committed
-          // yet, so the row isn't matchable. Each ack is one-shot (WhatsApp won't necessarily resend),
-          // so retry ONCE after a short delay to close that race rather than leave it stuck at SENT.
-          const timer = setTimeout(() => {
-            void advanceAck()
-              .then(retried => {
-                if (retried === 0) logNoop();
-              })
-              .catch(onAckError);
-          }, ACK_RECONCILE_DELAY_MS);
-          timer.unref?.();
-        })
-        .catch(onAckError);
-    }
-
-    // One ack payload, emitted identically over the socket and the webhook so a client coded
-    // against either channel sees the same shape. `id` mirrors the field every other message.*
-    // event carries (and the idempotency-key resolver reads). `ack` is a deprecated legacy field
-    // kept for backward compatibility — new consumers should read the neutral `status`.
-    const ackPayload = { id: messageId, messageId, status, ack: deliveryStatusToAck(status) };
-
-    // Push the live delivery/read tick to the dashboard over the websocket.
-    this.eventsGateway.emitMessageAck(id, ackPayload);
-
-    // Dispatch the delivery/read receipt to webhooks (#155). Outgoing `message.sent` is handled
-    // solely by `onMessageCreate`, so the ack path deliberately does NOT emit `message.sent`.
-    void this.webhookService.dispatch(id, 'message.ack', ackPayload);
-
-    // Surface delivery failures actively so consumers don't have to poll for them (#220). Use a
-    // distinct object (not the shared ackPayload) so this separate event can't be perturbed by an
-    // in-place payload mutation in the concurrent message.ack dispatch's webhook:before hook.
-    if (status === 'failed') {
-      void this.webhookService.dispatch(id, 'message.failed', { ...ackPayload });
-    }
-
-    // Notify plugins of the delivery/read receipt. The `message:ack` hook event was declared in
-    // the HookEvent union but never emitted, so any plugin registered for it silently never fired.
-    // Fire-and-forget: an ack is a notification with nothing downstream to cancel, so the hook's
-    // `continue` flag is moot. Delivery failures surface here as status `failed` — `message:failed`
-    // stays reserved for send-time send failures, which carry a distinct `{ error, input }` payload.
-    void this.hookManager.execute(
-      'message:ack',
-      { messageId, status, ack: deliveryStatusToAck(status) },
-      { sessionId: id, source: 'Engine' },
-    );
-  }
-
-  /** Engine callback body, lifted out of initializeEngine so the wiring table stays readable. */
   private handleEngineReady(id: string, engine: IWhatsAppEngine, phone: string, pushName: string): void {
     if (!this.isLiveEngine(id, engine)) return;
     this.logger.log(`Session ready: ${phone}`, {
@@ -1812,112 +1304,6 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
     // posts arrive through onMessage below; this just backfills what was already up before we
     // connected. Not awaited — onReady must not block on it.
     void this.seedStatuses(id, engine);
-  }
-
-  /** Engine callback body, lifted out of initializeEngine so the wiring table stays readable. */
-  private handleMessageRevoked(id: string, engine: IWhatsAppEngine, message: RevokedMessage): void {
-    if (!this.isLiveEngine(id, engine)) return;
-    this.logger.debug(`Message revoked: ${message.id}`, {
-      sessionId: id,
-      messageId: message.id,
-      action: 'message_revoked',
-    });
-
-    // Flag the stored message as revoked (best-effort; the message may not be in the
-    // DB). The dashboard renders the localized "message deleted" text, so no display
-    // string is persisted here.
-    //
-    // Match on `revokedId` (the ORIGINAL deleted message's id) when present: on wwebjs
-    // `message.id` is the revocation notification, which never matches a stored row.
-    // `revokedId` falls back to `id` (Baileys, where the two are the same).
-    const revokedWaMessageId = message.revokedId ?? message.id;
-    void this.messageRepository
-      .update({ sessionId: id, waMessageId: revokedWaMessageId }, { body: '', type: 'revoked' })
-      .catch(err => {
-        this.logger.error(`Failed to update revoked message: ${revokedWaMessageId}`, String(err));
-      });
-
-    // Notify consumers regardless of whether the row existed: webhook (message.revoked
-    // is a declared event) + the real-time dashboard stream.
-    const revokedPayload = message as unknown as Record<string, unknown>;
-    void this.webhookService.dispatch(id, 'message.revoked', revokedPayload);
-    this.eventsGateway.emitMessageRevoked(id, revokedPayload);
-  }
-
-  private async applyReaction(id: string, event: ReactionEvent): Promise<void> {
-    try {
-      // Guard the lookup key before it reaches TypeORM: `findOne` DROPS an undefined condition from
-      // the where-clause rather than matching nothing, so an engine that couldn't resolve the reacted
-      // message's id would silently match an arbitrary row and clobber/emit its reactions. `!msg` is
-      // no protection against that — the row it finds is real, just the wrong one.
-      if (!event.messageId) return;
-
-      const msg = await this.messageRepository.findOne({ where: { sessionId: id, waMessageId: event.messageId } });
-      if (!msg) return;
-
-      const metadata = msg.metadata || {};
-      const reactions = (metadata.reactions as Record<string, string>) || {};
-      if (!event.reaction) {
-        delete reactions[event.senderId];
-      } else {
-        reactions[event.senderId] = event.reaction;
-      }
-      metadata.reactions = reactions;
-      // Scoped update of ONLY the metadata column. A full-row save(msg) would re-persist the `status`
-      // read at findOne time, clobbering a concurrent ack UPDATE (SENT→DELIVERED/READ) that committed in
-      // the window between this findOne and the write — the mutation chain serializes reaction-vs-reaction
-      // but NOT reaction-vs-ack, so scoping the write to metadata is what keeps delivery state monotonic
-      // (#220). Other metadata fields are carried through untouched (they were read into `metadata`).
-      await this.messageRepository.update({ sessionId: id, waMessageId: event.messageId }, {
-        metadata,
-      } as QueryDeepPartialEntity<Message>);
-
-      this.eventsGateway.emitMessageReaction(id, { ...event, reactions });
-      // Webhook parity with the WebSocket broadcast: same payload (event + post-apply snapshot), so a
-      // webhook-only consumer observes reactions too. Idempotency for this event is salted per dispatch.
-      void this.webhookService.dispatch(id, 'message.reaction', { ...event, reactions });
-    } catch (err) {
-      this.logger.error(`Failed to update message reaction: ${event.messageId}`, String(err));
-    }
-  }
-
-  /** Queue a message-scoped mutation. A failed operation is isolated so later events still run. */
-  private enqueueMessageMutation(id: string, messageId: string, work: () => Promise<void>): void {
-    this.messageMutations.enqueue(`${id}:${messageId}`, work);
-  }
-
-  /** Persist an edit before notifying consumers, while still surfacing the occurrence if storage fails. */
-  private async applyMessageEdit(id: string, message: EditedMessage): Promise<void> {
-    try {
-      await this.messageRepository.update({ sessionId: id, waMessageId: message.messageId }, { body: message.body });
-    } catch (err) {
-      this.logger.error(`Failed to update edited message: ${message.messageId}`, String(err));
-    }
-
-    const editedPayload = message as unknown as Record<string, unknown>;
-    this.eventsGateway.emitMessageEdited(id, editedPayload);
-    void this.webhookService.dispatch(id, 'message.edited', editedPayload);
-  }
-
-  /**
-   * Reflect an OUTBOUND edit (REST MessageService.editMessage) in the stored row, routed through the
-   * same per-message mutation queue as the inbound edit/reaction paths so the two writers cannot
-   * interleave (latest-write-wins holds across both directions). Same best-effort semantics as
-   * applyMessageEdit: a missing row or a failed write must not fail the request — the engine edit
-   * already succeeded. Resolves once the queued write has run.
-   */
-  async recordOutboundMessageEdit(sessionId: string, messageId: string, body: string): Promise<void> {
-    await new Promise<void>(resolve => {
-      this.enqueueMessageMutation(sessionId, messageId, async () => {
-        try {
-          await this.messageRepository.update({ sessionId, waMessageId: messageId }, { body });
-        } catch (err) {
-          this.logger.warn(`Failed to update stored body of edited message ${messageId}`, { error: String(err) });
-        } finally {
-          resolve();
-        }
-      });
-    });
   }
 
   /**

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -24,6 +24,7 @@ import { BaileysStoredMessage } from '../../engine/adapters/baileys-stored-messa
 import { CreateSessionDto } from './dto';
 import { EngineFactory } from '../../engine/engine.factory';
 import { EngineRegistry } from '../../engine/engine-registry.service';
+import { decideReconnect, clampReconnectDelay, type ReconnectAttemptState } from './reconnect-policy';
 import { SessionLidResolver } from './session-lid-resolver.service';
 import { resolveAuthTimeoutMs } from '../../engine/adapters/whatsapp-web-js.adapter';
 import { paginate, ListOptions, resolveListWindow } from '../../common/utils/paginate';
@@ -71,13 +72,9 @@ const MEDIA_MESSAGE_TYPES = new Set(['image', 'video', 'audio', 'voice', 'sticke
 // proves 50 too few.
 const STATUS_SEED_LIMIT = 50;
 
-interface ReconnectState {
-  attempts: number;
+interface ReconnectState extends ReconnectAttemptState {
+  /** The pending attempt's timer. Lives here, not in the policy, which stays free of side effects. */
   timer: NodeJS.Timeout | null;
-  maxAttempts: number;
-  baseDelay: number;
-  /** When the last attempt was scheduled (epoch ms) — feeds the stability reset in scheduleReconnect. */
-  lastAttemptAt?: number;
 }
 
 // Reconnect-backoff bounds. An OPERATOR-supplied session.config feeds this math, so the values
@@ -86,21 +83,6 @@ interface ReconnectState {
 const RECONNECT_BASE_DELAY_MIN_MS = 1000;
 const RECONNECT_BASE_DELAY_MAX_MS = 300_000;
 const RECONNECT_MAX_ATTEMPTS_CAP = 20;
-const RECONNECT_DELAY_CAP_MS = 3_600_000;
-/**
- * A reconnect-attempt budget covers one CONTINUOUS bad stretch: once this much time has passed
- * since the last scheduled attempt the session demonstrably stayed up, so `attempts` resets to 0.
- * Without it a long-lived session would slowly accrue attempts toward an explicit cap across
- * unrelated transient drops and one day wedge FAILED for no current reason.
- */
-const RECONNECT_STABILITY_RESET_MS = 300_000;
-/**
- * A reconnect-loop alert fires once per this many CONSECUTIVE attempts of a session — one signal per
- * ongoing episode, not spam per attempt. A broken-forever setup retries without limit (by design), so
- * the 5th/10th/15th… scheduled attempt is the operator-facing tell; the streak resets via the
- * stability window above (or onReady), so a later episode re-arms the alert from attempt 5 again.
- */
-const RECONNECT_LOOP_ALERT_INTERVAL_ATTEMPTS = 5;
 /**
  * Session liveness watchdog. The engine layer is event-driven, so an engine that dies WITHOUT
  * firing an event (a silent Chromium crash) is never noticed: the row sits READY forever and never
@@ -140,11 +122,7 @@ export function resolveReconnectConfig(
   return { maxAttempts, baseDelay };
 }
 
-/** Clamp a computed backoff delay finite and within setTimeout's safe range (a huge value would
- *  overflow its 32-bit ms field and fire immediately). */
-export function clampReconnectDelay(rawDelay: number, baseDelay: number): number {
-  return clampNumber(Number.isFinite(rawDelay) ? rawDelay : baseDelay, 0, RECONNECT_DELAY_CAP_MS);
-}
+export { clampReconnectDelay };
 
 export function resolveMaxConcurrentSessions(configService?: Pick<ConfigService, 'get'>): number | null {
   const configured = configService?.get<number>('sessions.maxConcurrent', 0) ?? 0;
@@ -2277,15 +2255,11 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
     const state = this.reconnectStates.get(id);
     if (!state) return;
 
-    // Stability reset: the attempt budget covers one CONTINUOUS bad stretch. When the session stayed
-    // up ≥5 min since the last scheduled attempt it demonstrably recovered, so the next drop
-    // restarts the budget — unrelated transient drops must not accrue toward an explicit cap over
-    // the session's lifetime.
-    if (state.lastAttemptAt !== undefined && Date.now() - state.lastAttemptAt >= RECONNECT_STABILITY_RESET_MS) {
-      state.attempts = 0;
-    }
+    // All the backoff rules (stability reset, budget, exponential delay, loop cadence) live in the
+    // pure policy; this method only applies the effects the decision calls for.
+    const decision = decideReconnect(state);
 
-    if (state.attempts >= state.maxAttempts) {
+    if (decision.kind === 'exhausted') {
       this.logger.error(`Max reconnect attempts reached for session: ${session.name}`, undefined, {
         sessionId: id,
         attempts: state.attempts,
@@ -2293,14 +2267,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
       });
       // Don't leave the session silently stuck DISCONNECTED — mark it terminally FAILED with a reason
       // so findOne/findAll surface it via `lastError` and the dashboard shows it needs a restart.
-      // maxAttempts:0 means auto-reconnect is disabled, not that N attempts were tried and failed — say
-      // so instead of the misleading "failed after 0 attempts".
-      this.sessionErrors.set(
-        id,
-        state.maxAttempts === 0
-          ? 'Auto-reconnect is disabled (max attempts set to 0); the session was left disconnected — restart it manually.'
-          : `Reconnection failed after ${state.attempts} attempts — restart the session.`,
-      );
+      this.sessionErrors.set(id, decision.reason);
       void this.updateStatus(id, SessionStatus.FAILED);
       // Terminal path — evict the dead engine so it neither holds a concurrency slot nor makes a
       // subsequent start() reject the session as "already started". This mirrors onError's terminal
@@ -2314,22 +2281,13 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
       return;
     }
 
-    // Exponential backoff: baseDelay * 2^attempts (with jitter), clamped finite + within
-    // setTimeout's safe range so the timer can't overflow and fire immediately. With the default
-    // unlimited budget the delay parks at RECONNECT_DELAY_CAP_MS once the exponent outgrows it.
-    const delay = clampReconnectDelay(
-      state.baseDelay * Math.pow(2, state.attempts) + Math.random() * 1000,
-      state.baseDelay,
-    );
-    state.attempts++;
-    state.lastAttemptAt = Date.now();
-
+    const delay = decision.delayMs;
     const maxAttemptsLabel = Number.isFinite(state.maxAttempts) ? String(state.maxAttempts) : '∞';
     this.logger.log(
-      `Scheduling reconnect attempt ${state.attempts}/${maxAttemptsLabel} in ${Math.round(delay / 1000)}s`,
+      `Scheduling reconnect attempt ${decision.attempt}/${maxAttemptsLabel} in ${Math.round(delay / 1000)}s`,
       {
         sessionId: id,
-        attempt: state.attempts,
+        attempt: decision.attempt,
         delayMs: delay,
         action: 'reconnect_scheduled',
       },
@@ -2337,21 +2295,18 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
 
     incrementSessionReconnectAttempts();
 
-    // Loop alert every RECONNECT_LOOP_ALERT_INTERVAL_ATTEMPTS consecutive attempts: with the default
-    // unlimited budget a permanently-broken setup retries forever, and this is the one operator-facing
-    // signal per ongoing episode (not per attempt). The streak resets via the stability window/onReady,
-    // so a fresh episode re-arms the alert instead of continuing an old cadence.
-    if (state.attempts > 0 && state.attempts % RECONNECT_LOOP_ALERT_INTERVAL_ATTEMPTS === 0) {
-      this.logger.warn(`Session is reconnect-looping: attempt ${state.attempts} scheduled`, {
+    // One operator-facing signal per ongoing episode, not spam per attempt (see the policy).
+    if (decision.loopAlert) {
+      this.logger.warn(`Session is reconnect-looping: attempt ${decision.attempt} scheduled`, {
         sessionId: id,
-        attempts: state.attempts,
+        attempts: decision.attempt,
         nextDelayMs: delay,
         action: 'reconnect_loop',
       });
       incrementSessionReconnectLoopAlerts();
       void this.webhookService.dispatch(id, 'session.reconnect_loop', {
         sessionId: id,
-        attempts: state.attempts,
+        attempts: decision.attempt,
         nextDelayMs: delay,
       });
     }

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -24,6 +24,7 @@ import { BaileysStoredMessage } from '../../engine/adapters/baileys-stored-messa
 import { CreateSessionDto } from './dto';
 import { EngineFactory } from '../../engine/engine.factory';
 import { EngineRegistry } from '../../engine/engine-registry.service';
+import { KeyedMutationQueue } from '../../common/utils/keyed-mutation-queue';
 import { decideReconnect, clampReconnectDelay, type ReconnectAttemptState } from './reconnect-policy';
 import { SessionLidResolver } from './session-lid-resolver.service';
 import { resolveAuthTimeoutMs } from '../../engine/adapters/whatsapp-web-js.adapter';
@@ -211,7 +212,12 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
   // Serializes stored-message mutations per `${sessionId}:${waMessageId}`. Reactions perform a
   // read-modify-write and rapid edits must remain latest-write-wins; sharing one chain also preserves
   // order when different mutation kinds for the same message arrive together.
-  private messageMutationChains: Map<string, Promise<void>> = new Map();
+  private readonly messageMutations = new KeyedMutationQueue((key, err) => {
+    // Both current mutation implementations contain their own contextual error handling. Keep a
+    // final guard here so a future implementation cannot leak a rejected fire-and-forget promise
+    // or permanently block the message's later mutations.
+    this.logger.error(`Unexpected failure applying message mutation: ${key}`, String(err));
+  });
 
   // Destructive credential-teardown promises (logout rms of the session's on-disk WhatsApp auth
   // dir), keyed by session NAME — the on-disk auth-dir key (EngineFactory.wwjsAuthDir/baileysAuthDir
@@ -1916,23 +1922,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
 
   /** Queue a message-scoped mutation. A failed operation is isolated so later events still run. */
   private enqueueMessageMutation(id: string, messageId: string, work: () => Promise<void>): void {
-    const key = `${id}:${messageId}`;
-    const prior = this.messageMutationChains.get(key) ?? Promise.resolve();
-    const next = prior
-      .catch(() => undefined)
-      .then(work)
-      .catch(err => {
-        // Both current mutation implementations contain their own contextual error handling. Keep a
-        // final guard here so a future implementation cannot leak a rejected fire-and-forget promise
-        // or permanently block the message's later mutations.
-        this.logger.error(`Unexpected failure applying message mutation: ${messageId}`, String(err));
-      });
-    this.messageMutationChains.set(key, next);
-    void next.finally(() => {
-      if (this.messageMutationChains.get(key) === next) {
-        this.messageMutationChains.delete(key);
-      }
-    });
+    this.messageMutations.enqueue(`${id}:${messageId}`, work);
   }
 
   /** Persist an edit before notifying consumers, while still surfacing the occurrence if storage fails. */

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -27,6 +27,7 @@ import { EngineRegistry } from '../../engine/engine-registry.service';
 import { KeyedMutationQueue } from '../../common/utils/keyed-mutation-queue';
 import { decideReconnect, clampReconnectDelay, type ReconnectAttemptState } from './reconnect-policy';
 import { SessionLidResolver } from './session-lid-resolver.service';
+import { SessionLivenessWatchdog } from './session-liveness-watchdog.service';
 import { resolveAuthTimeoutMs } from '../../engine/adapters/whatsapp-web-js.adapter';
 import { paginate, ListOptions, resolveListWindow } from '../../common/utils/paginate';
 import { isUniqueConstraintError } from '../../common/utils/unique-constraint.util';
@@ -85,16 +86,6 @@ const RECONNECT_BASE_DELAY_MIN_MS = 1000;
 const RECONNECT_BASE_DELAY_MAX_MS = 300_000;
 const RECONNECT_MAX_ATTEMPTS_CAP = 20;
 /**
- * Session liveness watchdog. The engine layer is event-driven, so an engine that dies WITHOUT
- * firing an event (a silent Chromium crash) is never noticed: the row sits READY forever and never
- * reconnects. Every INTERVAL the watchdog actively probes each READY engine (feature-detected
- * `probeLiveness`, raced against TIMEOUT); MAX_FAILURES consecutive failures route the session
- * through the exact engine-disconnect path.
- */
-export const SESSION_WATCHDOG_INTERVAL_MS = 60_000;
-export const SESSION_WATCHDOG_PROBE_TIMEOUT_MS = 15_000;
-export const SESSION_WATCHDOG_MAX_FAILURES = 2;
-/**
  * Delay before retrying an ack UPDATE that matched 0 rows. A fast delivered/read ack can arrive before
  * the send's 2nd save (which writes waMessageId) has committed, so the first UPDATE finds no row. One
  * retry after this delay closes that race; the forward-only transition guard keeps it idempotent.
@@ -124,6 +115,11 @@ export function resolveReconnectConfig(
 }
 
 export { clampReconnectDelay };
+export {
+  SESSION_WATCHDOG_INTERVAL_MS,
+  SESSION_WATCHDOG_PROBE_TIMEOUT_MS,
+  SESSION_WATCHDOG_MAX_FAILURES,
+} from './session-liveness-watchdog.service';
 
 export function resolveMaxConcurrentSessions(configService?: Pick<ConfigService, 'get'>): number | null {
   const configured = configService?.get<number>('sessions.maxConcurrent', 0) ?? 0;
@@ -181,14 +177,6 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
 
   // Reconnection state per session
   private reconnectStates: Map<string, ReconnectState> = new Map();
-
-  // Consecutive liveness-probe failures per session (watchdog). Reset on a successful probe, on a
-  // non-READY tick, on onReady, and when the threshold routes the session to the disconnect path.
-  private readonly livenessFailures = new Map<string, number>();
-
-  // The single watchdog interval handle. Unref'd so it never keeps the process alive on its own;
-  // cleared (and nulled) in onModuleDestroy, so teardown stays idempotent.
-  private watchdogTimer: NodeJS.Timeout | null = null;
 
   // Last session.status value broadcast per session. Some engines signal one transition via BOTH
   // onStateChanged and a dedicated callback (onQRCode/onDisconnected), so this guards both the WS emit
@@ -265,6 +253,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
     private readonly engineFactory: EngineFactory,
     private readonly engineRegistry: EngineRegistry,
     private readonly lidResolver: SessionLidResolver,
+    private readonly watchdog: SessionLivenessWatchdog,
     private readonly eventsGateway: EventsGateway,
     private readonly webhookService: WebhookService,
     private readonly hookManager: HookManager,
@@ -307,7 +296,9 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
   async onApplicationBootstrap(): Promise<void> {
     // Start the liveness watchdog FIRST: it must run even when auto-start is disabled (sessions can
     // be started via the API at any time), so it can't sit behind the auto-start early-return below.
-    this.startWatchdog();
+    // The watchdog owns the probe cadence and failure counting; a session it proves dead comes
+    // back through the same disconnect path an engine-reported drop uses.
+    this.watchdog.start((id, engine, reason) => this.handleEngineDisconnected(id, engine, reason));
 
     if (!resolveFeatureFlags(this.configService).autoStartSessions) return;
 
@@ -346,12 +337,8 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
 
   async onModuleDestroy(): Promise<void> {
     // Stop the watchdog FIRST (before any teardown below can hang): no new probe/disconnect handling
-    // may start mid-shutdown. Nulling the handle keeps a second onModuleDestroy call safe.
-    if (this.watchdogTimer) {
-      clearInterval(this.watchdogTimer);
-      this.watchdogTimer = null;
-    }
-    this.livenessFailures.clear();
+    // may start mid-shutdown. stop() is idempotent, so a second onModuleDestroy call stays safe.
+    this.watchdog.stop();
 
     // Stop reconnect timers FIRST so nothing reschedules mid-teardown, and so this always runs even
     // if an engine.destroy() below hangs or throws.
@@ -1187,7 +1174,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
           reconnectState.attempts = 0;
         }
         // A fresh READY stretch starts the watchdog's failure budget clean too.
-        this.livenessFailures.delete(id);
+        this.watchdog.clear(id);
         this.sessionErrors.delete(id);
         // READY proves any in-flight stuck-auth recovery succeeded (or none was needed), so the
         // one-shot recovery budget is re-armed for a future episode.
@@ -2107,129 +2094,6 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
 
     // Attempt to reconnect
     this.scheduleReconnect(id, session);
-  }
-
-  /** Start the liveness watchdog (idempotent). One unref'd interval probes every registered engine. */
-  private startWatchdog(): void {
-    if (this.watchdogTimer) return;
-    this.watchdogTimer = setInterval(() => {
-      // allSettled inside the tick keeps a failing session from ever throwing into the timer.
-      void this.runWatchdogTick();
-    }, SESSION_WATCHDOG_INTERVAL_MS);
-    // The watchdog must never keep the process alive on its own.
-    this.watchdogTimer.unref();
-  }
-
-  /** Probe all live engines in parallel; a slow/failed probe must not delay or abort the others. */
-  private async runWatchdogTick(): Promise<void> {
-    // Mid-shutdown the disconnect path would schedule a reconnect racing onModuleDestroy's teardown
-    // (same guard as scheduleReconnect) — leave the sessions to the drain instead.
-    if (this.shutdownService?.isShuttingDown()) {
-      return;
-    }
-    await Promise.allSettled([...this.engines].map(([id, engine]) => this.probeSessionLiveness(id, engine)));
-  }
-
-  /**
-   * Actively probe one engine. Only READY sessions are expected to answer (anything else is owned by
-   * the QR/reconnect flows); engines without `probeLiveness` keep relying on engine events alone.
-   * MAX_FAILURES consecutive failures treat the session exactly like an engine-reported disconnect.
-   *
-   * ACTION_REQUIRED is probed too, but OBSERVE-ONLY: the engine is still running and a human has to
-   * act, and clearing that status is theirs to do (stop, then start). Acting on a failed probe would
-   * hand the session to the reconnect path and silently drop the very status that asked for
-   * attention — so the probe result only reaches the log. Without probing at all, a page that dies
-   * while waiting for the operator left no trace anywhere, which is what this closes.
-   */
-  private async probeSessionLiveness(id: string, engine: IWhatsAppEngine): Promise<void> {
-    const status = engine.getStatus();
-    const observeOnly = status === EngineStatus.ACTION_REQUIRED;
-    if (status !== EngineStatus.READY && !observeOnly) {
-      // Not expected to answer right now — and any accrued failures belong to a previous READY
-      // stretch, so the next one starts clean. This also self-cleans the observe-only counter below:
-      // every path out of ACTION_REQUIRED passes through a status that lands here (or through
-      // onReady, which clears it), so an observe-only count can never be inherited by a READY
-      // stretch and push it over MAX_FAILURES early.
-      this.livenessFailures.delete(id);
-      return;
-    }
-    // Feature-detect: an engine whose transport already self-detects death may skip the probe.
-    if (typeof engine.probeLiveness !== 'function') {
-      return;
-    }
-
-    // A wedged connection can hang the probe itself, so race it against a timeout; a timeout or a
-    // probe error both count as "not proven alive".
-    let alive: boolean;
-    let probeTimer: ReturnType<typeof setTimeout> | undefined;
-    try {
-      alive = await Promise.race([
-        engine.probeLiveness(),
-        new Promise<never>((_, reject) => {
-          probeTimer = setTimeout(
-            () => reject(new Error('liveness probe timed out')),
-            SESSION_WATCHDOG_PROBE_TIMEOUT_MS,
-          );
-        }),
-      ]);
-    } catch {
-      alive = false;
-    } finally {
-      if (probeTimer) clearTimeout(probeTimer);
-    }
-
-    // The session may have been stopped/restarted (engine superseded) while the probe was in flight;
-    // a stale result must not touch it (mirrors the isLiveEngine gate on engine callbacks).
-    if (!this.isLiveEngine(id, engine)) {
-      return;
-    }
-
-    if (alive) {
-      // Note a recovery on the observe-only path, so the log shows the page came back rather than
-      // leaving the earlier warning as the last word.
-      if (observeOnly && this.livenessFailures.has(id)) {
-        this.logger.log('Liveness probe answering again while the session awaits operator action', {
-          sessionId: id,
-          action: 'watchdog_probe_recovered',
-        });
-      }
-      this.livenessFailures.delete(id);
-      return;
-    }
-
-    const failures = (this.livenessFailures.get(id) ?? 0) + 1;
-    if (observeOnly) {
-      this.livenessFailures.set(id, failures);
-      // One warning per unresponsive stretch, not one per tick: a session can sit in
-      // ACTION_REQUIRED until a human gets to it, and at a 60s interval an unbounded log would bury
-      // everything else. The count keeps rising so the recovery branch above can tell it happened.
-      if (failures === 1) {
-        this.logger.warn(
-          'Liveness probe failed while the session awaits operator action; not reconnecting it — ' +
-            'the status is operator-owned. If the page is gone, stop and start the session.',
-          { sessionId: id, action: 'watchdog_probe_failed_observe_only' },
-        );
-      }
-      return;
-    }
-
-    if (failures < SESSION_WATCHDOG_MAX_FAILURES) {
-      this.livenessFailures.set(id, failures);
-      this.logger.warn('Liveness probe failed; will treat the session as dead after repeated failures', {
-        sessionId: id,
-        failures,
-        action: 'watchdog_probe_failed',
-      });
-      return;
-    }
-
-    this.livenessFailures.delete(id);
-    this.logger.warn('Liveness probe failed repeatedly; handling the session as disconnected', {
-      sessionId: id,
-      failures,
-      action: 'watchdog_disconnect',
-    });
-    await this.handleEngineDisconnected(id, engine, 'liveness probe failed (watchdog)');
   }
 
   private scheduleReconnect(id: string, session: Session): void {

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -23,6 +23,7 @@ import { Template } from '../template/entities/template.entity';
 import { BaileysStoredMessage } from '../../engine/adapters/baileys-stored-message.entity';
 import { CreateSessionDto } from './dto';
 import { EngineFactory } from '../../engine/engine.factory';
+import { EngineRegistry } from '../../engine/engine-registry.service';
 import { resolveAuthTimeoutMs } from '../../engine/adapters/whatsapp-web-js.adapter';
 import { LidMappingStoreService } from '../../engine/identity/lid-mapping-store.service';
 import { userPart } from '../../engine/identity/wa-id';
@@ -189,8 +190,12 @@ function isAuthTimeoutRejection(err: unknown): boolean {
 export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicationBootstrap {
   private readonly logger = createLogger('SessionService');
 
-  // In-memory map of active engine instances
-  private engines: Map<string, IWhatsAppEngine> = new Map();
+  // Live engine instances, owned by the shared EngineRegistry (the narrow port feature modules
+  // inject instead of this whole service). This service is the only writer: it creates, replaces and
+  // retires engines. `engines` remains a local alias so the lifecycle code below reads unchanged.
+  private get engines(): EngineRegistry {
+    return this.engineRegistry;
+  }
   // Bounded cache for inline @lid -> phone resolution (#263), keyed `${sessionId}:${lid}`. Caches
   // misses (null) too, so a chatty unmapped sender isn't re-queried on every message (which also
   // reduces engine rate-limit pressure). Best-effort feature, so staleness is acceptable.
@@ -225,8 +230,11 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
 
   // Sessions whose engine is mid-initialization (a start() is in flight). Reserved synchronously
   // in start() so a near-simultaneous second start() can't pass the engines.has() check during the
-  // awaited hook and orphan an engine the lifecycle could never destroy.
-  private initializingSessions: Set<string> = new Set();
+  // awaited hook and orphan an engine the lifecycle could never destroy. Backed by the registry so
+  // the infra import pre-flight sees starting sessions through the same port.
+  private get initializingSessions(): Set<string> {
+    return this.engineRegistry.initializing;
+  }
 
   // Serializes stored-message mutations per `${sessionId}:${waMessageId}`. Reactions perform a
   // read-modify-write and rapid edits must remain latest-write-wins; sharing one chain also preserves
@@ -277,6 +285,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
     @InjectDataSource('data')
     private readonly dataSource: DataSource,
     private readonly engineFactory: EngineFactory,
+    private readonly engineRegistry: EngineRegistry,
     private readonly eventsGateway: EventsGateway,
     private readonly webhookService: WebhookService,
     private readonly hookManager: HookManager,
@@ -669,7 +678,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
         // is gone (delete cannot be followed by a late status write). Identity-checked.
         await this.awaitInitialStatus(id, engine);
         await this.teardownEngineSafely(id, engine, e => e.forceDestroy(), 'force-destroy');
-        if (this.isLiveEngine(id, engine)) this.engines.delete(id);
+        this.engines.deleteIfLive(id, engine);
       }
 
       // FENCE #2 — immediately after the current engine is evicted, BEFORE the session:deleted hook
@@ -788,7 +797,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
         // start()'s finally), so summing the two sizes would double-count it; and `id` itself is
         // already reserved in `initializingSessions` (added at entry), so it must not count
         // against the cap it is being checked against.
-        const activeIds = new Set<string>([...this.engines.keys(), ...this.initializingSessions]);
+        const activeIds = new Set<string>(this.engines.activeIds());
         activeIds.delete(id);
         if (activeIds.size >= maxConcurrentSessions) {
           throw new BadRequestException(`Maximum concurrent sessions reached (${maxConcurrentSessions})`);
@@ -872,7 +881,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
         const resurrected = this.engines.get(id);
         if (resurrected) {
           await this.teardownEngineSafely(id, resurrected, e => e.destroy(), 'destroy');
-          if (this.isLiveEngine(id, resurrected)) this.engines.delete(id);
+          this.engines.deleteIfLive(id, resurrected);
         }
         // A delete() that raced this start purged the on-disk auth dirs BEFORE this init re-created
         // them — purge again so the window leaves no credential residue behind (no-op for a stop()).
@@ -888,13 +897,13 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
    * True only while `engine` is still the live engine registered for `id`. Each callback below
    * captures its own engine instance; once the session is stopped (engine removed from the map) or
    * restarted/reconnected (engine replaced), a late callback from the superseded engine must not
-   * mutate the session that now belongs to a different — or no — engine. `this.engines` is the
+   * mutate the session that now belongs to a different — or no — engine. The registry is the
    * single source of truth for the active engine, so identity comparison closes both the
    * post-stop and the stale-generation (stop→start / reconnect-replace) windows the one-shot
    * post-init guard does not cover.
    */
   private isLiveEngine(id: string, engine: IWhatsAppEngine): boolean {
-    return this.engines.get(id) === engine;
+    return this.engines.isLive(id, engine);
   }
 
   /**
@@ -2417,7 +2426,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
       const oldEngine = this.engines.get(id);
       if (oldEngine) {
         await this.teardownEngineSafely(id, oldEngine, e => e.destroy(), 'destroy');
-        if (this.isLiveEngine(id, oldEngine)) this.engines.delete(id);
+        this.engines.deleteIfLive(id, oldEngine);
       }
 
       // Credential-teardown fence — BEFORE engineFactory.create (inside initializeEngine). A logout
@@ -2448,7 +2457,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
         const resurrected = this.engines.get(id);
         if (resurrected) {
           await this.teardownEngineSafely(id, resurrected, e => e.destroy(), 'destroy');
-          if (this.isLiveEngine(id, resurrected)) this.engines.delete(id);
+          this.engines.deleteIfLive(id, resurrected);
         }
         // Same start/delete window as start()'s post-init guard: this re-init re-created auth dirs
         // delete() had already purged — purge again so no credentials outlive the row.
@@ -2501,7 +2510,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
       // become the last persisted status. Identity-checked: only the captured engine's promise.
       await this.awaitInitialStatus(id, engine);
       await this.teardownEngineSafely(id, engine, e => e.disconnect(), 'disconnect');
-      if (this.isLiveEngine(id, engine)) this.engines.delete(id);
+      this.engines.deleteIfLive(id, engine);
     }
 
     this.logger.log(`Session stopped: ${session.name}`, {
@@ -2565,7 +2574,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
     // raw logout that outlives its deadline race is tracked under the right name even if the row is
     // later deleted/recreated.
     const unlinked = await this.teardownEngineSafely(id, engine, e => e.logout(), 'logout', session.name);
-    if (this.isLiveEngine(id, engine)) this.engines.delete(id);
+    this.engines.deleteIfLive(id, engine);
     await this.updateStatus(id, SessionStatus.DISCONNECTED);
 
     if (!unlinked) {
@@ -2629,7 +2638,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
     // write so a delayed pre-initialize status update can never settle after the retirement.
     await this.awaitInitialStatus(id, engine);
     await this.teardownEngineSafely(id, engine, e => e.forceDestroy(), 'force-destroy');
-    if (this.isLiveEngine(id, engine)) this.engines.delete(id);
+    this.engines.deleteIfLive(id, engine);
 
     this.logger.warn(`Session force-killed: ${session.name}`, {
       sessionId: id,
@@ -2886,7 +2895,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
    * to refuse a full-replace restore that would orphan a running engine.
    */
   getActiveSessionIds(): string[] {
-    return [...new Set([...this.engines.keys(), ...this.initializingSessions])];
+    return this.engines.activeIds();
   }
 
   /**
@@ -2934,7 +2943,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
           // means the Chromium/socket may still be alive and writing, so the id lands in `failed`
           // and the caller (the infra import) can flag restartRequired instead of reporting a
           // clean stop for a wedged engine.
-          if (this.isLiveEngine(id, engine)) this.engines.delete(id);
+          this.engines.deleteIfLive(id, engine);
           if (tornDown) {
             stopped.push(id);
           } else {
@@ -2947,7 +2956,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
             sessionId: id,
             action: 'stop_orphan_failed',
           });
-          if (this.isLiveEngine(id, engine)) this.engines.delete(id);
+          this.engines.deleteIfLive(id, engine);
           failed.push(id);
         }
       }),

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -24,9 +24,8 @@ import { BaileysStoredMessage } from '../../engine/adapters/baileys-stored-messa
 import { CreateSessionDto } from './dto';
 import { EngineFactory } from '../../engine/engine.factory';
 import { EngineRegistry } from '../../engine/engine-registry.service';
+import { SessionLidResolver } from './session-lid-resolver.service';
 import { resolveAuthTimeoutMs } from '../../engine/adapters/whatsapp-web-js.adapter';
-import { LidMappingStoreService } from '../../engine/identity/lid-mapping-store.service';
-import { userPart } from '../../engine/identity/wa-id';
 import { paginate, ListOptions, resolveListWindow } from '../../common/utils/paginate';
 import { isUniqueConstraintError } from '../../common/utils/unique-constraint.util';
 import { resolveFeatureFlags } from '../../config/feature-flags';
@@ -196,11 +195,6 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
   private get engines(): EngineRegistry {
     return this.engineRegistry;
   }
-  // Bounded cache for inline @lid -> phone resolution (#263), keyed `${sessionId}:${lid}`. Caches
-  // misses (null) too, so a chatty unmapped sender isn't re-queried on every message (which also
-  // reduces engine rate-limit pressure). Best-effort feature, so staleness is acceptable.
-  private readonly lidPhoneCache = new Map<string, string | null>();
-  private static readonly LID_PHONE_CACHE_MAX = 5000;
   // Transient, human-readable reason for the most recent terminal engine failure,
   // keyed by session id. Surfaced on read so the dashboard can explain a FAILED
   // status; cleared when the session re-initializes or becomes ready.
@@ -286,16 +280,13 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
     private readonly dataSource: DataSource,
     private readonly engineFactory: EngineFactory,
     private readonly engineRegistry: EngineRegistry,
+    private readonly lidResolver: SessionLidResolver,
     private readonly eventsGateway: EventsGateway,
     private readonly webhookService: WebhookService,
     private readonly hookManager: HookManager,
     private readonly statusStore: StatusStoreService,
     @Optional()
     private readonly configService?: ConfigService,
-    // Shared lid<->phone table (global). Used to persist an inbound @lid sender's resolved phone so
-    // an inbound-only migrated contact's `@lid` and `@c.us` rows bridge in the read-path (#583 R3 Ph2).
-    @Optional()
-    private readonly lidMappingStore?: LidMappingStoreService,
     // Draining flag (set on a termination signal or an admin restart). Used to suppress a mid-shutdown
     // reconnect that would launch a fresh Chromium racing onModuleDestroy's teardown. @Optional so the
     // service degrades to today's behaviour if it is ever constructed without the (global) LoggerModule.
@@ -1326,7 +1317,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
             // attaches senderPhone (digits or null) before persist/dispatch so webhook/ws consumers
             // get it in a single pass. Only for privacy-id senders, so no lookup for normal numbers.
             if (resolveFeatureFlags(this.configService).resolveLidToPhone && incoming.isLidSender && !incoming.fromMe) {
-              incoming.senderPhone = await this.resolveSenderPhone(id, incoming.author ?? incoming.from);
+              incoming.senderPhone = await this.lidResolver.resolveSenderPhone(id, incoming.author ?? incoming.from);
             }
 
             const metadata: Record<string, unknown> = {};
@@ -2692,40 +2683,6 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
 
   getEngine(id: string): IWhatsAppEngine | undefined {
     return this.engines.get(id);
-  }
-
-  /**
-   * Best-effort resolution of a privacy-id sender (`@lid`) to a phone number for inline attachment on
-   * incoming messages (#263). Cached per session (incl. misses). Never throws — returns null on any
-   * failure or when the engine isn't available. Gated by the caller on `RESOLVE_LID_TO_PHONE`.
-   */
-  private async resolveSenderPhone(sessionId: string, contactId: string): Promise<string | null> {
-    const key = `${sessionId}:${contactId}`;
-    const cached = this.lidPhoneCache.get(key);
-    if (cached !== undefined) {
-      return cached;
-    }
-    let phone: string | null;
-    try {
-      phone = (await this.getEngine(sessionId)?.resolveContactPhone(contactId)) ?? null;
-    } catch {
-      phone = null;
-    }
-    // Bounded FIFO eviction: Map preserves insertion order, so the first key is the oldest.
-    if (this.lidPhoneCache.size >= SessionService.LID_PHONE_CACHE_MAX) {
-      for (const oldest of this.lidPhoneCache.keys()) {
-        this.lidPhoneCache.delete(oldest);
-        break;
-      }
-    }
-    this.lidPhoneCache.set(key, phone);
-    // Persist a real @lid -> phone resolution so the read-path can bridge this contact's `@lid` and
-    // `@c.us` rows even when the operator never sent to them (#583 R3 Phase 2). Reuses the resolution
-    // above — no extra network call — and is fire-and-forget so dispatch never blocks/fails on it.
-    if (phone) {
-      void this.lidMappingStore?.remember(userPart(contactId), phone, sessionId)?.catch(() => {});
-    }
-    return phone;
   }
 
   async getGroups(

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -45,6 +45,7 @@ import {
   IncomingMessage,
   ReactionEvent,
   EditedMessage,
+  RevokedMessage,
   GroupEvent,
   IncomingCallEvent,
 } from '../../engine/interfaces/whatsapp-engine.interface';
@@ -1136,236 +1137,8 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
 
         void this.updateStatus(id, SessionStatus.QR_READY);
       },
-      onReady: (phone: string, pushName: string): void => {
-        if (!this.isLiveEngine(id, engine)) return;
-        this.logger.log(`Session ready: ${phone}`, {
-          sessionId: id,
-          phone,
-          pushName,
-          action: 'ready',
-        });
-
-        void this.webhookService.dispatch(id, 'session.authenticated', { sessionId: id, phone, pushName });
-        this.eventsGateway.emitSessionAuthenticated(id, { phone, pushName });
-
-        // Execute hook for ready event
-        void this.hookManager.execute(
-          'session:ready',
-          { phone, pushName },
-          {
-            sessionId: id,
-            source: 'Engine',
-          },
-        );
-
-        // Reset reconnect attempts and clear any stale failure reason on success
-        const reconnectState = this.reconnectStates.get(id);
-        if (reconnectState) {
-          reconnectState.attempts = 0;
-        }
-        // A fresh READY stretch starts the watchdog's failure budget clean too.
-        this.watchdog.clear(id);
-        this.sessionErrors.delete(id);
-        // READY proves any in-flight stuck-auth recovery succeeded (or none was needed), so the
-        // one-shot recovery budget is re-armed for a future episode.
-        this.stuckAuthRecoveryUsed.delete(id);
-
-        void this.sessionRepository
-          .update(id, {
-            status: SessionStatus.READY,
-            phone,
-            pushName,
-            connectedAt: new Date(),
-            lastActiveAt: new Date(),
-          })
-          .catch(err =>
-            this.logger.warn('Failed to persist session ready state', {
-              sessionId: id,
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-
-        // Best-effort snapshot of the account's own contacts' currently-active statuses. Live status
-        // posts arrive through onMessage below; this just backfills what was already up before we
-        // connected. Not awaited — onReady must not block on it.
-        void this.seedStatuses(id, engine);
-      },
-      onMessage: (message): void => {
-        if (!this.isLiveEngine(id, engine)) return;
-        // Status/Story posts arrive via the inbound path for some engines; ingest them into the
-        // status store instead of the message pipeline. Mirrors the isStatusBroadcast guard in
-        // onMessageCreate below: an own-send echo (fromMe) stays a plain drop — never ingested,
-        // never dispatched — so a status you posted never re-appears in your own webhooks/API as
-        // if a contact had posted it.
-        if (message.isStatusBroadcast) {
-          if (message.fromMe) return;
-          const status = buildIncomingStatus(message);
-          if (status) {
-            void this.statusStore
-              .ingest(id, status)
-              // Dispatch only on a fresh insert: ingest also resolves with the pre-existing row
-              // for a duplicate delivery (or the winner's row after a lost insert race), and the
-              // webhook must fire once per status, not once per (re)delivery.
-              .then(({ row, created }) => {
-                // The ingest awaited; a stop()/delete() can retire this engine mid-flight — don't
-                // dispatch for a session that no longer exists (mirrors message.received's re-check).
-                if (!this.isLiveEngine(id, engine)) return;
-                if (created) this.dispatchStatusReceived(id, row);
-              })
-              .catch(err =>
-                this.logger.warn('Status ingest failed', {
-                  sessionId: id,
-                  error: err instanceof Error ? err.message : String(err),
-                }),
-              );
-          }
-          return;
-        }
-        // Ephemeral/disappearing messages: skip persist + dispatch when the operator opted out.
-        // A message is ephemeral when its chat has a disappearing-messages timer (ephemeralDuration > 0).
-        if (
-          !resolveFeatureFlags(this.configService).storeEphemeralMessages &&
-          message.ephemeralDuration &&
-          message.ephemeralDuration > 0
-        ) {
-          this.logger.debug('Skipping ephemeral message', {
-            sessionId: id,
-            messageId: message.id,
-            chatId: message.chatId,
-            ephemeralDuration: message.ephemeralDuration,
-          });
-          return;
-        }
-        this.logger.debug(`Message received from ${message.from}`, {
-          sessionId: id,
-          messageId: message.id,
-          from: message.from,
-          action: 'message_received',
-        });
-        // Update last active timestamp
-        void this.sessionRepository.update(id, { lastActiveAt: new Date() }).catch(() => undefined);
-        // Convert IncomingMessage to plain object for dispatch
-        const messageData = { ...message };
-
-        // Execute hook for message received - plugins can modify or stop processing
-        void this.hookManager
-          .execute('message:received', messageData, {
-            sessionId: id,
-            source: 'Engine',
-          })
-          .then(async ({ data: finalMessage }) => {
-            // `continue: false` is deliberately NOT read here. It means "stop the handler chain", which
-            // HookManager has already done — the plugins after the one that returned it never ran. It
-            // does not mean "this message never happened".
-            //
-            // Honouring it here used to skip everything below: the message was never written to the
-            // messages table, never dispatched to webhooks, and never emitted over the websocket. An
-            // auto-reply plugin returning `false` for its ordinary purpose — keeping other bots from
-            // answering the same message — silently erased the customer's message from the operator's
-            // own history, leaving a thread of bot replies answering nothing. Nothing in the hook
-            // contract (`HookResult.continue`, docs/19) or the webhook contract (`message.received`
-            // fires when "an inbound message arrives", docs/06) hinted at that, and a sandboxed
-            // marketplace plugin could swallow a session's entire inbound traffic with no audit trail.
-            //
-            // The message has already arrived at WhatsApp. A plugin can stop other plugins from acting
-            // on it; it cannot make the gateway forget it. Pre-action hooks are where a veto belongs —
-            // `message:sending` blocks a send that has not happened yet (core/hooks/sending-gate.ts).
-
-            // Persist the incoming message so the dashboard chats view can render history.
-            const incoming: IncomingMessage = finalMessage;
-
-            // Inline @lid -> phone resolution (#263), opt-in via RESOLVE_LID_TO_PHONE. Best-effort:
-            // attaches senderPhone (digits or null) before persist/dispatch so webhook/ws consumers
-            // get it in a single pass. Only for privacy-id senders, so no lookup for normal numbers.
-            if (resolveFeatureFlags(this.configService).resolveLidToPhone && incoming.isLidSender && !incoming.fromMe) {
-              incoming.senderPhone = await this.lidResolver.resolveSenderPhone(id, incoming.author ?? incoming.from);
-            }
-
-            const metadata = buildMessageMetadata(incoming);
-
-            const chatName = incoming.contact?.pushName ?? incoming.contact?.name ?? undefined;
-
-            const dbMessage = this.messageRepository.create({
-              sessionId: id,
-              waMessageId: storableWaMessageId(incoming.id),
-              chatId: incoming.chatId,
-              chatName,
-              // Group poster (participant JID) — `from` is the group JID, so this is the stable
-              // sender identity the chat view keys attribution runs/colors on. Undefined for 1:1.
-              author: incoming.author,
-              from: incoming.from,
-              to: incoming.to,
-              body: incoming.body,
-              type: incoming.type,
-              direction: incoming.fromMe ? MessageDirection.OUTGOING : MessageDirection.INCOMING,
-              timestamp: incoming.timestamp,
-              status: MessageStatus.SENT,
-              metadata,
-            });
-
-            // The hook chain above is async; a delete()/teardown can retire this engine while it
-            // awaits. Re-check liveness so a late continuation can't persist an orphan messages row
-            // (the row has no FK, so a session-delete cleanup would never reap it) or dispatch for a
-            // session that no longer exists. Mirrors the synchronous isLiveEngine gate at entry.
-            if (!this.isLiveEngine(id, engine)) return;
-
-            // De-duplicate at the source: the engine can re-fire `message` for one inbound message
-            // (#464). UNIQUE(sessionId, waMessageId) makes the insert the atomic dedup oracle — a
-            // near-simultaneous re-fire loses the race and is skipped here, so persist + webhook + WS
-            // happen exactly once. Fail-open: a non-conflict DB error still dispatches, so a real
-            // message is never dropped by a transient DB failure.
-            let isNewMessage = true;
-            let persisted = false;
-            try {
-              // `insert()` (not `save()`) is load-bearing: the UNIQUE(sessionId, waMessageId) constraint
-              // makes a duplicate insert throw, which is the atomic dedup oracle for #464 re-fires.
-              // Unlike `save()`, `insert()` does NOT merge DB-generated columns (@PrimaryGeneratedColumn,
-              // @CreateDateColumn) back onto the entity instance — so merge them explicitly here, before
-              // the `message:persisted` emit. `identifiers[0]` always carries the PK on both SQLite and
-              // Postgres; `generatedMaps[0]` adds createdAt where the driver returns it (Postgres yes;
-              // SQLite historically does not — acceptable; the PK is the load-bearing field for plugins).
-              const result = await this.messageRepository.insert(
-                dbMessage as unknown as QueryDeepPartialEntity<Message>,
-              );
-              Object.assign(dbMessage, result.identifiers[0] ?? {}, result.generatedMaps?.[0] ?? {});
-              persisted = true;
-            } catch (err) {
-              if (isUniqueConstraintError(err)) {
-                isNewMessage = false;
-              } else {
-                this.logger.error(`Failed to save incoming message ${incoming.id} to database`, String(err));
-              }
-            }
-            if (!isNewMessage) {
-              return; // duplicate re-fire — the original already persisted and dispatched
-            }
-
-            // Fire-and-forget: a plugin handler must never break the receive path. Both engine adapters
-            // (wwjs `message` and Baileys `upsert`) converge on this persist, so one emit covers inbound.
-            // The built-in FTS search provider is DB-synced and does NOT consume this; it exists for
-            // plugin providers (Spec 2) + general use.
-            // Gate ONLY the hook on `persisted`: on a non-unique insert error (transient SQLITE_BUSY /
-            // lock-timeout / connection drop) the row was never stored and `dbMessage.id` is undefined,
-            // so emitting `message:persisted` would hand plugins an id-less payload for a row that isn't
-            // in the DB. The webhook/WS dispatch below stays fail-open — a real inbound message must
-            // never be dropped on a transient DB failure; only the hook requires a durable row.
-            if (persisted) {
-              void this.hookManager
-                .execute(
-                  'message:persisted',
-                  { sessionId: id, message: dbMessage },
-                  { sessionId: id, source: 'SessionService' },
-                )
-                .catch(() => undefined);
-            }
-
-            // Dispatch to webhooks with potentially modified message
-            void this.webhookService.dispatch(id, 'message.received', finalMessage);
-            // Emit real-time event to WebSocket clients
-            this.eventsGateway.emitMessage(id, finalMessage);
-          })
-          .catch(err => this.logger.error(`onMessage handler failed for ${id}`, String(err)));
-      },
+      onReady: (phone, pushName): void => this.handleEngineReady(id, engine, phone, pushName),
+      onMessage: (message): void => this.handleInboundMessage(id, engine, message),
       onHistoryMessages: (messages): void => {
         if (!this.isLiveEngine(id, engine)) return;
         // Persist for the chat view only; no dispatch (these predate the live session).
@@ -1373,226 +1146,9 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
           this.logger.error(`Failed to persist history messages for ${id}`, String(err)),
         );
       },
-      onMessageCreate: (message): void => {
-        if (!this.isLiveEngine(id, engine)) return;
-        // `message_create` fires for every message the account creates, including sends composed on a
-        // linked phone — which the `message`/`onMessage` event never delivers. Incoming messages are
-        // already handled by `onMessage`, so only outgoing (`fromMe`) ones produce `message.sent` here.
-        if (!message.fromMe) {
-          return;
-        }
-
-        // Status/Story posts are account-created but not real conversations; don't emit `message.sent`
-        // for them. The adapter flags these (the engine-specific pseudo-JID stays out of this layer).
-        if (message.isStatusBroadcast) {
-          return;
-        }
-
-        this.logger.debug(`Message sent to ${message.to}`, {
-          sessionId: id,
-          messageId: message.id,
-          to: message.to,
-          action: 'message_sent',
-        });
-        // Update last active timestamp
-        void this.sessionRepository.update(id, { lastActiveAt: new Date() }).catch(() => undefined);
-        const messageData = { ...message };
-
-        // Execute hook for message sent - plugins can modify or stop processing
-        void this.hookManager
-          .execute('message:sent', messageData, {
-            sessionId: id,
-            source: 'Engine',
-          })
-          .then(async ({ data: finalMessage }) => {
-            // `continue: false` is not read here, for the same reason as the message:received path
-            // above: the send has already happened, so a plugin can stop the handler chain but cannot
-            // un-send it. Skipping the persist below dropped the operator's own outgoing message from
-            // history and from `message.sent` webhooks.
-
-            // Persist the outgoing message so local history reflects sends composed on a linked phone
-            // (message_create is the ONLY event those produce). It also fires for API-originated sends,
-            // which the REST send path persists itself — the UNIQUE(sessionId, waMessageId) index is
-            // the atomic dedup oracle between the two writers: the loser skips its insert, and
-            // persistSentState additionally drops its redundant PENDING row when the echo won. The
-            // webhook/WS dispatch below is identical whether the insert won, lost, or failed — the
-            // message.sent contract is unchanged.
-            const outgoing: IncomingMessage = finalMessage;
-            const metadata = buildMessageMetadata(outgoing, true);
-
-            // The ephemeral opt-out gates STORAGE only (mirrors onMessage); the live dispatch below
-            // is today's contract and stays.
-            const mayPersist =
-              resolveFeatureFlags(this.configService).storeEphemeralMessages ||
-              !(outgoing.ephemeralDuration && outgoing.ephemeralDuration > 0);
-
-            if (mayPersist) {
-              const dbMessage = this.messageRepository.create({
-                sessionId: id,
-                waMessageId: storableWaMessageId(outgoing.id),
-                chatId: outgoing.chatId,
-                from: outgoing.from,
-                to: outgoing.to,
-                body: outgoing.body,
-                type: outgoing.type,
-                direction: MessageDirection.OUTGOING,
-                timestamp: outgoing.timestamp,
-                status: MessageStatus.SENT,
-                metadata,
-              });
-              // The hook chain above is async; a delete()/teardown can retire this engine while it
-              // awaits. Re-check liveness so a late continuation can't persist an orphan row
-              // (mirrors onMessage).
-              if (!this.isLiveEngine(id, engine)) return;
-              let persisted = false;
-              try {
-                const result = await this.messageRepository.insert(
-                  dbMessage as unknown as QueryDeepPartialEntity<Message>,
-                );
-                Object.assign(dbMessage, result.identifiers[0] ?? {}, result.generatedMaps?.[0] ?? {});
-                persisted = true;
-              } catch (err) {
-                // Unique violation = the REST send path already persisted this API-originated send —
-                // the dedup oracle working as intended, not an error. Anything else is a real DB
-                // failure; fail open so a real send is never dropped on a transient DB fault.
-                if (!isUniqueConstraintError(err)) {
-                  this.logger.error(`Failed to save outgoing message ${outgoing.id} to database`, String(err));
-                }
-              }
-              if (persisted) {
-                // Fire-and-forget, mirroring onMessage: plugin providers (search etc.) see phone-
-                // composed sends exactly like API sends.
-                void this.hookManager
-                  .execute(
-                    'message:persisted',
-                    { sessionId: id, message: dbMessage },
-                    { sessionId: id, source: 'SessionService' },
-                  )
-                  .catch(() => undefined);
-              }
-            }
-
-            void this.webhookService.dispatch(id, 'message.sent', finalMessage);
-            // Emit real-time event to WebSocket clients (as message.sent, not message.received)
-            this.eventsGateway.emitMessageSent(id, finalMessage);
-          })
-          .catch(err => this.logger.error(`onMessageCreate handler failed for ${id}`, String(err)));
-      },
-      onMessageAck: (messageId, status: DeliveryStatus): void => {
-        if (!this.isLiveEngine(id, engine)) return;
-        this.logger.debug(`Message ack: ${messageId} -> ${status}`, {
-          sessionId: id,
-          messageId,
-          status,
-          action: 'message_ack',
-        });
-
-        // Reflect real delivery state on the stored message (#220): delivered/read/failed advance the
-        // stored status; pending/sent carry no upgrade (it's already SENT — visibly "not delivered").
-        // The UPDATE is guarded to the allowed prior statuses so delivery state only ADVANCES: an
-        // out-of-order/late ack cannot downgrade a higher status, which also makes these
-        // fire-and-forget writes race-safe at the DB level.
-        const messageStatus = deliveryStatusToMessageStatus(status);
-        if (messageStatus) {
-          // Scope by sessionId: waMessageId is unique per account/chat, not global — an ack on one
-          // session must never advance a same-id row in another session. The In() guard makes the
-          // UPDATE forward-only (a late/out-of-order ack can't downgrade) and idempotent on retry.
-          const advanceAck = (): Promise<number> =>
-            this.messageRepository
-              .update(
-                { sessionId: id, waMessageId: messageId, status: In(ackStatusTransitionFrom(messageStatus)) },
-                { status: messageStatus },
-              )
-              .then(result => result.affected ?? 0);
-
-          const logNoop = (): void =>
-            this.logger.debug(`Message ack ${messageId}: no status row advanced to ${messageStatus} (${status})`, {
-              sessionId: id,
-              messageId,
-              status,
-              action: 'message_ack_noop',
-            });
-
-          const onAckError = (err: unknown): void =>
-            this.logger.error(`Failed to advance ack for ${messageId}`, String(err));
-
-          void advanceAck()
-            .then(affected => {
-              if (affected > 0) return;
-              // affected:0 — most likely the send's 2nd save (which writes waMessageId) hasn't committed
-              // yet, so the row isn't matchable. Each ack is one-shot (WhatsApp won't necessarily resend),
-              // so retry ONCE after a short delay to close that race rather than leave it stuck at SENT.
-              const timer = setTimeout(() => {
-                void advanceAck()
-                  .then(retried => {
-                    if (retried === 0) logNoop();
-                  })
-                  .catch(onAckError);
-              }, ACK_RECONCILE_DELAY_MS);
-              timer.unref?.();
-            })
-            .catch(onAckError);
-        }
-
-        // One ack payload, emitted identically over the socket and the webhook so a client coded
-        // against either channel sees the same shape. `id` mirrors the field every other message.*
-        // event carries (and the idempotency-key resolver reads). `ack` is a deprecated legacy field
-        // kept for backward compatibility — new consumers should read the neutral `status`.
-        const ackPayload = { id: messageId, messageId, status, ack: deliveryStatusToAck(status) };
-
-        // Push the live delivery/read tick to the dashboard over the websocket.
-        this.eventsGateway.emitMessageAck(id, ackPayload);
-
-        // Dispatch the delivery/read receipt to webhooks (#155). Outgoing `message.sent` is handled
-        // solely by `onMessageCreate`, so the ack path deliberately does NOT emit `message.sent`.
-        void this.webhookService.dispatch(id, 'message.ack', ackPayload);
-
-        // Surface delivery failures actively so consumers don't have to poll for them (#220). Use a
-        // distinct object (not the shared ackPayload) so this separate event can't be perturbed by an
-        // in-place payload mutation in the concurrent message.ack dispatch's webhook:before hook.
-        if (status === 'failed') {
-          void this.webhookService.dispatch(id, 'message.failed', { ...ackPayload });
-        }
-
-        // Notify plugins of the delivery/read receipt. The `message:ack` hook event was declared in
-        // the HookEvent union but never emitted, so any plugin registered for it silently never fired.
-        // Fire-and-forget: an ack is a notification with nothing downstream to cancel, so the hook's
-        // `continue` flag is moot. Delivery failures surface here as status `failed` — `message:failed`
-        // stays reserved for send-time send failures, which carry a distinct `{ error, input }` payload.
-        void this.hookManager.execute(
-          'message:ack',
-          { messageId, status, ack: deliveryStatusToAck(status) },
-          { sessionId: id, source: 'Engine' },
-        );
-      },
-      onMessageRevoked: (message): void => {
-        if (!this.isLiveEngine(id, engine)) return;
-        this.logger.debug(`Message revoked: ${message.id}`, {
-          sessionId: id,
-          messageId: message.id,
-          action: 'message_revoked',
-        });
-
-        // Flag the stored message as revoked (best-effort; the message may not be in the
-        // DB). The dashboard renders the localized "message deleted" text, so no display
-        // string is persisted here.
-        //
-        // Match on `revokedId` (the ORIGINAL deleted message's id) when present: on wwebjs
-        // `message.id` is the revocation notification, which never matches a stored row.
-        // `revokedId` falls back to `id` (Baileys, where the two are the same).
-        const revokedWaMessageId = message.revokedId ?? message.id;
-        void this.messageRepository
-          .update({ sessionId: id, waMessageId: revokedWaMessageId }, { body: '', type: 'revoked' })
-          .catch(err => {
-            this.logger.error(`Failed to update revoked message: ${revokedWaMessageId}`, String(err));
-          });
-
-        // Notify consumers regardless of whether the row existed: webhook (message.revoked
-        // is a declared event) + the real-time dashboard stream.
-        const revokedPayload = message as unknown as Record<string, unknown>;
-        void this.webhookService.dispatch(id, 'message.revoked', revokedPayload);
-        this.eventsGateway.emitMessageRevoked(id, revokedPayload);
-      },
+      onMessageCreate: (message): void => this.handleOwnSendEcho(id, engine, message),
+      onMessageAck: (messageId, status): void => this.handleMessageAck(id, engine, messageId, status),
+      onMessageRevoked: (message): void => this.handleMessageRevoked(id, engine, message),
       onMessageReaction: (event): void => {
         if (!this.isLiveEngine(id, engine)) return;
         if (!event.messageId) {
@@ -1831,6 +1387,462 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
    * column). Invoked through the per-message serialization chain in onMessageReaction, so concurrent
    * reactions on the same message run sequentially and don't clobber each other.
    */
+  /** Engine callback body, lifted out of initializeEngine so the wiring table stays readable. */
+  private handleInboundMessage(id: string, engine: IWhatsAppEngine, message: IncomingMessage): void {
+    if (!this.isLiveEngine(id, engine)) return;
+    // Status/Story posts arrive via the inbound path for some engines; ingest them into the
+    // status store instead of the message pipeline. Mirrors the isStatusBroadcast guard in
+    // onMessageCreate below: an own-send echo (fromMe) stays a plain drop — never ingested,
+    // never dispatched — so a status you posted never re-appears in your own webhooks/API as
+    // if a contact had posted it.
+    if (message.isStatusBroadcast) {
+      if (message.fromMe) return;
+      const status = buildIncomingStatus(message);
+      if (status) {
+        void this.statusStore
+          .ingest(id, status)
+          // Dispatch only on a fresh insert: ingest also resolves with the pre-existing row
+          // for a duplicate delivery (or the winner's row after a lost insert race), and the
+          // webhook must fire once per status, not once per (re)delivery.
+          .then(({ row, created }) => {
+            // The ingest awaited; a stop()/delete() can retire this engine mid-flight — don't
+            // dispatch for a session that no longer exists (mirrors message.received's re-check).
+            if (!this.isLiveEngine(id, engine)) return;
+            if (created) this.dispatchStatusReceived(id, row);
+          })
+          .catch(err =>
+            this.logger.warn('Status ingest failed', {
+              sessionId: id,
+              error: err instanceof Error ? err.message : String(err),
+            }),
+          );
+      }
+      return;
+    }
+    // Ephemeral/disappearing messages: skip persist + dispatch when the operator opted out.
+    // A message is ephemeral when its chat has a disappearing-messages timer (ephemeralDuration > 0).
+    if (
+      !resolveFeatureFlags(this.configService).storeEphemeralMessages &&
+      message.ephemeralDuration &&
+      message.ephemeralDuration > 0
+    ) {
+      this.logger.debug('Skipping ephemeral message', {
+        sessionId: id,
+        messageId: message.id,
+        chatId: message.chatId,
+        ephemeralDuration: message.ephemeralDuration,
+      });
+      return;
+    }
+    this.logger.debug(`Message received from ${message.from}`, {
+      sessionId: id,
+      messageId: message.id,
+      from: message.from,
+      action: 'message_received',
+    });
+    // Update last active timestamp
+    void this.sessionRepository.update(id, { lastActiveAt: new Date() }).catch(() => undefined);
+    // Convert IncomingMessage to plain object for dispatch
+    const messageData = { ...message };
+
+    // Execute hook for message received - plugins can modify or stop processing
+    void this.hookManager
+      .execute('message:received', messageData, {
+        sessionId: id,
+        source: 'Engine',
+      })
+      .then(async ({ data: finalMessage }) => {
+        // `continue: false` is deliberately NOT read here. It means "stop the handler chain", which
+        // HookManager has already done — the plugins after the one that returned it never ran. It
+        // does not mean "this message never happened".
+        //
+        // Honouring it here used to skip everything below: the message was never written to the
+        // messages table, never dispatched to webhooks, and never emitted over the websocket. An
+        // auto-reply plugin returning `false` for its ordinary purpose — keeping other bots from
+        // answering the same message — silently erased the customer's message from the operator's
+        // own history, leaving a thread of bot replies answering nothing. Nothing in the hook
+        // contract (`HookResult.continue`, docs/19) or the webhook contract (`message.received`
+        // fires when "an inbound message arrives", docs/06) hinted at that, and a sandboxed
+        // marketplace plugin could swallow a session's entire inbound traffic with no audit trail.
+        //
+        // The message has already arrived at WhatsApp. A plugin can stop other plugins from acting
+        // on it; it cannot make the gateway forget it. Pre-action hooks are where a veto belongs —
+        // `message:sending` blocks a send that has not happened yet (core/hooks/sending-gate.ts).
+
+        // Persist the incoming message so the dashboard chats view can render history.
+        const incoming: IncomingMessage = finalMessage;
+
+        // Inline @lid -> phone resolution (#263), opt-in via RESOLVE_LID_TO_PHONE. Best-effort:
+        // attaches senderPhone (digits or null) before persist/dispatch so webhook/ws consumers
+        // get it in a single pass. Only for privacy-id senders, so no lookup for normal numbers.
+        if (resolveFeatureFlags(this.configService).resolveLidToPhone && incoming.isLidSender && !incoming.fromMe) {
+          incoming.senderPhone = await this.lidResolver.resolveSenderPhone(id, incoming.author ?? incoming.from);
+        }
+
+        const metadata = buildMessageMetadata(incoming);
+
+        const chatName = incoming.contact?.pushName ?? incoming.contact?.name ?? undefined;
+
+        const dbMessage = this.messageRepository.create({
+          sessionId: id,
+          waMessageId: storableWaMessageId(incoming.id),
+          chatId: incoming.chatId,
+          chatName,
+          // Group poster (participant JID) — `from` is the group JID, so this is the stable
+          // sender identity the chat view keys attribution runs/colors on. Undefined for 1:1.
+          author: incoming.author,
+          from: incoming.from,
+          to: incoming.to,
+          body: incoming.body,
+          type: incoming.type,
+          direction: incoming.fromMe ? MessageDirection.OUTGOING : MessageDirection.INCOMING,
+          timestamp: incoming.timestamp,
+          status: MessageStatus.SENT,
+          metadata,
+        });
+
+        // The hook chain above is async; a delete()/teardown can retire this engine while it
+        // awaits. Re-check liveness so a late continuation can't persist an orphan messages row
+        // (the row has no FK, so a session-delete cleanup would never reap it) or dispatch for a
+        // session that no longer exists. Mirrors the synchronous isLiveEngine gate at entry.
+        if (!this.isLiveEngine(id, engine)) return;
+
+        // De-duplicate at the source: the engine can re-fire `message` for one inbound message
+        // (#464). UNIQUE(sessionId, waMessageId) makes the insert the atomic dedup oracle — a
+        // near-simultaneous re-fire loses the race and is skipped here, so persist + webhook + WS
+        // happen exactly once. Fail-open: a non-conflict DB error still dispatches, so a real
+        // message is never dropped by a transient DB failure.
+        let isNewMessage = true;
+        let persisted = false;
+        try {
+          // `insert()` (not `save()`) is load-bearing: the UNIQUE(sessionId, waMessageId) constraint
+          // makes a duplicate insert throw, which is the atomic dedup oracle for #464 re-fires.
+          // Unlike `save()`, `insert()` does NOT merge DB-generated columns (@PrimaryGeneratedColumn,
+          // @CreateDateColumn) back onto the entity instance — so merge them explicitly here, before
+          // the `message:persisted` emit. `identifiers[0]` always carries the PK on both SQLite and
+          // Postgres; `generatedMaps[0]` adds createdAt where the driver returns it (Postgres yes;
+          // SQLite historically does not — acceptable; the PK is the load-bearing field for plugins).
+          const result = await this.messageRepository.insert(dbMessage as unknown as QueryDeepPartialEntity<Message>);
+          Object.assign(dbMessage, result.identifiers[0] ?? {}, result.generatedMaps?.[0] ?? {});
+          persisted = true;
+        } catch (err) {
+          if (isUniqueConstraintError(err)) {
+            isNewMessage = false;
+          } else {
+            this.logger.error(`Failed to save incoming message ${incoming.id} to database`, String(err));
+          }
+        }
+        if (!isNewMessage) {
+          return; // duplicate re-fire — the original already persisted and dispatched
+        }
+
+        // Fire-and-forget: a plugin handler must never break the receive path. Both engine adapters
+        // (wwjs `message` and Baileys `upsert`) converge on this persist, so one emit covers inbound.
+        // The built-in FTS search provider is DB-synced and does NOT consume this; it exists for
+        // plugin providers (Spec 2) + general use.
+        // Gate ONLY the hook on `persisted`: on a non-unique insert error (transient SQLITE_BUSY /
+        // lock-timeout / connection drop) the row was never stored and `dbMessage.id` is undefined,
+        // so emitting `message:persisted` would hand plugins an id-less payload for a row that isn't
+        // in the DB. The webhook/WS dispatch below stays fail-open — a real inbound message must
+        // never be dropped on a transient DB failure; only the hook requires a durable row.
+        if (persisted) {
+          void this.hookManager
+            .execute(
+              'message:persisted',
+              { sessionId: id, message: dbMessage },
+              { sessionId: id, source: 'SessionService' },
+            )
+            .catch(() => undefined);
+        }
+
+        // Dispatch to webhooks with potentially modified message
+        void this.webhookService.dispatch(id, 'message.received', finalMessage);
+        // Emit real-time event to WebSocket clients
+        this.eventsGateway.emitMessage(id, finalMessage);
+      })
+      .catch(err => this.logger.error(`onMessage handler failed for ${id}`, String(err)));
+  }
+
+  /** Engine callback body, lifted out of initializeEngine so the wiring table stays readable. */
+  private handleOwnSendEcho(id: string, engine: IWhatsAppEngine, message: IncomingMessage): void {
+    if (!this.isLiveEngine(id, engine)) return;
+    // `message_create` fires for every message the account creates, including sends composed on a
+    // linked phone — which the `message`/`onMessage` event never delivers. Incoming messages are
+    // already handled by `onMessage`, so only outgoing (`fromMe`) ones produce `message.sent` here.
+    if (!message.fromMe) {
+      return;
+    }
+
+    // Status/Story posts are account-created but not real conversations; don't emit `message.sent`
+    // for them. The adapter flags these (the engine-specific pseudo-JID stays out of this layer).
+    if (message.isStatusBroadcast) {
+      return;
+    }
+
+    this.logger.debug(`Message sent to ${message.to}`, {
+      sessionId: id,
+      messageId: message.id,
+      to: message.to,
+      action: 'message_sent',
+    });
+    // Update last active timestamp
+    void this.sessionRepository.update(id, { lastActiveAt: new Date() }).catch(() => undefined);
+    const messageData = { ...message };
+
+    // Execute hook for message sent - plugins can modify or stop processing
+    void this.hookManager
+      .execute('message:sent', messageData, {
+        sessionId: id,
+        source: 'Engine',
+      })
+      .then(async ({ data: finalMessage }) => {
+        // `continue: false` is not read here, for the same reason as the message:received path
+        // above: the send has already happened, so a plugin can stop the handler chain but cannot
+        // un-send it. Skipping the persist below dropped the operator's own outgoing message from
+        // history and from `message.sent` webhooks.
+
+        // Persist the outgoing message so local history reflects sends composed on a linked phone
+        // (message_create is the ONLY event those produce). It also fires for API-originated sends,
+        // which the REST send path persists itself — the UNIQUE(sessionId, waMessageId) index is
+        // the atomic dedup oracle between the two writers: the loser skips its insert, and
+        // persistSentState additionally drops its redundant PENDING row when the echo won. The
+        // webhook/WS dispatch below is identical whether the insert won, lost, or failed — the
+        // message.sent contract is unchanged.
+        const outgoing: IncomingMessage = finalMessage;
+        const metadata = buildMessageMetadata(outgoing, true);
+
+        // The ephemeral opt-out gates STORAGE only (mirrors onMessage); the live dispatch below
+        // is today's contract and stays.
+        const mayPersist =
+          resolveFeatureFlags(this.configService).storeEphemeralMessages ||
+          !(outgoing.ephemeralDuration && outgoing.ephemeralDuration > 0);
+
+        if (mayPersist) {
+          const dbMessage = this.messageRepository.create({
+            sessionId: id,
+            waMessageId: storableWaMessageId(outgoing.id),
+            chatId: outgoing.chatId,
+            from: outgoing.from,
+            to: outgoing.to,
+            body: outgoing.body,
+            type: outgoing.type,
+            direction: MessageDirection.OUTGOING,
+            timestamp: outgoing.timestamp,
+            status: MessageStatus.SENT,
+            metadata,
+          });
+          // The hook chain above is async; a delete()/teardown can retire this engine while it
+          // awaits. Re-check liveness so a late continuation can't persist an orphan row
+          // (mirrors onMessage).
+          if (!this.isLiveEngine(id, engine)) return;
+          let persisted = false;
+          try {
+            const result = await this.messageRepository.insert(dbMessage as unknown as QueryDeepPartialEntity<Message>);
+            Object.assign(dbMessage, result.identifiers[0] ?? {}, result.generatedMaps?.[0] ?? {});
+            persisted = true;
+          } catch (err) {
+            // Unique violation = the REST send path already persisted this API-originated send —
+            // the dedup oracle working as intended, not an error. Anything else is a real DB
+            // failure; fail open so a real send is never dropped on a transient DB fault.
+            if (!isUniqueConstraintError(err)) {
+              this.logger.error(`Failed to save outgoing message ${outgoing.id} to database`, String(err));
+            }
+          }
+          if (persisted) {
+            // Fire-and-forget, mirroring onMessage: plugin providers (search etc.) see phone-
+            // composed sends exactly like API sends.
+            void this.hookManager
+              .execute(
+                'message:persisted',
+                { sessionId: id, message: dbMessage },
+                { sessionId: id, source: 'SessionService' },
+              )
+              .catch(() => undefined);
+          }
+        }
+
+        void this.webhookService.dispatch(id, 'message.sent', finalMessage);
+        // Emit real-time event to WebSocket clients (as message.sent, not message.received)
+        this.eventsGateway.emitMessageSent(id, finalMessage);
+      })
+      .catch(err => this.logger.error(`onMessageCreate handler failed for ${id}`, String(err)));
+  }
+
+  /** Engine callback body, lifted out of initializeEngine so the wiring table stays readable. */
+  private handleMessageAck(id: string, engine: IWhatsAppEngine, messageId: string, status: DeliveryStatus): void {
+    if (!this.isLiveEngine(id, engine)) return;
+    this.logger.debug(`Message ack: ${messageId} -> ${status}`, {
+      sessionId: id,
+      messageId,
+      status,
+      action: 'message_ack',
+    });
+
+    // Reflect real delivery state on the stored message (#220): delivered/read/failed advance the
+    // stored status; pending/sent carry no upgrade (it's already SENT — visibly "not delivered").
+    // The UPDATE is guarded to the allowed prior statuses so delivery state only ADVANCES: an
+    // out-of-order/late ack cannot downgrade a higher status, which also makes these
+    // fire-and-forget writes race-safe at the DB level.
+    const messageStatus = deliveryStatusToMessageStatus(status);
+    if (messageStatus) {
+      // Scope by sessionId: waMessageId is unique per account/chat, not global — an ack on one
+      // session must never advance a same-id row in another session. The In() guard makes the
+      // UPDATE forward-only (a late/out-of-order ack can't downgrade) and idempotent on retry.
+      const advanceAck = (): Promise<number> =>
+        this.messageRepository
+          .update(
+            { sessionId: id, waMessageId: messageId, status: In(ackStatusTransitionFrom(messageStatus)) },
+            { status: messageStatus },
+          )
+          .then(result => result.affected ?? 0);
+
+      const logNoop = (): void =>
+        this.logger.debug(`Message ack ${messageId}: no status row advanced to ${messageStatus} (${status})`, {
+          sessionId: id,
+          messageId,
+          status,
+          action: 'message_ack_noop',
+        });
+
+      const onAckError = (err: unknown): void =>
+        this.logger.error(`Failed to advance ack for ${messageId}`, String(err));
+
+      void advanceAck()
+        .then(affected => {
+          if (affected > 0) return;
+          // affected:0 — most likely the send's 2nd save (which writes waMessageId) hasn't committed
+          // yet, so the row isn't matchable. Each ack is one-shot (WhatsApp won't necessarily resend),
+          // so retry ONCE after a short delay to close that race rather than leave it stuck at SENT.
+          const timer = setTimeout(() => {
+            void advanceAck()
+              .then(retried => {
+                if (retried === 0) logNoop();
+              })
+              .catch(onAckError);
+          }, ACK_RECONCILE_DELAY_MS);
+          timer.unref?.();
+        })
+        .catch(onAckError);
+    }
+
+    // One ack payload, emitted identically over the socket and the webhook so a client coded
+    // against either channel sees the same shape. `id` mirrors the field every other message.*
+    // event carries (and the idempotency-key resolver reads). `ack` is a deprecated legacy field
+    // kept for backward compatibility — new consumers should read the neutral `status`.
+    const ackPayload = { id: messageId, messageId, status, ack: deliveryStatusToAck(status) };
+
+    // Push the live delivery/read tick to the dashboard over the websocket.
+    this.eventsGateway.emitMessageAck(id, ackPayload);
+
+    // Dispatch the delivery/read receipt to webhooks (#155). Outgoing `message.sent` is handled
+    // solely by `onMessageCreate`, so the ack path deliberately does NOT emit `message.sent`.
+    void this.webhookService.dispatch(id, 'message.ack', ackPayload);
+
+    // Surface delivery failures actively so consumers don't have to poll for them (#220). Use a
+    // distinct object (not the shared ackPayload) so this separate event can't be perturbed by an
+    // in-place payload mutation in the concurrent message.ack dispatch's webhook:before hook.
+    if (status === 'failed') {
+      void this.webhookService.dispatch(id, 'message.failed', { ...ackPayload });
+    }
+
+    // Notify plugins of the delivery/read receipt. The `message:ack` hook event was declared in
+    // the HookEvent union but never emitted, so any plugin registered for it silently never fired.
+    // Fire-and-forget: an ack is a notification with nothing downstream to cancel, so the hook's
+    // `continue` flag is moot. Delivery failures surface here as status `failed` — `message:failed`
+    // stays reserved for send-time send failures, which carry a distinct `{ error, input }` payload.
+    void this.hookManager.execute(
+      'message:ack',
+      { messageId, status, ack: deliveryStatusToAck(status) },
+      { sessionId: id, source: 'Engine' },
+    );
+  }
+
+  /** Engine callback body, lifted out of initializeEngine so the wiring table stays readable. */
+  private handleEngineReady(id: string, engine: IWhatsAppEngine, phone: string, pushName: string): void {
+    if (!this.isLiveEngine(id, engine)) return;
+    this.logger.log(`Session ready: ${phone}`, {
+      sessionId: id,
+      phone,
+      pushName,
+      action: 'ready',
+    });
+
+    void this.webhookService.dispatch(id, 'session.authenticated', { sessionId: id, phone, pushName });
+    this.eventsGateway.emitSessionAuthenticated(id, { phone, pushName });
+
+    // Execute hook for ready event
+    void this.hookManager.execute(
+      'session:ready',
+      { phone, pushName },
+      {
+        sessionId: id,
+        source: 'Engine',
+      },
+    );
+
+    // Reset reconnect attempts and clear any stale failure reason on success
+    const reconnectState = this.reconnectStates.get(id);
+    if (reconnectState) {
+      reconnectState.attempts = 0;
+    }
+    // A fresh READY stretch starts the watchdog's failure budget clean too.
+    this.watchdog.clear(id);
+    this.sessionErrors.delete(id);
+    // READY proves any in-flight stuck-auth recovery succeeded (or none was needed), so the
+    // one-shot recovery budget is re-armed for a future episode.
+    this.stuckAuthRecoveryUsed.delete(id);
+
+    void this.sessionRepository
+      .update(id, {
+        status: SessionStatus.READY,
+        phone,
+        pushName,
+        connectedAt: new Date(),
+        lastActiveAt: new Date(),
+      })
+      .catch(err =>
+        this.logger.warn('Failed to persist session ready state', {
+          sessionId: id,
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      );
+
+    // Best-effort snapshot of the account's own contacts' currently-active statuses. Live status
+    // posts arrive through onMessage below; this just backfills what was already up before we
+    // connected. Not awaited — onReady must not block on it.
+    void this.seedStatuses(id, engine);
+  }
+
+  /** Engine callback body, lifted out of initializeEngine so the wiring table stays readable. */
+  private handleMessageRevoked(id: string, engine: IWhatsAppEngine, message: RevokedMessage): void {
+    if (!this.isLiveEngine(id, engine)) return;
+    this.logger.debug(`Message revoked: ${message.id}`, {
+      sessionId: id,
+      messageId: message.id,
+      action: 'message_revoked',
+    });
+
+    // Flag the stored message as revoked (best-effort; the message may not be in the
+    // DB). The dashboard renders the localized "message deleted" text, so no display
+    // string is persisted here.
+    //
+    // Match on `revokedId` (the ORIGINAL deleted message's id) when present: on wwebjs
+    // `message.id` is the revocation notification, which never matches a stored row.
+    // `revokedId` falls back to `id` (Baileys, where the two are the same).
+    const revokedWaMessageId = message.revokedId ?? message.id;
+    void this.messageRepository
+      .update({ sessionId: id, waMessageId: revokedWaMessageId }, { body: '', type: 'revoked' })
+      .catch(err => {
+        this.logger.error(`Failed to update revoked message: ${revokedWaMessageId}`, String(err));
+      });
+
+    // Notify consumers regardless of whether the row existed: webhook (message.revoked
+    // is a declared event) + the real-time dashboard stream.
+    const revokedPayload = message as unknown as Record<string, unknown>;
+    void this.webhookService.dispatch(id, 'message.revoked', revokedPayload);
+    this.eventsGateway.emitMessageRevoked(id, revokedPayload);
+  }
+
   private async applyReaction(id: string, event: ReactionEvent): Promise<void> {
     try {
       // Guard the lookup key before it reaches TypeORM: `findOne` DROPS an undefined condition from

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -27,6 +27,7 @@ import { EngineRegistry } from '../../engine/engine-registry.service';
 import { KeyedMutationQueue } from '../../common/utils/keyed-mutation-queue';
 import { decideReconnect, clampReconnectDelay, type ReconnectAttemptState } from './reconnect-policy';
 import { SessionLidResolver } from './session-lid-resolver.service';
+import { buildMessageMetadata, storableWaMessageId } from './message-row.mapper';
 import { SessionLivenessWatchdog } from './session-liveness-watchdog.service';
 import { resolveAuthTimeoutMs } from '../../engine/adapters/whatsapp-web-js.adapter';
 import { paginate, ListOptions, resolveListWindow } from '../../common/utils/paginate';
@@ -66,7 +67,6 @@ import {
 // marker in metadata — never NULL — or the dashboard renders an empty bubble (no placeholder) and the
 // by-type stats filter skips the row. Sources that lack the payload (wwjs own-send echo, media-free
 // history sync) get the omitted marker synthesized at the persistence chokepoints.
-const MEDIA_MESSAGE_TYPES = new Set(['image', 'video', 'audio', 'voice', 'sticker', 'document']);
 
 // How many recent status-broadcast messages the connect-time seed pulls (each with its media).
 // ponytail: fixed ceiling — the most-recent 50 cover a normal account's 24h of stories; anything
@@ -1008,17 +1008,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
         .filter(x => !seen.has(x))
         .map(x => {
           const m = byId.get(x)!;
-          const metadata: Record<string, unknown> = {};
-          if (m.media) {
-            metadata.media = m.media;
-          } else if (MEDIA_MESSAGE_TYPES.has(m.type)) {
-            // History sync maps messages media-free (footprint). Without the marker the row renders
-            // as an empty bubble — the DB copy wins over the engine-history placeholder in the
-            // dashboard merge — and the by-type stats filter would skip it.
-            metadata.media = { mimetype: '', omitted: true };
-          }
-          if (m.quotedMessage) metadata.quotedMessage = m.quotedMessage;
-          if (m.call) metadata.call = m.call;
+          const metadata = buildMessageMetadata(m, true);
           const row = this.messageRepository.create({
             sessionId: id,
             waMessageId: m.id,
@@ -1033,7 +1023,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
             direction: m.fromMe ? MessageDirection.OUTGOING : MessageDirection.INCOMING,
             timestamp: m.timestamp,
             status: MessageStatus.SENT,
-            metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+            metadata,
           });
           // The chat panel orders by createdAt; stamp the real time so history sorts correctly.
           if (m.timestamp) {
@@ -1291,26 +1281,13 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
               incoming.senderPhone = await this.lidResolver.resolveSenderPhone(id, incoming.author ?? incoming.from);
             }
 
-            const metadata: Record<string, unknown> = {};
-            if (incoming.media) {
-              metadata.media = incoming.media;
-            }
-            if (incoming.quotedMessage) {
-              metadata.quotedMessage = incoming.quotedMessage;
-            }
-            if (incoming.call) {
-              metadata.call = incoming.call;
-            }
+            const metadata = buildMessageMetadata(incoming);
 
             const chatName = incoming.contact?.pushName ?? incoming.contact?.name ?? undefined;
 
             const dbMessage = this.messageRepository.create({
               sessionId: id,
-              // Mirror saveOutgoingMessage's chokepoint: an engine that received a message but could
-              // not read its id back reports the empty sentinel, and NULL is what the non-partial
-              // (sessionId, waMessageId) unique index exempts — `''` would collide the second such
-              // message and lose the row.
-              waMessageId: incoming.id || undefined,
+              waMessageId: storableWaMessageId(incoming.id),
               chatId: incoming.chatId,
               chatName,
               // Group poster (participant JID) — `from` is the group JID, so this is the stable
@@ -1323,7 +1300,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
               direction: incoming.fromMe ? MessageDirection.OUTGOING : MessageDirection.INCOMING,
               timestamp: incoming.timestamp,
               status: MessageStatus.SENT,
-              metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+              metadata,
             });
 
             // The hook chain above is async; a delete()/teardown can retire this engine while it
@@ -1441,21 +1418,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
             // webhook/WS dispatch below is identical whether the insert won, lost, or failed — the
             // message.sent contract is unchanged.
             const outgoing: IncomingMessage = finalMessage;
-            const metadata: Record<string, unknown> = {};
-            if (outgoing.media) {
-              metadata.media = outgoing.media;
-            } else if (MEDIA_MESSAGE_TYPES.has(outgoing.type)) {
-              // The wwjs own-send echo carries no media field at all (Baileys emits an omitted
-              // marker); synthesize it so the dashboard renders the 📎 placeholder instead of an
-              // empty bubble, and the row stays countable in the by-type stats.
-              metadata.media = { mimetype: '', omitted: true };
-            }
-            if (outgoing.quotedMessage) {
-              metadata.quotedMessage = outgoing.quotedMessage;
-            }
-            if (outgoing.call) {
-              metadata.call = outgoing.call;
-            }
+            const metadata = buildMessageMetadata(outgoing, true);
 
             // The ephemeral opt-out gates STORAGE only (mirrors onMessage); the live dispatch below
             // is today's contract and stays.
@@ -1466,9 +1429,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
             if (mayPersist) {
               const dbMessage = this.messageRepository.create({
                 sessionId: id,
-                // Mirror onMessage's chokepoint: an unreadable id is the empty sentinel, stored as
-                // NULL — `''` would collide on the second such message.
-                waMessageId: outgoing.id || undefined,
+                waMessageId: storableWaMessageId(outgoing.id),
                 chatId: outgoing.chatId,
                 from: outgoing.from,
                 to: outgoing.to,
@@ -1477,7 +1438,7 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
                 direction: MessageDirection.OUTGOING,
                 timestamp: outgoing.timestamp,
                 status: MessageStatus.SENT,
-                metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+                metadata,
               });
               // The hook chain above is async; a delete()/teardown can retire this engine while it
               // awaits. Re-check liveness so a late continuation can't persist an orphan row

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -25,7 +25,7 @@ import { CreateSessionDto } from './dto';
 import { EngineFactory } from '../../engine/engine.factory';
 import { EngineRegistry } from '../../engine/engine-registry.service';
 import { KeyedMutationQueue } from '../../common/utils/keyed-mutation-queue';
-import { decideReconnect, clampReconnectDelay, type ReconnectAttemptState } from './reconnect-policy';
+import { decideReconnect, type ReconnectAttemptState } from './reconnect-policy';
 import { SessionLidResolver } from './session-lid-resolver.service';
 import { buildMessageMetadata, storableWaMessageId } from './message-row.mapper';
 import { SessionLivenessWatchdog } from './session-liveness-watchdog.service';
@@ -115,7 +115,8 @@ export function resolveReconnectConfig(
   return { maxAttempts, baseDelay };
 }
 
-export { clampReconnectDelay };
+// Re-exported so the existing spec import paths keep working after these moved out.
+export { clampReconnectDelay } from './reconnect-policy';
 export {
   SESSION_WATCHDOG_INTERVAL_MS,
   SESSION_WATCHDOG_PROBE_TIMEOUT_MS,

--- a/src/modules/status/status.module.ts
+++ b/src/modules/status/status.module.ts
@@ -1,11 +1,10 @@
 import { Module } from '@nestjs/common';
 import { StatusController } from './status.controller';
 import { StatusService } from './status.service';
-import { SessionModule } from '../session/session.module';
 import { StatusStoreModule } from '../status-store/status-store.module';
 
 @Module({
-  imports: [SessionModule, StatusStoreModule],
+  imports: [StatusStoreModule],
   controllers: [StatusController],
   providers: [StatusService],
   exports: [StatusService],

--- a/src/modules/status/status.service.spec.ts
+++ b/src/modules/status/status.service.spec.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, NotFoundException, PayloadTooLargeException } from '@nestjs/common';
 import { StatusService } from './status.service';
-import { SessionService } from '../session/session.service';
+import { EngineRegistry } from '../../engine/engine-registry.service';
+import { IWhatsAppEngine } from '../../engine/interfaces/whatsapp-engine.interface';
 import { StatusStoreService } from '../status-store/status-store.service';
 import { StorageService } from '../../common/storage/storage.service';
 import { HookManager } from '../../core/hooks';
@@ -14,7 +15,12 @@ describe('StatusService media validation and selection', () => {
     postImageStatus: jest.fn().mockResolvedValue({ id: 'image-status' }),
     postVideoStatus: jest.fn().mockResolvedValue({ id: 'video-status' }),
   };
-  const sessionService = { getEngine: jest.fn().mockReturnValue(engine) };
+  const engines = new EngineRegistry();
+  // Both ids the tests below post from; the store-only paths ('sess') never reach the engine.
+  engines.set('s1', engine as unknown as IWhatsAppEngine);
+  engines.set('sess', engine as unknown as IWhatsAppEngine);
+  // Asserts the store-backed read paths never resolve an engine at all.
+  const requireSpy = jest.spyOn(engines, 'require');
   // Pass-through gate: continue, input unchanged. The blocking/rewriting behaviour has its own
   // tests below.
   const passThrough = (_event: string, data: unknown) => Promise.resolve({ continue: true, data });
@@ -22,7 +28,7 @@ describe('StatusService media validation and selection', () => {
   const store = { list: jest.fn(), listByContact: jest.fn(), getMedia: jest.fn() };
   const storageService = { getFile: jest.fn() };
   const service = new StatusService(
-    sessionService as unknown as SessionService,
+    engines,
     hookManager as unknown as HookManager,
     store as unknown as StatusStoreService,
     storageService as unknown as StorageService,
@@ -41,7 +47,7 @@ describe('StatusService media validation and selection', () => {
 
       expect(out).toEqual([{ id: 'w1' }]);
       expect(store.list).toHaveBeenCalledWith('sess');
-      expect(sessionService.getEngine).not.toHaveBeenCalled();
+      expect(requireSpy).not.toHaveBeenCalled();
     });
 
     it('reads a contact statuses from the store, not the engine', async () => {
@@ -51,7 +57,7 @@ describe('StatusService media validation and selection', () => {
 
       expect(out).toEqual([{ id: 'w2' }]);
       expect(store.listByContact).toHaveBeenCalledWith('sess', 'contact@c.us');
-      expect(sessionService.getEngine).not.toHaveBeenCalled();
+      expect(requireSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/src/modules/status/status.service.ts
+++ b/src/modules/status/status.service.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
-import { SessionService } from '../session/session.service';
+import { EngineRegistry } from '../../engine/engine-registry.service';
 import { StatusStoreService } from '../status-store/status-store.service';
 import { StorageService } from '../../common/storage/storage.service';
 import type { Status, StatusResult, StatusPostOptions } from '../../engine/interfaces/whatsapp-engine.interface';
@@ -16,7 +16,7 @@ export class StatusService {
   // HookManager comes from the @Global() HooksModule, StorageService from the @Global()
   // StorageModule — neither needs a module import here.
   constructor(
-    private readonly sessionService: SessionService,
+    private readonly engines: EngineRegistry,
     private readonly hookManager: HookManager,
     private readonly store: StatusStoreService,
     private readonly storageService: StorageService,
@@ -82,10 +82,10 @@ export class StatusService {
   }
 
   async postTextStatus(sessionId: string, text: string, options: StatusPostOptions): Promise<StatusResult> {
-    const engine = this.sessionService.getEngine(sessionId);
-    if (!engine) {
-      throw new NotFoundException(`Session ${sessionId} not found or not connected`);
-    }
+    const engine = this.engines.require(
+      sessionId,
+      () => new NotFoundException(`Session ${sessionId} not found or not connected`),
+    );
     const gated = await this.gate(sessionId, 'status-text', { text, options });
     return engine.postTextStatus(gated.text, gated.options);
   }
@@ -102,10 +102,10 @@ export class StatusService {
       throw new BadRequestException('Either url or base64 must be provided');
     }
     assertBase64WithinMediaCap(base64);
-    const engine = this.sessionService.getEngine(sessionId);
-    if (!engine) {
-      throw new NotFoundException(`Session ${sessionId} not found or not connected`);
-    }
+    const engine = this.engines.require(
+      sessionId,
+      () => new NotFoundException(`Session ${sessionId} not found or not connected`),
+    );
     const gated = await this.gate(sessionId, 'status-image', {
       media: { mimetype: mimetype ?? 'image/jpeg', data: base64 || url || '' },
       options,
@@ -125,10 +125,10 @@ export class StatusService {
       throw new BadRequestException('Either url or base64 must be provided');
     }
     assertBase64WithinMediaCap(base64);
-    const engine = this.sessionService.getEngine(sessionId);
-    if (!engine) {
-      throw new NotFoundException(`Session ${sessionId} not found or not connected`);
-    }
+    const engine = this.engines.require(
+      sessionId,
+      () => new NotFoundException(`Session ${sessionId} not found or not connected`),
+    );
     const gated = await this.gate(sessionId, 'status-video', {
       media: { mimetype: mimetype ?? 'video/mp4', data: base64 || url || '' },
       options,
@@ -137,10 +137,10 @@ export class StatusService {
   }
 
   async deleteStatus(sessionId: string, statusId: string): Promise<void> {
-    const engine = this.sessionService.getEngine(sessionId);
-    if (!engine) {
-      throw new NotFoundException(`Session ${sessionId} not found or not connected`);
-    }
+    const engine = this.engines.require(
+      sessionId,
+      () => new NotFoundException(`Session ${sessionId} not found or not connected`),
+    );
     return engine.deleteStatus(statusId);
   }
 }

--- a/test/serve-static.e2e-spec.ts
+++ b/test/serve-static.e2e-spec.ts
@@ -4,15 +4,36 @@ import { NestFactory } from '@nestjs/core';
 import { ServeStaticModule } from '@nestjs/serve-static';
 import request from 'supertest';
 import { App } from 'supertest/types';
-import { mkdtempSync, mkdirSync, writeFileSync } from 'fs';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, realpathSync } from 'fs';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { join, sep, extname } from 'path';
+import type { Request, Response, NextFunction } from 'express';
 
-// Throwaway dashboard build, evaluated before the module decorator (forRoot reads rootPath eagerly).
-const distDir = mkdtempSync(join(tmpdir(), 'openwa-dash-'));
-writeFileSync(join(distDir, 'index.html'), '<!doctype html><title>OpenWA Dashboard</title>');
-mkdirSync(join(distDir, 'assets'));
-writeFileSync(join(distDir, 'assets', 'app.js'), 'console.log(1)');
+/**
+ * Two throwaway dashboard builds, evaluated before the module decorators (forRoot reads rootPath
+ * eagerly). The second deliberately sits under a DOT-SEGMENT directory, which is not exotic:
+ * `~/.openwa`, a CI checkout under `~/.cache`, and a `TMPDIR` inside a dotdir all produce it.
+ * `ServeStaticModule`'s own SPA fallback silently 404s every client-side route on such a path
+ * (it sends the index by absolute path, and Express's `send` refuses dot-segments), so the shape
+ * has to be covered explicitly or a real deployment class goes untested.
+ */
+function makeBuild(root: string): string {
+  mkdirSync(join(root, 'assets'), { recursive: true });
+  writeFileSync(join(root, 'index.html'), '<!doctype html><title>OpenWA Dashboard</title>');
+  writeFileSync(join(root, 'assets', 'app.js'), 'console.log(1)');
+  writeFileSync(join(root, '.env.secret'), 'TOKEN=nope');
+  return root;
+}
+
+const hasDotSegment = (p: string): boolean => p.split(sep).some(segment => segment.startsWith('.'));
+
+const osTmp = realpathSync(tmpdir());
+// The "plain" build must sit under a genuinely dot-free prefix. os.tmpdir() is NOT reliably
+// dot-free, and using it blindly would make BOTH cases dotted - which is exactly how this gap
+// stayed hidden. node_modules is gitignored, so nothing strays into the working tree.
+const dotFreeBase = hasDotSegment(osTmp) ? join(__dirname, '..', 'node_modules') : osTmp;
+const plainDist = makeBuild(join(mkdtempSync(join(dotFreeBase, 'openwa-dash-plain-')), 'dashboard', 'dist'));
+const dottedDist = makeBuild(join(mkdtempSync(join(osTmp, 'openwa-dash-')), '.dotted', 'dashboard', 'dist'));
 
 @Controller()
 class PingController {
@@ -22,30 +43,74 @@ class PingController {
   }
 }
 
+const EXCLUDE = ['/api/{*splat}', '/socket.io/{*splat}'];
+
 @Module({
-  imports: [
-    ServeStaticModule.forRoot({
-      rootPath: distDir,
-      exclude: ['/api/{*splat}', '/socket.io/{*splat}'],
-    }),
-  ],
+  imports: [ServeStaticModule.forRoot({ rootPath: plainDist, exclude: EXCLUDE })],
   controllers: [PingController],
 })
-class ServeStaticTestModule {}
+class PlainServeStaticModule {}
+
+@Module({
+  imports: [ServeStaticModule.forRoot({ rootPath: dottedDist, exclude: EXCLUDE })],
+  controllers: [PingController],
+})
+class DottedServeStaticModule {}
 
 /**
- * Regression lock for single-port dashboard serving (app.module.ts). Bootstraps the SAME
- * serve-static config (rootPath + exclude) via NestFactory against a throwaway build dir:
- * the SPA must be served at `/` with client-side fallback, while Nest keeps ownership of
- * `/api` so unknown API routes return JSON 404s (not the SPA index.html). Pins the Express 5
- * / path-to-regexp v8 wildcard syntax (`/api/{*splat}`) - if a dep bump breaks it, /api/*
- * would start returning index.html and these tests fail.
+ * Mirrors the SPA document handler main.ts installs (the CSP-nonce one), minus the nonce
+ * injection. It is load-bearing, not decoration: it reads the index with `readFileSync` and
+ * `res.send`s it, which is what makes client-side routes work at all on a dot-segment install
+ * path. Reproducing serve-static WITHOUT it - as this spec used to - tests a stack that does
+ * not exist in production and reports a failure the product does not have.
  */
-describe('Dashboard serve-static (e2e)', () => {
+function applyDashboardDocumentHandler(app: INestApplication<App>, distDir: string): void {
+  const dashboardIndex = readFileSync(join(distDir, 'index.html'), 'utf8');
+  app.use((req: Request, res: Response, next: NextFunction) => {
+    const excluded =
+      req.path.startsWith('/api/') ||
+      req.path === '/api' ||
+      req.path.startsWith('/socket.io/') ||
+      req.path === '/socket.io' ||
+      req.path.startsWith('/mcp/') ||
+      req.path === '/mcp' ||
+      req.path.startsWith('/assets/');
+    const documentRequest =
+      req.method === 'GET' &&
+      !excluded &&
+      ((req.headers.accept ?? '').includes('text/html') || extname(req.path) === '');
+    if (!documentRequest) return next();
+    res.setHeader('Cache-Control', 'no-store');
+    res.type('html').send(dashboardIndex);
+  });
+}
+
+describe('serve-static test fixtures', () => {
+  it('really does cover BOTH install-path shapes', () => {
+    // Without this, a dotted os.tmpdir() collapses the matrix onto one shape and the
+    // dot-segment case silently stops being tested.
+    expect(hasDotSegment(plainDist)).toBe(false);
+    expect(hasDotSegment(dottedDist)).toBe(true);
+  });
+});
+
+/**
+ * Regression lock for single-port dashboard serving (app.module.ts + main.ts). Bootstraps the SAME
+ * serve-static config (rootPath + exclude) AND the same document handler against a throwaway build:
+ * the SPA must be served at `/` with client-side fallback, while Nest keeps ownership of `/api` so
+ * unknown API routes return JSON 404s (not the SPA index.html). Pins the Express 5 /
+ * path-to-regexp v8 wildcard syntax (`/api/{*splat}`) - if a dep bump breaks it, /api/* would start
+ * returning index.html and these tests fail.
+ */
+describe.each([
+  ['a plain install path', PlainServeStaticModule, plainDist],
+  ['an install path with a dot-segment', DottedServeStaticModule, dottedDist],
+])('Dashboard serve-static (e2e) - %s', (_label, moduleClass, distDir) => {
   let app: INestApplication<App>;
 
   beforeAll(async () => {
-    app = await NestFactory.create(ServeStaticTestModule, { logger: false });
+    app = await NestFactory.create(moduleClass, { logger: false });
+    applyDashboardDocumentHandler(app, distDir);
     applyGlobalValidation(app);
     await app.init();
   });
@@ -67,9 +132,23 @@ describe('Dashboard serve-static (e2e)', () => {
     expect(res.headers['content-type']).toMatch(/html/);
   });
 
-  it('serves built assets', async () => {
+  it('serves index.html for a nested client-side route', async () => {
+    const res = await request(app.getHttpServer()).get('/sessions/abc/messages');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/html/);
+  });
+
+  it('serves built assets with their own content-type (not the SPA shell)', async () => {
     const res = await request(app.getHttpServer()).get('/assets/app.js');
     expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/javascript/);
+    expect(res.text).not.toContain('OpenWA Dashboard');
+  });
+
+  it('never leaks a dotfile out of the build directory', async () => {
+    // The SPA shell is an acceptable answer here; the file's CONTENTS must never be.
+    const res = await request(app.getHttpServer()).get('/.env.secret');
+    expect(res.text).not.toContain('TOKEN=');
   });
 
   it('lets Nest handle /api routes (real controller, not the SPA)', async () => {
@@ -83,5 +162,11 @@ describe('Dashboard serve-static (e2e)', () => {
     expect(res.status).toBe(404);
     expect(res.headers['content-type']).toMatch(/json/);
     expect(res.text).not.toContain('OpenWA Dashboard');
+  });
+
+  it('does not hand the SPA to a non-GET request', async () => {
+    // A mistyped POST must fail loudly rather than receiving a 200 HTML shell.
+    const res = await request(app.getHttpServer()).post('/sessions');
+    expect(res.status).not.toBe(200);
   });
 });

--- a/test/serve-static.e2e-spec.ts
+++ b/test/serve-static.e2e-spec.ts
@@ -44,15 +44,19 @@ class PingController {
 }
 
 const EXCLUDE = ['/api/{*splat}', '/socket.io/{*splat}'];
+// Mirrors app.module.ts: the module's own catch-all fallback is off, main.ts's document
+// handler owns SPA routes. Without this the module answers every unmatched GET with the
+// shell, which is the behaviour the missing-asset test below exists to prevent.
+const RENDER_DISABLED = '/__openwa_spa_fallback_owned_by_main_ts__';
 
 @Module({
-  imports: [ServeStaticModule.forRoot({ rootPath: plainDist, exclude: EXCLUDE })],
+  imports: [ServeStaticModule.forRoot({ rootPath: plainDist, exclude: EXCLUDE, renderPath: RENDER_DISABLED })],
   controllers: [PingController],
 })
 class PlainServeStaticModule {}
 
 @Module({
-  imports: [ServeStaticModule.forRoot({ rootPath: dottedDist, exclude: EXCLUDE })],
+  imports: [ServeStaticModule.forRoot({ rootPath: dottedDist, exclude: EXCLUDE, renderPath: RENDER_DISABLED })],
   controllers: [PingController],
 })
 class DottedServeStaticModule {}
@@ -145,9 +149,22 @@ describe.each([
     expect(res.text).not.toContain('OpenWA Dashboard');
   });
 
-  it('never leaks a dotfile out of the build directory', async () => {
-    // The SPA shell is an acceptable answer here; the file's CONTENTS must never be.
+  it('404s a missing asset instead of handing back the SPA shell', async () => {
+    // A mistyped <script src> must fail loudly. Answering 200 HTML makes the browser try to
+    // parse the shell as JavaScript and report a syntax error, hiding the real cause.
+    const res = await request(app.getHttpServer()).get('/assets/missing.js');
+    expect(res.status).toBe(404);
+    expect(res.text).not.toContain('OpenWA Dashboard');
+  });
+
+  it('404s a missing top-level file rather than serving the shell', async () => {
+    const res = await request(app.getHttpServer()).get('/favicon-missing.svg');
+    expect(res.status).toBe(404);
+  });
+
+  it('never serves a dotfile out of the build directory', async () => {
     const res = await request(app.getHttpServer()).get('/.env.secret');
+    expect(res.status).toBe(404);
     expect(res.text).not.toContain('TOKEN=');
   });
 


### PR DESCRIPTION
## Why

`SessionService` had grown to the point where ten feature services injected the whole lifecycle owner
purely to reach its private engine map, and the trickiest logic in the file — the reconnect backoff,
the liveness watchdog, the `@lid` cache, the per-message ordering chain — could only be reached by
driving a full session lifecycle. That combination meant the code most likely to break had the least
direct coverage.

## What changes

**The live engine is reachable through its own port.** The engine map moved to `EngineRegistry`,
exported from the already-global `EngineModule`. Eight feature modules (`call`, `catalog`, `channel`,
`contact`, `group`, `label`, `profile`, `status`) no longer import `SessionModule` at all; the two that
genuinely drive the lifecycle still hold `SessionService` deliberately. The engine-identity rule that
guards every lifecycle path was open-coded at around twenty call sites and is now `isLive` /
`deleteIfLive`, written once.

**Five self-contained concerns were lifted out**: `SessionLidResolver`, a pure `decideReconnect()` with
injected clock and jitter, `SessionLivenessWatchdog`, a general `KeyedMutationQueue`, and
`MessageProjector` for every path that turns an engine message callback into a persisted row.
`initializeEngine` drops from 807 lines to 327 — nearly all of it was callback bodies inlined into one
object literal, which hid the wiring under the handling.

Behaviour is unchanged throughout: the existing session specs pass untouched, and the split adds 77
tests over branches that previously needed hours of uptime or live engine callbacks to reach.

**The engine-agnostic init deadline moved out of the whatsapp-web.js adapter.** It applies to every
engine but was derived inline from a value the adapter owned, so the lifecycle owner imported one
specific engine's module to size a timeout that governs all of them.

## Security

`ctx.registerSearchProvider` is installed unconditionally in every worker context, and a plugin
declares itself a provider by posting `search-provider-register` over IPC — a path that never reaches
the capability router gating `ctx.messages` / `ctx.net` / `ctx.engine`. Nothing between that
declaration and the `SearchProviderRegistry` consulted the manifest, and under the shipped default
`SEARCH_PROVIDER=auto` a registered provider is also made **active**, superseding `builtin-fts`. A
plugin declaring no permissions at all could therefore see every query `GET /api/search` serves.

Registration now requires a new `search:provide` permission. `hasPermission` is a required field of
`RegisterPluginSearchProviderDeps`, so a future call site that forgets the gate fails to compile.

**Action required for search-provider plugins:** add `"permissions": ["search:provide"]` to the
manifest. Plugins that do not provide search are unaffected, as are all first-party plugins. No
gateway payload changes.

## Also fixed

A missing dashboard asset now returns 404 instead of the SPA shell. `ServeStaticModule`'s catch-all
answered every unmatched GET with `index.html`, so a stale `<script src>` came back `200 text/html`
and the browser reported a JavaScript syntax error from parsing the HTML — pointing at the wrong file
and hiding a broken build.

## Verification

Backend lint, build, `tsc --noEmit` over the full project including specs, 3999 unit tests and 137 e2e
tests pass; dashboard lint, typecheck, `i18n:check`, 220 unit tests and build pass. The local runs were
on Node 25, so CI on Node 22 is the proof that matters here.

The search gate was also verified behaviourally against a running gateway: a sandboxed plugin declaring
no permissions took over `/api/search` entirely on the current build, and after the change the same
plugin is refused, the active provider stays `builtin-fts`, and the host logs one
`sandbox_search_provider_denied` warning. The refusal also holds on the unattended boot-restore path,
which runs before the HTTP listener opens. Granting the permission restores registration.
