### PR TITLE
fix(plugins): let an operator disable a plugin whose code is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A plugin whose code is missing can now be switched off.** `enabledByOperator` is the standing
+  instruction to enable a plugin on every boot, and the only way to withdraw it is
+  `POST /api/plugins/{id}/disable`. That route answered 404 whenever the plugin was not loaded — which
+  is exactly the state an install lands in when its package directory is gone: an interrupted update,
+  or a directory that was never on the data volume. The registry entry survives with its config,
+  `ctx.storage` and the enable decision intact, so reinstalling the code brought the plugin straight
+  back up and no API call could prevent it. The only ways out were uninstalling, which also deletes
+  the plugin's stored data, or hand-editing `registry.json`.
+
+  `disable` records intent rather than performing a runtime operation, so it now clears the decision
+  against the registry when the plugin is not loaded and reports
+  `Plugin {id} is not loaded; it will not be enabled on boot`. This is the same reasoning the route
+  already applied to a plugin sitting in `error` after a failed restore. 404 is now reserved for an id
+  with no registry entry at all. Nothing is skipped in the process: there is no runtime in this state,
+  so no lifecycle hook goes unrun and no worker is left behind.
+
 ## [0.12.2] - 2026-08-01
 
 ### Changed

--- a/src/core/plugins/plugin-loader.service.ts
+++ b/src/core/plugins/plugin-loader.service.ts
@@ -11,6 +11,7 @@ import {
   PluginCapabilityPermission,
   PluginManifest,
   PluginInstance,
+  PluginRegistryEntry,
   PluginStatus,
   IPlugin,
   PluginType,
@@ -604,6 +605,15 @@ export class PluginLoaderService implements OnModuleInit, OnApplicationBootstrap
    */
   setOperatorEnabled(pluginId: string, enabled: boolean): void {
     this.pluginStorage.setPluginEnabledByOperator(pluginId, enabled);
+  }
+
+  /**
+   * The persisted registry entry for a plugin id, whether or not its code is currently loaded. Lets a
+   * caller distinguish "installed but not loaded" — which still owns config, storage and the
+   * `enabledByOperator` decision — from an id the gateway has genuinely never seen.
+   */
+  getRegistryEntry(pluginId: string): PluginRegistryEntry | undefined {
+    return this.pluginStorage.getPluginEntry(pluginId);
   }
 
   async enablePlugin(pluginId: string): Promise<void> {

--- a/src/modules/plugins/plugins.service.spec.ts
+++ b/src/modules/plugins/plugins.service.spec.ts
@@ -595,3 +595,52 @@ describe('isIngressCapable', () => {
     expect(isIngressCapable({ ingress: [{ route: 'events' }] })).toBe(false);
   });
 });
+
+describe('PluginsService — disable when the plugin is not loaded', () => {
+  let tmpDir: string;
+  let pluginsDir: string;
+  let config: ConfigService;
+
+  const build = () => {
+    const storage = new PluginStorageService(config);
+    const loader = new PluginLoaderService(config, new HookManager(), storage, {} as unknown as ModuleRef);
+    return { storage, loader, service: new PluginsService(loader, config) };
+  };
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'owa-disable-'));
+    pluginsDir = path.join(tmpDir, 'plugins');
+    fs.mkdirSync(pluginsDir, { recursive: true });
+    config = {
+      get: (k: string) => (k === 'plugins.dir' ? pluginsDir : k === 'dataDir' ? tmpDir : undefined),
+    } as unknown as ConfigService;
+  });
+  afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+  // Regression: a plugin whose package directory is gone (an interrupted update, or a directory that
+  // was never on the data volume) still has a registry entry carrying enabledByOperator — the standing
+  // instruction to enable it on every boot. disable() threw NotFound because the loader had nothing to
+  // tear down, so the operator could not withdraw that decision by any route: reinstalling the code
+  // brought the plugin straight back up.
+  it('clears the boot decision for an installed plugin whose code is missing', async () => {
+    const first = build();
+    first.service.install({ buffer: pkg() });
+    first.loader.setOperatorEnabled('svc-plg', true);
+
+    // The code disappears; a restart re-reads the registry but loads nothing.
+    fs.rmSync(path.join(pluginsDir, 'svc-plg'), { recursive: true, force: true });
+    const restarted = build();
+    expect(restarted.loader.getPlugin('svc-plg')).toBeUndefined();
+    expect(restarted.storage.getPluginEntry('svc-plg')?.enabledByOperator).toBe(true);
+
+    const res = await restarted.service.disable('svc-plg');
+
+    expect(res.success).toBe(true);
+    expect(restarted.storage.getPluginEntry('svc-plg')?.enabledByOperator).toBe(false);
+  });
+
+  it('still throws NotFound for an id with no registry entry at all', async () => {
+    const { service } = build();
+    await expect(service.disable('never-installed')).rejects.toThrow(/not found/i);
+  });
+});

