### PR TITLE
fix(auth): give the bootstrap key file one owner and a redirect lever

### DIFF
--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -10,19 +10,15 @@ import { ModuleRef } from '@nestjs/core';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Equal, IsNull, MoreThan, Not, Repository } from 'typeorm';
 import { randomBytes } from 'crypto';
-import { existsSync, readFileSync, unlinkSync } from 'fs';
-import { join } from 'path';
-import { writeSecretFile } from '../../common/utils/secret-file';
 import { ipMatches } from '../../common/utils/ip';
 import { hashApiKey } from './api-key-hash';
 import { ApiKey, ApiKeyRole } from './entities/api-key.entity';
 import { CreateApiKeyDto, UpdateApiKeyDto } from './dto';
 import { createLogger } from '../../common/services/logger.service';
+import { readBootstrapKey, removeBootstrapKey, writeBootstrapKey } from './bootstrap-key-file';
 import { ApiKeyUsageTracker } from './api-key-usage-tracker.service';
 import { EventsGateway, type ApiKeyEvictionReason } from '../events/events.gateway';
 import { KeyedAsyncLock } from '../integration/ordering-lock';
-
-const API_KEY_FILE = join(process.cwd(), 'data', '.api-key');
 
 /**
  * Resolves the API key to seed on first boot (when no keys exist yet).
@@ -92,7 +88,7 @@ export class AuthService implements OnModuleInit, OnModuleDestroy {
 
       // Save raw key to file for startup script to read (owner-only — it's the raw admin key).
       try {
-        writeSecretFile(API_KEY_FILE, displayKey);
+        writeBootstrapKey(displayKey);
       } catch (err) {
         this.logger.warn('Could not save API key file', { error: String(err) });
       }
@@ -139,14 +135,7 @@ export class AuthService implements OnModuleInit, OnModuleDestroy {
    * Returns null when the file is absent, unreadable, empty, or stale.
    */
   private async readLiveBootstrapKey(): Promise<string | null> {
-    if (!existsSync(API_KEY_FILE)) return null;
-    let rawKey: string;
-    try {
-      rawKey = readFileSync(API_KEY_FILE, 'utf-8').trim();
-    } catch (error) {
-      this.logger.warn(`Failed to read API key file: ${API_KEY_FILE}`, { error: String(error) });
-      return null;
-    }
+    const rawKey = readBootstrapKey(this.logger);
     if (!rawKey) return null;
     const stored = await this.apiKeyRepository.findOne({ where: { keyHash: this.hashKey(rawKey) } });
     const live = Boolean(stored && stored.isActive && (!stored.expiresAt || stored.expiresAt > new Date()));
@@ -166,7 +155,7 @@ export class AuthService implements OnModuleInit, OnModuleDestroy {
         return null;
       }
     }
-    this.removeBootstrapKeyFile('it no longer resolves to an active key');
+    removeBootstrapKey('it no longer resolves to an active key', this.logger);
     return null;
   }
 
