### PR TITLE
fix(dashboard): stop the QR modal from rotating the session lifecycle handlers

### DIFF
--- a/dashboard/src/pages/Sessions.tsx
+++ b/dashboard/src/pages/Sessions.tsx
@@ -106,10 +106,14 @@ export function Sessions() {
       sessionsRef.current = replaceSession(sessionsRef.current, updated);
       setSessions(sessionsRef.current);
       setSelectedSession(current => (current?.id === updated.id ? updated : current));
-      if (qrData?.sessionId === updated.id) setQrData(null);
+      // Functional form deliberately: reading `qrData` here would make it a dependency, and this
+      // callback is held by three lifecycle handlers (start/stop/logout). Opening or closing the QR
+      // modal would then rotate all three for a reason none of them care about. The updater also sees
+      // the CURRENT modal rather than the one captured when this callback was built.
+      setQrData(current => (current?.sessionId === updated.id ? null : current));
       await reconcileSessionCache(queryClient, queryKeys.sessions, updated);
     },
-    [queryClient, qrData?.sessionId],
+    [queryClient],
   );
 
   // Live session-feed subscription state: wildcard first, per-session fallback for scoped keys.


### PR DESCRIPTION
## The coupling

`applySessionResponse` clears the QR modal when the session that owned it changes, and it **read**
`qrData` to decide — so `qrData?.sessionId` had to sit in its dependency array.

That callback is held by three handlers: start, stop and logout. So simply **opening or closing the QR
modal** rebuilt all three, for a reason none of them care about.

## The fix

The functional updater form removes the read, and with it the dependency:

```ts
setQrData(current => (current?.sessionId === updated.id ? null : current));
```

It is also the more correct shape — it sees the **current** modal rather than whichever one was
captured when the callback was last built. The same pattern is already used a few lines below for the
`qr-code` socket event, so this is the file's own idiom rather than a new one.

## Why this one matters

`qrData` is written from nine places, but this was the pair that crossed a concern boundary — which is
what made `Sessions.tsx` qualify as a god object rather than merely a large page. What remains is the
QR poll effect depending on `qrData`, which is the QR concern depending on its own state.

## Verification

Partly by what did **not** happen: `react-hooks/exhaustive-deps` stays silent. It would not, if the
dependency were still needed — that rule is the check on this kind of change, and removing a dependency
the callback still reads is exactly what it exists to catch.

Dashboard typecheck, lint (0 errors), build and 234 unit tests pass. No backend files touched.
