### PR TITLE
test: close the MessageProjector and BaileysEvents spec gaps

### DIFF
--- a/src/engine/adapters/baileys-events.spec.ts
+++ b/src/engine/adapters/baileys-events.spec.ts
@@ -4,13 +4,26 @@ import { ConcurrencyLimiter } from '../../common/utils/concurrency-limiter';
 import type { WASocket } from '@whiskeysockets/baileys';
 
 /**
+ * `downloadMediaMessage` is a jest mock, not a silent no-op: the real-download branch
+ * (`baileys-events.ts:588-638`, reached whenever `isMediaType` is true and skipMediaDownload
+ * isn't set) calls `b.downloadMediaMessage(...)`, and this stub implements nothing else that
+ * branch needs — so if a non-media contentType were ever misclassified as media (the exact
+ * slip the Plan 2 mapper extraction could introduce), the call throws and that throw is caught
+ * by baileys-events.ts:632-637, leaving `media` unset. An `incoming.media` assertion alone
+ * can't tell "correctly not classified as media" from "misclassified, then crashed and got
+ * swallowed" — asserting `downloadMediaMessage` was never called can.
+ */
+const downloadMediaMessage = jest.fn();
+
+/**
  * Minimal Baileys lib stub. `mapMessage` calls `normalizeMessageContent` to unwrap
  * ephemeral / viewOnce / documentWithCaption wrappers; identity is the correct
  * behaviour for already-unwrapped content.
  */
 const libStub = {
   normalizeMessageContent: (content: unknown) => content,
-} as Awaited<ReturnType<BaileysEventsHost['loadLib']>>;
+  downloadMediaMessage,
+} as unknown as Awaited<ReturnType<BaileysEventsHost['loadLib']>>;
 
 function makeHost(overrides: Partial<BaileysEventsHost> = {}): BaileysEventsHost {
   const noop = (): void => undefined;
@@ -44,9 +57,16 @@ function makeHost(overrides: Partial<BaileysEventsHost> = {}): BaileysEventsHost
 }
 
 describe('BaileysEvents.mapMessage', () => {
-  it('maps a plain text message', async () => {
-    const events = new BaileysEvents(makeHost());
+  // Hoisted: every case uses the same plain fake host; a test that needs a different one can
+  // still call makeHost(overrides) directly and shadow this.
+  let events: BaileysEvents;
 
+  beforeEach(() => {
+    downloadMediaMessage.mockClear();
+    events = new BaileysEvents(makeHost());
+  });
+
+  it('maps a plain text message', async () => {
     const incoming = await events.mapMessage(
       {
         key: { id: 'wamid.1', remoteJid: '15550001111@s.whatsapp.net', fromMe: false },
@@ -59,11 +79,12 @@ describe('BaileysEvents.mapMessage', () => {
     expect(incoming.body).toBe('hello there');
     expect(incoming.media).toBeUndefined();
     expect(incoming.location).toBeUndefined();
+    // Guards against an isMediaType false positive on a non-media contentType (see the
+    // downloadMediaMessage doc comment above) — not just that `media` happens to end up unset.
+    expect(downloadMediaMessage).not.toHaveBeenCalled();
   });
 
   it('maps a static location, carrying name and address', async () => {
-    const events = new BaileysEvents(makeHost());
-
     const incoming = await events.mapMessage(
       {
         key: { id: 'wamid.2', remoteJid: '15550001111@s.whatsapp.net', fromMe: false },
@@ -86,11 +107,10 @@ describe('BaileysEvents.mapMessage', () => {
       description: 'Monas',
       address: 'Jakarta Pusat',
     });
+    expect(downloadMediaMessage).not.toHaveBeenCalled();
   });
 
   it('maps a LIVE location without name/address (only the static variant carries them)', async () => {
-    const events = new BaileysEvents(makeHost());
-
     const incoming = await events.mapMessage(
       {
         key: { id: 'wamid.3', remoteJid: '15550001111@s.whatsapp.net', fromMe: false },
@@ -104,11 +124,10 @@ describe('BaileysEvents.mapMessage', () => {
     expect(incoming.location?.longitude).toBe(2.5);
     expect(incoming.location?.description).toBeUndefined();
     expect(incoming.location?.address).toBeUndefined();
+    expect(downloadMediaMessage).not.toHaveBeenCalled();
   });
 
   it('emits an omitted media marker when the download is skipped, keeping mimetype and size', async () => {
-    const events = new BaileysEvents(makeHost());
-
     const incoming = await events.mapMessage(
       {
         key: { id: 'wamid.4', remoteJid: '15550001111@s.whatsapp.net', fromMe: true },
@@ -129,8 +148,6 @@ describe('BaileysEvents.mapMessage', () => {
   });
 
   it('carries the document filename onto the omitted marker', async () => {
-    const events = new BaileysEvents(makeHost());
-
     const incoming = await events.mapMessage(
       {
         key: { id: 'wamid.5', remoteJid: '15550001111@s.whatsapp.net', fromMe: true },
@@ -146,8 +163,6 @@ describe('BaileysEvents.mapMessage', () => {
   });
 
   it('resolves a quoted message from contextInfo', async () => {
-    const events = new BaileysEvents(makeHost());
-
     const incoming = await events.mapMessage(
       {
         key: { id: 'wamid.6', remoteJid: '15550001111@s.whatsapp.net', fromMe: false },
@@ -164,11 +179,10 @@ describe('BaileysEvents.mapMessage', () => {
 
     expect(incoming.quotedMessage?.id).toBe('wamid.original');
     expect(incoming.quotedMessage?.body).toBe('the original');
+    expect(downloadMediaMessage).not.toHaveBeenCalled();
   });
 
   it('leaves quotedMessage undefined when contextInfo has no stanzaId', async () => {
-    const events = new BaileysEvents(makeHost());
-
     const incoming = await events.mapMessage(
       {
         key: { id: 'wamid.7', remoteJid: '15550001111@s.whatsapp.net', fromMe: false },
@@ -181,5 +195,6 @@ describe('BaileysEvents.mapMessage', () => {
     );
 
     expect(incoming.quotedMessage).toBeUndefined();
+    expect(downloadMediaMessage).not.toHaveBeenCalled();
   });
 });

--- a/src/engine/adapters/baileys-events.spec.ts
+++ b/src/engine/adapters/baileys-events.spec.ts
@@ -1,7 +1,7 @@
 import { BaileysEvents, type BaileysEventsHost } from './baileys-events';
 import { createLogger } from '../../common/services/logger.service';
 import { ConcurrencyLimiter } from '../../common/utils/concurrency-limiter';
-import type { WASocket } from '@whiskeysockets/baileys';
+import type { WAMessage, WASocket } from '@whiskeysockets/baileys';
 
 /**
  * `downloadMediaMessage` is a jest mock, not a silent no-op: the real-download branch
@@ -115,7 +115,16 @@ describe('BaileysEvents.mapMessage', () => {
       {
         key: { id: 'wamid.3', remoteJid: '15550001111@s.whatsapp.net', fromMe: false },
         messageTimestamp: 1_700_000_000,
-        message: { liveLocationMessage: { degreesLatitude: 1.5, degreesLongitude: 2.5 } },
+        message: {
+          liveLocationMessage: {
+            degreesLatitude: 1.5,
+            degreesLongitude: 2.5,
+            // ILiveLocationMessage has neither field in the real proto; present here so a slip that
+            // reads them off the live variant (instead of the static-only `staticLm`) is caught.
+            name: 'SHOULD BE IGNORED',
+            address: 'SHOULD BE IGNORED',
+          },
+        } as WAMessage['message'],
       },
       'liveLocationMessage',
     );
@@ -162,6 +171,51 @@ describe('BaileysEvents.mapMessage', () => {
     expect(incoming.media?.omitted).toBe(true);
   });
 
+  it('classifies a sticker as media (pins stickerMessage in the isMediaType disjunction)', async () => {
+    const incoming = await events.mapMessage(
+      {
+        key: { id: 'wamid.8', remoteJid: '15550001111@s.whatsapp.net', fromMe: true },
+        messageTimestamp: 1_700_000_000,
+        message: { stickerMessage: { mimetype: 'image/webp', fileLength: 555 } },
+      },
+      'stickerMessage',
+      { skipMediaDownload: true },
+    );
+
+    expect(incoming.media).toEqual({
+      mimetype: 'image/webp',
+      filename: undefined,
+      omitted: true,
+      sizeBytes: 555,
+    });
+  });
+
+  it('classifies a documentWithCaptionMessage as media (pins it in the isMediaType disjunction)', async () => {
+    const incoming = await events.mapMessage(
+      {
+        key: { id: 'wamid.9', remoteJid: '15550001111@s.whatsapp.net', fromMe: true },
+        messageTimestamp: 1_700_000_000,
+        message: {
+          documentMessage: {
+            mimetype: 'application/pdf',
+            fileLength: 321,
+            fileName: 'contract.pdf',
+            caption: 'signed',
+          },
+        },
+      },
+      'documentWithCaptionMessage',
+      { skipMediaDownload: true },
+    );
+
+    expect(incoming.media).toEqual({
+      mimetype: 'application/pdf',
+      filename: 'contract.pdf',
+      omitted: true,
+      sizeBytes: 321,
+    });
+  });
+
   it('resolves a quoted message from contextInfo', async () => {
     const incoming = await events.mapMessage(
       {
@@ -196,5 +250,35 @@ describe('BaileysEvents.mapMessage', () => {
 
     expect(incoming.quotedMessage).toBeUndefined();
     expect(downloadMediaMessage).not.toHaveBeenCalled();
+  });
+
+  it('resolves a quoted reply, mention and disappearing timer riding on an imageMessage context (not extendedTextMessage)', async () => {
+    const incoming = await events.mapMessage(
+      {
+        key: { id: 'wamid.10', remoteJid: '15550001111@s.whatsapp.net', fromMe: false },
+        messageTimestamp: 1_700_000_000,
+        message: {
+          imageMessage: {
+            mimetype: 'image/jpeg',
+            caption: 'look',
+            contextInfo: {
+              stanzaId: 'wamid.original2',
+              expiration: 604800,
+              mentionedJid: ['15559998888@s.whatsapp.net'],
+              // No `conversation` on the quoted sub-message — only `imageMessage.caption` — so this
+              // also pins the qBody fallback chain beyond its first (`conversation`) arm.
+              quotedMessage: { imageMessage: { caption: 'quoted image caption' } },
+            },
+          },
+        },
+      },
+      'imageMessage',
+      { skipMediaDownload: true },
+    );
+
+    expect(incoming.quotedMessage?.id).toBe('wamid.original2');
+    expect(incoming.quotedMessage?.body).toBe('quoted image caption');
+    expect(incoming.ephemeralDuration).toBe(604800);
+    expect(incoming.mentionedIds).toEqual(['15559998888@s.whatsapp.net']);
   });
 });

--- a/src/engine/adapters/baileys-events.spec.ts
+++ b/src/engine/adapters/baileys-events.spec.ts
@@ -1,0 +1,185 @@
+import { BaileysEvents, type BaileysEventsHost } from './baileys-events';
+import { createLogger } from '../../common/services/logger.service';
+import { ConcurrencyLimiter } from '../../common/utils/concurrency-limiter';
+import type { WASocket } from '@whiskeysockets/baileys';
+
+/**
+ * Minimal Baileys lib stub. `mapMessage` calls `normalizeMessageContent` to unwrap
+ * ephemeral / viewOnce / documentWithCaption wrappers; identity is the correct
+ * behaviour for already-unwrapped content.
+ */
+const libStub = {
+  normalizeMessageContent: (content: unknown) => content,
+} as Awaited<ReturnType<BaileysEventsHost['loadLib']>>;
+
+function makeHost(overrides: Partial<BaileysEventsHost> = {}): BaileysEventsHost {
+  const noop = (): void => undefined;
+  return {
+    // getSocket/getSocketOrNull back the live-call and media-reupload paths only; mapMessage's
+    // own media path is never reached here (every media case passes skipMediaDownload: true).
+    getSocket: () => ({}) as WASocket,
+    getSocketOrNull: () => null,
+    logger: createLogger('BaileysEventsSpec'),
+    loadLib: () => Promise.resolve(libStub),
+    toNeutralJid: (jid: string) => jid,
+    normalizedSelfJid: () => '6280000000000@s.whatsapp.net',
+    // connectedAt only gates handleMessagesUpsert's history-replay skip; mapMessage itself never
+    // reads it.
+    connectedAt: 0,
+    inboundLimiter: new ConcurrencyLimiter(1),
+    recordKeyLidMappings: noop,
+    recordMessage: noop,
+    recordMessageEdit: noop,
+    putStoredMessage: () => undefined,
+    getOnMessage: () => undefined,
+    getOnMessageCreate: () => undefined,
+    getOnMessageRevoked: () => undefined,
+    getOnMessageEdited: () => undefined,
+    getOnMessageReaction: () => undefined,
+    getOnMessageAck: () => undefined,
+    getOnGroupEvent: () => undefined,
+    getOnCall: () => undefined,
+    ...overrides,
+  };
+}
+
+describe('BaileysEvents.mapMessage', () => {
+  it('maps a plain text message', async () => {
+    const events = new BaileysEvents(makeHost());
+
+    const incoming = await events.mapMessage(
+      {
+        key: { id: 'wamid.1', remoteJid: '15550001111@s.whatsapp.net', fromMe: false },
+        messageTimestamp: 1_700_000_000,
+        message: { conversation: 'hello there' },
+      },
+      'conversation',
+    );
+
+    expect(incoming.body).toBe('hello there');
+    expect(incoming.media).toBeUndefined();
+    expect(incoming.location).toBeUndefined();
+  });
+
+  it('maps a static location, carrying name and address', async () => {
+    const events = new BaileysEvents(makeHost());
+
+    const incoming = await events.mapMessage(
+      {
+        key: { id: 'wamid.2', remoteJid: '15550001111@s.whatsapp.net', fromMe: false },
+        messageTimestamp: 1_700_000_000,
+        message: {
+          locationMessage: {
+            degreesLatitude: -6.2,
+            degreesLongitude: 106.8,
+            name: 'Monas',
+            address: 'Jakarta Pusat',
+          },
+        },
+      },
+      'locationMessage',
+    );
+
+    expect(incoming.location).toEqual({
+      latitude: -6.2,
+      longitude: 106.8,
+      description: 'Monas',
+      address: 'Jakarta Pusat',
+    });
+  });
+
+  it('maps a LIVE location without name/address (only the static variant carries them)', async () => {
+    const events = new BaileysEvents(makeHost());
+
+    const incoming = await events.mapMessage(
+      {
+        key: { id: 'wamid.3', remoteJid: '15550001111@s.whatsapp.net', fromMe: false },
+        messageTimestamp: 1_700_000_000,
+        message: { liveLocationMessage: { degreesLatitude: 1.5, degreesLongitude: 2.5 } },
+      },
+      'liveLocationMessage',
+    );
+
+    expect(incoming.location?.latitude).toBe(1.5);
+    expect(incoming.location?.longitude).toBe(2.5);
+    expect(incoming.location?.description).toBeUndefined();
+    expect(incoming.location?.address).toBeUndefined();
+  });
+
+  it('emits an omitted media marker when the download is skipped, keeping mimetype and size', async () => {
+    const events = new BaileysEvents(makeHost());
+
+    const incoming = await events.mapMessage(
+      {
+        key: { id: 'wamid.4', remoteJid: '15550001111@s.whatsapp.net', fromMe: true },
+        messageTimestamp: 1_700_000_000,
+        message: { imageMessage: { mimetype: 'image/jpeg', fileLength: 1234, caption: 'look' } },
+      },
+      'imageMessage',
+      { skipMediaDownload: true },
+    );
+
+    expect(incoming.media).toEqual({
+      mimetype: 'image/jpeg',
+      filename: undefined,
+      omitted: true,
+      sizeBytes: 1234,
+    });
+    expect(incoming.body).toBe('look');
+  });
+
+  it('carries the document filename onto the omitted marker', async () => {
+    const events = new BaileysEvents(makeHost());
+
+    const incoming = await events.mapMessage(
+      {
+        key: { id: 'wamid.5', remoteJid: '15550001111@s.whatsapp.net', fromMe: true },
+        messageTimestamp: 1_700_000_000,
+        message: { documentMessage: { mimetype: 'application/pdf', fileLength: 99, fileName: 'invoice.pdf' } },
+      },
+      'documentMessage',
+      { skipMediaDownload: true },
+    );
+
+    expect(incoming.media?.filename).toBe('invoice.pdf');
+    expect(incoming.media?.omitted).toBe(true);
+  });
+
+  it('resolves a quoted message from contextInfo', async () => {
+    const events = new BaileysEvents(makeHost());
+
+    const incoming = await events.mapMessage(
+      {
+        key: { id: 'wamid.6', remoteJid: '15550001111@s.whatsapp.net', fromMe: false },
+        messageTimestamp: 1_700_000_000,
+        message: {
+          extendedTextMessage: {
+            text: 'replying',
+            contextInfo: { stanzaId: 'wamid.original', quotedMessage: { conversation: 'the original' } },
+          },
+        },
+      },
+      'extendedTextMessage',
+    );
+
+    expect(incoming.quotedMessage?.id).toBe('wamid.original');
+    expect(incoming.quotedMessage?.body).toBe('the original');
+  });
+
+  it('leaves quotedMessage undefined when contextInfo has no stanzaId', async () => {
+    const events = new BaileysEvents(makeHost());
+
+    const incoming = await events.mapMessage(
+      {
+        key: { id: 'wamid.7', remoteJid: '15550001111@s.whatsapp.net', fromMe: false },
+        messageTimestamp: 1_700_000_000,
+        message: {
+          extendedTextMessage: { text: 'no quote', contextInfo: { quotedMessage: { conversation: 'orphan' } } },
+        },
+      },
+      'extendedTextMessage',
+    );
+
+    expect(incoming.quotedMessage).toBeUndefined();
+  });
+});

--- a/src/modules/session/message-projector.service.spec.ts
+++ b/src/modules/session/message-projector.service.spec.ts
@@ -325,8 +325,12 @@ describe('MessageProjector', () => {
       await new Promise(resolve => setImmediate(resolve));
 
       expect(messageRepository.insert).toHaveBeenCalledTimes(1);
-      expect(eventsGateway.emitMessage).toHaveBeenCalledTimes(1);
-      expect(webhookService.dispatch).toHaveBeenCalledTimes(1);
+      // Pinned to the exact event name and args dispatchInboundMessage passes
+      // (message-projector.service.ts:321,323), matching the assertion style
+      // session.service.spec.ts uses for the same call sites — a bare call-count assertion would
+      // stay green even if the event name flipped to 'message.sent' or the wrong payload was sent.
+      expect(eventsGateway.emitMessage).toHaveBeenCalledWith(SESSION_ID, expect.anything());
+      expect(webhookService.dispatch).toHaveBeenCalledWith(SESSION_ID, 'message.received', expect.anything());
       expect(sessionRepository.update).toHaveBeenCalledTimes(1);
     });
 

--- a/src/modules/session/message-projector.service.spec.ts
+++ b/src/modules/session/message-projector.service.spec.ts
@@ -196,12 +196,12 @@ describe('MessageProjector', () => {
   });
 });
 
-// Separate top-level suite: handleInboundMessage's own stale-engine fences and early returns
-// (message-projector.service.ts:114-326) were previously exercised only indirectly through
-// session.service.spec.ts. Uses the TestingModule idiom (mirrors session.service.spec.ts) rather
-// than the direct-construction style above, so the full DI surface (ConfigService, SessionLidResolver)
-// is wired the same way production does.
-describe('MessageProjector', () => {
+// Separate top-level suite: handleInboundMessage's stale-engine fence and its isStatusBroadcast
+// early return (message-projector.service.ts:114-119) were previously exercised only indirectly
+// through session.service.spec.ts. Uses the TestingModule idiom (mirrors session.service.spec.ts)
+// rather than the direct-construction style above, so the full DI surface (ConfigService,
+// SessionLidResolver) is wired the same way production does.
+describe('MessageProjector (inbound projection)', () => {
   let projector: MessageProjector;
   let engines: EngineRegistry;
   let messageRepository: { create: jest.Mock; insert: jest.Mock; findOne: jest.Mock; update: jest.Mock };
@@ -332,6 +332,11 @@ describe('MessageProjector', () => {
       expect(eventsGateway.emitMessage).toHaveBeenCalledWith(SESSION_ID, expect.anything());
       expect(webhookService.dispatch).toHaveBeenCalledWith(SESSION_ID, 'message.received', expect.anything());
       expect(sessionRepository.update).toHaveBeenCalledTimes(1);
+      // Pins the ternary at message-projector.service.ts:255: a genuinely inbound message (fromMe:
+      // false) must be tagged INCOMING, not just "not OUTGOING".
+      expect(messageRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ direction: MessageDirection.INCOMING }),
+      );
     });
 
     it('routes a status broadcast to the status store instead of the message table', async () => {

--- a/src/modules/session/message-projector.service.spec.ts
+++ b/src/modules/session/message-projector.service.spec.ts
@@ -1,13 +1,16 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
 import { MessageProjector } from './message-projector.service';
 import { EngineRegistry } from '../../engine/engine-registry.service';
 import type { Repository } from 'typeorm';
-import type { Message } from '../message/entities/message.entity';
-import type { Session } from './entities/session.entity';
-import type { EventsGateway } from '../events/events.gateway';
-import type { WebhookService } from '../webhook/webhook.service';
-import type { HookManager } from '../../core/hooks';
-import type { StatusStoreService } from '../status-store/status-store.service';
-import type { SessionLidResolver } from './session-lid-resolver.service';
+import { Message, MessageDirection } from '../message/entities/message.entity';
+import { Session } from './entities/session.entity';
+import { EventsGateway } from '../events/events.gateway';
+import { WebhookService } from '../webhook/webhook.service';
+import { HookManager } from '../../core/hooks';
+import { StatusStoreService } from '../status-store/status-store.service';
+import { SessionLidResolver } from './session-lid-resolver.service';
 import type { IncomingMessage, IWhatsAppEngine } from '../../engine/interfaces/whatsapp-engine.interface';
 
 // Lets a queued mutation settle: the projector's chains are fire-and-forget, so the assertions need
@@ -189,6 +192,153 @@ describe('MessageProjector', () => {
       await projector.persistHistoryMessages('s1', [historyMessage({ id: 'DUP' }), historyMessage({ id: 'DUP' })]);
 
       expect(dedupIds(messageRepository.find)).toEqual(['DUP']);
+    });
+  });
+});
+
+// Separate top-level suite: handleInboundMessage's own stale-engine fences and early returns
+// (message-projector.service.ts:114-326) were previously exercised only indirectly through
+// session.service.spec.ts. Uses the TestingModule idiom (mirrors session.service.spec.ts) rather
+// than the direct-construction style above, so the full DI surface (ConfigService, SessionLidResolver)
+// is wired the same way production does.
+describe('MessageProjector', () => {
+  let projector: MessageProjector;
+  let engines: EngineRegistry;
+  let messageRepository: { create: jest.Mock; insert: jest.Mock; findOne: jest.Mock; update: jest.Mock };
+  let sessionRepository: { update: jest.Mock; findOne: jest.Mock };
+  let eventsGateway: { emitMessage: jest.Mock; emitMessageAck: jest.Mock; emitMessageRevoked: jest.Mock };
+  let webhookService: { dispatch: jest.Mock };
+  let hookManager: { execute: jest.Mock };
+  let statusStore: { ingest: jest.Mock };
+  let lidResolver: { resolveSenderPhone: jest.Mock };
+
+  const SESSION_ID = 'session-1';
+
+  /** A distinct object per test: EngineRegistry compares engine IDENTITY, not shape. */
+  const makeEngine = (): IWhatsAppEngine => ({}) as IWhatsAppEngine;
+
+  const makeIncoming = (overrides: Partial<IncomingMessage> = {}): IncomingMessage => ({
+    id: 'wamid.1',
+    chatId: '15550001111@c.us',
+    from: '15550001111@c.us',
+    to: 'me',
+    body: 'hello',
+    type: 'text',
+    timestamp: 1_700_000_000,
+    fromMe: false,
+    isGroup: false,
+    kind: 'individual',
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    messageRepository = {
+      create: jest.fn((row: unknown) => row),
+      insert: jest.fn().mockResolvedValue({ identifiers: [{ id: 1 }], generatedMaps: [{}] }),
+      findOne: jest.fn().mockResolvedValue(null),
+      update: jest.fn().mockResolvedValue(undefined),
+    };
+    sessionRepository = { update: jest.fn().mockResolvedValue(undefined), findOne: jest.fn().mockResolvedValue(null) };
+    eventsGateway = { emitMessage: jest.fn(), emitMessageAck: jest.fn(), emitMessageRevoked: jest.fn() };
+    webhookService = { dispatch: jest.fn() };
+    // Mirrors the real HookManager contract (hook-manager.service.ts `execute`/`runHandlers`): resolves
+    // `{ continue, data }`, passing `data` through unchanged when no hooks are registered — exactly
+    // this unit test's environment. `mockResolvedValue(undefined)` would make handleInboundMessage's
+    // `.then(({ data }) => ...)` destructure throw, silently short-circuiting every path below the hook
+    // call via its trailing `.catch(err => this.logger.error(...))` — every assertion past that point
+    // would then fail for a reason unrelated to the behaviour under test.
+    hookManager = { execute: jest.fn((_event: string, data: unknown) => Promise.resolve({ continue: true, data })) };
+    statusStore = { ingest: jest.fn().mockResolvedValue({ row: {}, created: false }) };
+    lidResolver = { resolveSenderPhone: jest.fn().mockResolvedValue(null) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MessageProjector,
+        // Real EngineRegistry, not a mock: the liveness fences under test are exactly its
+        // identity semantics. Mirrors session.service.spec.ts.
+        EngineRegistry,
+        { provide: getRepositoryToken(Message, 'data'), useValue: messageRepository },
+        { provide: getRepositoryToken(Session, 'data'), useValue: sessionRepository },
+        { provide: EventsGateway, useValue: eventsGateway },
+        { provide: WebhookService, useValue: webhookService },
+        { provide: HookManager, useValue: hookManager },
+        { provide: StatusStoreService, useValue: statusStore },
+        { provide: SessionLidResolver, useValue: lidResolver },
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+      ],
+    }).compile();
+
+    projector = module.get<MessageProjector>(MessageProjector);
+    engines = module.get<EngineRegistry>(EngineRegistry);
+  });
+
+  describe('handleInboundMessage', () => {
+    it('drops the message when the engine is no longer the live one for the session', () => {
+      const retired = makeEngine();
+      const current = makeEngine();
+      engines.set(SESSION_ID, current);
+
+      projector.handleInboundMessage(SESSION_ID, retired, makeIncoming());
+
+      // The fence returns before ANY side effect, including the fire-and-forget lastActiveAt
+      // update and the message:received hook call themselves — both are invoked synchronously
+      // (their own resolution is async, but the call into the mock is not), so asserting on them
+      // here, without awaiting the microtask queue, is what actually exercises the fence: the
+      // persist/dispatch/emit assertions below would hold regardless of this fence, since nothing
+      // downstream of a promise `.then()` can run before this synchronous block finishes.
+      expect(sessionRepository.update).not.toHaveBeenCalled();
+      expect(hookManager.execute).not.toHaveBeenCalled();
+      expect(messageRepository.insert).not.toHaveBeenCalled();
+      expect(eventsGateway.emitMessage).not.toHaveBeenCalled();
+      expect(webhookService.dispatch).not.toHaveBeenCalled();
+    });
+
+    // handleInboundMessage (:114-140) has no `fromMe` gate of its own — only handleOwnSendEcho
+    // (:328-334) drops a non-fromMe event. In production this method is wired to the engine's
+    // inbound-only `message`/`onMessage` callback (session-engine-event-wiring.ts:102), which by
+    // contract never delivers a fromMe echo (the comment at :329-331 spells out why: message_create
+    // is the only event that fires for those). But nothing inside handleInboundMessage itself enforces
+    // that contract — a fromMe message handed to it is still projected as an ordinary inbound row,
+    // just tagged OUTGOING (:255). Pinning this down protects the refactor from silently adding (or
+    // removing) a fromMe drop that does not exist today.
+    it('has no fromMe gate: a fromMe event on the inbound path is still persisted, tagged OUTGOING', async () => {
+      const engine = makeEngine();
+      engines.set(SESSION_ID, engine);
+
+      projector.handleInboundMessage(SESSION_ID, engine, makeIncoming({ fromMe: true }));
+      // The projection continues on a promise chain; let the microtask queue drain.
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(messageRepository.insert).toHaveBeenCalledTimes(1);
+      expect(messageRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ direction: MessageDirection.OUTGOING }),
+      );
+      expect(eventsGateway.emitMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it('persists, broadcasts and dispatches a normal inbound message', async () => {
+      const engine = makeEngine();
+      engines.set(SESSION_ID, engine);
+
+      projector.handleInboundMessage(SESSION_ID, engine, makeIncoming());
+      // The projection continues on a promise chain; let the microtask queue drain.
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(messageRepository.insert).toHaveBeenCalledTimes(1);
+      expect(eventsGateway.emitMessage).toHaveBeenCalledTimes(1);
+      expect(webhookService.dispatch).toHaveBeenCalledTimes(1);
+      expect(sessionRepository.update).toHaveBeenCalledTimes(1);
+    });
+
+    it('routes a status broadcast to the status store instead of the message table', async () => {
+      const engine = makeEngine();
+      engines.set(SESSION_ID, engine);
+
+      projector.handleInboundMessage(SESSION_ID, engine, makeIncoming({ isStatusBroadcast: true }));
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(statusStore.ingest).toHaveBeenCalledTimes(1);
+      expect(messageRepository.insert).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
`MessageProjector` and `BaileysEvents` are two of the units the v0.12.4 decomposition left behind, and
neither had a spec of its own. Both were covered only indirectly — the projector through
`session.service.spec.ts`, the events delegate through `baileys.adapter.spec.ts` — so a projection
stage that returned early, or a mapper branch that stopped classifying a message type, could regress
without turning anything red.

This adds direct coverage for both. No production file changes.

## What is now pinned

`MessageProjector`: the stale-engine fence on the inbound path, the status-broadcast routing, the
outgoing-direction tagging, and the persist → broadcast → dispatch sequence with the dispatched event
name and arguments.

`BaileysEvents.mapMessage`: plain text, static location (including the name/address asymmetry — the
live variant carries neither), the omitted-media marker for image and document, sticker and
captioned-document classification, quoted-context resolution, and the orphan-quote case where
`contextInfo` carries no `stanzaId`.

## Every assertion was checked against a mutation

A green test proves nothing until the thing it guards is broken and the test is watched failing. Each
case here was verified that way, and doing so exposed six assertions that passed on first write yet
could not fail:

- A fence test that asserted only on effects occurring after an `await` hop stayed green with the
  fence deleted.
- A "no media" assertion could not distinguish a message correctly skipping the media branch from one
  that entered it, threw, and had the error swallowed by a `catch`. Fixed by making the forbidden
  path observable rather than silently absent.
- A live-location fixture asserted `description` was `undefined` against a source that was `undefined`
  either way. A negative assertion proves nothing unless the fixture supplies a value that must be
  ignored.
- Only two of the six arms of the media-type disjunction were exercised: deleting `stickerMessage`
  from it passed the entire 4,067-test suite.
- The quoted-context chain was covered for one of its seven arms.
- The inbound test never asserted direction, so tagging every inbound message as outgoing repo-wide
  stayed green.

All six are now mutation-sensitive.

## Verification

Backend suite 4,051 → 4,065. Lint, `tsc --noEmit` over the full program including specs, format check,
build, e2e and the OpenAPI snapshot check all pass. `openapi.json` is untouched.
