### PR TITLE
fix(config): stop .env.example pinning the settings the dashboard owns

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,23 @@
 # =============================================================================
 # Copy this file to .env and customize as needed.
 # This is the Single Source of Truth for all configuration.
+#
+# WHY SO MANY LINES ARE COMMENTED OUT
+# -----------------------------------
+# A value present in .env wins over everything the dashboard saves. Configuration is filled from
+# three layers, each supplying only what the previous one left unset:
+#
+#     process environment  >  .env  >  data/.env.generated   (Dashboard > Infrastructure)
+#
+# So any setting shipped uncommented here becomes a PIN the moment you copy this file: the matching
+# dashboard control still moves, saves, and reports success, while the running value never changes.
+# Every setting the dashboard owns is therefore commented out, with its default shown. Uncomment
+# only what you intend to manage by hand — and remember that an EMPTY assignment pins just as hard
+# as a filled one (`DATABASE_PASSWORD=` is a set-to-empty value, not an absent one, so it shadows a
+# password the dashboard provisioned).
+#
+# Keep it that way: `src/config/env-precedence.spec.ts` fails if a dashboard-owned key is shipped
+# uncommented again.
 
 # =============================================================================
 # CORE SETTINGS
@@ -28,7 +45,11 @@ LOG_LEVEL=info                      # error | warn | info | debug
 # Docker Compose: this value only reaches the container from v0.12.0 onward — the bundled
 # docker-compose.yml did not forward it before then (#985), so setting it on an earlier version had
 # no effect and sessions stayed DISCONNECTED on boot regardless.
-AUTO_START_SESSIONS=false
+# Left commented deliberately. The production compose treats an unset value as off, so the default
+# below is unchanged there. The DEV compose defaults an unset value to `true`
+# (docker-compose.dev.yml: `${AUTO_START_SESSIONS:-true}`), which is its intended convenience —
+# uncommenting the line here turns that off again.
+# AUTO_START_SESSIONS=false
 # 0 = unlimited. Set a positive integer to cap concurrently running/initializing sessions.
 # A FAILED session is evicted by design (no live engine), so it does not hold a concurrency slot.
 MAX_CONCURRENT_SESSIONS=0
@@ -78,13 +99,13 @@ CORS_ORIGINS=*
 # ENGINE_TYPE=whatsapp-web.js
 
 # Engine-specific settings
-SESSION_DATA_PATH=./data/sessions
-PUPPETEER_HEADLESS=true
+# SESSION_DATA_PATH=./data/sessions
+# PUPPETEER_HEADLESS=true
 # Browser flags, comma- or space-separated. NOTE: this REPLACES the default list rather than adding to
 # it, so repeat the flags you still want — dropping --no-sandbox stops Chromium launching in a
 # container. `--lang=en-US` is appended automatically unless you pass your own `--lang`: WhatsApp Web
 # renders in the browser's language and the onboarding-modal handling below matches visible text.
-PUPPETEER_ARGS=--no-sandbox,--disable-setuid-sandbox,--disable-dev-shm-usage,--disable-gpu
+# PUPPETEER_ARGS=--no-sandbox,--disable-setuid-sandbox,--disable-dev-shm-usage,--disable-gpu
 # Path to a system Chromium/Chrome binary. Leave unset to use the bundled Puppeteer browser.
 # Required in the Docker image and on hosts without a bundled browser (e.g. Alpine/ARM).
 # PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
@@ -186,12 +207,12 @@ BAILEYS_SYNC_FULL_HISTORY=false
 # DATABASE
 # =============================================================================
 # Options: sqlite, postgres
-DATABASE_TYPE=sqlite
+# DATABASE_TYPE=sqlite
 POSTGRES_BUILTIN=false              # Use built-in PostgreSQL container?
 
 # PostgreSQL settings (ignored for sqlite, auto-configured if POSTGRES_BUILTIN=true)
-DATABASE_HOST=localhost
-DATABASE_PORT=5432
+# DATABASE_HOST=localhost
+# DATABASE_PORT=5432
 # PostgreSQL database name ONLY. Leave unset for SQLite (DATABASE_TYPE=sqlite) to use the
 # default file path ./data/openwa.sqlite — a bare value here would become the SQLite file PATH
 # and, under a read-only container rootfs, trigger a SQLITE_CANTOPEN boot-loop (#677).
