### PR TITLE
fix(plugins): name what a manifest-less directory is instead of implying a fault

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,9 @@ LOG_LEVEL=info                      # error | warn | info | debug
 # completed logout (200, credentials wiped) and an incomplete logout (502, `code: 'SESSION_LOGOUT_INCOMPLETE'`)
 # clear `phone`, so neither is auto-started on boot — an incomplete-logout session must be started
 # explicitly and the logout retried. A session that must stay down can simply be left as-is.
+# Docker Compose: this value only reaches the container from v0.12.0 onward — the bundled
+# docker-compose.yml did not forward it before then (#985), so setting it on an earlier version had
+# no effect and sessions stayed DISCONNECTED on boot regardless.
 AUTO_START_SESSIONS=false
 # 0 = unlimited. Set a positive integer to cap concurrently running/initializing sessions.
 # A FAILED session is evicted by design (no live engine), so it does not hold a concurrency slot.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   thing that verifies it. CI's shellcheck step now covers every script in `scripts/` instead of three
   of them; the BOM is exactly what it reports as SC1082, so the narrow scope is what let it survive.
 
+- **A stray directory under `data/plugins` no longer reads as a plugin fault.** Anything in there
+  without a `manifest.json` is skipped and logged, once per directory on every boot. The wording was a
+  bare "Plugin `<name>` missing manifest.json", which describes an internal failure rather than a
+  directory the loader simply does not recognise — an operator reporting an unrelated session problem
+  pasted two of these lines as evidence for it. The message now names what was skipped and what to do
+  about it. The `manifest_missing` action key is unchanged, so existing log filters still match.
+
+- **`.env.example` records when `AUTO_START_SESSIONS` began taking effect under Docker Compose.** The
+  bundled `docker-compose.yml` did not forward the variable into the container before v0.12.0, and
+  nothing else could supply it — there is no `env_file:` entry, `.env` is not mounted, and the build
+  context excludes it. Setting the flag on an earlier version therefore did nothing at all, and
+  authenticated sessions stayed `disconnected` after every restart with no indication why. The
+  forwarding itself was fixed in v0.12.0; this only stops the sample config from implying the value was
+  always live.
+
 ### Removed
 
 - `scripts/openwa.sh`, an orchestration helper superseded by the in-process Docker orchestration on

--- a/src/core/plugins/plugin-loader.service.ts
+++ b/src/core/plugins/plugin-loader.service.ts
@@ -340,10 +340,14 @@ export class PluginLoaderService implements OnModuleInit, OnApplicationBootstrap
       const manifestPath = path.join(pluginPath, 'manifest.json');
 
       if (!fs.existsSync(manifestPath)) {
-        this.logger.warn(`Plugin ${entry.name} missing manifest.json`, {
-          pluginPath,
-          action: 'manifest_missing',
-        });
+        // Operators do drop unrelated directories in here, and this fires on every boot for each one.
+        // The old bare "missing manifest.json" wording read like an internal fault — #981's reporter
+        // pasted it into an unrelated session bug as evidence. Say what was skipped and what to do.
+        this.logger.warn(
+          `Skipped ${entry.name}: not a plugin (no manifest.json). Delete the directory to silence this, ` +
+            `or add a manifest.json if it is meant to load.`,
+          { pluginPath, action: 'manifest_missing' },
+        );
         if (LEGACY_REMOVED_PLUGIN_IDS.has(entry.name)) {
           this.pluginStorage.deletePluginEntry(entry.name);
           this.logger.log(`Pruned stale registry entry for removed built-in plugin: ${entry.name}`, {


### PR DESCRIPTION
## Description

Two small corrections that came out of triaging #981, where a reporter's diagnosis was steered wrong by
what the software told them.

**The plugin scan's missing-manifest warning.** Any directory under `data/plugins` without a
`manifest.json` is skipped and logged, once per directory on every boot. The message read
`Plugin <name> missing manifest.json` — wording that describes a broken plugin rather than a directory
the loader simply does not recognise as one. In #981 the reporter had two such directories, named after
the engines, and pasted both lines into an unrelated session-startup report as evidence for it. The
warning now states what was skipped and what to do about it. Level stays `warn`, and the
`manifest_missing` action key is unchanged so existing log filters keep matching.

Silencing the warning was considered and rejected: the same code path is what surfaces a genuinely
broken plugin install, and there is no way to tell the two cases apart at scan time. Adding the engine
names to `LEGACY_REMOVED_PLUGIN_IDS` was also rejected — that set means "removed built-in plugin" and
triggers a registry delete, and engines have never been plugins.

**The `AUTO_START_SESSIONS` sample config.** The bundled `docker-compose.yml` did not forward this
variable into the container before v0.12.0, and nothing else could supply it: there is no `env_file:`
entry, `.env` is not mounted, and the build context excludes it. Setting the flag on any earlier
version therefore had no effect whatsoever — authenticated sessions stayed `disconnected` after every
restart with nothing to indicate why, which is exactly the report in #981. The forwarding itself was
fixed in v0.12.0; this change only stops `.env.example` from implying the value had always been live.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [ ] Tests added/updated — not applicable: no branch or behaviour was added. The change is a log
      string and two comment lines; a test asserting the wording would lock in prose without covering
      logic.
- [x] Documentation updated
- [x] Lint passes
- [x] Self-reviewed

Verified locally: `npm run lint`, `npx tsc --noEmit -p tsconfig.json` (full project, specs included),
`npm run build`, and `npm test` — 247 suites and 3999 tests passing, 1 suite and 5 tests skipped as
before. The dashboard is untouched by this branch.

## Related Issues

Refs #981
