### PR TITLE
fix(plugins): clear a plugin's hook error when its worker generation starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Plugin health no longer reports a hook error from a worker that already died.** The last
+  hook-handler error a sandboxed plugin reported is operator context on
+  `GET /api/plugins/{id}/health`, and it is scoped to one worker generation — the field's contract was
+  "a fresh enable starts from a clean slate". It was cleared only on `disablePlugin`, but a worker
+  crash and a failed enable both end a generation without going through disable. The replacement
+  worker therefore inherited the dead one's error, and health reported it as current: an operator
+  restarting a plugin to clear a fault saw the same fault reported against the healthy worker that
+  replaced it.
+
+  The record is now cleared where a generation *starts*, so it holds for every way one can end rather
+  than for the single path that happened to be handled.
+
 - **A rolled-back `POST /api/infra/import-data` no longer denies the engines it already stopped.** The
   orphan pre-flight runs *before* the transaction opens, and `stopOrphans: true` really destroys those
   engines there — a teardown the rollback cannot undo. Both rollback branches nevertheless returned a

--- a/src/core/plugins/plugin-loader-sandbox-routing.spec.ts
+++ b/src/core/plugins/plugin-loader-sandbox-routing.spec.ts
@@ -226,6 +226,26 @@ describe('PluginLoaderService — sandbox hook error surfacing', () => {
     expect(after.message ?? '').not.toContain('last hook error');
   });
 
+  it('does not carry a dead generation’s hook error into the worker that replaces it', async () => {
+    // The record is cleared on disable, but a crash never goes through disable. Without a clear on
+    // enable, the next worker inherits the previous one's error and checkPluginHealth reports it as
+    // current — the field's own contract says a fresh enable starts from a clean slate.
+    const loader = makeLoader();
+    const handler = await setupShim(loader, 'message:sent');
+    loader.hosts[0].dispatchHook.mockResolvedValue({ continue: true, error: 'boom' });
+    jest.spyOn(loggerOf(loader), 'warn').mockImplementation(() => undefined);
+
+    await handler({ data: {}, sessionId: 's1', source: 'Engine' });
+    expect((await loader.checkPluginHealth('p1')).message).toContain('last hook error');
+
+    // Worker crashes (intentional=false): the host is dropped without any disable running.
+    loader.capturedOnWorkerExit!(1, false);
+    await loader.enablePlugin('p1');
+
+    const after = await loader.checkPluginHealth('p1');
+    expect(after.message ?? '').not.toContain('last hook error');
+  });
+
   it('does not log or record anything when the worker reports no error', async () => {
     const loader = makeLoader();
     const handler = await setupShim(loader, 'message:sent');

--- a/src/core/plugins/plugin-loader.service.ts
+++ b/src/core/plugins/plugin-loader.service.ts
@@ -194,7 +194,9 @@ export class PluginLoaderService implements OnModuleInit, OnApplicationBootstrap
   // Live worker host per enabled sandboxed (untrusted) plugin. Built-ins are not in here.
   private readonly sandboxHosts = new Map<string, PluginWorkerHost>();
   // Last hook-handler error each sandboxed plugin's worker reported, surfaced via checkPluginHealth so a
-  // hook that keeps throwing is visible to the operator. Cleared on disable (fresh enable = fresh slate).
+  // hook that keeps throwing is visible to the operator. Scoped to ONE worker generation: cleared when a
+  // generation starts (enableSandboxed) and when one is deliberately ended (disablePlugin). Clearing at
+  // the start is what makes it hold for a crash or a failed enable, neither of which runs a disable.
   private readonly lastSandboxHookError = new Map<string, { event: string; error: string; at: Date }>();
   // Carries the firing event's sessionId across an in-process hook handler so ctx.config (a getter)
   // resolves the per-session slice. Per async call tree, so concurrent sessions don't cross over.
@@ -1078,6 +1080,12 @@ export class PluginLoaderService implements OnModuleInit, OnApplicationBootstrap
    * tears the worker back down.
    */
   private async enableSandboxed(pluginId: string, plugin: PluginInstance): Promise<void> {
+    // A new worker generation starts from a clean slate. disablePlugin clears this too, but a crash
+    // and a failed enable both end a generation WITHOUT going through disable — so clearing only
+    // there let the replacement worker inherit a dead one's hook error and report it through
+    // checkPluginHealth as current. Enforced here, at the one point every generation begins, rather
+    // than repeated on each way a generation can end.
+    this.lastSandboxHookError.delete(pluginId);
     // Containment guard: reject a manifest.main that escapes the plugin dir.
     const mainPath = resolvePluginMainPath(this.pluginsDir, pluginId, plugin.manifest.main);
     // The capability dispatcher runs a worker request through the SAME context an in-process plugin


### PR DESCRIPTION
## The problem

The last hook-handler error a sandboxed worker reported is surfaced on `GET /api/plugins/{id}/health`
as operator context. The field's own comment scoped it to one worker generation:

> Cleared on disable (fresh enable = fresh slate).

It was cleared in exactly one place — `disablePlugin`. But a worker **crash** goes through
`onWorkerExit`, and a **failed enable** goes through the catch that terminates the host. Neither runs a
disable. Both drop the host without clearing the record.

So the next enable installs a new host, `checkPluginHealth` finds the record again, and reports the dead
generation's error as current. An operator restarting a plugin *to clear a fault* saw the same fault
attributed to the healthy worker that replaced it.

The record is only read while a host exists (`checkPluginHealth` returns early otherwise), which is why
this is invisible while the plugin is down and only appears once it is brought back up.

## The fix

One line, at the start of `enableSandboxed`.

The invariant is about a generation **beginning**, so it belongs where generations begin rather than
repeated on each way one can end. Patching `onWorkerExit` alone would have missed the enable-failure
path, which returns early on `intentional=true`.

## Test

Drives the real enable path with a stubbed worker host: records an error through the hook shim, crashes
the worker (`onWorkerExit(1, false)`), re-enables, and asserts health carries nothing from before.

It fails without the fix with exactly the stale note:

```
Expected substring: not "last hook error"
Received string:        "last hook error in 'message:sent' at …: boom"
```

The sibling test for the disable path already existed and is unchanged, so both ways a generation ends
are now covered.

## Scope correction

An earlier plan described this as a six-step release set assembled across three sites with "no single
site performing all six". Checked at source, that is no longer accurate: `onWorkerExit` already
performs five — log-drop flush, search-provider unregister, `setPluginStatus(ERROR)`,
`hookManager.unregisterPlugin`, and `sandboxHosts.delete`. `lastSandboxHookError` was the only step
genuinely missing, so this PR fixes that alone rather than restructuring the release paths.

Noted but deliberately untouched: the lead comment on `onWorkerExit` still says broader crash cleanup
"is a pre-existing gap ... out of scope here", while the code below it already writes status and
unregisters hooks. That comment predates this change.

## Verification

Backend lint, `prettier --check`, `tsc --noEmit` over the full project including specs, build, 4012 unit
tests, 137 e2e tests, and the dashboard build all pass on Node 22.
