### PR TITLE
refactor(plugins): give the plugin capability surface its own module

### DIFF
--- a/src/core/plugins/plugin-capability-context.ts
+++ b/src/core/plugins/plugin-capability-context.ts
@@ -1,0 +1,420 @@
+import { NotFoundException } from '@nestjs/common';
+import { AsyncLocalStorage } from 'async_hooks';
+import type { HookManager, HookEvent } from '../hooks';
+import type { LidMappingStore } from '../../engine/identity/lid-mapping-store.service';
+import type { IWhatsAppEngine } from '../../engine/interfaces/whatsapp-engine.interface';
+import { toNeutralJid, userPart } from '../../engine/identity/wa-id';
+import { ConversationMappingConflict } from '../../modules/integration/conversation-mapping.service';
+import { createLogger } from '../../common/services/logger.service';
+import type { MessageService } from '../../modules/message/message.service';
+import { isPluginActiveForSession, resolvePluginConfig } from './plugin-activation';
+import { effectiveNetAllow, isNetHostAllowed, performPluginFetch } from './plugin-net';
+import { buildConversationSendFacade, type ConversationMediaType } from './conversation-send-facade';
+import { PluginHostServices } from './plugin-host-services';
+import { PluginStorageService } from './plugin-storage.service';
+import {
+  PluginCapabilityError,
+  PluginCapabilityPermission,
+  type PluginContext,
+  type PluginConversationsCapability,
+  type PluginEngineReadCapability,
+  type PluginHandoverCapability,
+  type PluginInstance,
+  type PluginLogger,
+  type PluginManifest,
+  type PluginMappingsCapability,
+  type PluginMessagingCapability,
+  type PluginNetCapability,
+} from './plugin.interfaces';
+
+/**
+ * Translate a normalized conversation media send into the concrete MessageService media method for the
+ * envelope's type. Kept pure (no `this`) so the loader binds it directly and it can be unit-tested in
+ * isolation. The switch is exhaustive over ConversationMediaType — adding a type without a case is a
+ * compile error here rather than a silent runtime fall-through.
+ */
+export function dispatchConversationMedia(
+  svc: Pick<MessageService, 'sendImage' | 'sendVideo' | 'sendAudio' | 'sendDocument'>,
+  sessionId: string,
+  opts: { chatId: string; url: string; type: ConversationMediaType; caption?: string },
+): Promise<unknown> {
+  const dto = { chatId: opts.chatId, url: opts.url, caption: opts.caption };
+  switch (opts.type) {
+    case 'image':
+      return svc.sendImage(sessionId, dto);
+    case 'video':
+      return svc.sendVideo(sessionId, dto);
+    case 'audio':
+      return svc.sendAudio(sessionId, dto);
+    case 'voice':
+      // A voice envelope is a PTT note: sendAudio with ptt classifies it as 'voice' and defaults the
+      // codec to audio/ogg;opus, so it renders as a WhatsApp voice bubble rather than an audio file.
+      return svc.sendAudio(sessionId, { ...dto, ptt: true });
+    case 'file':
+      return svc.sendDocument(sessionId, dto);
+  }
+}
+
+/**
+ * The capability surface a plugin actually touches: ctx.messages, ctx.engine, ctx.net, ctx.storage,
+ * ctx.conversations, ctx.handover, ctx.mappings — and the gates in front of every one of them.
+ *
+ * This is the security-review surface. A plugin supplies its own sessionId, so `assertSessionAllowed`
+ * (the static manifest boundary) and the operator-activation check are the boundary, not a
+ * convenience. Keeping them beside the verbs they guard means a reviewer reads one file rather than
+ * tracing gates through a loader that is otherwise about discovery, lifecycle and worker plumbing.
+ *
+ * It holds no plugin registry and no worker hosts: the loader owns those. Everything here is derived
+ * from the PluginInstance passed in.
+ */
+export class PluginCapabilityContext {
+  // Carries the firing event's sessionId across an in-process hook handler so ctx.config (a getter)
+  // resolves the per-session slice. Per async call tree, so concurrent sessions don't cross over.
+  private readonly hookSession = new AsyncLocalStorage<{ sessionId?: string }>();
+
+  constructor(
+    // The LOADER's logger, deliberately — a plugin's ctx.logger lines are prefixed with it, and that
+    // context is operator-visible. Creating a second logger here would silently retag every plugin
+    // log line the moment this moved out.
+    private readonly logger: ReturnType<typeof createLogger>,
+    private readonly hostServices: PluginHostServices,
+    private readonly hookManager: HookManager,
+    private readonly pluginStorage: PluginStorageService,
+    private readonly lidMappingStore?: LidMappingStore,
+  ) {}
+
+  /**
+   * Enforce a plugin's declared manifest permissions at the capability boundary. A plugin may only
+   * use a capability whose permission string it declares in `manifest.permissions`; anything else
+   * (including a manifest with no permissions) is denied. Runs first in each capability verb so a
+   * missing grant fails fast and uniformly as a PluginCapabilityError.
+   */
+  private assertPermission(manifest: PluginManifest, permission: PluginCapabilityPermission): void {
+    if (!(manifest.permissions ?? []).includes(permission)) {
+      throw new PluginCapabilityError(
+        `Plugin ${manifest.id} is missing the '${permission}' permission required for this capability`,
+      );
+    }
+  }
+
+  /**
+   * Enforce a plugin's manifest session scope. Runs BEFORE any engine/message resolution —
+   * sessionId is supplied by the plugin, so this is the security boundary. Absent = ['*'].
+   */
+  private assertSessionAllowed(manifest: PluginManifest, sessionId: string): void {
+    const allowed = manifest.sessions ?? ['*'];
+    if (!allowed.includes('*') && !allowed.includes(sessionId)) {
+      throw new PluginCapabilityError(`Plugin ${manifest.id} is not permitted to act on session ${sessionId}`);
+    }
+  }
+
+  /** Per-session activation gate: is this plugin currently activated for `sessionId`'s event? */
+  private isHookActive(plugin: PluginInstance, sessionId: string | undefined): boolean {
+    return isPluginActiveForSession(plugin.manifest.sessionScoped ?? true, plugin.activeSessions ?? ['*'], sessionId);
+  }
+
+  /**
+   * The capability session gate. A plugin may act on `sessionId` only if BOTH hold: its manifest scope
+   * allows the session (the static author boundary, assertSessionAllowed) AND the operator has activated
+   * the plugin for that session (the dynamic boundary, the same gate hook dispatch uses). manifest.sessions
+   * alone is not enough — a general adapter ships `['*']` and is scoped by operator activation, so without
+   * the activeSessions check a plugin activated for one session could reach another's engine/mappings/
+   * handover. Defaults (`activeSessions ?? ['*']`, `sessionScoped:false`) preserve every unrestricted flow.
+   */
+  private assertSessionActive(plugin: PluginInstance, sessionId: string): void {
+    this.assertSessionAllowed(plugin.manifest, sessionId);
+    if (!this.isHookActive(plugin, sessionId)) {
+      throw new PluginCapabilityError(`Plugin ${plugin.manifest.id} is not activated for session ${sessionId}`);
+    }
+  }
+
+  /**
+   * Scope-check, then resolve the live engine for a session. getEngine returns undefined for an
+   * unknown OR unstarted session (no throw), so guard it into a defined PluginCapabilityError.
+   * A present-but-not-READY engine throws EngineNotReadyError from the adapter on use (→ 409).
+   */
+  private resolveEngine(plugin: PluginInstance, sessionId: string): IWhatsAppEngine {
+    this.assertSessionActive(plugin, sessionId);
+    const engine = this.hostServices.getSessionService().getEngine(sessionId);
+    if (!engine) {
+      throw new PluginCapabilityError(`Session ${sessionId} has no active engine (unknown or not started)`);
+    }
+    return engine;
+  }
+
+  /** Engine read capabilities: require the `engine:read` permission, then resolve the live engine. */
+  private resolveEngineRead(plugin: PluginInstance, sessionId: string): IWhatsAppEngine {
+    this.assertPermission(plugin.manifest, PluginCapabilityPermission.ENGINE_READ);
+    return this.resolveEngine(plugin, sessionId);
+  }
+
+  /**
+   * Definitive "this session row no longer exists" probe for the stale-mapping repair paths below.
+   * True ONLY on a clean not-found from the sessions table; any other failure (service unresolvable,
+   * DB error) returns false, so the cross-session fences stay fail-CLOSED when the answer is
+   * indeterminate. The runtime engine map can't answer this — a stopped session has no engine but
+   * still owns its mappings.
+   */
+  private async isSessionGone(sessionId: string): Promise<boolean> {
+    try {
+      await this.hostServices.getSessionService().findOne(sessionId);
+      return false;
+    } catch (error) {
+      return error instanceof NotFoundException;
+    }
+  }
+  createPluginContext(plugin: PluginInstance): PluginContext {
+    const pluginLogger: PluginLogger = {
+      log: (message, meta) =>
+        this.logger.log(`[${plugin.manifest.id}] ${message}`, { ...meta, pluginId: plugin.manifest.id }),
+      debug: (message, meta) =>
+        this.logger.debug(`[${plugin.manifest.id}] ${message}`, { ...meta, pluginId: plugin.manifest.id }),
+      warn: (message, meta) =>
+        this.logger.warn(`[${plugin.manifest.id}] ${message}`, { ...meta, pluginId: plugin.manifest.id }),
+      error: (message, error, meta) =>
+        this.logger.error(
+          `[${plugin.manifest.id}] ${message}`,
+          error instanceof Error ? error.message : String(error),
+          { ...meta, pluginId: plugin.manifest.id },
+        ),
+    };
+
+    const hookSession = this.hookSession;
+    return {
+      pluginId: plugin.manifest.id,
+      manifest: plugin.manifest,
+      // Per-session: inside a hook, returns the override merged over the base for the firing session;
+      // outside a hook (lifecycle), the base config. A getter so it reflects live config edits too.
+      get config() {
+        return resolvePluginConfig(
+          plugin.config,
+          plugin.sessionConfig,
+          hookSession.getStore()?.sessionId,
+          plugin.manifest.sessionScoped !== false,
+        );
+      },
+      hookManager: this.hookManager,
+      logger: pluginLogger,
+      storage: this.pluginStorage.createPluginStorage(plugin.manifest.id),
+      registerHook: (event, handler, priority) => {
+        // Wrap with the per-session activation gate so an in-process plugin only handles events for
+        // the sessions it is activated for (mirrors the sandboxed shim), and scope the firing
+        // sessionId so ctx.config resolves the right per-session slice for the handler.
+        this.hookManager.register(
+          plugin.manifest.id,
+          event,
+          async hookCtx => {
+            if (!this.isHookActive(plugin, hookCtx.sessionId)) return { continue: true };
+            return this.hookSession.run({ sessionId: hookCtx.sessionId }, () => handler(hookCtx));
+          },
+          priority,
+        );
+      },
+      // In-process built-ins are not reached by the ingress pipeline (it dispatches to sandbox hosts),
+      // so fail loud rather than silently never firing. Sandboxed plugins get a real registerWebhook
+      // from the worker bootstrap.
+      registerWebhook: () => {
+        throw new PluginCapabilityError(
+          `Plugin ${plugin.manifest.id}: registerWebhook (ingress) is only available to sandboxed plugins`,
+        );
+      },
+      messages: {
+        sendText: async (sessionId, chatId, text) => {
+          // Validate permission + scope + that the session has a live engine BEFORE MessageService
+          // persists a pending row: a missing grant / dead session must fail with
+          // PluginCapabilityError, not a raw TypeError + orphaned row. resolveEngine also runs
+          // assertSessionActive.
+          this.assertPermission(plugin.manifest, PluginCapabilityPermission.MESSAGES_SEND);
+          this.resolveEngine(plugin, sessionId);
+          return this.hostServices.getMessageService().sendText(sessionId, { chatId, text });
+        },
+        reply: async (sessionId, chatId, quotedMessageId, text) => {
+          this.assertPermission(plugin.manifest, PluginCapabilityPermission.MESSAGES_SEND);
+          this.resolveEngine(plugin, sessionId);
+          return this.hostServices.getMessageService().reply(sessionId, { chatId, quotedMessageId, text });
+        },
+      } satisfies PluginMessagingCapability,
+      engine: {
+        getGroupInfo: async (sessionId, groupId) => this.resolveEngineRead(plugin, sessionId).getGroupInfo(groupId),
+        getContacts: async sessionId => this.resolveEngineRead(plugin, sessionId).getContacts(),
+        getContactById: async (sessionId, contactId) =>
+          this.resolveEngineRead(plugin, sessionId).getContactById(contactId),
+        checkNumberExists: async (sessionId, phone) =>
+          this.resolveEngineRead(plugin, sessionId).checkNumberExists(phone),
+        getChats: async sessionId => this.resolveEngineRead(plugin, sessionId).getChats(),
+        getChatHistory: async (sessionId, chatId, limit, includeMedia) =>
+          this.resolveEngineRead(plugin, sessionId).getChatHistory(
+            chatId,
+            // Clamp to the REST non-deep ceiling (MessageService.MAX_CHAT_HISTORY_LIMIT = 100) so an
+            // untrusted plugin can't request an unbounded history fetch.
+            Math.min(Math.max(Math.trunc(limit ?? 50), 1), 100),
+            includeMedia ?? false,
+          ),
+        canonicalChatId: (sessionId, chatId) => {
+          // resolveEngineRead is the gate only (engine:read permission + live session); the resolution
+          // itself is a synchronous host lid->phone lookup, not an engine call, mirroring the webhook
+          // from-filter. Not `async` (nothing to await) — a resolved promise satisfies the signature.
+          this.resolveEngineRead(plugin, sessionId);
+          return Promise.resolve(toNeutralJid(chatId, jid => this.lidMappingStore?.getCached(userPart(jid)) ?? null));
+        },
+      } satisfies PluginEngineReadCapability,
+      net: {
+        fetch: async (url, init) => {
+          // Two gates: the declared permission, then the effective host allowlist = manifest net.allow
+          // UNION the hosts of net.allowConfigHosts keys across the base config AND every per-session
+          // override. The host gate has no firing-session context for a sandboxed plugin's cap round-trip,
+          // so admit every operator-configured tenant host (all public + still SSRF-guarded at connect)
+          // rather than resolving a single, possibly wrong (base-only), one. The SSRF guard inside
+          // performPluginFetch still blocks internal IPs even when the host is allowlisted.
+          this.assertPermission(plugin.manifest, PluginCapabilityPermission.NET_FETCH);
+          const netConfigs = [plugin.config ?? {}, ...Object.values(plugin.sessionConfig ?? {})];
+          const allow = [
+            ...new Set(
+              netConfigs.flatMap(cfg =>
+                effectiveNetAllow(plugin.manifest.net?.allow, plugin.manifest.net?.allowConfigHosts, cfg),
+              ),
+            ),
+          ];
+          if (!isNetHostAllowed(allow, url)) {
+            throw new PluginCapabilityError(
+              `Plugin ${plugin.manifest.id} may not fetch ${url} — add its host to net.allow or net.allowConfigHosts`,
+            );
+          }
+          return performPluginFetch(url, init);
+        },
+      } satisfies PluginNetCapability,
+      conversations: buildConversationSendFacade({
+        manifest: plugin.manifest,
+        assertPermission: this.assertPermission.bind(this),
+        assertSessionActive: (sessionId: string) => this.assertSessionActive(plugin, sessionId),
+        resolveChatId: async env => {
+          if (!env.instanceId || !env.source?.externalConversationId) {
+            throw new PluginCapabilityError(
+              `Plugin ${plugin.manifest.id}: conversation.send requires chatId, or both instanceId and source to resolve one`,
+            );
+          }
+          const mapping = await this.hostServices
+            .getConversationMappingService()
+            .getByProvider(plugin.manifest.id, env.instanceId, env.source.externalConversationId);
+          if (!mapping) {
+            throw new PluginCapabilityError(
+              `Plugin ${plugin.manifest.id}: no conversation mapping for instance ${env.instanceId} / ${env.source.externalConversationId}`,
+            );
+          }
+          // Fail closed on a cross-session mapping: getByProvider keys on (pluginId, instanceId,
+          // providerConversationId) only, so a stale row can resolve to a chat owned by a DIFFERENT
+          // session than the envelope's. Parity with the assertSessionActive(m.sessionId) check on
+          // mappings.getByProvider below — never send through a session the mapping does not belong to.
+          // (mapping.sessionId is NOT NULL in the entity, so a plain inequality check suffices. The
+          // env.sessionId guard is for the type only — the facade rejects a missing sessionId first.)
+          if (env.sessionId && mapping.sessionId !== env.sessionId) {
+            // Repair path: the mapping's session was DELETED (operator re-paired under a new id), so
+            // the row is stale rather than cross-session. Rebind it to the envelope's session —
+            // already activation-gated by the facade — and let the send proceed; without this the
+            // dead session's rows bricked conversation.send permanently. A mapping owned by another
+            // EXISTING session is a genuine cross-session violation and still throws.
+            if (await this.isSessionGone(mapping.sessionId)) {
+              await this.hostServices.getConversationMappingService().rebindSession(mapping.id, env.sessionId);
+              this.logger.warn(
+                `Rebound conversation mapping for instance ${env.instanceId} / ${env.source.externalConversationId} ` +
+                  `from deleted session ${mapping.sessionId} to ${env.sessionId}`,
+                { pluginId: plugin.manifest.id, action: 'conversation_mapping_rebound' },
+              );
+              return mapping.chatId;
+            }
+            throw new PluginCapabilityError(
+              `Plugin ${plugin.manifest.id}: conversation mapping for instance ${env.instanceId} / ${env.source.externalConversationId} belongs to session ${mapping.sessionId}, not ${env.sessionId}`,
+            );
+          }
+          return mapping.chatId;
+        },
+        // Re-establish the in-flight hook context around the downstream send so an adapter that calls
+        // conversation.send from within its own ingress handling can't echo-loop back into itself via
+        // its own outbound message:sending hook. Gate on an ALREADY-in-flight event (mirrors the
+        // worker-cap wrap's `inFlight.length > 0` check): a plain top-level send must NOT suppress
+        // message:sending for unrelated observers (audit/moderation) — only genuine re-entrancy does.
+        runGuarded: (events, run) =>
+          (events as HookEvent[]).some(e => this.hookManager.isInFlight(e))
+            ? this.hookManager.runInFlight(events as HookEvent[], run)
+            : run(),
+        sendText: (sessionId, opts) => this.hostServices.getMessageService().sendText(sessionId, opts),
+        reply: (sessionId, opts) => this.hostServices.getMessageService().reply(sessionId, opts),
+        sendMedia: (sessionId, opts) =>
+          dispatchConversationMedia(this.hostServices.getMessageService(), sessionId, opts),
+        sendLocation: (sessionId, opts) => this.hostServices.getMessageService().sendLocation(sessionId, opts),
+      } satisfies Parameters<typeof buildConversationSendFacade>[0]) satisfies PluginConversationsCapability,
+      handover: {
+        set: async (key, state) => {
+          // Same gate as conversation.send: flipping handover is part of owning the conversation, so
+          // it reuses CONVERSATION_SEND rather than adding a new permission.
+          this.assertPermission(plugin.manifest, PluginCapabilityPermission.CONVERSATION_SEND);
+          this.assertSessionActive(plugin, key.sessionId);
+          const mapping = await this.hostServices.getConversationMappingService().get({
+            sessionId: key.sessionId,
+            chatId: key.chatId,
+            pluginId: plugin.manifest.id,
+            instanceId: key.instanceId,
+          });
+          if (!mapping) {
+            throw new PluginCapabilityError(
+              `Plugin ${plugin.manifest.id}: no conversation mapping for session ${key.sessionId} / chat ${key.chatId} / instance ${key.instanceId}`,
+            );
+          }
+          await this.hostServices.getConversationMappingService().setHandover(mapping.id, state);
+        },
+      } satisfies PluginHandoverCapability,
+      mappings: {
+        upsert: async (key, providerConversationId) => {
+          this.assertPermission(plugin.manifest, PluginCapabilityPermission.CONVERSATION_SEND);
+          this.assertSessionActive(plugin, key.sessionId);
+          const mappingKey = {
+            sessionId: key.sessionId,
+            chatId: key.chatId,
+            pluginId: plugin.manifest.id,
+            instanceId: key.instanceId,
+          };
+          try {
+            await this.hostServices.getConversationMappingService().upsert(mappingKey, providerConversationId);
+          } catch (error) {
+            if (!(error instanceof ConversationMappingConflict)) throw error;
+            // The reverse unique key is held by another row. If that row's session was DELETED
+            // (operator re-paired under a new id), the adapter can never converge — the forward key
+            // carries the new sessionId, so every upsert bricks on the dead session's row. Supersede
+            // the stale row and retry once. A row owned by an EXISTING session is a genuine conflict
+            // and rethrows.
+            const stale = await this.hostServices
+              .getConversationMappingService()
+              .getByProvider(plugin.manifest.id, key.instanceId, providerConversationId);
+            if (!stale || !(await this.isSessionGone(stale.sessionId))) throw error;
+            await this.hostServices.getConversationMappingService().delete(stale.id);
+            await this.hostServices.getConversationMappingService().upsert(mappingKey, providerConversationId);
+          }
+        },
+        get: async key => {
+          this.assertPermission(plugin.manifest, PluginCapabilityPermission.CONVERSATION_SEND);
+          this.assertSessionActive(plugin, key.sessionId);
+          const m = await this.hostServices.getConversationMappingService().get({
+            sessionId: key.sessionId,
+            chatId: key.chatId,
+            pluginId: plugin.manifest.id,
+            instanceId: key.instanceId,
+          });
+          return m ? { providerConversationId: m.providerConversationId, handoverState: m.handoverState } : null;
+        },
+        getByProvider: async (instanceId, providerConversationId) => {
+          this.assertPermission(plugin.manifest, PluginCapabilityPermission.CONVERSATION_SEND);
+          const m = await this.hostServices
+            .getConversationMappingService()
+            .getByProvider(plugin.manifest.id, instanceId, providerConversationId);
+          // Parity with get/upsert: a plugin may only read a mapping for a session it is activated for.
+          if (m) this.assertSessionActive(plugin, m.sessionId);
+          return m ? { sessionId: m.sessionId, chatId: m.chatId, handoverState: m.handoverState } : null;
+        },
+      } satisfies PluginMappingsCapability,
+    };
+  }
+
+  // ============================================================================
+  // Query Methods
+  // ============================================================================
+}

