### PR TITLE
fix(scripts): resolve backup/restore config the way the application does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   have reported failure while the stack was still coming up correctly. The deadline is now derived
   from the estimate the server already returns, with the old 60 as a floor. (#1019)
 
+- **`backup.sh` could archive a database the application had stopped using.** Both scripts resolved
+  every path from the process environment alone, while the application fills the same settings from
+  three layers: the environment, then `./.env`, then `<data dir>/.env.generated` — the file Dashboard >
+  Infrastructure writes. An install configured through the dashboard was therefore backed up at the
+  *default* paths.
+
+  That is not reliably loud. A missing database already failed the run, but a database left at a
+  default path from before the operator switched was archived instead and the run exited 0. A backup
+  that captured an abandoned database announces itself only during a restore. `backup.sh` was already
+  copying `.env.generated` into the archive without ever reading it.
+
+  Both scripts now resolve through the same three layers, in the application's order, so an explicit
+  environment value still wins. Only plain `KEY=value` lines are honoured: a value carrying quotes or
+  a trailing `#` comment is reported and skipped rather than guessed at, because a silently
+  mis-parsed path is the failure being fixed. The Postgres connection details `pg_dump` uses resolve
+  the same way, so a dashboard-provisioned database no longer needs its credentials restated in the
+  operator's shell.
+
 ## [0.12.2] - 2026-08-01
 
 ### Changed

--- a/docs/11-operational-runbooks.md
+++ b/docs/11-operational-runbooks.md
@@ -549,11 +549,14 @@ OPENWA_DATA_DIR=/srv/openwa/data \
 
 > The data directory is a Docker **named volume** (`openwa-data`) in the production
 > compose. Run the script where that volume is mounted — e.g. point `OPENWA_DATA_DIR`
-> at the volume's mountpoint, or run it inside a container with `/app/data` mounted. When operating
-> directly on the host mount, also set any path that does not use its default below `OPENWA_DATA_DIR`
-> (`MAIN_DATABASE_NAME` / `DATABASE_NAME` when the app overrides them, and `PLUGINS_DIR` only if it
-> points somewhere outside the data directory — unset, it follows `OPENWA_DATA_DIR` like the app's own
-> default does) to the corresponding host-visible path.
+> at the volume's mountpoint, or run it inside a container with `/app/data` mounted.
+>
+> The scripts resolve every other path the way the application does: an explicit environment value
+> first, then `./.env`, then `<data dir>/.env.generated`. Settings made through Dashboard >
+> Infrastructure therefore apply without being restated on the command line. Two caveats when
+> operating directly on the host mount: a path recorded inside the container (`/app/data/...`) is not
+> host-visible, so override it in the environment; and a value written with quotes or a trailing `#`
+> comment is reported and skipped rather than guessed at, so pass those explicitly too.
 
 **Verification:**
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -20,9 +20,10 @@
 # Environment:
 #   MAIN_DATABASE_NAME  auth/audit SQLite file (default: ./data/main.sqlite)
 #   DATABASE_NAME       data-store SQLite file (default: ./data/openwa.sqlite; sqlite only)
-#                       Both resolve EXACTLY like the app (src/config/configuration.ts): the
-#                       explicit env path wins, otherwise the fixed ./data default. They are NOT
-#                       derived from OPENWA_DATA_DIR — the app never does that either.
+#                       Both resolve EXACTLY like the app: the environment first, then ./.env, then
+#                       <data dir>/.env.generated, otherwise the fixed ./data default (see
+#                       lib-env.sh). They are NOT derived from OPENWA_DATA_DIR — the app never does
+#                       that either.
 #   OPENWA_DATA_DIR   data directory for the non-DB state below (default: ./data)
 #   BACKUP_DIR        where archives are written (default: ./backups)
 #   DATABASE_TYPE     sqlite (default) | postgres
@@ -40,23 +41,29 @@ set -euo pipefail
 # permissive operator umask for newly-created backup artifacts.
 umask 077
 
+# OPENWA_DATA_DIR and BACKUP_DIR steer the script itself and are never written to an env file, so
+# they stay environment-only. Everything below them is application configuration and must be read
+# through the same layers the app reads (see lib-env.sh).
 DATA_DIR="${OPENWA_DATA_DIR:-./data}"
 BACKUP_DIR="${BACKUP_DIR:-./backups}"
-DATABASE_TYPE="${DATABASE_TYPE:-sqlite}"
+# shellcheck source=scripts/lib-env.sh
+. "$(dirname "$0")/lib-env.sh"
+DATABASE_TYPE="$(openwa_resolve DATABASE_TYPE sqlite)"
 TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
 
-# Database paths resolve exactly like the app (src/config/configuration.ts): the explicit env path
-# wins, otherwise the fixed ./data default. OPENWA_DATA_DIR below only bases the non-DB state
-# directories — deriving DB paths from it would back up files the app never reads.
-MAIN_DB="${MAIN_DATABASE_NAME:-./data/main.sqlite}"
-DATA_DB="${DATABASE_NAME:-./data/openwa.sqlite}"
-SESSIONS_DIR="${SESSION_DATA_PATH:-$DATA_DIR/sessions}"
-BAILEYS_DIR="${BAILEYS_AUTH_DIR:-$DATA_DIR/baileys}"
-MEDIA_DIR="${STORAGE_LOCAL_PATH:-$DATA_DIR/media}"
+# Database paths resolve exactly like the app: an explicit environment value wins, then ./.env, then
+# the dashboard's <data dir>/.env.generated, otherwise the fixed ./data default. OPENWA_DATA_DIR
+# below only bases the non-DB state directories — deriving DB paths from it would back up files the
+# app never reads.
+MAIN_DB="$(openwa_resolve MAIN_DATABASE_NAME ./data/main.sqlite)"
+DATA_DB="$(openwa_resolve DATABASE_NAME ./data/openwa.sqlite)"
+SESSIONS_DIR="$(openwa_resolve SESSION_DATA_PATH "$DATA_DIR/sessions")"
+BAILEYS_DIR="$(openwa_resolve BAILEYS_AUTH_DIR "$DATA_DIR/baileys")"
+MEDIA_DIR="$(openwa_resolve STORAGE_LOCAL_PATH "$DATA_DIR/media")"
 # Installed plugin code. The app defaults this to <dataDir>/plugins — the same tree as the
 # registry and each plugin's ctx.storage below — so an unset PLUGINS_DIR must resolve there
 # too, or the archive silently omits the plugin packages.
-PLUGIN_PACKAGES_DIR="${PLUGINS_DIR:-$DATA_DIR/plugins}"
+PLUGIN_PACKAGES_DIR="$(openwa_resolve PLUGINS_DIR "$DATA_DIR/plugins")"
 PLUGIN_STATE_DIR="$DATA_DIR/plugins"
 GENERATED_ENV="$DATA_DIR/.env.generated"
 ADMIN_KEY_FILE="$DATA_DIR/.api-key"
@@ -119,11 +126,13 @@ if [ "$DATABASE_TYPE" = "postgres" ]; then
   if [ -n "${DATABASE_URL:-}" ]; then
     pg_dump "$DATABASE_URL" >"$STAGE/database.sql"
   else
-    PGPASSWORD="${DATABASE_PASSWORD:-}" pg_dump \
-      -h "${DATABASE_HOST:-localhost}" \
-      -p "${DATABASE_PORT:-5432}" \
-      -U "${DATABASE_USERNAME:-openwa}" \
-      "${DATABASE_NAME:-openwa}" >"$STAGE/database.sql"
+    # Same layered resolution as the paths above: a dashboard-provisioned Postgres keeps its
+    # connection details in <data dir>/.env.generated, never in the operator's shell.
+    PGPASSWORD="$(openwa_resolve DATABASE_PASSWORD '')" pg_dump \
+      -h "$(openwa_resolve DATABASE_HOST localhost)" \
+      -p "$(openwa_resolve DATABASE_PORT 5432)" \
+      -U "$(openwa_resolve DATABASE_USERNAME openwa)" \
+      "$(openwa_resolve DATABASE_NAME openwa)" >"$STAGE/database.sql"
   fi
   REQUIRED_MEMBERS+=("./database.sql")
 else

--- a/scripts/lib-env.sh
+++ b/scripts/lib-env.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# Shared configuration resolution for backup.sh and restore.sh.
+#
+# The application fills its configuration from three layers (src/config/load-env.ts), each supplying
+# only what the previous one left unset:
+#
+#   1. the process environment
+#   2. ./.env
+#   3. <data dir>/.env.generated   — written by Dashboard > Infrastructure
+#
+# These scripts used to read layer 1 only, so an install configured through the dashboard was backed
+# up at the DEFAULT paths. That is not reliably loud: a missing database fails the run, but a
+# database left at a default path from BEFORE the operator switched is archived instead, and the run
+# exits 0. A backup that captured an abandoned database only reveals itself during a restore.
+#
+# Deliberately conservative: only a plain `KEY=value` line is honoured. A value carrying quotes or a
+# `#` is reported and skipped rather than guessed at, because a silently mis-parsed path is the exact
+# failure this exists to prevent. Nothing here exports anything — each key is looked up by name, so a
+# stray entry in an operator's .env can never reach the script's own environment.
+
+# openwa_env_file_value <file> <key> — print the value from one env-file layer, or nothing.
+openwa_env_file_value() {
+  local file="$1" key="$2" line value
+  [ -f "$file" ] || return 0
+  line="$(grep -E "^[[:space:]]*(export[[:space:]]+)?${key}=" "$file" 2>/dev/null | tail -n 1)" || true
+  [ -n "$line" ] || return 0
+  value="${line#*=}"
+  case "$value" in
+    '')
+      return 0
+      ;;
+    *\"* | *\'* | *'#'*)
+      echo "[config] WARN: $file sets $key in a form these scripts do not parse (quotes or a trailing" >&2
+      echo "[config]       comment) — ignoring it. Pass $key in the environment if it matters here." >&2
+      return 0
+      ;;
+  esac
+  printf '%s' "$value"
+}
+
+# openwa_resolve <key> <default> — the application's precedence: environment, then ./.env, then
+# <data dir>/.env.generated, then the built-in default. Requires DATA_DIR to be set by the caller.
+openwa_resolve() {
+  local key="$1" fallback="$2" current value layer
+  current="$(printenv "$key" 2>/dev/null || true)"
+  if [ -n "$current" ]; then
+    printf '%s' "$current"
+    return 0
+  fi
+  for layer in "./.env" "${DATA_DIR:-./data}/.env.generated"; do
+    value="$(openwa_env_file_value "$layer" "$key")"
+    if [ -n "$value" ]; then
+      printf '%s' "$value"
+      return 0
+    fi
+  done
+  printf '%s' "$fallback"
+}

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -58,17 +58,21 @@ for arg in "$@"; do
 done
 
 DATA_DIR="${OPENWA_DATA_DIR:-./data}"