@@ -201,11 +222,11 @@ DATABASE_PORT=5432
 # Postgres where you get a project schema, or to share one DB across apps). The schema must
 # already exist — the built-in container creates it; for external/managed Postgres create it
 # once (CREATE SCHEMA openwa;). A missing schema fails fast at migration time.
-POSTGRES_SCHEMA=public
-DATABASE_USERNAME=openwa
+# POSTGRES_SCHEMA=public
+# DATABASE_USERNAME=openwa
 # MUST set a strong, unique value before using Postgres — no default is shipped.
 # Production refuses to start if this is empty or a known placeholder when DATABASE_TYPE=postgres.
-DATABASE_PASSWORD=
+# DATABASE_PASSWORD=
 DATABASE_SYNCHRONIZE=false          # WARNING: Set false in production! (data DB)
 DATABASE_LOGGING=false
 # Auth/audit (main) DB schema management. Default ON (zero-config first boot).
@@ -222,7 +243,7 @@ DATABASE_CONNECTION_TIMEOUT_MS=10000 # Fails fast if a new connection can't be a
 # =============================================================================
 # REDIS / QUEUE (Phase 2)
 # =============================================================================
-REDIS_ENABLED=false                 # Enable Redis for queue and caching
+# REDIS_ENABLED=false                 # Enable Redis for queue and caching
 REDIS_BUILTIN=false                 # Use built-in Redis container?
 # Process webhooks/ingress through the BullMQ queue (needs a reachable Redis via REDIS_HOST/REDIS_PORT).
 # Off by default (inline dispatch). In the bundled Docker Compose this is dashboard-managed
@@ -232,8 +253,8 @@ REDIS_BUILTIN=false                 # Use built-in Redis container?
 # CACHE_ENABLED=false
 
 # Redis settings (auto-configured if REDIS_BUILTIN=true)
-REDIS_HOST=localhost
-REDIS_PORT=6379
+# REDIS_HOST=localhost
+# REDIS_PORT=6379
 # Fail Redis queue/cache connection attempts after this many ms.
 REDIS_CONNECT_TIMEOUT_MS=5000
 # REDIS_USERNAME=
@@ -243,24 +264,24 @@ REDIS_CONNECT_TIMEOUT_MS=5000
 # STORAGE
 # =============================================================================
 # Options: local, s3
-STORAGE_TYPE=local
+# STORAGE_TYPE=local
 MINIO_BUILTIN=false                 # Use built-in MinIO container?
 
 # Local storage path (if STORAGE_TYPE=local)
-STORAGE_LOCAL_PATH=./data/media
+# STORAGE_LOCAL_PATH=./data/media
 
 # S3/MinIO settings (if STORAGE_TYPE=s3, auto-configured if MINIO_BUILTIN=true)
 # S3_ENDPOINT is OPTIONAL: leave it unset for standard AWS S3 (derived from region); set it only for
 # an S3-compatible store (MinIO, R2, …), which also enables path-style addressing.
 # S3_ENDPOINT=http://localhost:9000   # uncomment / set ONLY for an S3-compatible store (MinIO, R2)
-S3_BUCKET=openwa
-S3_REGION=us-east-1
+# S3_BUCKET=openwa
+# S3_REGION=us-east-1
 # MUST set strong, unique values before using S3/MinIO — no defaults shipped.
 # Production refuses to start if these are empty/placeholder when STORAGE_TYPE=s3 (external).
 # Canonical names (what the app reads first and the dashboard writes); the legacy
 # S3_ACCESS_KEY / S3_SECRET_KEY are still accepted as a fallback for older setups.
-S3_ACCESS_KEY_ID=
-S3_SECRET_ACCESS_KEY=
+# S3_ACCESS_KEY_ID=
+# S3_SECRET_ACCESS_KEY=
 
 # =============================================================================
 # WEBHOOK
@@ -355,8 +376,8 @@ WEBHOOK_SSRF_PROTECT=true
 # RATE LIMITING  (all TTLs are in MILLISECONDS)
 # =============================================================================
 # The "medium" tier is the one enforced on the API; short/long are optional extra tiers.
