### PR TITLE
refactor(infra): declare the generated-env location once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   generous window and never a shorter one. Splitting the two engines' windows needs its own env var
   and is a behaviour change, not a move.
 
+- **`data/.env.generated` has one declared location instead of three derived ones.** `InfraController`
+  re-built `path.resolve(process.cwd(), 'data', '.env.generated')` at each of its three readers — the
+  built-in-flag fallback behind the Docker probe, the config form's hydrate, and the merge base the
+  save path then writes back over — which made the file an undeclared dependency shared between
+  reading infrastructure status, rendering the form, and persisting credentials. Those are otherwise
+  independent concerns that touch none of the same state, so moving the file would have been a
+  three-site edit with nothing to catch a missed one. `generated-env.ts` now owns the path and the
+  parse.
+
+  Pure code motion: `infra.controller.spec.ts` passes with no edits, and the path is still resolved
+  per call rather than captured at import. `database/load-cli-env.ts` deliberately keeps its own copy
+  — it resolves the same filename against an injected `cwd` so it stays testable without `chdir`, and
+  folding it in would remove that seam.
+
 ### Fixed
 
 - **A rolled-back `POST /api/infra/import-data` no longer denies the engines it already stopped.** The

--- a/src/modules/infra/generated-env.ts
+++ b/src/modules/infra/generated-env.ts
@@ -1,0 +1,29 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as dotenv from 'dotenv';
+
+/**
+ * `data/.env.generated` — the dashboard-written env overlay, one KEY=value per line, merged into
+ * `process.env` on the next boot (after `process.env` and `.env`, all `override: false`).
+ *
+ * Resolved per call rather than captured at import: the location is relative to `process.cwd()`, and
+ * the controller has always re-derived it on each use.
+ *
+ * NOT shared with `database/load-cli-env.ts`, which resolves the same filename against an injected
+ * `cwd` so it stays testable without chdir. Folding that into this helper would remove its seam.
+ */
+export const generatedEnvPath = (): string => path.resolve(process.cwd(), 'data', '.env.generated');
+
+/**
+ * Parsed contents, or `{}` when the file has never been written.
+ *
+ * Three `InfraController` reads share this — the built-in-flag fallback behind the Docker probe, the
+ * config form's hydrate, and the merge base the save path writes back over. Re-deriving the location
+ * at each of them made the file an undeclared dependency shared between reading infrastructure
+ * status, rendering the form, and persisting credentials: three concerns that otherwise touch none of
+ * the same state.
+ */
+export function readGeneratedEnv(): Record<string, string> {
+  const envPath = generatedEnvPath();
+  return fs.existsSync(envPath) ? dotenv.parse(fs.readFileSync(envPath, 'utf8')) : {};
+}

--- a/src/modules/infra/infra.controller.ts
+++ b/src/modules/infra/infra.controller.ts
@@ -43,7 +43,7 @@ import { BLANK_SHADOWED_ENV_KEYS, isOsProvidedEnv } from '../../config/env-prece
 import * as fs from 'fs';
 import * as path from 'path';
 import { randomUUID } from 'crypto';
-import * as dotenv from 'dotenv';
+import { generatedEnvPath, readGeneratedEnv } from './generated-env';
 
 interface InfraStatus {
   // `builtIn` reflects whether OpenWA's own bundled container is actually running and backing this
@@ -576,10 +576,7 @@ export class InfraController implements OnApplicationBootstrap {
   /** Saved built-in intent flags from data/.env.generated — the fallback when Docker isn't reachable. */
   private readSavedBuiltinFlags(): { database: boolean; cache: boolean; storage: boolean } {
     try {
-      const envPath = path.resolve(process.cwd(), 'data', '.env.generated');
-      const saved: Record<string, string> = fs.existsSync(envPath)
-        ? dotenv.parse(fs.readFileSync(envPath, 'utf8'))
-        : {};
+      const saved = readGeneratedEnv();
       return {
         database: saved.POSTGRES_BUILTIN === 'true',
         cache: saved.REDIS_BUILTIN === 'true',
@@ -611,8 +608,7 @@ export class InfraController implements OnApplicationBootstrap {
   @ApiOperation({ summary: 'Read the saved infrastructure configuration for the dashboard form' })
   @ApiResponse({ status: 200, description: 'Saved configuration (secrets omitted)' })
   getConfig(): SavedConfigResponse {
-    const envPath = path.resolve(process.cwd(), 'data', '.env.generated');
-    const saved: Record<string, string> = fs.existsSync(envPath) ? dotenv.parse(fs.readFileSync(envPath, 'utf8')) : {};
+    const saved = readGeneratedEnv();
 
     // Secrets (passwords, S3 keys) are never returned; the form shows a "set" indicator
     // and an empty submission preserves the stored value (see saveConfig). This lets the
@@ -673,10 +669,8 @@ export class InfraController implements OnApplicationBootstrap {
       // field (`undefined`) leaves its stored key alone — only values actually submitted
       // are written. `existing` below is therefore the base for every key the payload
       // does not mention.
-      const envPath = path.resolve(process.cwd(), 'data', '.env.generated');
-      const existing: Record<string, string> = fs.existsSync(envPath)
-        ? dotenv.parse(fs.readFileSync(envPath, 'utf8'))
-        : {};
+      const envPath = generatedEnvPath();
+      const existing = readGeneratedEnv();
       const updates: Record<string, string> = {};
       // Keys to remove from the merged result — used to drop stale settings when the
       // user switches mode (postgres->sqlite, s3->local, built-in->external) so a reload


### PR DESCRIPTION
## Why

`InfraController` re-built `path.resolve(process.cwd(), 'data', '.env.generated')` at each of its three
readers:

- the built-in-flag fallback behind the Docker probe (`readSavedBuiltinFlags`),
- the config form's hydrate (`getConfig`),
- the merge base the save path then writes back over (`saveConfig`).

Those three are otherwise independent concerns — reading infrastructure status, rendering a form, and
persisting credentials touch none of the same state. The file was the one thing coupling them, and it
coupled them by coincidence of a repeated expression rather than by any declaration. Moving the file,
or changing how it is parsed, meant finding three sites with nothing to catch a missed one.

## What changes

`generated-env.ts` owns the path and the parse. It resolves per call rather than capturing at import,
because the location is relative to `process.cwd()` and the controller has always re-derived it.

`database/load-cli-env.ts` keeps its own copy deliberately: it resolves the same filename against an
injected `cwd` so it stays testable without `chdir`. Folding it into this helper would remove that
seam, so it is left alone.

The now-unused `dotenv` import leaves the controller with it.

## Scope

Pure code motion. No behaviour change, no response shape change, `openapi.json` untouched.

`infra.controller.spec.ts` passes **with no edits**, which is the point rather than a convenience: its
`jest.mock('fs')` is module-registry-wide, so the extracted module reads through the same stub the
controller did.

The literal `'.env.generated'` now appears zero times in `infra.controller.ts`.

## Verification

Backend lint, build, `tsc --noEmit` over the full project including specs, 4011 unit tests and 137 e2e
tests pass on Node 22. No dashboard files are touched.