-# Database targets resolve exactly like the app (src/config/configuration.ts): explicit env path,
-# else the fixed ./data defaults. They may legitimately live outside OPENWA_DATA_DIR.
-MAIN_DB="${MAIN_DATABASE_NAME:-./data/main.sqlite}"
-DATA_DB="${DATABASE_NAME:-./data/openwa.sqlite}"
-SESSIONS_DIR="${SESSION_DATA_PATH:-$DATA_DIR/sessions}"
-BAILEYS_DIR="${BAILEYS_AUTH_DIR:-$DATA_DIR/baileys}"
-MEDIA_DIR="${STORAGE_LOCAL_PATH:-$DATA_DIR/media}"
+# shellcheck source=scripts/lib-env.sh
+. "$(dirname "$0")/lib-env.sh"
+# Database targets resolve exactly like the app: an explicit environment value, then ./.env, then the
+# dashboard's <data dir>/.env.generated, else the fixed ./data defaults. They may legitimately live
+# outside OPENWA_DATA_DIR. This reads the config of the install being restored INTO, which is why it
+# happens here rather than after the archive's own .env.generated is written over it further down.
+MAIN_DB="$(openwa_resolve MAIN_DATABASE_NAME ./data/main.sqlite)"
+DATA_DB="$(openwa_resolve DATABASE_NAME ./data/openwa.sqlite)"
+SESSIONS_DIR="$(openwa_resolve SESSION_DATA_PATH "$DATA_DIR/sessions")"
+BAILEYS_DIR="$(openwa_resolve BAILEYS_AUTH_DIR "$DATA_DIR/baileys")"
+MEDIA_DIR="$(openwa_resolve STORAGE_LOCAL_PATH "$DATA_DIR/media")"
 # Installed plugin code. The app defaults this to <dataDir>/plugins — the same tree as the
 # registry and each plugin's ctx.storage below — so an unset PLUGINS_DIR must resolve there
 # too, or the archive silently omits the plugin packages.
