### PR TITLE
refactor(plugins): move the config-defaults seeder out of the loader

### DIFF
--- a/src/core/plugins/config-defaults.util.spec.ts
+++ b/src/core/plugins/config-defaults.util.spec.ts
@@ -1,0 +1,42 @@
+import { seedConfigDefaults } from './config-defaults.util';
+
+describe('seedConfigDefaults', () => {
+  const schema = {
+    type: 'object' as const,
+    properties: {
+      timezone: { type: 'string' as const, default: 'UTC' },
+      cooldownSec: { type: 'number' as const, default: 3600 },
+      schedule: { type: 'object' as const, required: true }, // no default — must stay absent
+      rules: { type: 'array' as const, default: [{ q: 'hi', a: 'hello' }] },
+    },
+  };
+
+  it('seeds schema defaults for absent keys only', () => {
+    const out = seedConfigDefaults(schema, { timezone: 'Asia/Jakarta' });
+    expect(out).toEqual({
+      timezone: 'Asia/Jakarta', // explicit value wins
+      cooldownSec: 3600,
+      rules: [{ q: 'hi', a: 'hello' }],
+    });
+    expect(out).not.toHaveProperty('schedule'); // required-without-default is never invented
+  });
+
+  it('returns the input unchanged when nothing is missing (and no schema)', () => {
+    const config = { timezone: 'UTC', cooldownSec: 1, rules: [] };
+    expect(seedConfigDefaults(schema, config)).toBe(config);
+    expect(seedConfigDefaults(undefined, config)).toBe(config);
+  });
+
+  it('deep-clones object/array defaults so runtime and persisted copies cannot share references', () => {
+    const out = seedConfigDefaults(schema, {});
+    const again = seedConfigDefaults(schema, {});
+    expect(out.rules).toEqual(again.rules);
+    expect(out.rules).not.toBe(again.rules);
+    expect((out.rules as unknown[])[0]).not.toBe((again.rules as unknown[])[0]);
+  });
+
+  it('null is an explicit value and is not overwritten by the default', () => {
+    const out = seedConfigDefaults(schema, { timezone: null });
+    expect(out.timezone).toBeNull();
+  });
+});

--- a/src/core/plugins/config-defaults.util.ts
+++ b/src/core/plugins/config-defaults.util.ts
@@ -1,0 +1,27 @@
+import type { PluginConfigSchema } from './plugin.interfaces';
+
+/**
+ * Fill config keys the schema declares a `default` for and that are absent (undefined) in the
+ * stored config. Seeding happens at LOAD time (fresh installs and every boot), so a plugin whose
+ * schema fields carry defaults never runs its lifecycle with them missing — the failure class of
+ * "enable throws: <field> is required/has no value" for defaulted fields. Explicit values — even
+ * null — are never overwritten, and object/array defaults are deep-cloned so the seeded runtime
+ * config and the persisted entry can't share a mutable reference. Required fields WITHOUT a
+ * declared default stay absent on purpose: those need real operator input, not an invented value.
+ */
+export function seedConfigDefaults(
+  schema: PluginConfigSchema | undefined,
+  config: Record<string, unknown>,
+): Record<string, unknown> {
+  const properties = schema?.properties;
+  if (!properties) return config;
+  let seeded: Record<string, unknown> | undefined;
+  for (const [key, field] of Object.entries(properties)) {
+    if (config[key] !== undefined || field === null || typeof field !== 'object') continue;
+    const value = field.default;
+    if (value === undefined) continue;
+    if (!seeded) seeded = { ...config };
+    seeded[key] = value !== null && typeof value === 'object' ? structuredClone(value) : value;
+  }
+  return seeded ?? config;
+}

--- a/src/core/plugins/plugin-loader.service.spec.ts
+++ b/src/core/plugins/plugin-loader.service.spec.ts
@@ -115,7 +115,7 @@ describe('dispatchConversationMedia', () => {
 
 import * as fs from 'fs';
 import * as os from 'os';
-import { PluginLoaderService, seedConfigDefaults } from './plugin-loader.service';
+import { PluginLoaderService } from './plugin-loader.service';
 import { ConfigService } from '@nestjs/config';
 import { ModuleRef } from '@nestjs/core';
 import { HookManager } from '../hooks';
@@ -577,47 +577,6 @@ describe('PluginLoaderService — loadPlugin seeds configSchema defaults', () =>
 
     expect(loader.getPlugin('seeded-plg')?.config).toEqual({ timezone: 'UTC' });
     expect(storage.getPluginEntry('seeded-plg')?.config).toEqual({ timezone: 'UTC' });
-  });
-});
-
-describe('seedConfigDefaults', () => {
-  const schema = {
-    type: 'object' as const,
-    properties: {
-      timezone: { type: 'string' as const, default: 'UTC' },
-      cooldownSec: { type: 'number' as const, default: 3600 },
-      schedule: { type: 'object' as const, required: true }, // no default — must stay absent
-      rules: { type: 'array' as const, default: [{ q: 'hi', a: 'hello' }] },
-    },
-  };
-
-  it('seeds schema defaults for absent keys only', () => {
-    const out = seedConfigDefaults(schema, { timezone: 'Asia/Jakarta' });
-    expect(out).toEqual({
-      timezone: 'Asia/Jakarta', // explicit value wins
-      cooldownSec: 3600,
-      rules: [{ q: 'hi', a: 'hello' }],
-    });
-    expect(out).not.toHaveProperty('schedule'); // required-without-default is never invented
-  });
-
-  it('returns the input unchanged when nothing is missing (and no schema)', () => {
-    const config = { timezone: 'UTC', cooldownSec: 1, rules: [] };
-    expect(seedConfigDefaults(schema, config)).toBe(config);
-    expect(seedConfigDefaults(undefined, config)).toBe(config);
-  });
-
-  it('deep-clones object/array defaults so runtime and persisted copies cannot share references', () => {
-    const out = seedConfigDefaults(schema, {});
-    const again = seedConfigDefaults(schema, {});
-    expect(out.rules).toEqual(again.rules);
-    expect(out.rules).not.toBe(again.rules);
-    expect((out.rules as unknown[])[0]).not.toBe((again.rules as unknown[])[0]);
-  });
-
-  it('null is an explicit value and is not overwritten by the default', () => {
-    const out = seedConfigDefaults(schema, { timezone: null });
-    expect(out.timezone).toBeNull();
   });
 });
 