--- a/src/core/plugins/plugin-capability.spec.ts
+++ b/src/core/plugins/plugin-capability.spec.ts
@@ -64,9 +64,11 @@ describe('PluginLoaderService capability facade — ctx.messages', () => {
   });
 
   function contextFor(plugin: PluginInstance): PluginContext {
-    return (loader as unknown as { createPluginContext: (p: PluginInstance) => PluginContext }).createPluginContext(
-      plugin,
-    );
+    // The capability surface moved to PluginCapabilityContext; the loader holds one. Every assertion
+    // below is unchanged — only the reach-in points at the object that owns the surface now.
+    return (
+      loader as unknown as { capabilities: { createPluginContext: (p: PluginInstance) => PluginContext } }
+    ).capabilities.createPluginContext(plugin);
   }
 
   it('messages.sendText delegates to MessageService.sendText with a wrapped dto', async () => {
@@ -171,9 +173,11 @@ describe('PluginLoaderService capability facade — ctx.engine', () => {
   }
 
   function contextFor(plugin: PluginInstance): PluginContext {
-    return (loader as unknown as { createPluginContext: (p: PluginInstance) => PluginContext }).createPluginContext(
-      plugin,
-    );
+    // The capability surface moved to PluginCapabilityContext; the loader holds one. Every assertion
+    // below is unchanged — only the reach-in points at the object that owns the surface now.
+    return (
+      loader as unknown as { capabilities: { createPluginContext: (p: PluginInstance) => PluginContext } }
+    ).capabilities.createPluginContext(plugin);
   }
 
   it('engine.getGroupInfo delegates to SessionService.getEngine(id).getGroupInfo', async () => {
@@ -268,9 +272,11 @@ describe('PluginLoaderService capability facade — ctx.net', () => {
     return { manifest, status: PluginStatus.INSTALLED, config: {}, instance: null };
   }
   function contextFor(loader: PluginLoaderService, plugin: PluginInstance): PluginContext {
-    return (loader as unknown as { createPluginContext: (p: PluginInstance) => PluginContext }).createPluginContext(
-      plugin,
-    );
+    // The capability surface moved to PluginCapabilityContext; the loader holds one. Every assertion
+    // below is unchanged — only the reach-in points at the object that owns the surface now.
+    return (
+      loader as unknown as { capabilities: { createPluginContext: (p: PluginInstance) => PluginContext } }
+    ).capabilities.createPluginContext(plugin);
   }
 
   it('denies net.fetch when the plugin does not declare net:fetch', async () => {
@@ -315,9 +321,11 @@ describe('PluginLoaderService capability facade — ctx.conversations', () => {
   });
 
   function contextFor(plugin: PluginInstance): PluginContext {
-    return (loader as unknown as { createPluginContext: (p: PluginInstance) => PluginContext }).createPluginContext(
-      plugin,
-    );
+    // The capability surface moved to PluginCapabilityContext; the loader holds one. Every assertion
+    // below is unchanged — only the reach-in points at the object that owns the surface now.
+    return (
+      loader as unknown as { capabilities: { createPluginContext: (p: PluginInstance) => PluginContext } }
+    ).capabilities.createPluginContext(plugin);
   }
 
   const sendEnv = {

--- a/src/core/plugins/plugin-loader-activation.spec.ts
+++ b/src/core/plugins/plugin-loader-activation.spec.ts
@@ -41,8 +41,8 @@ describe('PluginLoaderService — per-session activation gate (hook delivery)', 
 
   function register(plugin: PluginInstance, handler: HookHandler): void {
     const ctx = (
-      loader as unknown as { createPluginContext: (p: PluginInstance) => PluginContext }
-    ).createPluginContext(plugin);
+      loader as unknown as { capabilities: { createPluginContext: (p: PluginInstance) => PluginContext } }
+    ).capabilities.createPluginContext(plugin);
     ctx.registerHook('message:received', handler);
   }
 

--- a/src/core/plugins/plugin-loader-conversation-repair.spec.ts
+++ b/src/core/plugins/plugin-loader-conversation-repair.spec.ts
@@ -55,9 +55,11 @@ describe('PluginLoaderService — stale conversation-mapping repair', () => {
   });
 
   function contextFor(plugin: PluginInstance): PluginContext {
-    return (loader as unknown as { createPluginContext: (p: PluginInstance) => PluginContext }).createPluginContext(
-      plugin,
-    );
+    // The capability surface moved to PluginCapabilityContext; the loader holds one. Every assertion
+    // below is unchanged — only the reach-in points at the object that owns the surface now.
+    return (
+      loader as unknown as { capabilities: { createPluginContext: (p: PluginInstance) => PluginContext } }
+    ).capabilities.createPluginContext(plugin);
   }
 
   function makePlugin(activeSessions?: string[]): PluginInstance {

--- a/src/core/plugins/plugin-loader.service.spec.ts
+++ b/src/core/plugins/plugin-loader.service.spec.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
-import { resolvePluginMainPath, buildSandboxWorkerEnv, dispatchConversationMedia } from './plugin-loader.service';
+import { resolvePluginMainPath, buildSandboxWorkerEnv } from './plugin-loader.service';
+import { dispatchConversationMedia } from './plugin-capability-context';
 
 /** Regression lock: a plugin's manifest.main must not escape its plugin directory. */
 describe('resolvePluginMainPath', () => {

--- a/src/core/plugins/plugin-loader.service.ts
+++ b/src/core/plugins/plugin-loader.service.ts
@@ -1,58 +1,36 @@
-import {
-  Injectable,
-  NotFoundException,
-  OnApplicationBootstrap,
-  OnModuleInit,
-  OnModuleDestroy,
-  Optional,
-} from '@nestjs/common';
+import { Injectable, OnApplicationBootstrap, OnModuleInit, OnModuleDestroy, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { ModuleRef } from '@nestjs/core';
-import { toNeutralJid, userPart } from '../../engine/identity/wa-id';
 import { LidMappingStoreService } from '../../engine/identity/lid-mapping-store.service';
-import { AsyncLocalStorage } from 'async_hooks';
 import * as fs from 'fs';
 import * as path from 'path';
 import { createLogger } from '../../common/services/logger.service';
 import { HookManager, HookEvent, KNOWN_HOOK_EVENTS, isKnownHookEvent } from '../hooks';
 import {
-  PluginCapabilityError,
   PluginCapabilityPermission,
-  PluginEngineReadCapability,
   PluginManifest,
-  PluginMessagingCapability,
-  PluginNetCapability,
-  PluginConversationsCapability,
-  PluginHandoverCapability,
-  PluginMappingsCapability,
   PluginInstance,
   PluginStatus,
-  PluginContext,
   IPlugin,
   PluginType,
-  PluginLogger,
   validateIngressManifest,
   warnUnauthenticatedIngressRoutes,
   warnUnsignedTimestampRoutes,
 } from './plugin.interfaces';
 import { validatePluginManifest } from './plugin-manifest';
-import { effectiveNetAllow, isNetHostAllowed, performPluginFetch } from './plugin-net';
 import { PluginStorageService } from './plugin-storage.service';
 import { seedConfigDefaults } from './config-defaults.util';
 import { PluginHostServices } from './plugin-host-services';
+import { PluginCapabilityContext } from './plugin-capability-context';
 import { isPluginActiveForSession, resolvePluginConfig } from './plugin-activation';
 import { PluginWorkerHost } from './sandbox/plugin-worker-host';
 import { WorkerThreadChannel } from './sandbox/worker-thread-channel';
 import { dispatchCapabilityVerb } from './sandbox/capability-router';
 import { PluginLogLevel } from './sandbox/protocol';
-import { buildConversationSendFacade, ConversationMediaType } from './conversation-send-facade';
 import { shouldDispatchToPlugin } from './handover-gate';
 import { makeOnWebhookSubscribe } from './webhook-subscribe.util';
 import { registerPluginSearchProvider, unregisterPluginSearchProvider } from './search-provider-registration.util';
 import { INGRESS_DISPATCH_TIMEOUT_MS } from '../../modules/integration/integration.constants';
-import type { IWhatsAppEngine } from '../../engine/interfaces/whatsapp-engine.interface';
-import { ConversationMappingConflict } from '../../modules/integration/conversation-mapping.service';
-import type { MessageService } from '../../modules/message/message.service';
 import type { IngressJobData } from '../../modules/queue/processors/ingress.processor';
 
 /** Default per-plugin heap cap for the sandbox worker; an OOM terminates the worker, not the host. */
@@ -150,34 +128,6 @@ export function buildSandboxWorkerEnv(source: NodeJS.ProcessEnv = process.env): 
   return env;
 }
 
-/**
- * Translate a normalized conversation media send into the concrete MessageService media method for the
- * envelope's type. Kept pure (no `this`) so the loader binds it directly and it can be unit-tested in
- * isolation. The switch is exhaustive over ConversationMediaType — adding a type without a case is a
- * compile error here rather than a silent runtime fall-through.
- */
-export function dispatchConversationMedia(
-  svc: Pick<MessageService, 'sendImage' | 'sendVideo' | 'sendAudio' | 'sendDocument'>,
-  sessionId: string,
-  opts: { chatId: string; url: string; type: ConversationMediaType; caption?: string },
-): Promise<unknown> {
-  const dto = { chatId: opts.chatId, url: opts.url, caption: opts.caption };
-  switch (opts.type) {
-    case 'image':
-      return svc.sendImage(sessionId, dto);
-    case 'video':
-      return svc.sendVideo(sessionId, dto);
-    case 'audio':
-      return svc.sendAudio(sessionId, dto);
-    case 'voice':
-      // A voice envelope is a PTT note: sendAudio with ptt classifies it as 'voice' and defaults the
-      // codec to audio/ogg;opus, so it renders as a WhatsApp voice bubble rather than an audio file.
-      return svc.sendAudio(sessionId, { ...dto, ptt: true });
-    case 'file':
-      return svc.sendDocument(sessionId, dto);
-  }
-}
-
 // Plugin ids whose bundled-extension code was permanently removed (v0.7 — superseded by the
 // marketplace chat-flow / group-translate; also reserved in plugin-installer). A leftover
 // directory without a manifest marks them as deleted on disk, so the stale registry entry (which
@@ -198,12 +148,11 @@ export class PluginLoaderService implements OnModuleInit, OnApplicationBootstrap
   // generation starts (enableSandboxed) and when one is deliberately ended (disablePlugin). Clearing at
   // the start is what makes it hold for a crash or a failed enable, neither of which runs a disable.
   private readonly lastSandboxHookError = new Map<string, { event: string; error: string; at: Date }>();
-  // Carries the firing event's sessionId across an in-process hook handler so ctx.config (a getter)
-  // resolves the per-session slice. Per async call tree, so concurrent sessions don't cross over.
-  private readonly hookSession = new AsyncLocalStorage<{ sessionId?: string }>();
   private readonly pluginsDir: string;
   /** Resolves host services at call time; see PluginHostServices for why it is not constructor-injected. */
   private readonly hostServices: PluginHostServices;
+  /** Owns the capability surface handed to plugins — permissions, session scope, engine resolution. */
+  private readonly capabilities: PluginCapabilityContext;
 
   constructor(
     private readonly configService: ConfigService,
@@ -220,6 +169,13 @@ export class PluginLoaderService implements OnModuleInit, OnApplicationBootstrap
   ) {
     this.pluginsDir = this.configService.get<string>('plugins.dir') ?? './plugins';
     this.hostServices = new PluginHostServices(this.moduleRef);
+    this.capabilities = new PluginCapabilityContext(
+      this.logger,
+      this.hostServices,
+      this.hookManager,
+      this.pluginStorage,
+      this.lidMappingStore,
+    );
   }
 
   onModuleInit(): void {
@@ -650,7 +606,7 @@ export class PluginLoaderService implements OnModuleInit, OnApplicationBootstrap
         await host.terminate().catch(() => undefined);
         this.sandboxHosts.delete(pluginId);
       } else {
-        const context = this.createPluginContext(plugin);
+        const context = this.capabilities.createPluginContext(plugin);
         if (plugin.instance?.onDisable) {
           await plugin.instance.onDisable(context);
         }
@@ -695,7 +651,7 @@ export class PluginLoaderService implements OnModuleInit, OnApplicationBootstrap
 
     // Call onUnload (in-process plugins; a sandboxed one received it above, before terminate)
     if (plugin.instance?.onUnload) {
-      const context = this.createPluginContext(plugin);
+      const context = this.capabilities.createPluginContext(plugin);
       await plugin.instance.onUnload(context);
     }
 
@@ -767,7 +723,7 @@ export class PluginLoaderService implements OnModuleInit, OnApplicationBootstrap
       if (sandboxHost) {
         sandboxHost.sendConfigChange(plugin.config);
       } else if (plugin.instance?.onConfigChange) {
-        const context = this.createPluginContext(plugin);
+        const context = this.capabilities.createPluginContext(plugin);
         void plugin.instance.onConfigChange(context, plugin.config);
       }
     }
@@ -937,87 +893,6 @@ export class PluginLoaderService implements OnModuleInit, OnApplicationBootstrap
   }
 
   /**
-   * Enforce a plugin's declared manifest permissions at the capability boundary. A plugin may only
-   * use a capability whose permission string it declares in `manifest.permissions`; anything else
-   * (including a manifest with no permissions) is denied. Runs first in each capability verb so a
-   * missing grant fails fast and uniformly as a PluginCapabilityError.
-   */
-  private assertPermission(manifest: PluginManifest, permission: PluginCapabilityPermission): void {
-    if (!(manifest.permissions ?? []).includes(permission)) {
-      throw new PluginCapabilityError(
-        `Plugin ${manifest.id} is missing the '${permission}' permission required for this capability`,
-      );
-    }
-  }
-
-  /**
-   * Enforce a plugin's manifest session scope. Runs BEFORE any engine/message resolution —
-   * sessionId is supplied by the plugin, so this is the security boundary. Absent = ['*'].
-   */
-  private assertSessionAllowed(manifest: PluginManifest, sessionId: string): void {
-    const allowed = manifest.sessions ?? ['*'];
-    if (!allowed.includes('*') && !allowed.includes(sessionId)) {
-      throw new PluginCapabilityError(`Plugin ${manifest.id} is not permitted to act on session ${sessionId}`);
-    }
-  }
-
-  /** Per-session activation gate: is this plugin currently activated for `sessionId`'s event? */
-  private isHookActive(plugin: PluginInstance, sessionId: string | undefined): boolean {
-    return isPluginActiveForSession(plugin.manifest.sessionScoped ?? true, plugin.activeSessions ?? ['*'], sessionId);
-  }
-
-  /**
-   * The capability session gate. A plugin may act on `sessionId` only if BOTH hold: its manifest scope
-   * allows the session (the static author boundary, assertSessionAllowed) AND the operator has activated
-   * the plugin for that session (the dynamic boundary, the same gate hook dispatch uses). manifest.sessions
-   * alone is not enough — a general adapter ships `['*']` and is scoped by operator activation, so without
-   * the activeSessions check a plugin activated for one session could reach another's engine/mappings/
-   * handover. Defaults (`activeSessions ?? ['*']`, `sessionScoped:false`) preserve every unrestricted flow.
-   */
-  private assertSessionActive(plugin: PluginInstance, sessionId: string): void {
-    this.assertSessionAllowed(plugin.manifest, sessionId);
-    if (!this.isHookActive(plugin, sessionId)) {
-      throw new PluginCapabilityError(`Plugin ${plugin.manifest.id} is not activated for session ${sessionId}`);
-    }
-  }
-
-  /**
-   * Scope-check, then resolve the live engine for a session. getEngine returns undefined for an
-   * unknown OR unstarted session (no throw), so guard it into a defined PluginCapabilityError.
-   * A present-but-not-READY engine throws EngineNotReadyError from the adapter on use (→ 409).
-   */
-  private resolveEngine(plugin: PluginInstance, sessionId: string): IWhatsAppEngine {
-    this.assertSessionActive(plugin, sessionId);
-    const engine = this.hostServices.getSessionService().getEngine(sessionId);
-    if (!engine) {
-      throw new PluginCapabilityError(`Session ${sessionId} has no active engine (unknown or not started)`);
-    }
-    return engine;
-  }
-
-  /** Engine read capabilities: require the `engine:read` permission, then resolve the live engine. */
-  private resolveEngineRead(plugin: PluginInstance, sessionId: string): IWhatsAppEngine {
-    this.assertPermission(plugin.manifest, PluginCapabilityPermission.ENGINE_READ);
-    return this.resolveEngine(plugin, sessionId);
-  }
-
-  /**
-   * Definitive "this session row no longer exists" probe for the stale-mapping repair paths below.
-   * True ONLY on a clean not-found from the sessions table; any other failure (service unresolvable,
-   * DB error) returns false, so the cross-session fences stay fail-CLOSED when the answer is
-   * indeterminate. The runtime engine map can't answer this — a stopped session has no engine but
-   * still owns its mappings.
-   */
-  private async isSessionGone(sessionId: string): Promise<boolean> {
-    try {
-      await this.hostServices.getSessionService().findOne(sessionId);
-      return false;
-    } catch (error) {
-      return error instanceof NotFoundException;
-    }
-  }
-
-  /**
    * Build a worker host for a sandboxed (untrusted) plugin. Overridable so tests can inject a fake
    * instead of spawning a real OS thread. Production loads the compiled worker bootstrap from dist.
    */
@@ -1052,7 +927,7 @@ export class PluginLoaderService implements OnModuleInit, OnApplicationBootstrap
 
   /** Built-in (trusted) enable: require + run the lifecycle in-process with the live capability context. */
   private async enableInProcess(pluginId: string, plugin: PluginInstance): Promise<void> {
-    const context = this.createPluginContext(plugin);
+    const context = this.capabilities.createPluginContext(plugin);
 
     if (!plugin.instance) {
       // Containment guard: reject a manifest.main that escapes the plugin dir.
@@ -1091,7 +966,7 @@ export class PluginLoaderService implements OnModuleInit, OnApplicationBootstrap
     // The capability dispatcher runs a worker request through the SAME context an in-process plugin
     // gets, so permission + session-scope checks (assertPermission / assertSessionActive) apply
     // identically. The worker can only ask; the host is the gatekeeper.
-    const context = this.createPluginContext(plugin);
+    const context = this.capabilities.createPluginContext(plugin);
 
     // When the worker subscribes to a hook, register a shim with the hook manager that dispatches the
     // event into the worker (time-bounded, so a wedged plugin can't stall the chain). The shim looks
@@ -1131,7 +1006,14 @@ export class PluginLoaderService implements OnModuleInit, OnApplicationBootstrap
           if (!liveHost) return { continue: true };
           // Per-session activation gate: a session-scoped plugin only sees events for the sessions
           // it is activated for. Pass-through (don't dispatch into the worker) otherwise.
-          if (!this.isHookActive(plugin, hookCtx.sessionId)) return { continue: true };
+          if (
+            !isPluginActiveForSession(
+              plugin.manifest.sessionScoped ?? true,
+              plugin.activeSessions ?? ['*'],
+              hookCtx.sessionId,
+            )
+          )
+            return { continue: true };
           // Handover gate: once a human has taken over (or closed) a conversation, the bot stops
           // seeing its inbound messages. Scoped to message:received only — every other hook event is
           // unaffected. Best-effort + fail-open: a lookup failure (or an event/mapping shape the gate
@@ -1326,261 +1208,6 @@ export class PluginLoaderService implements OnModuleInit, OnApplicationBootstrap
       throw error;
     }
   }
-
-  private createPluginContext(plugin: PluginInstance): PluginContext {
-    const pluginLogger: PluginLogger = {
-      log: (message, meta) =>
-        this.logger.log(`[${plugin.manifest.id}] ${message}`, { ...meta, pluginId: plugin.manifest.id }),
-      debug: (message, meta) =>
-        this.logger.debug(`[${plugin.manifest.id}] ${message}`, { ...meta, pluginId: plugin.manifest.id }),
-      warn: (message, meta) =>
-        this.logger.warn(`[${plugin.manifest.id}] ${message}`, { ...meta, pluginId: plugin.manifest.id }),
-      error: (message, error, meta) =>
-        this.logger.error(
-          `[${plugin.manifest.id}] ${message}`,
-          error instanceof Error ? error.message : String(error),
-          { ...meta, pluginId: plugin.manifest.id },
-        ),
-    };
-
-    const hookSession = this.hookSession;
-    return {
-      pluginId: plugin.manifest.id,
-      manifest: plugin.manifest,
-      // Per-session: inside a hook, returns the override merged over the base for the firing session;
-      // outside a hook (lifecycle), the base config. A getter so it reflects live config edits too.
-      get config() {
-        return resolvePluginConfig(
-          plugin.config,
-          plugin.sessionConfig,
-          hookSession.getStore()?.sessionId,
-          plugin.manifest.sessionScoped !== false,
-        );
-      },
-      hookManager: this.hookManager,
-      logger: pluginLogger,
-      storage: this.pluginStorage.createPluginStorage(plugin.manifest.id),
-      registerHook: (event, handler, priority) => {
-        // Wrap with the per-session activation gate so an in-process plugin only handles events for
-        // the sessions it is activated for (mirrors the sandboxed shim), and scope the firing
-        // sessionId so ctx.config resolves the right per-session slice for the handler.
-        this.hookManager.register(
-          plugin.manifest.id,
-          event,
-          async hookCtx => {
-            if (!this.isHookActive(plugin, hookCtx.sessionId)) return { continue: true };
-            return this.hookSession.run({ sessionId: hookCtx.sessionId }, () => handler(hookCtx));
-          },
-          priority,
-        );
-      },
-      // In-process built-ins are not reached by the ingress pipeline (it dispatches to sandbox hosts),
-      // so fail loud rather than silently never firing. Sandboxed plugins get a real registerWebhook
-      // from the worker bootstrap.
-      registerWebhook: () => {
-        throw new PluginCapabilityError(
-          `Plugin ${plugin.manifest.id}: registerWebhook (ingress) is only available to sandboxed plugins`,
-        );
-      },
-      messages: {
-        sendText: async (sessionId, chatId, text) => {
-          // Validate permission + scope + that the session has a live engine BEFORE MessageService
-          // persists a pending row: a missing grant / dead session must fail with
-          // PluginCapabilityError, not a raw TypeError + orphaned row. resolveEngine also runs
-          // assertSessionActive.
-          this.assertPermission(plugin.manifest, PluginCapabilityPermission.MESSAGES_SEND);
-          this.resolveEngine(plugin, sessionId);
-          return this.hostServices.getMessageService().sendText(sessionId, { chatId, text });
-        },
-        reply: async (sessionId, chatId, quotedMessageId, text) => {
-          this.assertPermission(plugin.manifest, PluginCapabilityPermission.MESSAGES_SEND);
-          this.resolveEngine(plugin, sessionId);
-          return this.hostServices.getMessageService().reply(sessionId, { chatId, quotedMessageId, text });
-        },
-      } satisfies PluginMessagingCapability,
-      engine: {
-        getGroupInfo: async (sessionId, groupId) => this.resolveEngineRead(plugin, sessionId).getGroupInfo(groupId),
-        getContacts: async sessionId => this.resolveEngineRead(plugin, sessionId).getContacts(),
-        getContactById: async (sessionId, contactId) =>
-          this.resolveEngineRead(plugin, sessionId).getContactById(contactId),
-        checkNumberExists: async (sessionId, phone) =>
-          this.resolveEngineRead(plugin, sessionId).checkNumberExists(phone),
-        getChats: async sessionId => this.resolveEngineRead(plugin, sessionId).getChats(),
-        getChatHistory: async (sessionId, chatId, limit, includeMedia) =>
-          this.resolveEngineRead(plugin, sessionId).getChatHistory(
-            chatId,
-            // Clamp to the REST non-deep ceiling (MessageService.MAX_CHAT_HISTORY_LIMIT = 100) so an
-            // untrusted plugin can't request an unbounded history fetch.
-            Math.min(Math.max(Math.trunc(limit ?? 50), 1), 100),
-            includeMedia ?? false,
-          ),
-        canonicalChatId: (sessionId, chatId) => {
-          // resolveEngineRead is the gate only (engine:read permission + live session); the resolution
-          // itself is a synchronous host lid->phone lookup, not an engine call, mirroring the webhook
-          // from-filter. Not `async` (nothing to await) — a resolved promise satisfies the signature.
-          this.resolveEngineRead(plugin, sessionId);
-          return Promise.resolve(toNeutralJid(chatId, jid => this.lidMappingStore?.getCached(userPart(jid)) ?? null));
-        },
-      } satisfies PluginEngineReadCapability,
-      net: {
-        fetch: async (url, init) => {
-          // Two gates: the declared permission, then the effective host allowlist = manifest net.allow
-          // UNION the hosts of net.allowConfigHosts keys across the base config AND every per-session
-          // override. The host gate has no firing-session context for a sandboxed plugin's cap round-trip,
-          // so admit every operator-configured tenant host (all public + still SSRF-guarded at connect)
-          // rather than resolving a single, possibly wrong (base-only), one. The SSRF guard inside
-          // performPluginFetch still blocks internal IPs even when the host is allowlisted.
-          this.assertPermission(plugin.manifest, PluginCapabilityPermission.NET_FETCH);
-          const netConfigs = [plugin.config ?? {}, ...Object.values(plugin.sessionConfig ?? {})];
-          const allow = [
-            ...new Set(
-              netConfigs.flatMap(cfg =>
-                effectiveNetAllow(plugin.manifest.net?.allow, plugin.manifest.net?.allowConfigHosts, cfg),
-              ),
-            ),
-          ];
-          if (!isNetHostAllowed(allow, url)) {
-            throw new PluginCapabilityError(
-              `Plugin ${plugin.manifest.id} may not fetch ${url} — add its host to net.allow or net.allowConfigHosts`,
-            );
-          }
-          return performPluginFetch(url, init);
-        },
-      } satisfies PluginNetCapability,
-      conversations: buildConversationSendFacade({
-        manifest: plugin.manifest,
-        assertPermission: this.assertPermission.bind(this),
-        assertSessionActive: (sessionId: string) => this.assertSessionActive(plugin, sessionId),
-        resolveChatId: async env => {
-          if (!env.instanceId || !env.source?.externalConversationId) {
-            throw new PluginCapabilityError(
-              `Plugin ${plugin.manifest.id}: conversation.send requires chatId, or both instanceId and source to resolve one`,
-            );
-          }
-          const mapping = await this.hostServices
-            .getConversationMappingService()
-            .getByProvider(plugin.manifest.id, env.instanceId, env.source.externalConversationId);
-          if (!mapping) {
-            throw new PluginCapabilityError(
-              `Plugin ${plugin.manifest.id}: no conversation mapping for instance ${env.instanceId} / ${env.source.externalConversationId}`,
-            );
-          }
-          // Fail closed on a cross-session mapping: getByProvider keys on (pluginId, instanceId,
-          // providerConversationId) only, so a stale row can resolve to a chat owned by a DIFFERENT
-          // session than the envelope's. Parity with the assertSessionActive(m.sessionId) check on
-          // mappings.getByProvider below — never send through a session the mapping does not belong to.
-          // (mapping.sessionId is NOT NULL in the entity, so a plain inequality check suffices. The
-          // env.sessionId guard is for the type only — the facade rejects a missing sessionId first.)
-          if (env.sessionId && mapping.sessionId !== env.sessionId) {
-            // Repair path: the mapping's session was DELETED (operator re-paired under a new id), so
-            // the row is stale rather than cross-session. Rebind it to the envelope's session —
-            // already activation-gated by the facade — and let the send proceed; without this the
-            // dead session's rows bricked conversation.send permanently. A mapping owned by another
-            // EXISTING session is a genuine cross-session violation and still throws.
-            if (await this.isSessionGone(mapping.sessionId)) {
-              await this.hostServices.getConversationMappingService().rebindSession(mapping.id, env.sessionId);
-              this.logger.warn(
-                `Rebound conversation mapping for instance ${env.instanceId} / ${env.source.externalConversationId} ` +
-                  `from deleted session ${mapping.sessionId} to ${env.sessionId}`,
-                { pluginId: plugin.manifest.id, action: 'conversation_mapping_rebound' },
-              );
-              return mapping.chatId;
-            }
-            throw new PluginCapabilityError(
-              `Plugin ${plugin.manifest.id}: conversation mapping for instance ${env.instanceId} / ${env.source.externalConversationId} belongs to session ${mapping.sessionId}, not ${env.sessionId}`,
-            );
-          }
-          return mapping.chatId;
-        },
-        // Re-establish the in-flight hook context around the downstream send so an adapter that calls
-        // conversation.send from within its own ingress handling can't echo-loop back into itself via
-        // its own outbound message:sending hook. Gate on an ALREADY-in-flight event (mirrors the
-        // worker-cap wrap's `inFlight.length > 0` check): a plain top-level send must NOT suppress
-        // message:sending for unrelated observers (audit/moderation) — only genuine re-entrancy does.
-        runGuarded: (events, run) =>
-          (events as HookEvent[]).some(e => this.hookManager.isInFlight(e))
-            ? this.hookManager.runInFlight(events as HookEvent[], run)
-            : run(),
-        sendText: (sessionId, opts) => this.hostServices.getMessageService().sendText(sessionId, opts),
-        reply: (sessionId, opts) => this.hostServices.getMessageService().reply(sessionId, opts),
-        sendMedia: (sessionId, opts) =>
-          dispatchConversationMedia(this.hostServices.getMessageService(), sessionId, opts),
-        sendLocation: (sessionId, opts) => this.hostServices.getMessageService().sendLocation(sessionId, opts),
-      } satisfies Parameters<typeof buildConversationSendFacade>[0]) satisfies PluginConversationsCapability,
-      handover: {
-        set: async (key, state) => {
-          // Same gate as conversation.send: flipping handover is part of owning the conversation, so
-          // it reuses CONVERSATION_SEND rather than adding a new permission.
-          this.assertPermission(plugin.manifest, PluginCapabilityPermission.CONVERSATION_SEND);
-          this.assertSessionActive(plugin, key.sessionId);
-          const mapping = await this.hostServices.getConversationMappingService().get({
-            sessionId: key.sessionId,
-            chatId: key.chatId,
-            pluginId: plugin.manifest.id,
-            instanceId: key.instanceId,
-          });
-          if (!mapping) {
-            throw new PluginCapabilityError(
-              `Plugin ${plugin.manifest.id}: no conversation mapping for session ${key.sessionId} / chat ${key.chatId} / instance ${key.instanceId}`,
-            );
-          }
-          await this.hostServices.getConversationMappingService().setHandover(mapping.id, state);
-        },
-      } satisfies PluginHandoverCapability,
-      mappings: {
-        upsert: async (key, providerConversationId) => {
-          this.assertPermission(plugin.manifest, PluginCapabilityPermission.CONVERSATION_SEND);
-          this.assertSessionActive(plugin, key.sessionId);
-          const mappingKey = {
-            sessionId: key.sessionId,
-            chatId: key.chatId,
-            pluginId: plugin.manifest.id,
-            instanceId: key.instanceId,
-          };
-          try {
-            await this.hostServices.getConversationMappingService().upsert(mappingKey, providerConversationId);
-          } catch (error) {
-            if (!(error instanceof ConversationMappingConflict)) throw error;
-            // The reverse unique key is held by another row. If that row's session was DELETED
-            // (operator re-paired under a new id), the adapter can never converge — the forward key
-            // carries the new sessionId, so every upsert bricks on the dead session's row. Supersede
-            // the stale row and retry once. A row owned by an EXISTING session is a genuine conflict
-            // and rethrows.
-            const stale = await this.hostServices
-              .getConversationMappingService()
-              .getByProvider(plugin.manifest.id, key.instanceId, providerConversationId);
-            if (!stale || !(await this.isSessionGone(stale.sessionId))) throw error;
-            await this.hostServices.getConversationMappingService().delete(stale.id);
-            await this.hostServices.getConversationMappingService().upsert(mappingKey, providerConversationId);
-          }
-        },
-        get: async key => {
-          this.assertPermission(plugin.manifest, PluginCapabilityPermission.CONVERSATION_SEND);
-          this.assertSessionActive(plugin, key.sessionId);
-          const m = await this.hostServices.getConversationMappingService().get({
-            sessionId: key.sessionId,
-            chatId: key.chatId,
-            pluginId: plugin.manifest.id,
-            instanceId: key.instanceId,
-          });
-          return m ? { providerConversationId: m.providerConversationId, handoverState: m.handoverState } : null;
-        },
-        getByProvider: async (instanceId, providerConversationId) => {
-          this.assertPermission(plugin.manifest, PluginCapabilityPermission.CONVERSATION_SEND);
-          const m = await this.hostServices
-            .getConversationMappingService()
-            .getByProvider(plugin.manifest.id, instanceId, providerConversationId);
-          // Parity with get/upsert: a plugin may only read a mapping for a session it is activated for.
-          if (m) this.assertSessionActive(plugin, m.sessionId);
-          return m ? { sessionId: m.sessionId, chatId: m.chatId, handoverState: m.handoverState } : null;
-        },
-      } satisfies PluginMappingsCapability,
-    };
-  }
-
-  // ============================================================================
-  // Query Methods
-  // ============================================================================
 
   getPlugin(pluginId: string): PluginInstance | undefined {
     return this.plugins.get(pluginId);


### PR DESCRIPTION
Third step on `plugin-loader.service.ts`, and the one with the most value: it removes the
security-review audience.

## Why

`createPluginContext` and its seven gate helpers are the surface a plugin can actually reach —
`ctx.messages`, `ctx.engine`, `ctx.net`, `ctx.storage`, `ctx.conversations`, `ctx.handover`,
`ctx.mappings` — plus the gates in front of each. A plugin supplies its own `sessionId`, so
`assertSessionAllowed` (the static manifest boundary) and the operator-activation check **are** the
security boundary.

They sat inside a loader otherwise concerned with directory discovery, lifecycle and worker plumbing.
Reviewing the boundary meant reading 1640 lines to find 330.

## What moves

`PluginCapabilityContext` holds the seven gate helpers, `createPluginContext`, and the hook
`AsyncLocalStorage`. It holds **no** plugin registry and **no** worker hosts — I verified the moved
range references neither `this.plugins` nor `this.sandboxHosts`. Everything it needs comes from the
`PluginInstance` it is handed.

The constructor **signature is untouched** — the facade is built in the body, as `PluginHostServices`
already is. All 33 positional spec constructions and the three subclasses overriding
`createSandboxHost` compile and pass unchanged.

1640 → 1267 lines.

## Two things this surfaced

**The loader's logger is passed in, not recreated.** A plugin's `ctx.logger` lines carry that logger's
context, and it is operator-visible. A fresh `createLogger('PluginCapabilityContext')` silently
retagged every plugin log line — the sandbox log-relay tests caught it, which is exactly what they are
for.

**`dispatchConversationMedia` moved too.** Leaving it in the loader would have made the new module
import the loader while the loader imports the new module — a require cycle, in a file that already
pays a lazy-require tax to avoid precisely that class of problem. The loader no longer references it.

## Spec changes: pointer-only

Four files, +29/−18, and no assertion, fixture or harness touched:

- three reach-in helpers (`plugin-capability`, `plugin-loader-conversation-repair`,
  `plugin-loader-activation`) now name the object that owns the surface;
- one import line follows `dispatchConversationMedia`.

The plan this came from predicted zero spec edits. That was wrong for the same reason it was wrong
twice before this week: these specs reach into private members, so a member that moves takes its
reach-in with it. Recorded rather than glossed.

307 plugin tests pass; 4012 overall, unchanged.

## Verification

Backend lint, `prettier --check`, `tsc --noEmit` over the full project including specs, build, 4012 unit
tests, 137 e2e tests, and the dashboard build all pass on Node 22.
