### PR TITLE
refactor(auth): give coalesced API-key usage stats their own service

### DIFF
--- a/src/modules/auth/api-key-usage-tracker.service.ts
+++ b/src/modules/auth/api-key-usage-tracker.service.ts
@@ -1,0 +1,114 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ApiKey } from './entities/api-key.entity';
+import { createLogger } from '../../common/services/logger.service';
+
+/**
+ * Coalesced usage statistics for API keys: `usageCount` and `lastUsedAt`.
+ *
+ * These are advisory — authentication never reads them — but they are written on the per-request
+ * authentication hot path, so a naive implementation costs one DB write per request. The accumulator
+ * below collapses that to at most one write per key per window, keeping the returned entity accurate
+ * by adding the not-yet-persisted deltas to the value it hands back.
+ *
+ * It lives outside AuthService because the pending map was the one piece of state shared between
+ * three otherwise-unrelated concerns: the authN hot path that increments it, admin key lifecycle that
+ * drops a deleted or revoked key's counters, and shutdown that flushes what is left. None of those
+ * change for the same reason.
+ */
+@Injectable()
+export class ApiKeyUsageTracker {
+  private readonly logger = createLogger('ApiKeyUsageTracker');
+
+  /** Coalesce per-request usage-stat writes to at most one DB write per key per window. */
+  private static readonly STAT_FLUSH_INTERVAL_MS = 60_000;
+  /** Upper bound for the best-effort usage-stat flush on shutdown — teardown must not stall on a wedged DB. */
+  private static readonly SHUTDOWN_FLUSH_TIMEOUT_MS = 5_000;
+  /** keyId -> usage increments observed but not yet persisted (flushed on the next windowed write). */
+  private readonly pending = new Map<string, number>();
+
+  constructor(
+    @InjectRepository(ApiKey, 'main')
+    private readonly apiKeyRepository: Repository<ApiKey>,
+  ) {}
+
+  /**
+   * Record one use of `apiKey`. Takes the ENTITY, not an id: it mutates `lastUsedAt`/`usageCount` on
+   * the instance the caller is about to return, so the response reflects the true count including
+   * increments still pending. Never throws — a stat-write failure must not fail an authenticated
+   * request that already passed validation.
+   */
+  async record(apiKey: ApiKey): Promise<void> {
+    const pending = (this.pending.get(apiKey.id) ?? 0) + 1;
+    const previousLastUsedAt = apiKey.lastUsedAt;
+    apiKey.lastUsedAt = new Date();
+    apiKey.usageCount += pending; // DB value + all not-yet-persisted increments (incl. this request)
+
+    const due =
+      !previousLastUsedAt ||
+      apiKey.lastUsedAt.getTime() - previousLastUsedAt.getTime() >= ApiKeyUsageTracker.STAT_FLUSH_INTERVAL_MS;
+    if (!due) {
+      this.pending.set(apiKey.id, pending);
+      return;
+    }
+    this.pending.delete(apiKey.id);
+    try {
+      await this.apiKeyRepository.save(apiKey);
+    } catch (error) {
+      // Lost-update safe: a failed windowed write must not drop the accumulated increments —
+      // merge them back (accumulate, never overwrite, in case a concurrent path re-added a
+      // delta) so the next windowed write or the shutdown flush persists them.
+      this.pending.set(apiKey.id, (this.pending.get(apiKey.id) ?? 0) + pending);
+      this.logger.warn('Usage-stat write failed; delta kept pending for the next flush', {
+        keyId: apiKey.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  /** Drop a key's pending counters — the key is gone (deleted) or must stop counting (revoked). */
+  forget(keyId: string): void {
+    this.pending.delete(keyId);
+  }
+
+  /**
+   * Best-effort flush of the coalesced counters on teardown. Nest runs the owning service's
+   * onModuleDestroy before the TypeORM connection closes (the DataSource is destroyed in
+   * onApplicationShutdown, the last lifecycle hook), so the DB is still writable here. Bounded so a
+   * wedged DB cannot stall shutdown past the grace window; whatever is still unflushed after the
+   * bound is dropped — the counters are advisory statistics, authentication never depends on them.
+   */
+  async flushOnShutdown(): Promise<void> {
+    if (this.pending.size === 0) return;
+    this.logger.log(`Flushing usage stats for ${this.pending.size} API key(s) before shutdown`);
+    const timeout = new Promise<'timeout'>(resolve =>
+      setTimeout(() => resolve('timeout'), ApiKeyUsageTracker.SHUTDOWN_FLUSH_TIMEOUT_MS).unref(),
+    );
+    const result = await Promise.race([this.flushPending().then(() => 'done' as const), timeout]);
+    if (result === 'timeout') {
+      this.logger.warn('Usage-stat shutdown flush exceeded its time bound; remaining deltas dropped');
+    }
+  }
+
+  /** Persist every accumulated delta with an atomic increment; entries that fail stay pending. */
+  private async flushPending(): Promise<void> {
+    for (const [keyId, delta] of [...this.pending.entries()]) {
+      if (delta <= 0) {
+        this.pending.delete(keyId);
+        continue;
+      }
+      try {
+        // Atomic UPDATE ... SET usageCount = usageCount + delta — no read-modify-write race with a
+        // concurrent windowed save, unlike reloading the row and saving it back.
+        await this.apiKeyRepository.increment({ id: keyId }, 'usageCount', delta);
+        this.pending.delete(keyId);
+      } catch (error) {
+        this.logger.warn('Usage-stat flush failed for a key; delta kept pending', {
+          keyId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  }
+}

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { APP_GUARD } from '@nestjs/core';
 import { ApiKey } from './entities/api-key.entity';
 import { AuthService } from './auth.service';
+import { ApiKeyUsageTracker } from './api-key-usage-tracker.service';
 import { AuthController } from './auth.controller';
 import { AuthValidateController } from './auth-validate.controller';
 import { ApiKeyGuard } from './guards/api-key.guard';
@@ -14,6 +15,7 @@ import { ProxyAwareThrottlerGuard } from '../../common/security/proxy-aware-thro
   controllers: [AuthController, AuthValidateController],
   providers: [
     AuthService,
+    ApiKeyUsageTracker,
     {
       provide: APP_GUARD,
       useClass: ProxyAwareThrottlerGuard,

--- a/src/modules/auth/auth.service.spec.ts
+++ b/src/modules/auth/auth.service.spec.ts
@@ -9,6 +9,7 @@ import { UnauthorizedException, NotFoundException, ConflictException } from '@ne
 import { createHash, createHmac } from 'crypto';
 import * as fs from 'fs';
 import { AuthService, resolveSeedApiKey, bannerKeyLine } from './auth.service';
+import { ApiKeyUsageTracker } from './api-key-usage-tracker.service';
 import { ApiKey, ApiKeyRole } from './entities/api-key.entity';
 
 // Helpers
@@ -104,6 +105,7 @@ describe('AuthService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AuthService,
+        ApiKeyUsageTracker,
         {
           provide: getRepositoryToken(ApiKey, 'main'),
           useValue: repository,

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -18,6 +18,7 @@ import { hashApiKey } from './api-key-hash';
 import { ApiKey, ApiKeyRole } from './entities/api-key.entity';
 import { CreateApiKeyDto, UpdateApiKeyDto } from './dto';
 import { createLogger } from '../../common/services/logger.service';
+import { ApiKeyUsageTracker } from './api-key-usage-tracker.service';
 import { EventsGateway, type ApiKeyEvictionReason } from '../events/events.gateway';
 import { KeyedAsyncLock } from '../integration/ordering-lock';
 
@@ -57,13 +58,6 @@ export function bannerKeyLine(displayKey: string, isNewKey: boolean): string {
 export class AuthService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = createLogger('AuthService');
 
-  /** Coalesce per-request usage-stat writes to at most one DB write per key per window. */
-  private static readonly STAT_FLUSH_INTERVAL_MS = 60_000;
-  /** Upper bound for the best-effort usage-stat flush on shutdown — teardown must not stall on a wedged DB. */
-  private static readonly SHUTDOWN_FLUSH_TIMEOUT_MS = 5_000;
-  /** keyId -> usage increments observed but not yet persisted (flushed on the next windowed write). */
-  private readonly pendingUsage = new Map<string, number>();
-
   /**
    * Serializes every last-usable-admin check with the mutation it guards, in ONE critical section.
    * The check is check-then-act across awaits: without serialization, two concurrent requests that
@@ -80,6 +74,7 @@ export class AuthService implements OnModuleInit, OnModuleDestroy {
   constructor(
     @InjectRepository(ApiKey, 'main')
     private readonly apiKeyRepository: Repository<ApiKey>,
+    private readonly usageTracker: ApiKeyUsageTracker,
     private readonly moduleRef: ModuleRef,
   ) {}
 
@@ -131,44 +126,9 @@ export class AuthService implements OnModuleInit, OnModuleDestroy {
     this.logger.log('');
   }
 
-  /**
-   * Best-effort flush of the coalesced usage-stat counters on teardown. Nest runs onModuleDestroy
-   * before the TypeORM connection closes (the DataSource is destroyed in onApplicationShutdown, the
-   * last lifecycle hook), so the DB is still writable here. Bounded so a wedged DB cannot stall
-   * shutdown past the grace window; whatever is still unflushed after the bound is dropped — the
-   * counters are advisory statistics, authentication never depends on them.
-   */
+  /** Flush the coalesced usage counters before the DB connection closes. See ApiKeyUsageTracker. */
   async onModuleDestroy(): Promise<void> {
-    if (this.pendingUsage.size === 0) return;
-    this.logger.log(`Flushing usage stats for ${this.pendingUsage.size} API key(s) before shutdown`);
-    const timeout = new Promise<'timeout'>(resolve =>
-      setTimeout(() => resolve('timeout'), AuthService.SHUTDOWN_FLUSH_TIMEOUT_MS).unref(),
-    );
-    const result = await Promise.race([this.flushPendingUsage().then(() => 'done' as const), timeout]);
-    if (result === 'timeout') {
-      this.logger.warn('Usage-stat shutdown flush exceeded its time bound; remaining deltas dropped');
-    }
-  }
-
-  /** Persist every accumulated usage delta with an atomic increment; entries that fail stay pending. */
-  private async flushPendingUsage(): Promise<void> {
-    for (const [keyId, delta] of [...this.pendingUsage.entries()]) {
-      if (delta <= 0) {
-        this.pendingUsage.delete(keyId);
-        continue;
-      }
-      try {
-        // Atomic UPDATE ... SET usageCount = usageCount + delta — no read-modify-write race with a
-        // concurrent windowed save, unlike reloading the row and saving it back.
-        await this.apiKeyRepository.increment({ id: keyId }, 'usageCount', delta);
-        this.pendingUsage.delete(keyId);
-      } catch (error) {
-        this.logger.warn('Usage-stat flush failed for a key; delta kept pending', {
-          keyId,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-    }
+    await this.usageTracker.flushOnShutdown();
   }
 
   /**
@@ -364,7 +324,7 @@ export class AuthService implements OnModuleInit, OnModuleDestroy {
       const target = await this.findOne(id);
       await this.assertNotLastUsableAdmin(target);
       // Drop any un-flushed usage accumulator so a deleted key leaves nothing behind in the Map.
-      this.pendingUsage.delete(id);
+      this.usageTracker.forget(id);
       await this.apiKeyRepository.remove(target);
       this.removeBootstrapKeyFileIfMatching(target);
     };
@@ -391,7 +351,7 @@ export class AuthService implements OnModuleInit, OnModuleDestroy {
       await this.assertNotLastUsableAdmin(target);
       // A revoked key fails validation before its next flush, so its accumulator would orphan —
       // drop it here.
-      this.pendingUsage.delete(id);
+      this.usageTracker.forget(id);
       target.isActive = false;
       const saved = await this.apiKeyRepository.save(target);
       this.removeBootstrapKeyFileIfMatching(target);
@@ -516,35 +476,8 @@ export class AuthService implements OnModuleInit, OnModuleDestroy {
       }
     }
 
-    // Update usage stats — coalesced. Validation above is unchanged/synchronous; only
-    // the stat WRITE is throttled to at most once per key per window. usageCount stays
-    // accurate via an in-memory accumulator; the returned object reflects the true count.
-    const pending = (this.pendingUsage.get(apiKey.id) ?? 0) + 1;
-    const previousLastUsedAt = apiKey.lastUsedAt;
-    apiKey.lastUsedAt = new Date();
-    apiKey.usageCount += pending; // DB value + all not-yet-persisted increments (incl. this request)
-
-    const due =
-      !previousLastUsedAt ||
-      apiKey.lastUsedAt.getTime() - previousLastUsedAt.getTime() >= AuthService.STAT_FLUSH_INTERVAL_MS;
-    if (due) {
-      this.pendingUsage.delete(apiKey.id);
-      try {
-        await this.apiKeyRepository.save(apiKey);
-      } catch (error) {
-        // Lost-update safe: a failed windowed write must not drop the accumulated increments —
-        // merge them back (accumulate, never overwrite, in case a concurrent path re-added a
-        // delta) so the next windowed write or the shutdown flush persists them. Validation
-        // itself succeeded, so a stat-write failure must not fail the request.
-        this.pendingUsage.set(apiKey.id, (this.pendingUsage.get(apiKey.id) ?? 0) + pending);
-        this.logger.warn('Usage-stat write failed; delta kept pending for the next flush', {
-          keyId: apiKey.id,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-    } else {
-      this.pendingUsage.set(apiKey.id, pending);
-    }
+    // Advisory stats only; the tracker coalesces the write and never throws.
+    await this.usageTracker.record(apiKey);
 
     return apiKey;
   }


### PR DESCRIPTION
## Why

`pendingUsage` was the one piece of state shared between three concerns that change for entirely
different reasons:

- the **per-request authentication hot path** incremented it (`auth.service.ts:522-546`),
- **admin key lifecycle** dropped a deleted or revoked key's counters (`:367`, `:394`),
- **shutdown** flushed whatever was left (`:141-172`).

That shared map is what made `AuthService` a god object rather than merely a large one — the concerns
otherwise touch none of the same state.

## What moves

`ApiKeyUsageTracker` owns the map, both window constants, the windowed save and the bounded shutdown
flush.

`record()` takes the **entity**, not an id: the hot path mutates `lastUsedAt`/`usageCount` on the
instance `validateApiKey` is about to return, so the response reflects the true count including
increments still pending. `forget(keyId)` replaces the two lifecycle deletes.

`AuthService` keeps a one-line `onModuleDestroy` that delegates. Five spec callsites drive shutdown
through it (`spec:713, :729, :732, :737, :749`), and it is the natural owner of the Nest hook — the
tracker exposes `flushOnShutdown()` rather than implementing the hook itself, so the flush has exactly
one trigger rather than two.

## Scope

572 → 505 lines; `grep -c pendingUsage auth.service.ts` returns 0.

Behaviour is identical — the coalescing window, the lost-update merge that re-accumulates on a failed
windowed write, and the 5s bounded shutdown flush all moved verbatim.

Spec change is **two lines**: the provider and its import. No assertion, harness or fixture was touched.
141 auth tests pass.

## Remaining

`auth.service.ts` still has one spanning item — the `API_KEY_FILE` module const derived from
`process.cwd()`, shared between operator bootstrap and admin lifecycle. That is a separate change and
carries a real e2e defect with it: `test/setup-e2e.ts` redirects both SQLite databases but has no lever
for this path, so an e2e boot rewrites the developer's repo-root `data/.api-key`. Fixing it means making
the path injected rather than a const, which is why it is not bundled here.

## Verification

Backend lint, `prettier --check`, `tsc --noEmit` over the full project including specs, build, 4012 unit
tests, 137 e2e tests, and the dashboard build all pass on Node 22.