--- a/src/core/plugins/plugin-loader.service.ts
+++ b/src/core/plugins/plugin-loader.service.ts
@@ -31,7 +31,6 @@ import {
   IPlugin,
   PluginType,
   PluginLogger,
-  PluginConfigSchema,
   validateIngressManifest,
   warnUnauthenticatedIngressRoutes,
   warnUnsignedTimestampRoutes,
@@ -39,6 +38,7 @@ import {
 import { validatePluginManifest } from './plugin-manifest';
 import { effectiveNetAllow, isNetHostAllowed, performPluginFetch } from './plugin-net';
 import { PluginStorageService } from './plugin-storage.service';
+import { seedConfigDefaults } from './config-defaults.util';
 import { isPluginActiveForSession, resolvePluginConfig } from './plugin-activation';
 import { PluginWorkerHost } from './sandbox/plugin-worker-host';
 import { WorkerThreadChannel } from './sandbox/worker-thread-channel';
@@ -189,32 +189,6 @@ export function dispatchConversationMedia(
 // still reports them installed/enabled) is pruned on boot. Scoped to these known ids so a
 // temporarily-unreadable plugin dir (e.g. an unmounted volume) never loses its persisted config.
 const LEGACY_REMOVED_PLUGIN_IDS = new Set(['auto-reply', 'translation']);
-
-/**
- * Fill config keys the schema declares a `default` for and that are absent (undefined) in the
- * stored config. Seeding happens at LOAD time (fresh installs and every boot), so a plugin whose
- * schema fields carry defaults never runs its lifecycle with them missing — the failure class of
- * "enable throws: <field> is required/has no value" for defaulted fields. Explicit values — even
- * null — are never overwritten, and object/array defaults are deep-cloned so the seeded runtime
- * config and the persisted entry can't share a mutable reference. Required fields WITHOUT a
- * declared default stay absent on purpose: those need real operator input, not an invented value.
- */
-export function seedConfigDefaults(
-  schema: PluginConfigSchema | undefined,
-  config: Record<string, unknown>,
-): Record<string, unknown> {
-  const properties = schema?.properties;
-  if (!properties) return config;
-  let seeded: Record<string, unknown> | undefined;
-  for (const [key, field] of Object.entries(properties)) {
-    if (config[key] !== undefined || field === null || typeof field !== 'object') continue;
-    const value = field.default;
-    if (value === undefined) continue;
-    if (!seeded) seeded = { ...config };
-    seeded[key] = value !== null && typeof value === 'object' ? structuredClone(value) : value;
-  }
-  return seeded ?? config;
-}
 
 @Injectable()
 export class PluginLoaderService implements OnModuleInit, OnApplicationBootstrap, OnModuleDestroy {


### PR DESCRIPTION
First step of unpicking `plugin-loader.service.ts`, taken deliberately small.

## Why

`seedConfigDefaults` is a pure function — sixteen lines, no `this`, no injected dependency — that lived
inside a 1713-line service module with 31 imports. Reaching it meant loading the whole loader graph:
BullMQ, ModuleRef, the sandbox worker host, plugin storage, the hook manager. Its own spec block paid
that price just to test schema defaulting.

## What changes

It moves to `config-defaults.util.ts` with its tests colocated beside it, matching how
`search-provider-registration.util.ts` and `webhook-subscribe.util.ts` were already lifted out of the
same file.

The loader's `PluginConfigSchema` import goes with it — seeding was its only use.

Nothing imported the symbol through the `core/plugins` barrel, so no re-export is added. Narrowing that
surface is part of the point rather than an oversight.

## Scope

Pure code motion. No behaviour change, no API surface change.

The suite total is identical at **4011** because nothing was added: the four tests moved verbatim, the
loader spec drops 56 → 52, and the new file accounts for the rest. Suite count goes 248 → 249 for the
new file alone.

No CHANGELOG entry — per CONTRIBUTING, that is for user-visible changes, and a pure function changing
files is not one.

## Note on sequencing

An earlier plan justified this step as breaking a `plugin-loader` ↔ `plugin-storage` require cycle. That
cycle does not exist today — `plugin-storage.service.ts` imports nothing from the loader. It would only
appear if a later step moved config seeding to where storage can reach it. The justification above is
the present-tense one; the sequencing benefit is a bonus, not the reason.

## Verification

Backend lint, `prettier --check`, `tsc --noEmit` over the full project including specs, build, 4011 unit
tests, 137 e2e tests, and the dashboard build all pass on Node 22.