-RATE_LIMIT_MEDIUM_TTL=60000         # window in ms (default 60000 = 60s)
-RATE_LIMIT_MEDIUM_LIMIT=100         # max requests per window
+# RATE_LIMIT_MEDIUM_TTL=60000         # window in ms (default 60000 = 60s)
+# RATE_LIMIT_MEDIUM_LIMIT=100         # max requests per window
 # RATE_LIMIT_SHORT_TTL=1000         # 1s burst window (default)
 # RATE_LIMIT_SHORT_LIMIT=10
 # RATE_LIMIT_LONG_TTL=3600000       # 1h window (default)
@@ -488,7 +509,7 @@ PLUGINS_DIR=./data/plugins          # Plugin directory (default: ./data/plugins)
 # SECURITY
 # =============================================================================
 # Master API key (leave empty to disable, or set to secure value)
-API_MASTER_KEY=
+# API_MASTER_KEY=
 
 # First-boot default admin key. By default a cryptographically random key is
 # generated (printed in the startup banner / written to data/.api-key). Set this
@@ -512,7 +533,7 @@ API_MASTER_KEY=
 # DEVELOPER SETTINGS
 # =============================================================================
 ENABLE_SWAGGER=true                 # Enable API documentation at /api/docs (set false to disable on exposed deployments)
-BODY_SIZE_LIMIT=25mb                # Max request body size (base64 media sends ride in the JSON body)
+# BODY_SIZE_LIMIT=25mb                # Max request body size (base64 media sends ride in the JSON body)
 # Aggregate cap on request-body bytes buffered across ALL connections. Once exceeded, new requests
 # get 503 + Retry-After without their body being read (protects against slow-body memory pinning).
 # Keep it >= BODY_SIZE_LIMIT. Default: 4 x BODY_SIZE_LIMIT (100 MiB with the default 25mb cap).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mis-parsed path is the failure being fixed. The Postgres connection details `pg_dump` uses resolve
   the same way, so a dashboard-provisioned database no longer needs its credentials restated in the
   operator's shell.
+- **`cp .env.example .env` pinned 23 settings the dashboard is supposed to own.** Configuration is
+  filled from the process environment, then `.env`, then `data/.env.generated`, each supplying only
+  what the previous layer left unset. Every value shipped uncommented in `.env.example` therefore
+  became a permanent pin the moment an operator followed the documented setup step: the matching
+  dashboard control still moved, saved and reported success, while the running value never changed.
+
+  The blank-forward fix above cannot reach this. `clearBlankEnv` runs before `.env` is read, so it
+  only clears blanks arriving from the process environment. A value in `.env` — including an *empty*
+  one, since dotenv treats `KEY=` as present rather than absent — is never cleared. That made
+  `DATABASE_PASSWORD=` the sharpest case: it shadowed a password the dashboard had provisioned, the
+  next production boot refused to start, and the dashboard could not warn about it, because the
+  save-time guard reads a snapshot taken before `.env` was loaded and so validated the file value it
+  was writing rather than the one that would win.
+
+  All 23 are now commented out with their defaults shown, so copying the file pins nothing. Each was
+  checked against its application-level default first; none changes behaviour when absent. One
+  deliberate exception is called out in the file: the dev compose defaults an unset
+  `AUTO_START_SESSIONS` to `true`, so a dev stack that had inherited `false` from a copied
+  `.env.example` now gets the dev default it was always meant to have. A test derives the key set
+  from `docker-compose.yml` and fails if a dashboard-owned key is shipped uncommented again.
 
 ## [0.12.2] - 2026-08-01
 