-PLUGIN_PACKAGES_DIR="${PLUGINS_DIR:-$DATA_DIR/plugins}"
+PLUGIN_PACKAGES_DIR="$(openwa_resolve PLUGINS_DIR "$DATA_DIR/plugins")"
 PLUGIN_STATE_DIR="$DATA_DIR/plugins"
 RESTORE_TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
 RESOLVED_CWD="$(pwd -P)"

--- a/scripts/smoke-test-backup-restore.sh
+++ b/scripts/smoke-test-backup-restore.sh
@@ -242,4 +242,56 @@ fi
 pass "(e) min-content check fails hard and removes the defective archive"
 
 echo ""
+echo "==> (f) data/.env.generated supplies paths the environment does not"
+# The dangerous shape: the app was pointed elsewhere through the dashboard, and a database from
+# before that switch is still sitting at the DEFAULT path. Resolving from the process environment
+# alone then archives the abandoned file and exits 0 — a backup that only reveals itself as wrong
+# during a restore. A missing default would at least fail loudly; a stale one does not.
+F="$WORK/f"
+mkdir -p "$F/state" "$F/live" "$F/data" "$F/extract" "$F/restore/state"
+make_fixture "$F/live/auth.sqlite" "foxtrot-live-main"
+make_fixture "$F/live/store.sqlite" "foxtrot-live-data"
+make_fixture "$F/data/main.sqlite" "STALE-main"
+make_fixture "$F/data/openwa.sqlite" "STALE-data"
+printf 'DATABASE_TYPE=sqlite\nMAIN_DATABASE_NAME=%s\nDATABASE_NAME=%s\n' \
+  "$F/live/auth.sqlite" "$F/live/store.sqlite" >"$F/state/.env.generated"
+(
+  cd "$F"
+  OPENWA_DATA_DIR="$F/state" BACKUP_DIR="$F/out" "$BACKUP" >/dev/null
+)
+ARCHIVE_F="$(ls "$F"/out/openwa-backup-*.tar.gz)"
+tar -xzf "$ARCHIVE_F" -C "$F/extract"
+if [ "$(db_fingerprint "$F/extract/main.sqlite")" != "foxtrot-live-main" ]; then
+  fail "(f) backup archived the stale default main DB instead of the one data/.env.generated names"
+fi
+if [ "$(db_fingerprint "$F/extract/openwa.sqlite")" != "foxtrot-live-data" ]; then
+  fail "(f) backup archived the stale default data DB instead of the one data/.env.generated names"
+fi
+# restore.sh must read the SAME layer, or it writes the databases somewhere backup.sh never looked.
+printf 'DATABASE_TYPE=sqlite\nMAIN_DATABASE_NAME=%s\nDATABASE_NAME=%s\n' \
+  "$F/restore/auth.sqlite" "$F/restore/store.sqlite" >"$F/restore/state/.env.generated"
+(
+  cd "$F/restore"
+  OPENWA_DATA_DIR="$F/restore/state" "$RESTORE" "$ARCHIVE_F" >/dev/null
+)
+if [ "$(db_fingerprint "$F/restore/auth.sqlite")" != "foxtrot-live-main" ]; then
+  fail "(f) restore ignored the MAIN_DATABASE_NAME in data/.env.generated"
+fi
+if [ "$(db_fingerprint "$F/restore/store.sqlite")" != "foxtrot-live-data" ]; then
+  fail "(f) restore ignored the DATABASE_NAME in data/.env.generated"
+fi
+# An explicit environment value must still win — that is the app's precedence, not ours to change.
+(
+  cd "$F"
+  MAIN_DATABASE_NAME="$F/data/main.sqlite" DATABASE_NAME="$F/data/openwa.sqlite" \
+    OPENWA_DATA_DIR="$F/state" BACKUP_DIR="$F/out2" "$BACKUP" >/dev/null
+)
+rm -rf "${F:?}/extract2" && mkdir -p "$F/extract2"
+tar -xzf "$(ls "$F"/out2/openwa-backup-*.tar.gz)" -C "$F/extract2"
+if [ "$(db_fingerprint "$F/extract2/main.sqlite")" != "STALE-main" ]; then
+  fail "(f) an explicit environment path lost to data/.env.generated — precedence is inverted"
+fi
+pass "(f) data/.env.generated resolves paths for both scripts, and the environment still wins"
+
+echo ""
 echo "All smoke tests passed!"