@@ -177,24 +166,9 @@ export class AuthService implements OnModuleInit, OnModuleDestroy {
    * removing it cannot break first-boot seeding — seeding writes it only when no keys exist.
    */
   private removeBootstrapKeyFileIfMatching(apiKey: ApiKey): void {
-    try {
-      if (!existsSync(API_KEY_FILE)) return;
-      const fileKey = readFileSync(API_KEY_FILE, 'utf-8').trim();
-      if (!fileKey || this.hashKey(fileKey) !== apiKey.keyHash) return;
-      this.removeBootstrapKeyFile('its key was revoked or deleted');
-    } catch (error) {
-      this.logger.warn(`Failed to inspect API key file: ${API_KEY_FILE}`, { error: String(error) });
-    }
-  }
-
-  private removeBootstrapKeyFile(reason: string): void {
-    try {
-      unlinkSync(API_KEY_FILE);
-      this.logger.log(`Removed stale bootstrap API key file (${reason}): ${API_KEY_FILE}`);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return; // already gone
-      this.logger.warn(`Failed to remove stale API key file: ${API_KEY_FILE}`, { error: String(error) });
-    }
+    const fileKey = readBootstrapKey(this.logger);
+    if (!fileKey || this.hashKey(fileKey) !== apiKey.keyHash) return;
+    removeBootstrapKey('its key was revoked or deleted', this.logger);
   }
 
   private async seedApiKey(rawKey: string, name: string, role: ApiKeyRole): Promise<ApiKey> {

--- a/src/modules/auth/bootstrap-key-file.spec.ts
+++ b/src/modules/auth/bootstrap-key-file.spec.ts
@@ -1,0 +1,88 @@
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { bootstrapKeyFilePath, readBootstrapKey, writeBootstrapKey, removeBootstrapKey } from './bootstrap-key-file';
+
+const logger = { log: jest.fn(), warn: jest.fn() };
+
+describe('bootstrap key file', () => {
+  let dir: string;
+  const original = process.env.BOOTSTRAP_KEY_FILE;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'owa-bootkey-'));
+    process.env.BOOTSTRAP_KEY_FILE = join(dir, '.api-key');
+    logger.log.mockClear();
+    logger.warn.mockClear();
+  });
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.BOOTSTRAP_KEY_FILE;
+    else process.env.BOOTSTRAP_KEY_FILE = original;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  describe('bootstrapKeyFilePath', () => {
+    it('honours BOOTSTRAP_KEY_FILE', () => {
+      expect(bootstrapKeyFilePath()).toBe(join(dir, '.api-key'));
+    });
+
+    it('falls back to data/.api-key under the working directory', () => {
+      delete process.env.BOOTSTRAP_KEY_FILE;
+
+      expect(bootstrapKeyFilePath()).toBe(join(process.cwd(), 'data', '.api-key'));
+    });
+
+    it('re-reads the env on every call, so a redirect set after import still takes effect', () => {
+      // This is the whole point: it used to be a module const evaluated at import from process.cwd(),
+      // so an e2e setup that redirects it could not — and an e2e boot rewrote the developer's file.
+      const moved = join(dir, 'moved.key');
+      process.env.BOOTSTRAP_KEY_FILE = moved;
+
+      expect(bootstrapKeyFilePath()).toBe(moved);
+    });
+  });
+
+  describe('readBootstrapKey', () => {
+    it('returns null when the file is absent', () => {
+      expect(readBootstrapKey(logger)).toBeNull();
+    });
+
+    it('returns null for an empty or whitespace-only file rather than a blank key', () => {
+      writeFileSync(join(dir, '.api-key'), '   \n');
+
+      expect(readBootstrapKey(logger)).toBeNull();
+    });
+
+    it('returns the trimmed key', () => {
+      writeFileSync(join(dir, '.api-key'), '  owa_k1_abc \n');
+
+      expect(readBootstrapKey(logger)).toBe('owa_k1_abc');
+    });
+  });
+
+  describe('writeBootstrapKey', () => {
+    it('writes to the resolved path', () => {
+      writeBootstrapKey('owa_k1_written');
+
+      expect(readFileSync(join(dir, '.api-key'), 'utf-8')).toContain('owa_k1_written');
+    });
+  });
+
+  describe('removeBootstrapKey', () => {
+    it('removes the file and says why', () => {
+      writeFileSync(join(dir, '.api-key'), 'owa_k1_abc');
+
+      removeBootstrapKey('its key was revoked or deleted', logger);
+
+      expect(existsSync(join(dir, '.api-key'))).toBe(false);
+      expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('revoked or deleted'));
+    });
+
+    it('treats an already-absent file as success, not a failure to report', () => {
+      removeBootstrapKey('gone anyway', logger);
+
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/modules/auth/bootstrap-key-file.ts
+++ b/src/modules/auth/bootstrap-key-file.ts
@@ -1,0 +1,53 @@
+import { existsSync, readFileSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import { writeSecretFile } from '../../common/utils/secret-file';
+import type { LoggerService } from '../../common/services/logger.service';
+
+/**
+ * `data/.api-key` — the bootstrap key file.
+ *
+ * It is an operator convenience: the first-boot banner quotes it, and backup scripts read it. It is
+ * never read for seeding or for authentication, so removing it can never lock anyone out.
+ *
+ * The point of gathering the four file operations here is that the file is a single resource touched
+ * by two concerns that otherwise share nothing — first-boot seeding writes it, and admin key
+ * lifecycle unlinks it when the key it holds is revoked or deleted. As a module const reached from
+ * both, it was the coupling; as a resource with one owner, each concern asks for what it needs.
+ *
+ * The path resolves PER CALL, and honours `BOOTSTRAP_KEY_FILE`. Both matter: it used to be a const
+ * evaluated at import from `process.cwd()`, so nothing could redirect it — which is why an e2e boot
+ * (whose setup redirects both databases) still wrote and unlinked the developer's real repo-root
+ * `data/.api-key`.
+ */
+export function bootstrapKeyFilePath(): string {
+  return process.env.BOOTSTRAP_KEY_FILE || join(process.cwd(), 'data', '.api-key');
+}
+
+/** The raw key the file holds, or null when absent, unreadable or empty. Never throws. */
+export function readBootstrapKey(logger: Pick<LoggerService, 'warn'>): string | null {
+  const file = bootstrapKeyFilePath();
+  if (!existsSync(file)) return null;
+  try {
+    return readFileSync(file, 'utf-8').trim() || null;
+  } catch (error) {
+    logger.warn(`Failed to read API key file: ${file}`, { error: String(error) });
+    return null;
+  }
+}
+
+/** Write the key owner-only (0600) — it is a live credential until the operator rotates it. */
+export function writeBootstrapKey(displayKey: string): void {
+  writeSecretFile(bootstrapKeyFilePath(), displayKey);
+}
+
+/** Remove the file. Absent is success, not a failure — the caller's intent is "make it gone". */
+export function removeBootstrapKey(reason: string, logger: Pick<LoggerService, 'log' | 'warn'>): void {
+  const file = bootstrapKeyFilePath();
+  try {
+    unlinkSync(file);
+    logger.log(`Removed stale bootstrap API key file (${reason}): ${file}`);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return; // already gone
+    logger.warn(`Failed to remove stale API key file: ${file}`, { error: String(error) });
+  }
+}

--- a/test/setup-e2e.ts
+++ b/test/setup-e2e.ts
@@ -16,6 +16,12 @@ process.env.DATABASE_NAME = e2eDataDb;
 const e2eMainDb = join(tmpdir(), `openwa-e2e-main-${process.pid}.sqlite`);
 rmSync(e2eMainDb, { force: true });
 process.env.MAIN_DATABASE_NAME = e2eMainDb;
+// The bootstrap key file is written on first boot (no keys yet — which every e2e run is) and unlinked
+// when that key is revoked or deleted. Without a lever it resolves under the repo root, so an e2e run
+// rewrote the DEVELOPER'S ./data/.api-key. Point it at the same throwaway temp dir as the databases.
+const e2eKeyFile = join(tmpdir(), `openwa-e2e-key-${process.pid}`);
+rmSync(e2eKeyFile, { force: true });
+process.env.BOOTSTRAP_KEY_FILE = e2eKeyFile;
 process.env.QUEUE_ENABLED = 'false';
 // Likewise force Redis off per suite: queue-on.e2e-spec.ts flips REDIS_ENABLED=true at module
 // load and can't restore it when it self-skips, so without this reset later suites in the same


### PR DESCRIPTION
## Why

`data/.api-key` was a module const derived from `process.cwd()` and **evaluated at import**, reached
directly by two concerns that otherwise share nothing:

- first-boot seeding **writes** it,
- admin key lifecycle **unlinks** it when the key it holds is revoked or deleted.

It was the last item spanning `AuthService`'s concerns — the other one, `pendingUsage`, left in #1026.

## What changes

`bootstrap-key-file.ts` owns the path and the four file operations. `AuthService` keeps the auth logic
— hashing, the `API_KEY_PEPPER`-mismatch reasoning, the liveness lookup — and no longer names the path
or calls `fs`. The two concerns ask the owner for what they need instead of both reaching for the same
const.

## The defect this fixes

The path now resolves **per call** and honours `BOOTSTRAP_KEY_FILE`. An e2e run redirects both
databases to temp files but had no lever for this path, so it wrote the developer's repo-root
`data/.api-key` on every run. `setup-e2e.ts` now points it at the same throwaway temp dir.

**It is demonstrated, not asserted.** Removing the new lever and re-running e2e changes the file's
mtime; restoring it leaves the file untouched.

Worth recording how nearly this was reported wrong: a **content hash shows nothing** on a machine whose
`.env` sets `ALLOW_DEV_API_KEY`, because `resolveSeedApiKey()` then returns the fixed `'dev-admin-key'`
and the rewrite is byte-identical. My first probe used a hash and concluded there was no defect. Without
that env var — the default — the function returns a fresh random key, so an e2e run **replaces** the
operator's bootstrap key.

## Tests

Nine, covering the owner: env override, `process.cwd()` fallback, empty/whitespace handling, write,
remove, and absent-is-success. One of them pins the property the old const could not have — that the
path re-reads the env on **every** call, which is the whole reason a redirect now works.

`auth.service.spec.ts` passes with **zero edits**. 141 auth tests; 4021 overall.

## Scope

`auth.service.ts` 572 → 479 across this and the usage-tracker extraction. Both spanning items are gone,
so the file no longer satisfies the second half of the god-object test at any line count.

## Verification

Backend lint, `prettier --check`, `tsc --noEmit` over the full project including specs, build, 4021 unit
tests, 137 e2e tests, and the dashboard build all pass on Node 22.
