### PR TITLE
test(auth): scan controller paths with `path` instead of splitting on '/'

### DIFF
--- a/src/modules/auth/global-route-fence-coverage.spec.ts
+++ b/src/modules/auth/global-route-fence-coverage.spec.ts
@@ -9,7 +9,7 @@
 // a @SessionScoped controller) and carries neither @RequireUnscopedKey, @Public, nor an entry in
 // ALLOWLIST below — so a future endpoint cannot silently re-introduce the gap.
 import { readdirSync, readFileSync } from 'fs';
-import { join } from 'path';
+import { basename, join, sep } from 'path';
 
 /**
  * Handlers that are deliberately global AND deliberately reachable by a session-restricted key,
@@ -184,11 +184,15 @@ export class ThingController {
     const modulesDir = join(__dirname, '..');
     const offenders: string[] = [];
     for (const file of listControllerFiles(modulesDir)) {
-      const basename = file.split('/').pop() as string;
+      // Derive the file name through `path`, and normalize separators before matching: `join()`
+      // yields backslashes on Windows, so splitting on '/' left the whole path as the "basename",
+      // no ALLOWLIST key ever matched, and every allowlisted controller was reported as an offender.
+      const fileName = basename(file);
+      const posixPath = file.split(sep).join('/');
       for (const handler of handlersMissingGlobalFence(readFileSync(file, 'utf8'))) {
-        const key = `${basename} :: ${handler}`;
+        const key = `${fileName} :: ${handler}`;
         if (ALLOWLIST.has(key)) continue;
-        offenders.push(`${file.replace(/.*\/src\//, 'src/')} :: ${handler}`);
+        offenders.push(`${posixPath.replace(/.*\/src\//, 'src/')} :: ${handler}`);
       }
     }
     expect(offenders).toEqual([]);


### PR DESCRIPTION
## Description

`global-route-fence-coverage.spec.ts` builds controller paths with `join()` but derives the basename with `split('/')`. On Windows `join()` yields backslashes, so the "basename" is the entire absolute path, no `ALLOWLIST` key ever matches, and all 16 deliberately-global handlers are reported as offenders:

```
● no real controller exposes an unfenced deployment-global route

  - Array []
  + Array [
  +   "D:\OpenWA\src\modules\audit\audit.controller.ts :: findAll",
  +   "D:\OpenWA\src\modules\auth\auth-validate.controller.ts :: validate",
  ...16 entries
```

The suite therefore cannot pass on a Windows checkout — it is red on a clean `origin/main`, independent of any local change. CI is unaffected, which is presumably why it went unnoticed.

This takes the file name from `basename()` and normalizes separators to POSIX before the `src/` match used in the failure message. Both are no-ops on Linux, so CI behavior is unchanged; on Windows the suite goes 8/8.

I checked the guard still bites rather than merely going quiet — with the fix in place, renaming one `ALLOWLIST` key makes the suite fail and name that handler:

```
+   "src/modules/audit/audit.controller.ts :: findAll",
Tests: 1 failed, 7 passed, 8 total
```

Split out from #1047, as suggested there.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] Tests added/updated — this is the test fix; verified by mutation, see above
- [ ] Documentation updated — not user-visible, no `CHANGELOG` entry
- [x] Lint passes
- [x] Self-reviewed