### PR DESCRIPTION
## The failure

`backup.sh` and `restore.sh` read every path from the process environment alone. The application
fills the same settings from three layers (`src/config/load-env.ts`):

1. the process environment
2. `./.env`
3. `<data dir>/.env.generated` — written by Dashboard > Infrastructure

So an install configured through the dashboard was backed up at the **default** paths.

That is not reliably loud. `backup_sqlite` already fails hard when a database is missing, which
covers the obvious case. The dangerous shape is the other one: a database left at a default path from
*before* the operator switched. Then the run archives the abandoned file and exits `0` — a backup that
announces itself as wrong only during a restore.

`backup.sh` was already copying `.env.generated` into the archive without ever reading it, and
`docs/11-operational-runbooks.md` pushed the gap onto the operator, telling them to restate
`MAIN_DATABASE_NAME` / `DATABASE_NAME` by hand "when the app overrides them".

## The change

`scripts/lib-env.sh` resolves a key through the three layers in the application's order. Both scripts
use it for the database paths, the state directories, and the Postgres connection details `pg_dump`
needs — so a dashboard-provisioned database no longer needs its credentials restated in the
operator's shell.

Deliberate constraints:

- **An explicit environment value still wins.** Inverting the precedence would be a worse bug than the
  one being fixed, so the new smoke case asserts that direction too.