--- a/src/config/env-precedence.spec.ts
+++ b/src/config/env-precedence.spec.ts
@@ -207,4 +207,20 @@ describe.each(['docker-compose.yml', 'docker-compose.dev.yml'])('every blank for
   it('has a BLANK_SHADOWED_ENV_KEYS entry for each one', () => {
     expect(blankForwards().filter(key => !BLANK_SHADOWED_ENV_KEYS.includes(key))).toEqual([]);
   });
+
+  // Clearing a blank forward only lets data/.env.generated win when nothing ABOVE it supplies a
+  // value. `.env` sits above it and is loaded at load-env.ts:60 — after clearBlankEnv has already
+  // run at :50 — so a value shipped uncommented in `.env.example` survives `cp .env.example .env`
+  // as a permanent pin that the clear list structurally cannot reach. An empty assignment pins just
+  // as hard: dotenv treats `KEY=` as present, so `DATABASE_PASSWORD=` shadows a dashboard-provisioned
+  // password and the next production boot refuses to start.
+  it('ships none of them uncommented in .env.example', () => {
+    const example = fs.readFileSync(path.join(__dirname, '../../.env.example'), 'utf8');
+    const uncommented = example
+      .split('\n')
+      .map(line => /^([A-Z0-9_]+)=/.exec(line)?.[1])
+      .filter((key): key is string => key !== undefined);
+    expect(uncommented).toContain('NODE_ENV'); // the file really does ship some keys uncommented
+    expect(uncommented.filter(key => blankForwards().includes(key))).toEqual([]);
+  });
 });


### PR DESCRIPTION
## The failure

Configuration is filled from three layers (`src/config/load-env.ts`), each supplying only what the
previous one left unset:

```
process environment  >  .env  >  data/.env.generated   (Dashboard > Infrastructure)
```

Every value shipped **uncommented** in `.env.example` therefore becomes a permanent pin the moment an
operator runs the documented setup step, `cp .env.example .env`. The matching dashboard control still
moves, saves and reports success — the running value simply never changes. 23 keys were in that
state, covering the database, storage, Redis, engine launch, rate limits and the master key.

The dashboard does surface *some* of this (`envPinNote` on the Infrastructure page compares the
running value against the saved one), but only for the three backends that have a status probe, and
only after the fact. The operator did nothing wrong: they followed the instructions.

## Why the blank-forward fix does not cover it

`clearBlankEnv` runs at `load-env.ts:50`. `.env` is read at `:60`. So the clear list only ever sees
blanks arriving from the **process environment** — a value in `.env` is never cleared.

An *empty* assignment pins just as hard, because dotenv treats `KEY=` as present rather than absent.
Verified against the installed dotenv 17.4.1:

```
after .env       : ""
after .generated : ""      <- injected env (0); the dashboard value was discarded
```

`DATABASE_PASSWORD=` is the sharpest case. It shadows a password the dashboard provisioned, so the
next production boot refuses to start on the `env.validation.ts` Postgres check — and the dashboard
cannot warn about it, because `recordOsEnvKeys` snapshots *before* `.env` is loaded, so
`isOsProvidedEnv('DATABASE_PASSWORD')` is false and the save-time guard validates the file value it is
writing rather than the one that will actually win. It saves cleanly and the boot still fails.

## The change

All 23 keys are commented out with their defaults left visible, so copying the file pins nothing and
the documentation value is unchanged.

Each key was checked against its application-level default before being commented; none changes
behaviour when absent. Two worth stating:

- `DATABASE_USERNAME` — the app has **no** default (`configuration.ts:170` passes
  `process.env.DATABASE_USERNAME` through) and `env.validation.ts:75` requires it under Postgres. The
  shipped `openwa` was a default the application itself does not have. A Postgres operator now gets a
  loud boot error naming the variable instead of silently connecting as `openwa`, and a
  dashboard-provisioned database supplies it from `.env.generated`.
- `AUTO_START_SESSIONS` — **one deliberate behaviour change**, called out in the file itself. The
  production compose treats an unset value as off, so nothing moves there. The *dev* compose defaults
  an unset value to `true` (`docker-compose.dev.yml`: `${AUTO_START_SESSIONS:-true}`), so a dev stack
  that had inherited `false` from a copied `.env.example` now gets the dev default it was always meant
  to have.

A header block explains the precedence and why the lines are commented, so a future edit does not
helpfully uncomment them again.

## Test

The new assertion derives the key set from `docker-compose.yml` rather than restating it — a
hand-maintained list is exactly how the clear list drifted in the first place. It carries a
known-positive check (`expect(uncommented).toContain('NODE_ENV')`) so a pattern that matched nothing
could not pass it vacuously.

Mutation-tested: uncommenting a single key fails it by name.

```
  expected [] to equal
  + Array [ "STORAGE_TYPE" ]
```

## Verification

- backend suite 4050 tests, lint, `tsc --noEmit` — clean
- `.env.example` still parses as valid dotenv: 31 keys, of which 0 are blank-forwarded