--- a/src/modules/plugins/plugins.service.ts
+++ b/src/modules/plugins/plugins.service.ts
@@ -151,7 +151,18 @@ export class PluginsService {
     const plugin = this.pluginLoader.getPlugin(id);
 
     if (!plugin) {
-      throw new NotFoundException(`Plugin ${id} not found`);
+      // Not loaded, but the registry may still hold its entry — and with it `enabledByOperator`, the
+      // standing instruction to enable it on every boot. A plugin whose code went missing (an
+      // interrupted update, a package directory outside the data volume) is exactly that case: there is
+      // no runtime to tear down, so `disablePlugin` can never run, and until now the operator had no way
+      // to withdraw the decision at all. `disable` expresses intent rather than performing a runtime
+      // operation, so honour it against the registry; reinstalling the code must not silently resurrect
+      // a plugin the operator switched off. A 404 now means only what it should: an id nobody knows.
+      if (!this.pluginLoader.getRegistryEntry(id)) {
+        throw new NotFoundException(`Plugin ${id} not found`);
+      }
+      this.pluginLoader.setOperatorEnabled(id, false);
+      return { success: true, message: `Plugin ${id} is not loaded; it will not be enabled on boot` };
     }
 
     if (plugin.status !== PluginStatus.ENABLED) {


### PR DESCRIPTION
## Problem

A plugin can exist in the registry — entry, config, per-plugin storage, and the `enabledByOperator` decision that boot reads — while its package directory is gone. An interrupted update leaves that state, and so does a directory that was never on the data volume in the first place.

In that state `POST /plugins/:id/disable` returned **404**:

```ts
const plugin = this.pluginLoader.getPlugin(id);
if (!plugin) {
  throw new NotFoundException(`Plugin ${id} not found`);
}
if (plugin.status !== PluginStatus.ENABLED) {
  // Clear the decision here too: a plugin sitting in ERROR after a failed restore is not ENABLED,
  // and disabling it must stop the gateway retrying it on every boot.
  this.pluginLoader.setOperatorEnabled(id, false);
  ...
```

The branch immediately below already recognises that clearing the boot decision matters even when there is nothing running. The `!plugin` guard returns before reaching it, so the operator had **no route at all** to withdraw a standing instruction to enable the plugin on every boot. Reinstalling the code later brought it straight back up. The only workarounds were uninstalling — which also destroys the plugin's stored data — or hand-editing `registry.json`.

Observed on a 0.12.1 host: two registry entries left at `enabledByOperator: true` after their code was lost, both answering 404 to every disable attempt.

## Change

`disable` expresses intent; it is not a runtime operation, and the registry is where intent lives. When the plugin is not loaded but a registry entry exists, the decision is now cleared against the registry and the call succeeds. A 404 is reserved for an id with no entry at all — which is what a 404 should mean.

`PluginLoaderService.getRegistryEntry` is added to make that distinction available; it reads through to the storage service's existing accessor.

Nothing else changes: there is no runtime to tear down in this state, so no lifecycle hook is skipped and no worker is left behind.

## Tests

Two cases in `plugins.service.spec.ts`, using the existing real-loader-and-disk harness: a plugin is installed and marked enabled-by-operator, its directory is removed, and a fresh loader and service are built over the same registry — reproducing a restart that re-reads the registry and loads nothing. Disabling it then succeeds and clears the flag. The second case asserts an unknown id still throws NotFound.

Reverting the change fails the first and leaves the other 46 green.

`src/modules/plugins` + `src/core/plugins`: 443 passed. `tsc --noEmit` and eslint clean.