- **Nothing is exported.** Each key is looked up by name, so a stray entry in an operator's `.env`
  can never reach the script's own environment.
- **Only plain `KEY=value` lines are honoured.** A value carrying quotes or a trailing `#` comment is
  reported and skipped rather than guessed at — a silently mis-parsed path is precisely the failure
  this exists to prevent. `.env.generated` is machine-written and always in this form; the warning
  exists for hand-edited `.env` files.
- `OPENWA_DATA_DIR` and `BACKUP_DIR` steer the script rather than the application and are never
  written to an env file, so they stay environment-only.

## Tests

New smoke case **(f)** reproduces the dangerous shape exactly: a stale database sitting at the default
path while `data/.env.generated` names the live one. It asserts four things — backup takes the live
database, restore writes to the path the same layer names, and an explicit environment value still
overrides both.

Watched failing first, on the real defect:

```
==> (f) data/.env.generated supplies paths the environment does not
FAIL: (f) backup archived the stale default main DB instead of the one data/.env.generated names
```

The precedence assertion is separately mutation-proven, since the first failure short-circuits before
it runs — inverting the lookup order in `lib-env.sh` produces:

```
FAIL: (f) an explicit environment path lost to data/.env.generated — precedence is inverted
```

## Verification

- `shellcheck scripts/*.sh` (0.11.0, the CI version) — clean, including the new `lib-env.sh`
- backup/restore smoke test — 6/6 cases pass
- backend suite 4048 tests, unchanged — nothing on the gateway is touched