### PR TITLE
refactor(dashboard): move Infrastructure and Sessions state into custom hooks

### DIFF
--- a/dashboard/src/hooks/useConfigSave.ts
+++ b/dashboard/src/hooks/useConfigSave.ts
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { infraApi, type SaveConfigPayload } from '../services/api';
+import { useToast } from './useToast';
+
+export interface UseConfigSaveArgs {
+  buildPayload: () => SaveConfigPayload;
+  /** Called with the profile list from a successful save. One-way: this hook never reads restart state. */
+  onSaved: (profiles: string[]) => void;
+}
+
+export interface ConfigSave {
+  saving: boolean;
+  savePending: boolean;
+  saveConfig: () => Promise<void>;
+}
+
+/**
+ * Owns the save-configuration request: the in-flight `saving` flag, `savePending` (set once a save
+ * succeeds; only a full page reload from a completed restart clears it — see Infrastructure.tsx's
+ * envPinNote logic), and the two failure toasts. Hands the new profile list to `onSaved` instead of
+ * driving the restart modal directly, so the edge to the restart flow stays one-way.
+ */
+export function useConfigSave({ buildPayload, onSaved }: UseConfigSaveArgs): ConfigSave {
+  const { t } = useTranslation();
+  const toast = useToast();
+  const [saving, setSaving] = useState(false);
+  const [savePending, setSavePending] = useState(false);
+
+  const saveConfig = async () => {
+    setSaving(true);
+    try {
+      const result = await infraApi.saveConfig(buildPayload());
+      if (result.saved) {
+        setSavePending(true);
+        onSaved(result.profiles || []);
+      } else {
+        toast.error(t('infrastructure.toasts.saveFailed'), result.message);
+      }
+    } catch (err) {
+      toast.error(t('infrastructure.toasts.saveFailed'), err instanceof Error ? err.message : t('common.unknownError'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return { saving, savePending, saveConfig };
+}

--- a/dashboard/src/hooks/useDataBackup.ts
+++ b/dashboard/src/hooks/useDataBackup.ts
@@ -1,0 +1,114 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { infraApi } from '../services/api';
+import { useToast } from './useToast';
+
+export interface DataBackup {
+  migrating: boolean;
+  exportBackup: () => Promise<void>;
+  importBackup: (file: File) => Promise<void>;
+}
+
+/**
+ * Owns the data-migration flows used around a database/storage backend switch (#488): exporting a
+ * full JSON dump (call before switching, while still on the old backend) and importing one back
+ * (replaces all current data), including the 409 stop-orphans confirm/retry.
+ */
+export function useDataBackup(): DataBackup {
+  const { t } = useTranslation();
+  const toast = useToast();
+  const [migrating, setMigrating] = useState(false);
+
+  // Download a JSON backup of all Data-DB tables. Called BEFORE a DB switch (while still on the old
+  // database) so the data can be re-imported into the new one — switching otherwise starts empty (#488).
+  const exportBackup = async () => {
+    setMigrating(true);
+    try {
+      const dump = await infraApi.exportData();
+      const blob = new Blob([JSON.stringify(dump, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `openwa-backup-${dump.exportedAt?.slice(0, 10) || 'data'}.json`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      toast.error(
+        t('infrastructure.migration.exportFailed'),
+        err instanceof Error ? err.message : t('common.unknownError'),
+      );
+    } finally {
+      setMigrating(false);
+    }
+  };
+
+  // POST the replace-all restore and fold the backend's orphan-engine contract into the UI. A 409
+  // means live engines exist for sessions the backup would remove (the server message lists them);
+  // the contract's preferred retry is stopOrphans=true, which stops those engines inside the
+  // request, so offer it as a confirm. force=true is deliberately not offered (the api client does
+  // not even send it): it leaves the engines running until a restart.
+  const runImport = async (tables: Record<string, unknown[]>, stopOrphans = false): Promise<void> => {
+    try {
+      const res = await infraApi.importData(tables, stopOrphans ? { stopOrphans: true } : undefined);
+      if (res.imported) {
+        // notices carry non-fatal operator messages (orphan teardown details); restartRequired
+        // means a teardown failed and only a restart guarantees cleanup — surface both on success.
+        if (res.restartRequired || (res.notices && res.notices.length > 0)) {
+          toast.warning(t('infrastructure.migration.importOk'), (res.notices ?? []).join('; ') || undefined);
+        } else {
+          toast.success(t('infrastructure.migration.importOk'));
+        }
+      } else {
+        toast.error(
+          t('infrastructure.migration.importFailed'),
+          (res.warnings || []).slice(0, 3).join('; ') || res.message,
+        );
+      }
+    } catch (err) {
+      const status = (err as { status?: number } | null)?.status;
+      if (status === 409 && !stopOrphans && err instanceof Error) {
+        // The confirm doubles as the refusal display: OK retries with stopOrphans=true, Cancel
+        // leaves the engines (and the current data) untouched. A 409 on the retry itself (an
+        // engine started mid-import) falls through to the plain error toast — no confirm loop.
+        if (window.confirm(err.message)) await runImport(tables, true);
+        else toast.error(t('infrastructure.migration.importFailed'), err.message);
+        return;
+      }
+      // A large backup can exceed the request body cap (default 25mb) — give an actionable message
+      // instead of a bare "Payload Too Large". The status is carried on the Error by the api client.
+      const detail =
+        status === 413
+          ? t('infrastructure.migration.importTooLarge')
+          : err instanceof Error
+            ? err.message
+            : t('common.unknownError');
+      toast.error(t('infrastructure.migration.importFailed'), detail);
+    }
+  };
+
+  // Restore a previously-exported backup into the CURRENT database (use after switching + restart).
+  // Import REPLACES all current data, so validate + confirm (showing the row count) before any call.
+  const importBackup = async (file: File) => {
+    let parsed: { tables?: Record<string, unknown[]> };
+    try {
+      parsed = JSON.parse(await file.text()) as { tables?: Record<string, unknown[]> };
+    } catch {
+      toast.error(t('infrastructure.migration.importFailed'), t('infrastructure.migration.invalidFile'));
+      return;
+    }
+    if (!parsed?.tables || typeof parsed.tables !== 'object') {
+      toast.error(t('infrastructure.migration.importFailed'), t('infrastructure.migration.invalidFile'));
+      return;
+    }
+    const rows = Object.values(parsed.tables).reduce((n, a) => n + (Array.isArray(a) ? a.length : 0), 0);
+    if (!window.confirm(t('infrastructure.migration.importConfirm', { rows }))) return;
+    setMigrating(true);
+    try {
+      await runImport(parsed.tables);
+    } finally {
+      setMigrating(false);
+    }
+  };
+
+  return { migrating, exportBackup, importBackup };
+}

--- a/dashboard/src/hooks/useInfraConfigForm.ts
+++ b/dashboard/src/hooks/useInfraConfigForm.ts
@@ -1,0 +1,277 @@
+import { useEffect, useRef, useState } from 'react';
+import type { InfraStatus, SavedConfig, SaveConfigPayload } from '../services/api';
+
+export interface DatabaseConfig {
+  type: 'sqlite' | 'postgres';
+  builtIn: boolean;
+  host: string;
+  port: string;
+  username: string;
+  password: string;
+  database: string;
+  schema: string;
+  poolSize: number;
+  sslEnabled: boolean;
+  sslRejectUnauthorized: boolean;
+}
+
+export interface RedisConfig {
+  builtIn: boolean;
+  host: string;
+  port: string;
+  password: string;
+  connected: boolean;
+}
+
+export interface StorageConfig {
+  type: 'local' | 's3';
+  builtIn: boolean;
+  localPath: string;
+  s3Bucket: string;
+  s3Region: string;
+  s3AccessKey: string;
+  s3SecretKey: string;
+  s3Endpoint: string;
+}
+
+export interface EngineConfig {
+  type: string;
+  headless: boolean;
+  sessionDataPath: string;
+  browserArgs: string;
+}
+
+export interface InfraConfigForm {
+  dbConfig: DatabaseConfig;
+  redisConfig: RedisConfig;
+  storageConfig: StorageConfig;
+  engineConfig: EngineConfig;
+  redisEnabled: boolean;
+  queueEnabled: boolean;
+  setRedisEnabled: (enabled: boolean) => void;
+  setQueueEnabled: (enabled: boolean) => void;
+  /** For the LIVE redis.connected indicator only — not an editable form field. See Infrastructure.tsx. */
+  setRedisConnected: (connected: boolean) => void;
+  updateDbConfig: (key: keyof DatabaseConfig, value: string | number | boolean) => void;
+  updateRedisConfig: (key: keyof RedisConfig, value: string | boolean) => void;
+  updateStorageConfig: (key: keyof StorageConfig, value: string | boolean) => void;
+  updateEngineConfig: (key: keyof EngineConfig, value: string | boolean) => void;
+  buildSavePayload: () => SaveConfigPayload;
+}
+
+/**
+ * Owns the editable infrastructure form: dbConfig/redisConfig/storageConfig/engineConfig, the
+ * redis-enabled/queue-enabled toggles, and the hydration that seeds them from the two server
+ * sources (live /status + saved /config). Takes those two query results (plus the resolved current
+ * engine) as arguments rather than calling the query hooks itself — the page already holds them for
+ * its own loading/error early returns, and passing them in keeps this hook testable without a
+ * QueryClientProvider.
+ *
+ * `redisConfig.connected` and the page's `queueStats` are LIVE indicators, not editable form state —
+ * they are seeded by a separate effect that lives in the page (every refetch, not just once), and
+ * `setRedisConnected` is the narrow write-path that effect uses into this hook's redisConfig.
+ */
+export function useInfraConfigForm(
+  infraStatus: InfraStatus | undefined,
+  savedConfig: SavedConfig | undefined,
+  currentEngine: string,
+): InfraConfigForm {
+  const [dbConfig, setDbConfig] = useState<DatabaseConfig>({
+    type: 'sqlite',
+    builtIn: false,
+    host: 'localhost',
+    port: '5432',
+    username: 'postgres',
+    password: '',
+    database: 'openwa',
+    schema: 'public',
+    poolSize: 10,
+    sslEnabled: false,
+    sslRejectUnauthorized: true,
+  });
+
+  const [redisConfig, setRedisConfig] = useState<RedisConfig>({
+    builtIn: false,
+    host: 'localhost',
+    port: '6379',
+    password: '',
+    connected: false,
+  });
+
+  const [storageConfig, setStorageConfig] = useState<StorageConfig>({
+    type: 'local',
+    builtIn: false,
+    localPath: './data/media',
+    s3Bucket: '',
+    s3Region: 'ap-southeast-1',
+    s3AccessKey: '',
+    s3SecretKey: '',
+    s3Endpoint: '',
+  });
+
+  const [engineConfig, setEngineConfig] = useState<EngineConfig>({
+    type: 'whatsapp-web.js',
+    headless: true,
+    sessionDataPath: './data/sessions',
+    browserArgs: '--no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage --disable-gpu',
+  });
+
+  const [redisEnabled, setRedisEnabledState] = useState(false);
+  const [queueEnabled, setQueueEnabled] = useState(false);
+
+  // Whether the editable form has been seeded from the server once. After that, a background refetch
+  // (react-query refetchOnWindowFocus) must NOT re-seed the editable fields or it would wipe the
+  // operator's in-progress, unsaved edits. A successful save restarts → full page reload, re-arming it.
+  const formHydrated = useRef(false);
+
+  // The engine radio seeds ONCE from the running engine (which honours a real ENGINE_TYPE env override
+  // over the saved .env.generated value — see the effect below), then is never re-stamped by a background
+  // refetch. `engineTouched` additionally wins over a late first resolution: if the operator clicked a
+  // different engine before /engines/current resolved, the delayed seed must not revert their selection (#735).
+  const engineHydrated = useRef(false);
+  const engineTouched = useRef(false);
+
+  /** Whether engineConfig.type reflects a real value (seeded from the running engine or user-picked)
+   * rather than the useState default — the save payload omits `type` when it doesn't. */
+  const engineTypeKnown = (): boolean => engineHydrated.current || engineTouched.current;
+
+  // Seed the EDITABLE selections from live /status ONCE (the running selection), guarded so a refetch
+  // can't clobber an unsaved edit. These are also the badge sources, so on first paint they show what's
+  // actually running (#488 family).
+  useEffect(() => {
+    if (!infraStatus || formHydrated.current) return;
+    setDbConfig(prev => ({
+      ...prev,
+      type: (infraStatus.database.type as 'sqlite' | 'postgres') || 'sqlite',
+      host: infraStatus.database.host || 'localhost',
+      // builtIn reflects whether OpenWA's bundled container is actually running (live), not saved intent.
+      builtIn: infraStatus.database.builtIn,
+    }));
+    setRedisConfig(prev => ({
+      ...prev,
+      host: infraStatus.redis.host,
+      port: String(infraStatus.redis.port),
+      builtIn: infraStatus.redis.builtIn,
+    }));
+    setRedisEnabledState(infraStatus.redis.enabled);
+    setStorageConfig(prev => ({
+      ...prev,
+      type: infraStatus.storage.type,
+      localPath: infraStatus.storage.path || './uploads',
+      builtIn: infraStatus.storage.builtIn,
+    }));
+    setQueueEnabled(infraStatus.queue.enabled);
+  }, [infraStatus]);
+
+  // Hydrate the editable form from the saved config (data/.env.generated) ONCE — only the detail fields
+  // /status does not expose (username, pool size, SSL flags, S3 details, host/port). The "what's
+  // running" fields (type, redis enabled, storage type, built-in) are owned by the live /status effect
+  // above. Secrets are never returned, so their inputs stay empty; an empty submit preserves the stored
+  // secret on the backend (#226).
+  useEffect(() => {
+    if (!savedConfig || formHydrated.current) return;
+    // NOTE: builtIn for db/redis/storage is owned by the live /status effect above (it reflects the
+    // actually-running bundled container), so it is intentionally NOT set here from saved intent.
+    setDbConfig(prev => ({
+      ...prev,
+      host: savedConfig.database.host || prev.host,
+      port: savedConfig.database.port || prev.port,
+      username: savedConfig.database.username || prev.username,
+      database: savedConfig.database.database || prev.database,
+      schema: savedConfig.database.schema || prev.schema,
+      poolSize: savedConfig.database.poolSize,
+      sslEnabled: savedConfig.database.sslEnabled,
+      sslRejectUnauthorized: savedConfig.database.sslRejectUnauthorized,
+    }));
+    setRedisConfig(prev => ({
+      ...prev,
+      host: savedConfig.redis.host || prev.host,
+      port: savedConfig.redis.port || prev.port,
+    }));
+    setStorageConfig(prev => ({
+      ...prev,
+      localPath: savedConfig.storage.localPath || prev.localPath,
+      s3Bucket: savedConfig.storage.s3Bucket || prev.s3Bucket,
+      s3Region: savedConfig.storage.s3Region || prev.s3Region,
+      s3Endpoint: savedConfig.storage.s3Endpoint || prev.s3Endpoint,
+    }));
+    setEngineConfig(prev => ({
+      ...prev,
+      headless: savedConfig.engine.headless,
+      sessionDataPath: savedConfig.engine.sessionDataPath || prev.sessionDataPath,
+      browserArgs: savedConfig.engine.browserArgs || prev.browserArgs,
+    }));
+  }, [savedConfig]);
+
+  // Lock the editable form once both sources have seeded it, so later background refetches only refresh
+  // the live indicators above and never overwrite unsaved edits.
+  useEffect(() => {
+    if (infraStatus && savedConfig) formHydrated.current = true;
+  }, [infraStatus, savedConfig]);
+
+  // The active engine reflects what's actually running (honours a real-env ENGINE_TYPE override),
+  // so seed the selected radio from it rather than the saved .env.generated value — but only ONCE, and
+  // never after the operator has touched it. Without this guard a background refetch (or a late first
+  // resolution racing an early click) re-stamps the running engine over an in-progress selection (#735).
+  useEffect(() => {
+    if (!currentEngine || engineHydrated.current || engineTouched.current) return;
+    engineHydrated.current = true;
+    setEngineConfig(prev => (prev.type === currentEngine ? prev : { ...prev, type: currentEngine }));
+  }, [currentEngine]);
+
+  const updateDbConfig = (key: keyof DatabaseConfig, value: string | number | boolean) =>
+    setDbConfig(prev => ({ ...prev, [key]: value }));
+  const updateRedisConfig = (key: keyof RedisConfig, value: string | boolean) =>
+    setRedisConfig(prev => ({ ...prev, [key]: value }));
+  const updateStorageConfig = (key: keyof StorageConfig, value: string | boolean) =>
+    setStorageConfig(prev => ({ ...prev, [key]: value }));
+  const updateEngineConfig = (key: keyof EngineConfig, value: string | boolean) => {
+    if (key === 'type') engineTouched.current = true;
+    setEngineConfig(prev => ({ ...prev, [key]: value }));
+  };
+
+  // Disabling Redis also disables the queue, since queue processing depends on it.
+  const setRedisEnabled = (enabled: boolean) => {
+    setRedisEnabledState(enabled);
+    if (!enabled) setQueueEnabled(false);
+  };
+
+  const setRedisConnected = (connected: boolean) => setRedisConfig(prev => ({ ...prev, connected }));
+
+  const buildSavePayload = (): SaveConfigPayload => ({
+    database: { ...dbConfig },
+    // `connected` is runtime-only status, not persisted configuration. Keep it out of the
+    // whitelisted backend DTO so a valid dashboard save cannot be rejected as an unknown field.
+    redis: {
+      enabled: redisEnabled,
+      builtIn: redisConfig.builtIn,
+      host: redisConfig.host,
+      port: redisConfig.port,
+      password: redisConfig.password,
+    },
+    queue: { enabled: queueEnabled },
+    storage: { ...storageConfig },
+    // Only send `type` once we actually know it — either the radio seeded from the running engine
+    // or the operator picked one. If /engines/current never resolved (endpoint down), engineConfig.type
+    // still holds its useState default, and sending that would persist ENGINE_TYPE and silently flip
+    // the engine on the next restart. The backend treats an absent `type` as "leave ENGINE_TYPE alone".
+    engine: engineTypeKnown() ? { ...engineConfig } : { ...engineConfig, type: undefined },
+  });
+
+  return {
+    dbConfig,
+    redisConfig,
+    storageConfig,
+    engineConfig,
+    redisEnabled,
+    queueEnabled,
+    setRedisEnabled,
+    setQueueEnabled,
+    setRedisConnected,
+    updateDbConfig,
+    updateRedisConfig,
+    updateStorageConfig,
+    updateEngineConfig,
+    buildSavePayload,
+  };
+}

--- a/dashboard/src/hooks/useRestartFlow.ts
+++ b/dashboard/src/hooks/useRestartFlow.ts
@@ -46,7 +46,11 @@ export function useRestartFlow(): RestartFlow {
   const [dbSwitch, setDbSwitch] = useState(false);
   const [storageSwitch, setStorageSwitch] = useState(false);
 
-  const open = ({ profiles: newProfiles, dbSwitch: nextDbSwitch, storageSwitch: nextStorageSwitch }: RestartOpenRequest) => {
+  const open = ({
+    profiles: newProfiles,
+    dbSwitch: nextDbSwitch,
+    storageSwitch: nextStorageSwitch,
+  }: RestartOpenRequest) => {
     setProfiles(prev => ({ previous: prev.pending, pending: newProfiles }));
     setDbSwitch(nextDbSwitch);
     setStorageSwitch(nextStorageSwitch);

--- a/dashboard/src/hooks/useRestartFlow.ts
+++ b/dashboard/src/hooks/useRestartFlow.ts
@@ -1,0 +1,135 @@
+import { useState } from 'react';
+import { infraApi } from '../services/api';
+import { restartPollAttempts } from '../utils/restartPoll';
+
+export type RestartStatus = 'idle' | 'restarting' | 'waiting' | 'success' | 'error';
+
+export interface RestartOpenRequest {
+  profiles: string[];
+  dbSwitch: boolean;
+  storageSwitch: boolean;
+}
+
+export interface RestartFlow {
+  showRestartModal: boolean;
+  restartCountdown: number;
+  restartStatus: RestartStatus;
+  pendingProfiles: string[];
+  previousProfiles: string[];
+  dbSwitch: boolean;
+  storageSwitch: boolean;
+  open: (req: RestartOpenRequest) => void;
+  close: () => void;
+  start: () => void;
+}
+
+/**
+ * Owns the post-save restart modal: the show/countdown/status state machine, the pending/previous
+ * profile pair that drives `infraApi.restart(...)`, and the db/storage-switch flags the modal's
+ * data-loss warning reads (#488). `open()` is the single entry point a caller (the page's save
+ * `onSaved`) uses to hand over a fresh save result.
+ *
+ * The profile pair is one state object rotated by a single functional update, not two separate
+ * setters reading each other's render-scoped value — React StrictMode double-invokes updater
+ * functions, which would otherwise make the rotation order fragile.
+ */
+export function useRestartFlow(): RestartFlow {
+  const [showRestartModal, setShowRestartModal] = useState(false);
+  const [restartCountdown, setRestartCountdown] = useState(0);
+  const [restartStatus, setRestartStatus] = useState<RestartStatus>('idle');
+  const [profiles, setProfiles] = useState<{ pending: string[]; previous: string[] }>({
+    pending: [],
+    previous: [],
+  });
+  // Set when the just-saved config changes the DB or storage backend vs what's running, so the restart
+  // modal can warn that the new backend starts empty and offer a data backup before switching (#488).
+  const [dbSwitch, setDbSwitch] = useState(false);
+  const [storageSwitch, setStorageSwitch] = useState(false);
+
+  const open = ({ profiles: newProfiles, dbSwitch: nextDbSwitch, storageSwitch: nextStorageSwitch }: RestartOpenRequest) => {
+    setProfiles(prev => ({ previous: prev.pending, pending: newProfiles }));
+    setDbSwitch(nextDbSwitch);
+    setStorageSwitch(nextStorageSwitch);
+    setShowRestartModal(true);
+  };
+
+  // Dismissal is only offered in the idle state — while a restart is running there is deliberately
+  // no way to close the progress view. Shared by the modal's onClose and the "Later" button; both
+  // only ever fire while idle, since "Later" is rendered exclusively inside the idle branch.
+  const close = () => {
+    if (restartStatus === 'idle') setShowRestartModal(false);
+  };
+
+  const checkServerHealth = (stopCountdown?: () => void, estimatedTime?: number) => {
+    let attempts = 0;
+    const maxAttempts = restartPollAttempts(estimatedTime);
+
+    const check = async () => {
+      try {
+        await infraApi.healthCheck();
+        stopCountdown?.();
+        setRestartCountdown(0);
+        setRestartStatus('success');
+        setTimeout(() => window.location.reload(), 2000);
+      } catch {
+        attempts++;
+        if (attempts < maxAttempts) setTimeout(check, 1000);
+        else setRestartStatus('error');
+      }
+    };
+
+    setTimeout(check, 3000);
+  };
+
+  const start = async () => {
+    setRestartStatus('restarting');
+    setRestartCountdown(30);
+
+    const profilesToRemove = profiles.previous.filter(p => !profiles.pending.includes(p));
+
+    // Kept outside the try: the poll deadline is derived from it, and the restart call is expected to
+    // fail sometimes (the server may go down before it answers).
+    let estimatedTime: number | undefined;
+    try {
+      const response = await infraApi.restart(profiles.pending, profilesToRemove);
+      estimatedTime = response.estimatedTime;
+      if (response.estimatedTime) setRestartCountdown(response.estimatedTime);
+    } catch {
+      // Expected — server shutting down
+    }
+
+    setRestartStatus('waiting');
+    let intervalRef: ReturnType<typeof setInterval> | null = null;
+    const stopCountdown = () => {
+      if (intervalRef) {
+        clearInterval(intervalRef);
+        intervalRef = null;
+      }
+    };
+
+    intervalRef = setInterval(() => {
+      setRestartCountdown(prev => {
+        if (prev <= 1) {
+          stopCountdown();
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    checkServerHealth(stopCountdown, estimatedTime);
+  };
+
+  return {
+    showRestartModal,
+    restartCountdown,
+    restartStatus,
+    pendingProfiles: profiles.pending,
+    previousProfiles: profiles.previous,
+    dbSwitch,
+    storageSwitch,
+    open,
+    close,
+    start,
+  };
+}

--- a/dashboard/src/hooks/useSessionCreateForm.ts
+++ b/dashboard/src/hooks/useSessionCreateForm.ts
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { sessionApi, type Session } from '../services/api';
+import { useToast } from './useToast';
+
+export interface UseSessionCreateFormArgs {
+  onCreated: (session: Session) => void;
+  onFailed: (message: string) => void;
+}
+
+export interface SessionCreateForm {
+  showCreateModal: boolean;
+  setShowCreateModal: (open: boolean) => void;
+  newSessionName: string;
+  setNewSessionName: (name: string) => void;
+  creating: boolean;
+  handleCreate: () => Promise<void>;
+}
+
+/**
+ * Owns the "New Session" modal: its open/closed state, the typed name, and the in-flight `creating`
+ * flag. This is a separate feature from onboarding a session onto WhatsApp — `handleCreate` never
+ * touches `qrData`/pairing state and never opens the QR modal (that's `handleStart`/`handleShowQR`).
+ * Its only outward edges are the created `Session` and a failure message: the page owns appending to
+ * `sessions` and invalidating the shared query cache, so this hook stays independent of that state.
+ */
+export function useSessionCreateForm({ onCreated, onFailed }: UseSessionCreateFormArgs): SessionCreateForm {
+  const { t } = useTranslation();
+  const toast = useToast();
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [newSessionName, setNewSessionName] = useState('');
+  const [creating, setCreating] = useState(false);
+
+  const handleCreate = async () => {
+    if (!newSessionName.trim()) return;
+    try {
+      setCreating(true);
+      const newSession = await sessionApi.create(newSessionName);
+      setNewSessionName('');
+      setShowCreateModal(false);
+      toast.success(t('sessions.create.successTitle'), t('sessions.create.successDesc', { name: newSession.name }));
+      onCreated(newSession);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : t('sessions.create.errorDefault');
+      toast.error(t('sessions.create.errorTitle'), msg);
+      onFailed(msg);
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return { showCreateModal, setShowCreateModal, newSessionName, setNewSessionName, creating, handleCreate };
+}

--- a/dashboard/src/hooks/useSessionFeed.ts
+++ b/dashboard/src/hooks/useSessionFeed.ts
@@ -1,0 +1,89 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import type { RefObject } from 'react';
+import type { Session } from '../services/api';
+import { useWebSocket } from './useWebSocket';
+import { createSessionFeedState, noteSessionFeedError, subscribeSessionFeed } from '../utils/sessionFeedSubscription';
+
+export interface SessionFeed {
+  isConnected: boolean;
+}
+
+export interface UseSessionFeedArgs {
+  sessions: Session[];
+  sessionsRef: RefObject<Session[]>;
+  onQRCode: (event: { sessionId: string; qrCode: string }) => void;
+  onSessionStatus: (event: { sessionId: string; status: string }) => void;
+}
+
+/**
+ * Owns the ONE `useWebSocket` call for the Sessions page plus the live session-feed subscription
+ * (wildcard first, per-session fallback for scoped keys): `feedStateRef`, the transient
+ * `feedErrorFrame`, and the four effects that keep the subscription correct across connect/reconnect
+ * and roster changes. `useWebSocket` opens its own socket per call — a second call site anywhere else
+ * on this page would double every handshake, subscribe storm, and `session.status` toast.
+ *
+ * `onQRCode`/`onSessionStatus` are owned by the caller (the page), not this hook: reacting to a status
+ * push touches `sessions`/`selectedSession` state that lives in the page body (see the `useSessionList`
+ * rejection), so this hook only wires the callbacks through — it never mutates the session list itself.
+ */
+export function useSessionFeed({ sessions, sessionsRef, onQRCode, onSessionStatus }: UseSessionFeedArgs): SessionFeed {
+  // Live session-feed subscription state: wildcard first, per-session fallback for scoped keys.
+  const feedStateRef = useRef(createSessionFeedState());
+  // Most recent server error frame; folded into feedStateRef by the effect below (kept as state
+  // so the fallback runs after `subscribe` exists — the handler can't reference it directly).
+  const [feedErrorFrame, setFeedErrorFrame] = useState<{ code: string } | null>(null);
+
+  const { isConnected, subscribe } = useWebSocket({
+    onQRCode,
+    onSessionStatus,
+    onServerError: useCallback((frame: { code: string }) => {
+      setFeedErrorFrame(frame);
+    }, []),
+  });
+
+  // Fold a server error frame into the feed state: a session-scoped key may not join the '*'
+  // room — silently fall back to one subscription per listed session (the list endpoint is
+  // already scope-filtered server-side), otherwise no status/QR push ever arrives and the QR
+  // modal sits on "generating" forever.
+  useEffect(() => {
+    if (!feedErrorFrame) return;
+    if (noteSessionFeedError(feedStateRef.current, feedErrorFrame.code)) {
+      subscribeSessionFeed(
+        { subscribe },
+        feedStateRef.current,
+        sessionsRef.current.map(s => s.id),
+      );
+    }
+  }, [feedErrorFrame, subscribe, sessionsRef]);
+
+  // Join the live session feed (wildcard attempt, or per-session rooms after a scope fallback).
+  useEffect(() => {
+    if (isConnected) {
+      subscribeSessionFeed(
+        { subscribe },
+        feedStateRef.current,
+        sessionsRef.current.map(s => s.id),
+      );
+    }
+  }, [isConnected, subscribe, sessionsRef]);
+
+  // Rooms are per-socket on the backend: a reconnect lands on a fresh socket with no
+  // subscriptions, so the per-session dedup set must be forgotten or the join effect
+  // above would skip every already-listed id and no feed frame would arrive again.
+  useEffect(() => {
+    if (!isConnected) feedStateRef.current.subscribedIds.clear();
+  }, [isConnected]);
+
+  // In per-session mode, sessions loaded/created after the fallback still need their rooms.
+  useEffect(() => {
+    if (isConnected && feedStateRef.current.scope === 'per-session') {
+      subscribeSessionFeed(
+        { subscribe },
+        feedStateRef.current,
+        sessions.map(s => s.id),
+      );
+    }
+  }, [isConnected, sessions, subscribe]);
+
+  return { isConnected };
+}

--- a/dashboard/src/hooks/useSessionPairing.ts
+++ b/dashboard/src/hooks/useSessionPairing.ts
@@ -1,0 +1,210 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import type { RefObject } from 'react';
+import { useTranslation } from 'react-i18next';
+import { sessionApi, type Session } from '../services/api';
+import { isValidPairingPhone } from '../utils/sessionForm';
+
+export interface QrData {
+  sessionId: string;
+  sessionName: string;
+  qrCode: string;
+}
+
+export interface UseSessionPairingArgs {
+  sessions: Session[];
+  sessionsRef: RefObject<Session[]>;
+  reloadSessions: () => Promise<Session[]>;
+}
+
+export interface SessionPairing {
+  qrData: QrData | null;
+  pairingMode: boolean;
+  phoneNumber: string;
+  pairingCode: string | null;
+  requestingPairing: boolean;
+  pairingError: string | null;
+  setPhoneNumber: (value: string) => void;
+  selectPairingTab: (mode: boolean) => void;
+  handleChangeNumber: () => void;
+  handleGeneratePairingCode: () => Promise<void>;
+  handleShowQR: (id: string) => Promise<void>;
+  handleCloseQRModal: () => void;
+  applyQrPush: (event: { sessionId: string; qrCode: string }) => void;
+  dismissQrForSession: (sessionId: string) => void;
+}
+
+/**
+ * Owns the QR / pairing-code modal: the six state vars behind it, the poll-while-open effect, and
+ * the handlers that drive it. `phoneNumber`/`pairingCode`/`pairingError` live HERE rather than in an
+ * extracted panel component, because the panel renders only while `pairingMode` is true — a
+ * component that unmounts on every QR<->Phone tab toggle would discard whatever the operator had
+ * typed. `Sessions.test.ts` pins this exact case.
+ *
+ * `applyQrPush` and `dismissQrForSession` are both `useCallback(…, [])` built on the FUNCTIONAL
+ * `setQrData` form: reading `qrData` directly would make each a dependency of `applySessionResponse`
+ * (held by the page's stop/force-kill/unlink handlers), rotating its identity for a reason none of
+ * those callers care about.
+ */
+export function useSessionPairing({ sessions, sessionsRef, reloadSessions }: UseSessionPairingArgs): SessionPairing {
+  const { t } = useTranslation();
+  const [qrData, setQrData] = useState<QrData | null>(null);
+  const [pairingMode, setPairingMode] = useState(false);
+  const [phoneNumber, setPhoneNumber] = useState('');
+  const [pairingCode, setPairingCode] = useState<string | null>(null);
+  const [requestingPairing, setRequestingPairing] = useState(false);
+  const [pairingError, setPairingError] = useState<string | null>(null);
+
+  const qrRefreshInterval = useRef<ReturnType<typeof setInterval> | null>(null);
+  const currentSessionName = useRef<string>('');
+
+  const fetchQR = useCallback(
+    async (sessionId: string) => {
+      // Guard: if session is already connected, stop polling immediately. Read the ref (not `sessions`)
+      // so fetchQR keeps a stable identity — otherwise the polling interval is torn down and restarted on
+      // every sessions update.
+      const currentSession = sessionsRef.current.find(s => s.id === sessionId);
+      if (currentSession?.status === 'ready') {
+        setQrData(null);
+        currentSessionName.current = '';
+        return;
+      }
+      // Poll only while a QR actually exists to refresh (qr_ready): before that the endpoint 400s
+      // by design (the engine hasn't produced one), and the WS session.qr push covers first display.
+      if (currentSession?.status !== 'qr_ready') return;
+      try {
+        const qr = await sessionApi.getQR(sessionId);
+        setQrData({ sessionId, sessionName: currentSessionName.current, qrCode: qr.qrCode });
+        if (qr.status === 'ready') {
+          setQrData(null);
+          currentSessionName.current = '';
+          reloadSessions();
+        }
+      } catch {
+        // Keep qrData alive so the polling interval keeps retrying until the QR
+        // is ready. Only stop polling if the session itself has failed. 'authenticating' is included so
+        // the modal (and the pairing-code panel mounted in it) survives the brief post-link handshake
+        // instead of being torn down mid-pairing — it closes on the real 'ready'/'failed' transition.
+        const updated = await sessionApi.get(sessionId).catch(() => null);
+        const stillInitializing = updated && ['initializing', 'qr_ready', 'authenticating'].includes(updated.status);
+        if (!stillInitializing) {
+          setQrData(null);
+          currentSessionName.current = '';
+          reloadSessions();
+        }
+      }
+    },
+    [reloadSessions, sessionsRef],
+  );
+
+  useEffect(() => {
+    if (qrData) {
+      currentSessionName.current = qrData.sessionName;
+      qrRefreshInterval.current = setInterval(() => {
+        fetchQR(qrData.sessionId);
+      }, 5000);
+    }
+    return () => {
+      if (qrRefreshInterval.current) clearInterval(qrRefreshInterval.current);
+    };
+  }, [qrData, fetchQR]);
+
+  const handleCloseQRModal = useCallback(() => {
+    setQrData(null);
+    setPairingMode(false);
+    setPhoneNumber('');
+    setPairingCode(null);
+    setPairingError(null);
+  }, []);
+
+  // Shared by both pairing tabs: switching tabs always clears a stale error from the other tab.
+  const selectPairingTab = useCallback((mode: boolean) => {
+    setPairingMode(mode);
+    setPairingError(null);
+  }, []);
+
+  const handleChangeNumber = useCallback(() => {
+    setPairingCode(null);
+    setPhoneNumber('');
+  }, []);
+
+  const handleGeneratePairingCode = async () => {
+    // Guard against a second concurrent request: the button is disabled while in flight, but the
+    // input's Enter handler is not, so a rapid double-Enter would otherwise fire overlapping POSTs.
+    if (requestingPairing) return;
+    if (!qrData || !phoneNumber.trim()) return;
+    if (!isValidPairingPhone(phoneNumber)) {
+      setPairingError(t('sessions.pairing.invalidPhone'));
+      return;
+    }
+    try {
+      setRequestingPairing(true);
+      setPairingError(null);
+      const res = await sessionApi.requestPairingCode(qrData.sessionId, phoneNumber.trim());
+      setPairingCode(res.pairingCode);
+    } catch (err) {
+      setPairingError(err instanceof Error ? err.message : t('common.errorGeneric'));
+    } finally {
+      setRequestingPairing(false);
+    }
+  };
+
+  const handleShowQR = async (id: string) => {
+    const session = sessions.find(s => s.id === id);
+    // Nothing to show for an already-connected session.
+    if (session?.status === 'ready') return;
+    const sessionName = session?.name || '';
+    // Reset any pairing sub-state from a previous open so a freshly opened modal never shows a
+    // stale code/phone belonging to a different session.
+    setPairingMode(false);
+    setPhoneNumber('');
+    setPairingCode(null);
+    setPairingError(null);
+    // Show loading state immediately so the modal opens and polling starts
+    // even before Chromium has finished initializing.
+    setQrData({ sessionId: id, sessionName, qrCode: '' });
+    currentSessionName.current = sessionName;
+    // Eager-fetch only when a QR already exists (qr_ready): before that the endpoint 400s BY DESIGN
+    // (the engine hasn't produced one), and the WS session.qr push + gated 5s poll deliver it
+    // without spamming the console with expected failures.
+    if (session?.status === 'qr_ready') {
+      try {
+        const qr = await sessionApi.getQR(id);
+        setQrData({ sessionId: id, sessionName, qrCode: qr.qrCode });
+      } catch (err) {
+        console.error('Failed to get QR:', err);
+        // Do not clear qrData here — keep the loading modal open so the
+        // polling interval (every 5 s) retries until the QR becomes available.
+      }
+    }
+  };
+
+  // Fill the open QR modal straight from the push — the REST endpoint 400s BY DESIGN until a QR
+  // exists, so fetching it eagerly just spams the console with expected failures.
+  const applyQrPush = useCallback((event: { sessionId: string; qrCode: string }) => {
+    setQrData(prev => (prev && prev.sessionId === event.sessionId ? { ...prev, qrCode: event.qrCode } : prev));
+  }, []);
+
+  // Clear the modal when the session that owned it stops, so it never hangs on a disconnected
+  // session's stale code. Functional form deliberately: reading `qrData` here would make it a
+  // dependency everywhere this is held (the page's stop/force-kill/unlink handlers).
+  const dismissQrForSession = useCallback((sessionId: string) => {
+    setQrData(current => (current?.sessionId === sessionId ? null : current));
+  }, []);
+
+  return {
+    qrData,
+    pairingMode,
+    phoneNumber,
+    pairingCode,
+    requestingPairing,
+    pairingError,
+    setPhoneNumber,
+    selectPairingTab,
+    handleChangeNumber,
+    handleGeneratePairingCode,
+    handleShowQR,
+    handleCloseQRModal,
+    applyQrPush,
+    dismissQrForSession,
+  };
+}

--- a/dashboard/src/pages/Infrastructure.test.ts
+++ b/dashboard/src/pages/Infrastructure.test.ts
@@ -57,11 +57,22 @@ const SAVED_CONFIG: SavedConfig = {
   },
   // headless: false deliberately differs from the component's useState default (true) — asserting
   // it reads false is what proves this field came from /config, not from the initial state.
-  engine: { type: 'whatsapp-web.js', headless: false, sessionDataPath: '/data/custom-sessions', browserArgs: '--headless=new --custom-flag' },
+  engine: {
+    type: 'whatsapp-web.js',
+    headless: false,
+    sessionDataPath: '/data/custom-sessions',
+    browserArgs: '--headless=new --custom-flag',
+  },
 };
 
 const ENGINES: Engine[] = [
-  { id: 'whatsapp-web.js', name: 'WhatsApp Web (Puppeteer)', enabled: true, features: [], library: { name: 'whatsapp-web.js', version: '1.34.7' } },
+  {
+    id: 'whatsapp-web.js',
+    name: 'WhatsApp Web (Puppeteer)',
+    enabled: true,
+    features: [],
+    library: { name: 'whatsapp-web.js', version: '1.34.7' },
+  },
   { id: 'baileys', name: 'Baileys', enabled: true, features: [] },
 ];
 
@@ -117,7 +128,9 @@ function installFetchStub(): void {
     if (method === 'GET' && path === '/api/infra/engines') return Promise.resolve(jsonResponse(ENGINES));
     if (method === 'GET' && path === '/api/infra/engines/current') return Promise.resolve(jsonResponse(CURRENT_ENGINE));
     if (method === 'PUT' && path === '/api/infra/config') {
-      return Promise.resolve(jsonResponse({ message: 'Configuration saved', saved: true, envPath: '.env.generated', profiles: [] }));
+      return Promise.resolve(
+        jsonResponse({ message: 'Configuration saved', saved: true, envPath: '.env.generated', profiles: [] }),
+      );
     }
     if (method === 'POST' && path === '/api/infra/restart') {
       return Promise.resolve(
@@ -128,7 +141,9 @@ function installFetchStub(): void {
       return Promise.resolve(jsonResponse({ status: 'ok', details: {} }));
     }
     if (method === 'GET' && path === '/api/infra/export-data') {
-      return Promise.resolve(jsonResponse({ exportedAt: new Date(0).toISOString(), dataDbType: 'postgres', tables: {}, counts: {} }));
+      return Promise.resolve(
+        jsonResponse({ exportedAt: new Date(0).toISOString(), dataDbType: 'postgres', tables: {}, counts: {} }),
+      );
     }
     if (method === 'POST' && path === '/api/infra/import-data') {
       return Promise.resolve(jsonResponse({ imported: true, counts: {} }));

--- a/dashboard/src/pages/Infrastructure.test.ts
+++ b/dashboard/src/pages/Infrastructure.test.ts
@@ -1,0 +1,277 @@
+// Render smoke test for the Infrastructure page under the bare `node --test` runner. Mirrors
+// Chats.test.ts's harness: same providers, same fetch-stub-with-recorded-calls approach, same
+// loader hooks. This page could not be imported by the harness at all before this file existed —
+// it imports four SVG icons, and the loader only handled .css/.json/.tsx/.ts (see the `.svg`
+// branch added to vite-shim-hooks.mjs alongside this test).
+//
+// Providers: QueryClientProvider (four GET queries: status/config/engines/current-engine) →
+// RoleProvider (harmless here, kept for parity with App.tsx) → ToastProvider (useToast throws
+// without it). No Router — the page uses no router hooks.
+import '../test-helpers/register-hooks.ts';
+import { test, before, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createElement } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { InfraStatus, SavedConfig, Engine } from '../services/api';
+import type { installJsdomGlobals as installJsdomGlobalsFn } from '../test-helpers/jsdom.ts';
+
+// ── Fixtures + fetch stub ────────────────────────────────────────────────────
+
+// database.host is kept IDENTICAL between /status and /config on purpose: both the live-seed
+// effect (from infraStatus) and the saved-config hydrate effect write dbConfig.host, and which one
+// wins depends on which query settles last — a race this test does not want to pin. username,
+// database name, schema and pool size are written ONLY by the saved-config effect, so asserting on
+// those (not host) is what actually proves /config hydration without being timing-sensitive.
+const INFRA_STATUS: InfraStatus = {
+  database: { connected: true, type: 'postgres', host: 'shared-db-host', builtIn: false },
+  redis: { enabled: false, connected: false, host: 'localhost', port: 6379, builtIn: false },
+  queue: { enabled: false, webhooks: { pending: 0, completed: 0, failed: 0 } },
+  storage: { type: 'local', path: './data/media', builtIn: false },
+  engine: { type: 'whatsapp-web.js', headless: true },
+};
+
+const SAVED_CONFIG: SavedConfig = {
+  database: {
+    type: 'postgres',
+    builtIn: false,
+    host: 'shared-db-host',
+    port: '6543',
+    username: 'openwa_admin',
+    database: 'openwa_prod',
+    schema: 'appschema',
+    poolSize: 7,
+    sslEnabled: false,
+    sslRejectUnauthorized: true,
+    passwordSet: true,
+  },
+  redis: { enabled: false, builtIn: false, host: 'localhost', port: '6379', passwordSet: false },
+  queue: { enabled: false },
+  storage: {
+    type: 'local',
+    builtIn: false,
+    localPath: './data/media',
+    s3Bucket: '',
+    s3Region: 'ap-southeast-1',
+    s3Endpoint: '',
+    s3CredentialsSet: false,
+  },
+  // headless: false deliberately differs from the component's useState default (true) — asserting
+  // it reads false is what proves this field came from /config, not from the initial state.
+  engine: { type: 'whatsapp-web.js', headless: false, sessionDataPath: '/data/custom-sessions', browserArgs: '--headless=new --custom-flag' },
+};
+
+const ENGINES: Engine[] = [
+  { id: 'whatsapp-web.js', name: 'WhatsApp Web (Puppeteer)', enabled: true, features: [], library: { name: 'whatsapp-web.js', version: '1.34.7' } },
+  { id: 'baileys', name: 'Baileys', enabled: true, features: [] },
+];
+
+const CURRENT_ENGINE = { engineType: 'whatsapp-web.js' };
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+interface FetchCall {
+  method: string;
+  path: string;
+  body?: unknown;
+}
+
+const fetchCalls: FetchCall[] = [];
+
+function resetFetchCalls(): void {
+  fetchCalls.length = 0;
+}
+
+function findFetchCall(method: string, path: string): FetchCall | undefined {
+  return fetchCalls.find(c => c.method === method && c.path === path);
+}
+
+// URL router for every endpoint the page can hit. Anything else 404s loudly rather than resolving
+// into a confusing downstream failure.
+//
+// ⚠️ /api/health/ready is NOT under /api/infra — routing it on an /api/infra prefix would 404 it
+// and drop checkServerHealth into its up-to-60-attempt, 1s-interval poll. It is stubbed here for
+// completeness even though none of the three cases below drive the restart flow far enough to hit it.
+function installFetchStub(): void {
+  globalThis.fetch = (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+    const method = init?.method ?? 'GET';
+    const path = url.replace(/^https?:\/\/[^/]+/, '');
+
+    let body: unknown;
+    if (typeof init?.body === 'string') {
+      try {
+        body = JSON.parse(init.body);
+      } catch {
+        body = init.body;
+      }
+    }
+    fetchCalls.push({ method, path, body });
+
+    if (method === 'GET' && path === '/api/infra/status') return Promise.resolve(jsonResponse(INFRA_STATUS));
+    if (method === 'GET' && path === '/api/infra/config') return Promise.resolve(jsonResponse(SAVED_CONFIG));
+    if (method === 'GET' && path === '/api/infra/engines') return Promise.resolve(jsonResponse(ENGINES));
+    if (method === 'GET' && path === '/api/infra/engines/current') return Promise.resolve(jsonResponse(CURRENT_ENGINE));
+    if (method === 'PUT' && path === '/api/infra/config') {
+      return Promise.resolve(jsonResponse({ message: 'Configuration saved', saved: true, envPath: '.env.generated', profiles: [] }));
+    }
+    if (method === 'POST' && path === '/api/infra/restart') {
+      return Promise.resolve(
+        jsonResponse({ message: 'restarting', restarting: true, profiles: [], profilesToRemove: [], estimatedTime: 5 }),
+      );
+    }
+    if (method === 'GET' && path === '/api/health/ready') {
+      return Promise.resolve(jsonResponse({ status: 'ok', details: {} }));
+    }
+    if (method === 'GET' && path === '/api/infra/export-data') {
+      return Promise.resolve(jsonResponse({ exportedAt: new Date(0).toISOString(), dataDbType: 'postgres', tables: {}, counts: {} }));
+    }
+    if (method === 'POST' && path === '/api/infra/import-data') {
+      return Promise.resolve(jsonResponse({ imported: true, counts: {} }));
+    }
+    return Promise.resolve(jsonResponse({ message: `unstubbed ${method} ${path}` }, 404));
+  };
+}
+
+// ── DOM helpers ──────────────────────────────────────────────────────────────
+// The page's labels are plain siblings of their inputs (no htmlFor/id, no wrapping) — the DB/Redis/
+// Storage/Engine detail fields are NOT reachable via getByLabelText. These walk the same
+// .form-group / .toggle-row structure the page renders instead.
+
+function fieldInput(container: HTMLElement, labelText: string): HTMLInputElement {
+  const label = Array.from(container.querySelectorAll('.form-group > label')).find(l => l.textContent === labelText);
+  if (!label) throw new Error(`no field labeled "${labelText}"`);
+  const input = label.parentElement?.querySelector('input');
+  if (!input) throw new Error(`no input in the "${labelText}" field`);
+  return input as HTMLInputElement;
+}
+
+function toggleInput(container: HTMLElement, labelText: string): HTMLInputElement {
+  const span = Array.from(container.querySelectorAll('.toggle-info > span')).find(s => s.textContent === labelText);
+  if (!span) throw new Error(`no toggle labeled "${labelText}"`);
+  const input = span.closest('.toggle-row')?.querySelector('input[type="checkbox"]');
+  if (!input) throw new Error(`no checkbox for toggle "${labelText}"`);
+  return input as HTMLInputElement;
+}
+
+// ── Harness bootstrap ────────────────────────────────────────────────────────
+
+type RTL = typeof import('@testing-library/react');
+type InfrastructureModule = typeof import('./Infrastructure.tsx');
+type RoleModule = typeof import('../components/RoleProvider.tsx');
+type ToastModule = typeof import('../components/Toast.tsx');
+
+let rtl: RTL;
+let Infrastructure: InfrastructureModule['Infrastructure'];
+let RoleProvider: RoleModule['RoleProvider'];
+let ToastProvider: ToastModule['ToastProvider'];
+let installJsdomGlobals: typeof installJsdomGlobalsFn;
+let queryClient: QueryClient | undefined;
+
+before(async () => {
+  ({ installJsdomGlobals } = await import('../test-helpers/jsdom.ts'));
+  await installJsdomGlobals();
+  installFetchStub();
+  await import('../i18n/index.ts');
+  rtl = await import('@testing-library/react');
+  ({ RoleProvider } = await import('../components/RoleProvider.tsx'));
+  ({ ToastProvider } = await import('../components/Toast.tsx'));
+  ({ Infrastructure } = await import('./Infrastructure.tsx'));
+});
+
+afterEach(() => {
+  rtl.cleanup();
+  queryClient?.clear();
+  queryClient = undefined;
+});
+
+function renderInfrastructure(): { container: HTMLElement } {
+  queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 1_000 } } });
+  return rtl.render(
+    createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      createElement(RoleProvider, null, createElement(ToastProvider, null, createElement(Infrastructure))),
+    ),
+  );
+}
+
+// ── Smoke tests ──────────────────────────────────────────────────────────────
+
+test('Infrastructure renders and the config form hydrates from /status and /config', async () => {
+  const { screen, waitFor } = rtl;
+  resetFetchCalls();
+  const { container } = renderInfrastructure();
+
+  await screen.findByText('Database Configuration');
+
+  await waitFor(() => {
+    // dbConfig.type comes ONLY from /status (the live-seed effect) — sqlite is the useState default,
+    // so a checked Postgres radio here proves /status actually hydrated the form.
+    const dbRadios = container.querySelectorAll('input[name="dbType"]');
+    assert.equal((dbRadios[1] as HTMLInputElement).checked, true, 'expected the Postgres radio to be selected');
+
+    // These fields are written ONLY by the saved-config hydrate effect (never by the /status
+    // effect), so they pin /config hydration specifically, without the host/port race.
+    assert.equal(fieldInput(container, 'Username').value, 'openwa_admin');
+    assert.equal(fieldInput(container, 'Database Name').value, 'openwa_prod');
+    assert.equal(fieldInput(container, 'Schema').value, 'appschema');
+    assert.equal(fieldInput(container, 'Pool Size').value, '7');
+
+    // Engine detail fields are also /config-only; headless flips the useState default (true) to
+    // false, so a false checkbox proves hydration rather than an untouched default.
+    assert.equal(toggleInput(container, 'Headless Mode').checked, false);
+    assert.equal(fieldInput(container, 'Session Data Path').value, '/data/custom-sessions');
+    assert.equal(fieldInput(container, 'Browser Arguments').value, '--headless=new --custom-flag');
+  });
+});
+
+test('editing a database field and saving PUTs the edited value in the request body', async () => {
+  const { screen, waitFor, fireEvent } = rtl;
+  resetFetchCalls();
+  const { container } = renderInfrastructure();
+
+  await screen.findByText('Database Configuration');
+  // Wait for the postgres detail form (and its Host field) to actually be present before editing it.
+  await waitFor(() => assert.equal(fieldInput(container, 'Username').value, 'openwa_admin'));
+
+  const hostInput = fieldInput(container, 'Host');
+  fireEvent.change(hostInput, { target: { value: 'edited-host.example.com' } });
+  assert.equal(hostInput.value, 'edited-host.example.com');
+
+  fireEvent.click(screen.getByRole('button', { name: 'Save Configuration' }));
+
+  // The optimistic DOM value alone would pass even if the PUT body were wrong — assert the wire call.
+  await waitFor(() => {
+    const call = findFetchCall('PUT', '/api/infra/config');
+    assert.ok(call, 'expected a PUT to /infra/config');
+    const body = call!.body as { database?: { host?: string } };
+    assert.equal(body.database?.host, 'edited-host.example.com');
+  });
+});
+
+test('a successful save opens the restart modal', async () => {
+  const { screen, waitFor, fireEvent, within } = rtl;
+  resetFetchCalls();
+  renderInfrastructure();
+
+  await screen.findByText('Database Configuration');
+  const saveButton = await screen.findByRole('button', { name: 'Save Configuration' });
+  fireEvent.click(saveButton);
+
+  await waitFor(() => {
+    const call = findFetchCall('PUT', '/api/infra/config');
+    assert.ok(call, 'expected the save to have PUT /infra/config');
+  });
+
+  const dialog = await screen.findByRole('dialog');
+  within(dialog).getByText('Configuration saved');
+  // The idle restart state offers both actions; asserting the button exists (not clicking it) keeps
+  // this test clear of handleRestart's uncancelled setInterval/setTimeout chain.
+  within(dialog).getByRole('button', { name: 'Restart Now' });
+  within(dialog).getByRole('button', { name: 'Restart Later' });
+});

--- a/dashboard/src/pages/Infrastructure.tsx
+++ b/dashboard/src/pages/Infrastructure.tsx
@@ -57,9 +57,11 @@ export function Infrastructure() {
   const configSave = useConfigSave({
     buildPayload: configForm.buildSavePayload,
     onSaved: profiles => {
-      // Scope: this warns on a backend-TYPE change (local↔s3) and a built-in↔external flip — the cases
-      // that point at a different store. It does NOT warn on same-backend repointing (e.g. a new S3
-      // bucket/endpoint or a new local path); region/endpoint aren't on /status to compare reliably.
+      // Flag a backend switch vs what's actually running so the restart modal can warn about the
+      // empty-database / orphaned-media data move before it happens. A switch is: changing type;
+      // flipping built-in↔external (different physical backend); OR retargeting an external Postgres
+      // to a different host/port/database (also a different, empty DB). Host/port/db aren't all in
+      // /status, so compare the edited form against the still-cached saved config.
       const dbExternalRetarget =
         configForm.dbConfig.type === 'postgres' &&
         !configForm.dbConfig.builtIn &&
@@ -72,6 +74,9 @@ export function Infrastructure() {
         (configForm.dbConfig.type !== infraStatus.database.type ||
           (configForm.dbConfig.type === 'postgres' && configForm.dbConfig.builtIn !== infraStatus.database.builtIn) ||
           dbExternalRetarget);
+      // Scope: this warns on a backend-TYPE change (local↔s3) and a built-in↔external flip — the cases
+      // that point at a different store. It does NOT warn on same-backend repointing (e.g. a new S3
+      // bucket/endpoint or a new local path); region/endpoint aren't on /status to compare reliably.
       const storageSwitch =
         !!infraStatus &&
         (configForm.storageConfig.type !== infraStatus.storage.type ||

--- a/dashboard/src/pages/Infrastructure.tsx
+++ b/dashboard/src/pages/Infrastructure.tsx
@@ -123,9 +123,15 @@ export function Infrastructure() {
   // host/.env environment variable, which wins at runtime — so a dashboard change to it won't apply
   // until that variable is unset. Surface that honestly instead of letting the control look effective.
   const dbPinnedByEnv =
-    !configSave.savePending && !!infraStatus && !!savedConfig && infraStatus.database.type !== savedConfig.database.type;
+    !configSave.savePending &&
+    !!infraStatus &&
+    !!savedConfig &&
+    infraStatus.database.type !== savedConfig.database.type;
   const redisPinnedByEnv =
-    !configSave.savePending && !!infraStatus && !!savedConfig && infraStatus.redis.enabled !== savedConfig.redis.enabled;
+    !configSave.savePending &&
+    !!infraStatus &&
+    !!savedConfig &&
+    infraStatus.redis.enabled !== savedConfig.redis.enabled;
   const storagePinnedByEnv =
     !configSave.savePending && !!infraStatus && !!savedConfig && infraStatus.storage.type !== savedConfig.storage.type;
   const envPinNote = (pinned: boolean) =>
@@ -317,7 +323,11 @@ export function Infrastructure() {
               <small>{t('infrastructure.migration.backupHint')}</small>
             </div>
             <div className="data-migration-actions">
-              <button className="btn-secondary btn-sm" onClick={dataBackup.exportBackup} disabled={dataBackup.migrating}>
+              <button
+                className="btn-secondary btn-sm"
+                onClick={dataBackup.exportBackup}
+                disabled={dataBackup.migrating}
+              >
                 {dataBackup.migrating ? <Loader2 size={14} className="animate-spin" /> : <Download size={14} />}
                 {t('infrastructure.migration.export')}
               </button>
@@ -605,7 +615,8 @@ export function Infrastructure() {
               // S3 selected but the backend isn't reachable → warn instead of a misleading green.
               const s3Unreachable =
                 configForm.storageConfig.type === 's3' && infraStatus?.storage.s3Available === false;
-              const cls = configForm.storageConfig.type !== 's3' ? 'sqlite' : s3Unreachable ? 'disconnected' : 'connected';
+              const cls =
+                configForm.storageConfig.type !== 's3' ? 'sqlite' : s3Unreachable ? 'disconnected' : 'connected';
               return (
                 <span className={`status-indicator ${cls}`}>
                   ●{' '}
@@ -764,11 +775,7 @@ export function Infrastructure() {
                         onClick={dataBackup.exportBackup}
                         disabled={dataBackup.migrating}
                       >
-                        {dataBackup.migrating ? (
-                          <Loader2 size={14} className="animate-spin" />
-                        ) : (
-                          <Download size={14} />
-                        )}
+                        {dataBackup.migrating ? <Loader2 size={14} className="animate-spin" /> : <Download size={14} />}
                         {t('infrastructure.migration.downloadBackup')}
                       </button>
                     )}
@@ -801,7 +808,9 @@ export function Infrastructure() {
                   className="restart-progress-fill"
                   style={{
                     width:
-                      restartFlow.restartCountdown > 0 ? `${((30 - restartFlow.restartCountdown) / 30) * 100}%` : '100%',
+                      restartFlow.restartCountdown > 0
+                        ? `${((30 - restartFlow.restartCountdown) / 30) * 100}%`
+                        : '100%',
                   }}
                 />
               </div>

--- a/dashboard/src/pages/Infrastructure.tsx
+++ b/dashboard/src/pages/Infrastructure.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import {
   Database,
@@ -13,11 +13,14 @@ import {
   Download,
   Upload,
 } from 'lucide-react';
-import { infraApi, API_BASE_URL } from '../services/api';
+import { API_BASE_URL } from '../services/api';
 import { copyToClipboard } from '../utils/clipboard';
-import { restartPollAttempts } from '../utils/restartPoll';
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { useInfraStatusQuery, useInfraConfigQuery, useEnginesQuery, useCurrentEngineQuery } from '../hooks/queries';
+import { useInfraConfigForm } from '../hooks/useInfraConfigForm';
+import { useConfigSave } from '../hooks/useConfigSave';
+import { useRestartFlow } from '../hooks/useRestartFlow';
+import { useDataBackup } from '../hooks/useDataBackup';
 import { PageHeader } from '../components/PageHeader';
 import { Modal } from '../components/Modal';
 import { useToast } from '../hooks/useToast';
@@ -27,46 +30,6 @@ import sqliteIcon from '../assets/icons/sqlite.svg';
 import postgresIcon from '../assets/icons/postgresql.svg';
 import folderIcon from '../assets/icons/folder.svg';
 import s3Icon from '../assets/icons/s3.svg';
-
-interface DatabaseConfig {
-  type: 'sqlite' | 'postgres';
-  builtIn: boolean;
-  host: string;
-  port: string;
-  username: string;
-  password: string;
-  database: string;
-  schema: string;
-  poolSize: number;
-  sslEnabled: boolean;
-  sslRejectUnauthorized: boolean;
-}
-
-interface RedisConfig {
-  builtIn: boolean;
-  host: string;
-  port: string;
-  password: string;
-  connected: boolean;
-}
-
-interface StorageConfig {
-  type: 'local' | 's3';
-  builtIn: boolean;
-  localPath: string;
-  s3Bucket: string;
-  s3Region: string;
-  s3AccessKey: string;
-  s3SecretKey: string;
-  s3Endpoint: string;
-}
-
-interface EngineConfig {
-  type: string;
-  headless: boolean;
-  sessionDataPath: string;
-  browserArgs: string;
-}
 
 interface QueueStats {
   pending: number;
@@ -83,175 +46,52 @@ export function Infrastructure() {
   const { data: engines = [] } = useEnginesQuery();
   const { data: currentEngineData } = useCurrentEngineQuery();
   const currentEngine = currentEngineData?.engineType ?? '';
-  const [saving, setSaving] = useState(false);
-  const [showRestartModal, setShowRestartModal] = useState(false);
-  const [restartCountdown, setRestartCountdown] = useState(0);
-  const [restartStatus, setRestartStatus] = useState<'idle' | 'restarting' | 'waiting' | 'success' | 'error'>('idle');
 
-  const [dbConfig, setDbConfig] = useState<DatabaseConfig>({
-    type: 'sqlite',
-    builtIn: false,
-    host: 'localhost',
-    port: '5432',
-    username: 'postgres',
-    password: '',
-    database: 'openwa',
-    schema: 'public',
-    poolSize: 10,
-    sslEnabled: false,
-    sslRejectUnauthorized: true,
-  });
+  const configForm = useInfraConfigForm(infraStatus, savedConfig, currentEngine);
+  const restartFlow = useRestartFlow();
+  const dataBackup = useDataBackup();
 
-  const [redisConfig, setRedisConfig] = useState<RedisConfig>({
-    builtIn: false,
-    host: 'localhost',
-    port: '6379',
-    password: '',
-    connected: false,
-  });
-
-  const [storageConfig, setStorageConfig] = useState<StorageConfig>({
-    type: 'local',
-    builtIn: false,
-    localPath: './data/media',
-    s3Bucket: '',
-    s3Region: 'ap-southeast-1',
-    s3AccessKey: '',
-    s3SecretKey: '',
-    s3Endpoint: '',
+  // Reads dbConfig/storageConfig (from configForm) plus infraStatus/savedConfig to decide whether the
+  // just-saved config crosses to a different backend, then hands the restart flow everything it needs
+  // to open — the one-way edge between the save and restart hooks.
+  const configSave = useConfigSave({
+    buildPayload: configForm.buildSavePayload,
+    onSaved: profiles => {
+      // Scope: this warns on a backend-TYPE change (local↔s3) and a built-in↔external flip — the cases
+      // that point at a different store. It does NOT warn on same-backend repointing (e.g. a new S3
+      // bucket/endpoint or a new local path); region/endpoint aren't on /status to compare reliably.
+      const dbExternalRetarget =
+        configForm.dbConfig.type === 'postgres' &&
+        !configForm.dbConfig.builtIn &&
+        !!savedConfig &&
+        (configForm.dbConfig.host !== savedConfig.database.host ||
+          configForm.dbConfig.port !== savedConfig.database.port ||
+          configForm.dbConfig.database !== savedConfig.database.database);
+      const dbSwitch =
+        !!infraStatus &&
+        (configForm.dbConfig.type !== infraStatus.database.type ||
+          (configForm.dbConfig.type === 'postgres' && configForm.dbConfig.builtIn !== infraStatus.database.builtIn) ||
+          dbExternalRetarget);
+      const storageSwitch =
+        !!infraStatus &&
+        (configForm.storageConfig.type !== infraStatus.storage.type ||
+          (configForm.storageConfig.type === 's3' && configForm.storageConfig.builtIn !== infraStatus.storage.builtIn));
+      restartFlow.open({ profiles, dbSwitch, storageSwitch });
+    },
   });
 
   const [queueStats, setQueueStats] = useState({
     webhooks: { pending: 0, completed: 0, failed: 0 } as QueueStats,
   });
 
-  const [engineConfig, setEngineConfig] = useState<EngineConfig>({
-    type: 'whatsapp-web.js',
-    headless: true,
-    sessionDataPath: './data/sessions',
-    browserArgs: '--no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage --disable-gpu',
-  });
-
-  const [redisEnabled, setRedisEnabled] = useState(false);
-  const [queueEnabled, setQueueEnabled] = useState(false);
-  const [pendingProfiles, setPendingProfiles] = useState<string[]>([]);
-  const [previousProfiles, setPreviousProfiles] = useState<string[]>([]);
-  // Set when the just-saved config changes the DB or storage backend vs what's running, so the restart
-  // modal can warn that the new backend starts empty and offer a data backup before switching (#488).
-  const [dbSwitch, setDbSwitch] = useState(false);
-  const [storageSwitch, setStorageSwitch] = useState(false);
-  const [migrating, setMigrating] = useState(false);
-  // After a successful save (before the restart reloads the page), /config holds the new value but
-  // /status still holds the old one — so suppress the "pinned by environment" note, which infers a pin
-  // from exactly that divergence and would otherwise mislabel a pending change.
-  const [savePending, setSavePending] = useState(false);
-
-  // Whether the editable form has been seeded from the server once. After that, a background refetch
-  // (react-query refetchOnWindowFocus) must NOT re-seed the editable fields or it would wipe the
-  // operator's in-progress, unsaved edits. A successful save restarts → full page reload, re-arming it.
-  const formHydrated = useRef(false);
-
-  // The engine radio seeds ONCE from the running engine (which honours a real ENGINE_TYPE env override
-  // over the saved .env.generated value — see the effect below), then is never re-stamped by a background
-  // refetch. `engineTouched` additionally wins over a late first resolution: if the operator clicked a
-  // different engine before /engines/current resolved, the delayed seed must not revert their selection (#735).
-  const engineHydrated = useRef(false);
-  const engineTouched = useRef(false);
-
-  /** Whether engineConfig.type reflects a real value (seeded from the running engine or user-picked)
-   * rather than the useState default — the save payload omits `type` when it doesn't. */
-  const engineTypeKnown = (): boolean => engineHydrated.current || engineTouched.current;
-
   // LIVE indicators (not editable) — always reflect the running process, every refetch.
   useEffect(() => {
     if (!infraStatus) return;
-    setRedisConfig(prev => ({ ...prev, connected: infraStatus.redis.connected }));
+    configForm.setRedisConnected(infraStatus.redis.connected);
     setQueueStats({ webhooks: infraStatus.queue.webhooks });
+    // configForm is a fresh object every render; only infraStatus identity should re-arm this effect.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [infraStatus]);
-
-  // Seed the EDITABLE selections from live /status ONCE (the running selection), guarded so a refetch
-  // can't clobber an unsaved edit. These are also the badge sources, so on first paint they show what's
-  // actually running (#488 family).
-  useEffect(() => {
-    if (!infraStatus || formHydrated.current) return;
-    setDbConfig(prev => ({
-      ...prev,
-      type: (infraStatus.database.type as 'sqlite' | 'postgres') || 'sqlite',
-      host: infraStatus.database.host || 'localhost',
-      // builtIn reflects whether OpenWA's bundled container is actually running (live), not saved intent.
-      builtIn: infraStatus.database.builtIn,
-    }));
-    setRedisConfig(prev => ({
-      ...prev,
-      host: infraStatus.redis.host,
-      port: String(infraStatus.redis.port),
-      builtIn: infraStatus.redis.builtIn,
-    }));
-    setRedisEnabled(infraStatus.redis.enabled);
-    setStorageConfig(prev => ({
-      ...prev,
-      type: infraStatus.storage.type,
-      localPath: infraStatus.storage.path || './uploads',
-      builtIn: infraStatus.storage.builtIn,
-    }));
-    setQueueEnabled(infraStatus.queue.enabled);
-  }, [infraStatus]);
-
-  // Hydrate the editable form from the saved config (data/.env.generated) ONCE — only the detail fields
-  // /status does not expose (username, pool size, SSL flags, S3 details, host/port). The "what's
-  // running" fields (type, redis enabled, storage type, built-in) are owned by the live /status effect
-  // above. Secrets are never returned, so their inputs stay empty; an empty submit preserves the stored
-  // secret on the backend (#226).
-  useEffect(() => {
-    if (!savedConfig || formHydrated.current) return;
-    // NOTE: builtIn for db/redis/storage is owned by the live /status effect above (it reflects the
-    // actually-running bundled container), so it is intentionally NOT set here from saved intent.
-    setDbConfig(prev => ({
-      ...prev,
-      host: savedConfig.database.host || prev.host,
-      port: savedConfig.database.port || prev.port,
-      username: savedConfig.database.username || prev.username,
-      database: savedConfig.database.database || prev.database,
-      schema: savedConfig.database.schema || prev.schema,
-      poolSize: savedConfig.database.poolSize,
-      sslEnabled: savedConfig.database.sslEnabled,
-      sslRejectUnauthorized: savedConfig.database.sslRejectUnauthorized,
-    }));
-    setRedisConfig(prev => ({
-      ...prev,
-      host: savedConfig.redis.host || prev.host,
-      port: savedConfig.redis.port || prev.port,
-    }));
-    setStorageConfig(prev => ({
-      ...prev,
-      localPath: savedConfig.storage.localPath || prev.localPath,
-      s3Bucket: savedConfig.storage.s3Bucket || prev.s3Bucket,
-      s3Region: savedConfig.storage.s3Region || prev.s3Region,
-      s3Endpoint: savedConfig.storage.s3Endpoint || prev.s3Endpoint,
-    }));
-    setEngineConfig(prev => ({
-      ...prev,
-      headless: savedConfig.engine.headless,
-      sessionDataPath: savedConfig.engine.sessionDataPath || prev.sessionDataPath,
-      browserArgs: savedConfig.engine.browserArgs || prev.browserArgs,
-    }));
-  }, [savedConfig]);
-
-  // Lock the editable form once both sources have seeded it, so later background refetches only refresh
-  // the live indicators above and never overwrite unsaved edits.
-  useEffect(() => {
-    if (infraStatus && savedConfig) formHydrated.current = true;
-  }, [infraStatus, savedConfig]);
-
-  // The active engine reflects what's actually running (honours a real-env ENGINE_TYPE override),
-  // so seed the selected radio from it rather than the saved .env.generated value — but only ONCE, and
-  // never after the operator has touched it. Without this guard a background refetch (or a late first
-  // resolution racing an early click) re-stamps the running engine over an in-progress selection (#735).
-  useEffect(() => {
-    if (!currentEngine || engineHydrated.current || engineTouched.current) return;
-    engineHydrated.current = true;
-    setEngineConfig(prev => (prev.type === currentEngine ? prev : { ...prev, type: currentEngine }));
-  }, [currentEngine]);
 
   if (loading) {
     return (
@@ -279,242 +119,15 @@ export function Infrastructure() {
     );
   }
 
-  const updateDbConfig = (key: keyof DatabaseConfig, value: string | number | boolean) =>
-    setDbConfig(prev => ({ ...prev, [key]: value }));
-  const updateRedisConfig = (key: keyof RedisConfig, value: string | boolean) =>
-    setRedisConfig(prev => ({ ...prev, [key]: value }));
-  const updateStorageConfig = (key: keyof StorageConfig, value: string | boolean) =>
-    setStorageConfig(prev => ({ ...prev, [key]: value }));
-  const updateEngineConfig = (key: keyof EngineConfig, value: string | boolean) => {
-    if (key === 'type') engineTouched.current = true;
-    setEngineConfig(prev => ({ ...prev, [key]: value }));
-  };
-
-  const handleSaveConfig = async () => {
-    setSaving(true);
-    try {
-      const payload = {
-        database: { ...dbConfig },
-        // `connected` is runtime-only status, not persisted configuration. Keep it out of the
-        // whitelisted backend DTO so a valid dashboard save cannot be rejected as an unknown field.
-        redis: {
-          enabled: redisEnabled,
-          builtIn: redisConfig.builtIn,
-          host: redisConfig.host,
-          port: redisConfig.port,
-          password: redisConfig.password,
-        },
-        queue: { enabled: queueEnabled },
-        storage: { ...storageConfig },
-        // Only send `type` once we actually know it — either the radio seeded from the running engine
-        // or the operator picked one. If /engines/current never resolved (endpoint down), engineConfig.type
-        // still holds its useState default, and sending that would persist ENGINE_TYPE and silently flip
-        // the engine on the next restart. The backend treats an absent `type` as "leave ENGINE_TYPE alone".
-        engine: engineTypeKnown() ? { ...engineConfig } : { ...engineConfig, type: undefined },
-      };
-
-      const result = await infraApi.saveConfig(payload);
-      if (result.saved) {
-        setSavePending(true);
-        setPreviousProfiles(pendingProfiles);
-        setPendingProfiles(result.profiles || []);
-        // Flag a backend switch vs what's actually running so the restart modal can warn about the
-        // empty-database / orphaned-media data move before it happens. A switch is: changing type;
-        // flipping built-in↔external (different physical backend); OR retargeting an external Postgres
-        // to a different host/port/database (also a different, empty DB). Host/port/db aren't all in
-        // /status, so compare the edited form against the still-cached saved config.
-        const dbExternalRetarget =
-          dbConfig.type === 'postgres' &&
-          !dbConfig.builtIn &&
-          !!savedConfig &&
-          (dbConfig.host !== savedConfig.database.host ||
-            dbConfig.port !== savedConfig.database.port ||
-            dbConfig.database !== savedConfig.database.database);
-        setDbSwitch(
-          !!infraStatus &&
-            (dbConfig.type !== infraStatus.database.type ||
-              (dbConfig.type === 'postgres' && dbConfig.builtIn !== infraStatus.database.builtIn) ||
-              dbExternalRetarget),
-        );
-        // Scope: this warns on a backend-TYPE change (local↔s3) and a built-in↔external flip — the cases
-        // that point at a different store. It does NOT warn on same-backend repointing (e.g. a new S3
-        // bucket/endpoint or a new local path); region/endpoint aren't on /status to compare reliably.
-        setStorageSwitch(
-          !!infraStatus &&
-            (storageConfig.type !== infraStatus.storage.type ||
-              (storageConfig.type === 's3' && storageConfig.builtIn !== infraStatus.storage.builtIn)),
-        );
-        setShowRestartModal(true);
-      } else {
-        toast.error(t('infrastructure.toasts.saveFailed'), result.message);
-      }
-    } catch (err) {
-      toast.error(t('infrastructure.toasts.saveFailed'), err instanceof Error ? err.message : t('common.unknownError'));
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  // Download a JSON backup of all Data-DB tables. Called BEFORE a DB switch (while still on the old
-  // database) so the data can be re-imported into the new one — switching otherwise starts empty (#488).
-  const handleExportBackup = async () => {
-    setMigrating(true);
-    try {
-      const dump = await infraApi.exportData();
-      const blob = new Blob([JSON.stringify(dump, null, 2)], { type: 'application/json' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `openwa-backup-${dump.exportedAt?.slice(0, 10) || 'data'}.json`;
-      a.click();
-      URL.revokeObjectURL(url);
-    } catch (err) {
-      toast.error(
-        t('infrastructure.migration.exportFailed'),
-        err instanceof Error ? err.message : t('common.unknownError'),
-      );
-    } finally {
-      setMigrating(false);
-    }
-  };
-
-  // POST the replace-all restore and fold the backend's orphan-engine contract into the UI. A 409
-  // means live engines exist for sessions the backup would remove (the server message lists them);
-  // the contract's preferred retry is stopOrphans=true, which stops those engines inside the
-  // request, so offer it as a confirm. force=true is deliberately not offered (the api client does
-  // not even send it): it leaves the engines running until a restart.
-  const runImport = async (tables: Record<string, unknown[]>, stopOrphans = false): Promise<void> => {
-    try {
-      const res = await infraApi.importData(tables, stopOrphans ? { stopOrphans: true } : undefined);
-      if (res.imported) {
-        // notices carry non-fatal operator messages (orphan teardown details); restartRequired
-        // means a teardown failed and only a restart guarantees cleanup — surface both on success.
-        if (res.restartRequired || (res.notices && res.notices.length > 0)) {
-          toast.warning(t('infrastructure.migration.importOk'), (res.notices ?? []).join('; ') || undefined);
-        } else {
-          toast.success(t('infrastructure.migration.importOk'));
-        }
-      } else {
-        toast.error(
-          t('infrastructure.migration.importFailed'),
-          (res.warnings || []).slice(0, 3).join('; ') || res.message,
-        );
-      }
-    } catch (err) {
-      const status = (err as { status?: number } | null)?.status;
-      if (status === 409 && !stopOrphans && err instanceof Error) {
-        // The confirm doubles as the refusal display: OK retries with stopOrphans=true, Cancel
-        // leaves the engines (and the current data) untouched. A 409 on the retry itself (an
-        // engine started mid-import) falls through to the plain error toast — no confirm loop.
-        if (window.confirm(err.message)) await runImport(tables, true);
-        else toast.error(t('infrastructure.migration.importFailed'), err.message);
-        return;
-      }
-      // A large backup can exceed the request body cap (default 25mb) — give an actionable message
-      // instead of a bare "Payload Too Large". The status is carried on the Error by the api client.
-      const detail =
-        status === 413
-          ? t('infrastructure.migration.importTooLarge')
-          : err instanceof Error
-            ? err.message
-            : t('common.unknownError');
-      toast.error(t('infrastructure.migration.importFailed'), detail);
-    }
-  };
-
-  // Restore a previously-exported backup into the CURRENT database (use after switching + restart).
-  // Import REPLACES all current data, so validate + confirm (showing the row count) before any call.
-  const handleImportBackup = async (file: File) => {
-    let parsed: { tables?: Record<string, unknown[]> };
-    try {
-      parsed = JSON.parse(await file.text()) as { tables?: Record<string, unknown[]> };
-    } catch {
-      toast.error(t('infrastructure.migration.importFailed'), t('infrastructure.migration.invalidFile'));
-      return;
-    }
-    if (!parsed?.tables || typeof parsed.tables !== 'object') {
-      toast.error(t('infrastructure.migration.importFailed'), t('infrastructure.migration.invalidFile'));
-      return;
-    }
-    const rows = Object.values(parsed.tables).reduce((n, a) => n + (Array.isArray(a) ? a.length : 0), 0);
-    if (!window.confirm(t('infrastructure.migration.importConfirm', { rows }))) return;
-    setMigrating(true);
-    try {
-      await runImport(parsed.tables);
-    } finally {
-      setMigrating(false);
-    }
-  };
-
-  const handleRestart = async () => {
-    setRestartStatus('restarting');
-    setRestartCountdown(30);
-
-    const profilesToRemove = previousProfiles.filter(p => !pendingProfiles.includes(p));
-
-    // Kept outside the try: the poll deadline is derived from it, and the restart call is expected to
-    // fail sometimes (the server may go down before it answers).
-    let estimatedTime: number | undefined;
-    try {
-      const response = await infraApi.restart(pendingProfiles, profilesToRemove);
-      estimatedTime = response.estimatedTime;
-      if (response.estimatedTime) setRestartCountdown(response.estimatedTime);
-    } catch {
-      // Expected — server shutting down
-    }
-
-    setRestartStatus('waiting');
-    let intervalRef: ReturnType<typeof setInterval> | null = null;
-    const stopCountdown = () => {
-      if (intervalRef) {
-        clearInterval(intervalRef);
-        intervalRef = null;
-      }
-    };
-
-    intervalRef = setInterval(() => {
-      setRestartCountdown(prev => {
-        if (prev <= 1) {
-          stopCountdown();
-          return 0;
-        }
-        return prev - 1;
-      });
-    }, 1000);
-
-    checkServerHealth(stopCountdown, estimatedTime);
-  };
-
-  const checkServerHealth = async (stopCountdown?: () => void, estimatedTime?: number) => {
-    let attempts = 0;
-    const maxAttempts = restartPollAttempts(estimatedTime);
-
-    const check = async () => {
-      try {
-        await infraApi.healthCheck();
-        stopCountdown?.();
-        setRestartCountdown(0);
-        setRestartStatus('success');
-        setTimeout(() => window.location.reload(), 2000);
-      } catch {
-        attempts++;
-        if (attempts < maxAttempts) setTimeout(check, 1000);
-        else setRestartStatus('error');
-      }
-    };
-
-    setTimeout(check, 3000);
-  };
-
   // A setting whose RUNNING value (/status) differs from the SAVED file (/config) is being pinned by a
   // host/.env environment variable, which wins at runtime — so a dashboard change to it won't apply
   // until that variable is unset. Surface that honestly instead of letting the control look effective.
   const dbPinnedByEnv =
-    !savePending && !!infraStatus && !!savedConfig && infraStatus.database.type !== savedConfig.database.type;
+    !configSave.savePending && !!infraStatus && !!savedConfig && infraStatus.database.type !== savedConfig.database.type;
   const redisPinnedByEnv =
-    !savePending && !!infraStatus && !!savedConfig && infraStatus.redis.enabled !== savedConfig.redis.enabled;
+    !configSave.savePending && !!infraStatus && !!savedConfig && infraStatus.redis.enabled !== savedConfig.redis.enabled;
   const storagePinnedByEnv =
-    !savePending && !!infraStatus && !!savedConfig && infraStatus.storage.type !== savedConfig.storage.type;
+    !configSave.savePending && !!infraStatus && !!savedConfig && infraStatus.storage.type !== savedConfig.storage.type;
   const envPinNote = (pinned: boolean) =>
     pinned ? (
       <p className="env-pin-note">
@@ -534,30 +147,30 @@ export function Infrastructure() {
               <Database size={20} />
               <h2>{t('infrastructure.database.title')}</h2>
             </div>
-            <span className={`status-indicator ${dbConfig.type === 'postgres' ? 'connected' : 'sqlite'}`}>
-              ● {dbConfig.type === 'postgres' ? 'PostgreSQL' : 'SQLite'}
+            <span className={`status-indicator ${configForm.dbConfig.type === 'postgres' ? 'connected' : 'sqlite'}`}>
+              ● {configForm.dbConfig.type === 'postgres' ? 'PostgreSQL' : 'SQLite'}
             </span>
           </div>
           {envPinNote(dbPinnedByEnv)}
 
           <div className="radio-group">
-            <label className={`radio-option ${dbConfig.type === 'sqlite' ? 'selected' : ''}`}>
+            <label className={`radio-option ${configForm.dbConfig.type === 'sqlite' ? 'selected' : ''}`}>
               <input
                 type="radio"
                 name="dbType"
-                checked={dbConfig.type === 'sqlite'}
-                onChange={() => updateDbConfig('type', 'sqlite')}
+                checked={configForm.dbConfig.type === 'sqlite'}
+                onChange={() => configForm.updateDbConfig('type', 'sqlite')}
               />
               <img src={sqliteIcon} alt="" className="watermark-icon" />
               <span>{t('infrastructure.database.sqlite')}</span>
               <small>{t('infrastructure.database.sqliteDesc')}</small>
             </label>
-            <label className={`radio-option ${dbConfig.type === 'postgres' ? 'selected' : ''}`}>
+            <label className={`radio-option ${configForm.dbConfig.type === 'postgres' ? 'selected' : ''}`}>
               <input
                 type="radio"
                 name="dbType"
-                checked={dbConfig.type === 'postgres'}
-                onChange={() => updateDbConfig('type', 'postgres')}
+                checked={configForm.dbConfig.type === 'postgres'}
+                onChange={() => configForm.updateDbConfig('type', 'postgres')}
               />
               <img src={postgresIcon} alt="" className="watermark-icon" />
               <span>{t('infrastructure.database.postgres')}</span>
@@ -565,7 +178,7 @@ export function Infrastructure() {
             </label>
           </div>
 
-          {dbConfig.type === 'postgres' && (
+          {configForm.dbConfig.type === 'postgres' && (
             <>
               <div className="toggle-row toggle-row-spaced">
                 <div className="toggle-info">
@@ -575,23 +188,31 @@ export function Infrastructure() {
                 <label className="toggle-switch">
                   <input
                     type="checkbox"
-                    checked={dbConfig.builtIn}
-                    onChange={e => updateDbConfig('builtIn', e.target.checked)}
+                    checked={configForm.dbConfig.builtIn}
+                    onChange={e => configForm.updateDbConfig('builtIn', e.target.checked)}
                   />
                   <span className="toggle-slider"></span>
                 </label>
               </div>
 
-              {!dbConfig.builtIn && (
+              {!configForm.dbConfig.builtIn && (
                 <div className="config-form">
                   <div className="form-row">
                     <div className="form-group">
                       <label>{t('common.host')}</label>
-                      <input type="text" value={dbConfig.host} onChange={e => updateDbConfig('host', e.target.value)} />
+                      <input
+                        type="text"
+                        value={configForm.dbConfig.host}
+                        onChange={e => configForm.updateDbConfig('host', e.target.value)}
+                      />
                     </div>
                     <div className="form-group small">
                       <label>{t('common.port')}</label>
-                      <input type="text" value={dbConfig.port} onChange={e => updateDbConfig('port', e.target.value)} />
+                      <input
+                        type="text"
+                        value={configForm.dbConfig.port}
+                        onChange={e => configForm.updateDbConfig('port', e.target.value)}
+                      />
                     </div>
                   </div>
                   <div className="form-row">
@@ -599,16 +220,16 @@ export function Infrastructure() {
                       <label>{t('common.username')}</label>
                       <input
                         type="text"
-                        value={dbConfig.username}
-                        onChange={e => updateDbConfig('username', e.target.value)}
+                        value={configForm.dbConfig.username}
+                        onChange={e => configForm.updateDbConfig('username', e.target.value)}
                       />
                     </div>
                     <div className="form-group">
                       <label>{t('common.password')}</label>
                       <input
                         type="password"
-                        value={dbConfig.password}
-                        onChange={e => updateDbConfig('password', e.target.value)}
+                        value={configForm.dbConfig.password}
+                        onChange={e => configForm.updateDbConfig('password', e.target.value)}
                       />
                     </div>
                   </div>
@@ -617,8 +238,8 @@ export function Infrastructure() {
                       <label>{t('infrastructure.database.dbName')}</label>
                       <input
                         type="text"
-                        value={dbConfig.database}
-                        onChange={e => updateDbConfig('database', e.target.value)}
+                        value={configForm.dbConfig.database}
+                        onChange={e => configForm.updateDbConfig('database', e.target.value)}
                       />
                     </div>
                     <div className="form-group small">
@@ -627,8 +248,8 @@ export function Infrastructure() {
                         type="number"
                         min="1"
                         max="50"
-                        value={dbConfig.poolSize}
-                        onChange={e => updateDbConfig('poolSize', parseInt(e.target.value))}
+                        value={configForm.dbConfig.poolSize}
+                        onChange={e => configForm.updateDbConfig('poolSize', parseInt(e.target.value))}
                       />
                     </div>
                   </div>
@@ -637,8 +258,8 @@ export function Infrastructure() {
                       <label>{t('infrastructure.database.schema')}</label>
                       <input
                         type="text"
-                        value={dbConfig.schema}
-                        onChange={e => updateDbConfig('schema', e.target.value)}
+                        value={configForm.dbConfig.schema}
+                        onChange={e => configForm.updateDbConfig('schema', e.target.value)}
                         placeholder="public"
                       />
                       <small>{t('infrastructure.database.schemaDesc')}</small>
@@ -652,13 +273,13 @@ export function Infrastructure() {
                     <label className="toggle-switch">
                       <input
                         type="checkbox"
-                        checked={dbConfig.sslEnabled}
-                        onChange={e => updateDbConfig('sslEnabled', e.target.checked)}
+                        checked={configForm.dbConfig.sslEnabled}
+                        onChange={e => configForm.updateDbConfig('sslEnabled', e.target.checked)}
                       />
                       <span className="toggle-slider"></span>
                     </label>
                   </div>
-                  {dbConfig.sslEnabled && (
+                  {configForm.dbConfig.sslEnabled && (
                     <div className="toggle-row">
                       <div className="toggle-info">
                         <span>{t('infrastructure.database.sslRejectUnauthorized')}</span>
@@ -667,8 +288,8 @@ export function Infrastructure() {
                       <label className="toggle-switch">
                         <input
                           type="checkbox"
-                          checked={dbConfig.sslRejectUnauthorized}
-                          onChange={e => updateDbConfig('sslRejectUnauthorized', e.target.checked)}
+                          checked={configForm.dbConfig.sslRejectUnauthorized}
+                          onChange={e => configForm.updateDbConfig('sslRejectUnauthorized', e.target.checked)}
                         />
                         <span className="toggle-slider"></span>
                       </label>
@@ -696,21 +317,21 @@ export function Infrastructure() {
               <small>{t('infrastructure.migration.backupHint')}</small>
             </div>
             <div className="data-migration-actions">
-              <button className="btn-secondary btn-sm" onClick={handleExportBackup} disabled={migrating}>
-                {migrating ? <Loader2 size={14} className="animate-spin" /> : <Download size={14} />}
+              <button className="btn-secondary btn-sm" onClick={dataBackup.exportBackup} disabled={dataBackup.migrating}>
+                {dataBackup.migrating ? <Loader2 size={14} className="animate-spin" /> : <Download size={14} />}
                 {t('infrastructure.migration.export')}
               </button>
-              <label className="btn-secondary btn-sm" style={{ cursor: migrating ? 'default' : 'pointer' }}>
+              <label className="btn-secondary btn-sm" style={{ cursor: dataBackup.migrating ? 'default' : 'pointer' }}>
                 <Upload size={14} />
                 {t('infrastructure.migration.import')}
                 <input
                   type="file"
                   accept="application/json,.json"
                   className="hidden-file-input"
-                  disabled={migrating}
+                  disabled={dataBackup.migrating}
                   onChange={e => {
                     const file = e.target.files?.[0];
-                    if (file) void handleImportBackup(file);
+                    if (file) void dataBackup.importBackup(file);
                     e.target.value = '';
                   }}
                 />
@@ -726,17 +347,20 @@ export function Infrastructure() {
               <Cpu size={20} />
               <h2>{t('infrastructure.engine.title')}</h2>
             </div>
-            <span className="status-indicator connected">● {currentEngine || engineConfig.type}</span>
+            <span className="status-indicator connected">● {currentEngine || configForm.engineConfig.type}</span>
           </div>
 
           <div className="radio-group">
             {engines.map(engine => (
-              <label key={engine.id} className={`radio-option ${engineConfig.type === engine.id ? 'selected' : ''}`}>
+              <label
+                key={engine.id}
+                className={`radio-option ${configForm.engineConfig.type === engine.id ? 'selected' : ''}`}
+              >
                 <input
                   type="radio"
                   name="engineType"
-                  checked={engineConfig.type === engine.id}
-                  onChange={() => updateEngineConfig('type', engine.id)}
+                  checked={configForm.engineConfig.type === engine.id}
+                  onChange={() => configForm.updateEngineConfig('type', engine.id)}
                 />
                 <Cpu className="watermark-icon" />
                 <span>{engine.name}</span>
@@ -763,7 +387,7 @@ export function Infrastructure() {
             </p>
           )}
 
-          {engineConfig.type === 'whatsapp-web.js' ? (
+          {configForm.engineConfig.type === 'whatsapp-web.js' ? (
             <div className="config-form">
               <div className="toggle-row">
                 <div className="toggle-info">
@@ -773,8 +397,8 @@ export function Infrastructure() {
                 <label className="toggle-switch">
                   <input
                     type="checkbox"
-                    checked={engineConfig.headless}
-                    onChange={e => updateEngineConfig('headless', e.target.checked)}
+                    checked={configForm.engineConfig.headless}
+                    onChange={e => configForm.updateEngineConfig('headless', e.target.checked)}
                   />
                   <span className="toggle-slider"></span>
                 </label>
@@ -783,16 +407,16 @@ export function Infrastructure() {
                 <label>{t('infrastructure.engine.sessionDataPath')}</label>
                 <input
                   type="text"
-                  value={engineConfig.sessionDataPath}
-                  onChange={e => updateEngineConfig('sessionDataPath', e.target.value)}
+                  value={configForm.engineConfig.sessionDataPath}
+                  onChange={e => configForm.updateEngineConfig('sessionDataPath', e.target.value)}
                 />
               </div>
               <div className="form-group">
                 <label>{t('infrastructure.engine.browserArgs')}</label>
                 <input
                   type="text"
-                  value={engineConfig.browserArgs}
-                  onChange={e => updateEngineConfig('browserArgs', e.target.value)}
+                  value={configForm.engineConfig.browserArgs}
+                  onChange={e => configForm.updateEngineConfig('browserArgs', e.target.value)}
                   placeholder="--no-sandbox --disable-gpu"
                 />
               </div>
@@ -812,11 +436,13 @@ export function Infrastructure() {
               <h2>{t('infrastructure.redis.title')}</h2>
             </div>
             <span
-              className={`status-indicator ${redisEnabled && redisConfig.connected ? 'connected' : 'disconnected'}`}
+              className={`status-indicator ${
+                configForm.redisEnabled && configForm.redisConfig.connected ? 'connected' : 'disconnected'
+              }`}
             >
               ●{' '}
-              {redisEnabled
-                ? redisConfig.connected
+              {configForm.redisEnabled
+                ? configForm.redisConfig.connected
                   ? t('infrastructure.statusLabels.connected')
                   : t('infrastructure.statusLabels.disconnected')
                 : t('infrastructure.statusLabels.disabled')}
@@ -827,9 +453,9 @@ export function Infrastructure() {
           <div
             className="toggle-row"
             style={{
-              borderBottom: redisEnabled ? '1px solid var(--border)' : 'none',
-              marginBottom: redisEnabled ? '1.5rem' : 0,
-              paddingBottom: redisEnabled ? '1.25rem' : 0,
+              borderBottom: configForm.redisEnabled ? '1px solid var(--border)' : 'none',
+              marginBottom: configForm.redisEnabled ? '1.5rem' : 0,
+              paddingBottom: configForm.redisEnabled ? '1.25rem' : 0,
             }}
           >
             <div className="toggle-info">
@@ -839,17 +465,14 @@ export function Infrastructure() {
             <label className="toggle-switch">
               <input
                 type="checkbox"
-                checked={redisEnabled}
-                onChange={e => {
-                  setRedisEnabled(e.target.checked);
-                  if (!e.target.checked) setQueueEnabled(false);
-                }}
+                checked={configForm.redisEnabled}
+                onChange={e => configForm.setRedisEnabled(e.target.checked)}
               />
               <span className="toggle-slider"></span>
             </label>
           </div>
 
-          {redisEnabled ? (
+          {configForm.redisEnabled ? (
             <>
               <div className="toggle-row toggle-row-spaced-bottom">
                 <div className="toggle-info">
@@ -859,38 +482,38 @@ export function Infrastructure() {
                 <label className="toggle-switch">
                   <input
                     type="checkbox"
-                    checked={redisConfig.builtIn}
-                    onChange={e => updateRedisConfig('builtIn', e.target.checked)}
+                    checked={configForm.redisConfig.builtIn}
+                    onChange={e => configForm.updateRedisConfig('builtIn', e.target.checked)}
                   />
                   <span className="toggle-slider"></span>
                 </label>
               </div>
 
-              {!redisConfig.builtIn && (
+              {!configForm.redisConfig.builtIn && (
                 <div className="config-form">
                   <div className="form-row">
                     <div className="form-group">
                       <label>{t('common.host')}</label>
                       <input
                         type="text"
-                        value={redisConfig.host}
-                        onChange={e => updateRedisConfig('host', e.target.value)}
+                        value={configForm.redisConfig.host}
+                        onChange={e => configForm.updateRedisConfig('host', e.target.value)}
                       />
                     </div>
                     <div className="form-group small">
                       <label>{t('common.port')}</label>
                       <input
                         type="text"
-                        value={redisConfig.port}
-                        onChange={e => updateRedisConfig('port', e.target.value)}
+                        value={configForm.redisConfig.port}
+                        onChange={e => configForm.updateRedisConfig('port', e.target.value)}
                       />
                     </div>
                     <div className="form-group">
                       <label>{t('common.password')}</label>
                       <input
                         type="password"
-                        value={redisConfig.password}
-                        onChange={e => updateRedisConfig('password', e.target.value)}
+                        value={configForm.redisConfig.password}
+                        onChange={e => configForm.updateRedisConfig('password', e.target.value)}
                         placeholder={t('infrastructure.redis.passwordOptional')}
                       />
                     </div>
@@ -904,12 +527,16 @@ export function Infrastructure() {
                   <small>{t('infrastructure.redis.queueDesc')}</small>
                 </div>
                 <label className="toggle-switch">
-                  <input type="checkbox" checked={queueEnabled} onChange={e => setQueueEnabled(e.target.checked)} />
+                  <input
+                    type="checkbox"
+                    checked={configForm.queueEnabled}
+                    onChange={e => configForm.setQueueEnabled(e.target.checked)}
+                  />
                   <span className="toggle-slider"></span>
                 </label>
               </div>
 
-              {queueEnabled && (
+              {configForm.queueEnabled && (
                 <div className="queue-stats">
                   <h3>{t('infrastructure.redis.statsTitle')}</h3>
                   <div className="stats-row">
@@ -976,12 +603,13 @@ export function Infrastructure() {
             </div>
             {(() => {
               // S3 selected but the backend isn't reachable → warn instead of a misleading green.
-              const s3Unreachable = storageConfig.type === 's3' && infraStatus?.storage.s3Available === false;
-              const cls = storageConfig.type !== 's3' ? 'sqlite' : s3Unreachable ? 'disconnected' : 'connected';
+              const s3Unreachable =
+                configForm.storageConfig.type === 's3' && infraStatus?.storage.s3Available === false;
+              const cls = configForm.storageConfig.type !== 's3' ? 'sqlite' : s3Unreachable ? 'disconnected' : 'connected';
               return (
                 <span className={`status-indicator ${cls}`}>
                   ●{' '}
-                  {storageConfig.type === 's3'
+                  {configForm.storageConfig.type === 's3'
                     ? s3Unreachable
                       ? t('infrastructure.storage.s3Unreachable')
                       : 'S3'
@@ -993,23 +621,23 @@ export function Infrastructure() {
           {envPinNote(storagePinnedByEnv)}
 
           <div className="radio-group">
-            <label className={`radio-option ${storageConfig.type === 'local' ? 'selected' : ''}`}>
+            <label className={`radio-option ${configForm.storageConfig.type === 'local' ? 'selected' : ''}`}>
               <input
                 type="radio"
                 name="storageType"
-                checked={storageConfig.type === 'local'}
-                onChange={() => updateStorageConfig('type', 'local')}
+                checked={configForm.storageConfig.type === 'local'}
+                onChange={() => configForm.updateStorageConfig('type', 'local')}
               />
               <img src={folderIcon} alt="" className="watermark-icon" />
               <span>{t('infrastructure.storage.local')}</span>
               <small>{t('infrastructure.storage.localDesc')}</small>
             </label>
-            <label className={`radio-option ${storageConfig.type === 's3' ? 'selected' : ''}`}>
+            <label className={`radio-option ${configForm.storageConfig.type === 's3' ? 'selected' : ''}`}>
               <input
                 type="radio"
                 name="storageType"
-                checked={storageConfig.type === 's3'}
-                onChange={() => updateStorageConfig('type', 's3')}
+                checked={configForm.storageConfig.type === 's3'}
+                onChange={() => configForm.updateStorageConfig('type', 's3')}
               />
               <img src={s3Icon} alt="" className="watermark-icon" />
               <span>{t('infrastructure.storage.s3')}</span>
@@ -1018,18 +646,18 @@ export function Infrastructure() {
           </div>
 
           <div className="config-form">
-            {storageConfig.type === 'local' && (
+            {configForm.storageConfig.type === 'local' && (
               <div className="form-group">
                 <label>{t('infrastructure.storage.storagePath')}</label>
                 <input
                   type="text"
-                  value={storageConfig.localPath}
-                  onChange={e => updateStorageConfig('localPath', e.target.value)}
+                  value={configForm.storageConfig.localPath}
+                  onChange={e => configForm.updateStorageConfig('localPath', e.target.value)}
                 />
               </div>
             )}
 
-            {storageConfig.type === 's3' && (
+            {configForm.storageConfig.type === 's3' && (
               <>
                 <div className="toggle-row toggle-row-spaced">
                   <div className="toggle-info">
@@ -1039,30 +667,30 @@ export function Infrastructure() {
                   <label className="toggle-switch">
                     <input
                       type="checkbox"
-                      checked={storageConfig.builtIn}
-                      onChange={e => updateStorageConfig('builtIn', e.target.checked)}
+                      checked={configForm.storageConfig.builtIn}
+                      onChange={e => configForm.updateStorageConfig('builtIn', e.target.checked)}
                     />
                     <span className="toggle-slider"></span>
                   </label>
                 </div>
 
-                {!storageConfig.builtIn && (
+                {!configForm.storageConfig.builtIn && (
                   <>
                     <div className="form-row">
                       <div className="form-group">
                         <label>{t('infrastructure.storage.bucket')}</label>
                         <input
                           type="text"
-                          value={storageConfig.s3Bucket}
-                          onChange={e => updateStorageConfig('s3Bucket', e.target.value)}
+                          value={configForm.storageConfig.s3Bucket}
+                          onChange={e => configForm.updateStorageConfig('s3Bucket', e.target.value)}
                         />
                       </div>
                       <div className="form-group">
                         <label>{t('infrastructure.storage.region')}</label>
                         <input
                           type="text"
-                          value={storageConfig.s3Region}
-                          onChange={e => updateStorageConfig('s3Region', e.target.value)}
+                          value={configForm.storageConfig.s3Region}
+                          onChange={e => configForm.updateStorageConfig('s3Region', e.target.value)}
                         />
                       </div>
                     </div>
@@ -1071,16 +699,16 @@ export function Infrastructure() {
                         <label>{t('infrastructure.storage.accessKey')}</label>
                         <input
                           type="text"
-                          value={storageConfig.s3AccessKey}
-                          onChange={e => updateStorageConfig('s3AccessKey', e.target.value)}
+                          value={configForm.storageConfig.s3AccessKey}
+                          onChange={e => configForm.updateStorageConfig('s3AccessKey', e.target.value)}
                         />
                       </div>
                       <div className="form-group">
                         <label>{t('infrastructure.storage.secretKey')}</label>
                         <input
                           type="password"
-                          value={storageConfig.s3SecretKey}
-                          onChange={e => updateStorageConfig('s3SecretKey', e.target.value)}
+                          value={configForm.storageConfig.s3SecretKey}
+                          onChange={e => configForm.updateStorageConfig('s3SecretKey', e.target.value)}
                         />
                       </div>
                     </div>
@@ -1088,8 +716,8 @@ export function Infrastructure() {
                       <label>{t('infrastructure.storage.endpoint')}</label>
                       <input
                         type="text"
-                        value={storageConfig.s3Endpoint}
-                        onChange={e => updateStorageConfig('s3Endpoint', e.target.value)}
+                        value={configForm.storageConfig.s3Endpoint}
+                        onChange={e => configForm.updateStorageConfig('s3Endpoint', e.target.value)}
                         placeholder={t('infrastructure.storage.endpointHint')}
                       />
                     </div>
@@ -1101,42 +729,46 @@ export function Infrastructure() {
         </section>
       </div>
 
-      {showRestartModal && (
+      {restartFlow.showRestartModal && (
         <Modal
           open
-          onClose={() => {
-            // Dismissal is only offered in the idle state (the "Later" path) — while a restart is
-            // running there is deliberately no way to close the progress view.
-            if (restartStatus === 'idle') setShowRestartModal(false);
-          }}
+          onClose={restartFlow.close}
           title={
             <>
-              {restartStatus === 'idle' && t('infrastructure.restart.idleTitle')}
-              {restartStatus === 'restarting' && t('infrastructure.restart.restartingTitle')}
-              {restartStatus === 'waiting' && t('infrastructure.restart.waitingTitle')}
-              {restartStatus === 'success' && t('infrastructure.restart.successTitle')}
-              {restartStatus === 'error' && t('infrastructure.restart.errorTitle')}
+              {restartFlow.restartStatus === 'idle' && t('infrastructure.restart.idleTitle')}
+              {restartFlow.restartStatus === 'restarting' && t('infrastructure.restart.restartingTitle')}
+              {restartFlow.restartStatus === 'waiting' && t('infrastructure.restart.waitingTitle')}
+              {restartFlow.restartStatus === 'success' && t('infrastructure.restart.successTitle')}
+              {restartFlow.restartStatus === 'error' && t('infrastructure.restart.errorTitle')}
             </>
           }
           className="restart-modal"
           closeLabel={t('common.close')}
           hideCloseButton
         >
-          {restartStatus === 'idle' && (
+          {restartFlow.restartStatus === 'idle' && (
             <>
               <p className="restart-idle-desc">
                 <Trans i18nKey="infrastructure.restart.idleDesc" components={{ code: <code />, br: <br /> }} />
               </p>
-              {(dbSwitch || storageSwitch) && (
+              {(restartFlow.dbSwitch || restartFlow.storageSwitch) && (
                 <div className="migration-warning">
                   <AlertTriangle size={18} />
                   <div>
                     <strong>{t('infrastructure.migration.title')}</strong>
-                    {dbSwitch && <p>{t('infrastructure.migration.dbWarning')}</p>}
-                    {storageSwitch && <p>{t('infrastructure.migration.storageWarning')}</p>}
-                    {dbSwitch && (
-                      <button className="btn-secondary btn-sm" onClick={handleExportBackup} disabled={migrating}>
-                        {migrating ? <Loader2 size={14} className="animate-spin" /> : <Download size={14} />}
+                    {restartFlow.dbSwitch && <p>{t('infrastructure.migration.dbWarning')}</p>}
+                    {restartFlow.storageSwitch && <p>{t('infrastructure.migration.storageWarning')}</p>}
+                    {restartFlow.dbSwitch && (
+                      <button
+                        className="btn-secondary btn-sm"
+                        onClick={dataBackup.exportBackup}
+                        disabled={dataBackup.migrating}
+                      >
+                        {dataBackup.migrating ? (
+                          <Loader2 size={14} className="animate-spin" />
+                        ) : (
+                          <Download size={14} />
+                        )}
                         {t('infrastructure.migration.downloadBackup')}
                       </button>
                     )}
@@ -1144,44 +776,47 @@ export function Infrastructure() {
                 </div>
               )}
               <div className="restart-actions">
-                <button className="btn-secondary" onClick={() => setShowRestartModal(false)}>
+                <button className="btn-secondary" onClick={restartFlow.close}>
                   {t('infrastructure.restart.later')}
                 </button>
-                <button className="btn-primary" onClick={handleRestart}>
+                <button className="btn-primary" onClick={restartFlow.start}>
                   {t('infrastructure.restart.now')}
                 </button>
               </div>
             </>
           )}
 
-          {(restartStatus === 'restarting' || restartStatus === 'waiting') && (
+          {(restartFlow.restartStatus === 'restarting' || restartFlow.restartStatus === 'waiting') && (
             <>
               <div className="restart-countdown">
                 <Loader2 className="animate-spin restart-status-icon" size={48} />
                 <p className="restart-countdown-msg">
-                  {restartCountdown > 0
-                    ? t('infrastructure.restart.restartingMsg', { count: restartCountdown })
+                  {restartFlow.restartCountdown > 0
+                    ? t('infrastructure.restart.restartingMsg', { count: restartFlow.restartCountdown })
                     : t('infrastructure.restart.checking')}
                 </p>
               </div>
               <div className="restart-progress-track">
                 <div
                   className="restart-progress-fill"
-                  style={{ width: restartCountdown > 0 ? `${((30 - restartCountdown) / 30) * 100}%` : '100%' }}
+                  style={{
+                    width:
+                      restartFlow.restartCountdown > 0 ? `${((30 - restartFlow.restartCountdown) / 30) * 100}%` : '100%',
+                  }}
                 />
               </div>
               <p className="restart-dont-close">{t('infrastructure.restart.dontClose')}</p>
             </>
           )}
 
-          {restartStatus === 'success' && (
+          {restartFlow.restartStatus === 'success' && (
             <>
               <CheckCircle size={48} className="restart-status-icon" />
               <p className="restart-success-msg">{t('infrastructure.restart.successMsg')}</p>
             </>
           )}
 
-          {restartStatus === 'error' && (
+          {restartFlow.restartStatus === 'error' && (
             <>
               <p className="restart-error-msg">{t('infrastructure.restart.errorMsg')}</p>
               <button className="btn-primary" onClick={() => window.location.reload()}>
@@ -1193,9 +828,9 @@ export function Infrastructure() {
       )}
 
       <footer className="page-footer">
-        <button className="btn-primary large" onClick={handleSaveConfig} disabled={saving}>
-          {saving ? <Loader2 className="animate-spin" size={20} /> : <Save size={20} />}
-          {saving ? t('infrastructure.saving') : t('infrastructure.saveConfig')}
+        <button className="btn-primary large" onClick={configSave.saveConfig} disabled={configSave.saving}>
+          {configSave.saving ? <Loader2 className="animate-spin" size={20} /> : <Save size={20} />}
+          {configSave.saving ? t('infrastructure.saving') : t('infrastructure.saveConfig')}
         </button>
       </footer>
     </div>

--- a/dashboard/src/pages/Sessions.test.ts
+++ b/dashboard/src/pages/Sessions.test.ts
@@ -108,7 +108,9 @@ function installFetchStub(): void {
     const sessionIdMatch = path.match(/^\/api\/sessions\/([^/]+)$/);
     if (method === 'GET' && sessionIdMatch) {
       const found = SESSIONS.find(s => s.id === sessionIdMatch[1]);
-      return found ? Promise.resolve(jsonResponse(found)) : Promise.resolve(jsonResponse({ message: 'not found' }, 404));
+      return found
+        ? Promise.resolve(jsonResponse(found))
+        : Promise.resolve(jsonResponse({ message: 'not found' }, 404));
     }
     if (method === 'DELETE' && sessionIdMatch) {
       return Promise.resolve(new Response(null, { status: 204 }));

--- a/dashboard/src/pages/Sessions.test.ts
+++ b/dashboard/src/pages/Sessions.test.ts
@@ -1,0 +1,259 @@
+// Render smoke test for the Sessions page under the bare `node --test` runner. Mirrors
+// Chats.test.ts's harness (same providers pattern, same recorded-fetch-stub approach, same loader
+// hooks) but adds two things Chats does not need: RoleProvider must actually grant write access
+// (useRole().canWrite gates every action button), and the WebSocket hook must be kept dormant
+// (see the sessionStorage note below) rather than stubbed.
+//
+// This file exists to build the safety net BEFORE Sessions.tsx is decomposed into hooks/child
+// components. The case that matters most pins the exact bug class that decomposition risks: the
+// pairing panel (QR modal, Phone tab) renders only while `pairingMode` is true, and the tab
+// buttons just flip that boolean — so `phoneNumber` only survives a QR<->Phone toggle today
+// because Sessions.tsx itself owns the state. Moving it into an extracted child that unmounts on
+// tab switch would silently discard it, exactly like the chat draft and staged attachment bugs
+// Chats.test.ts caught.
+import '../test-helpers/register-hooks.ts';
+import { test, before, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createElement } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { Session } from '../services/api';
+import type { installJsdomGlobals as installJsdomGlobalsFn } from '../test-helpers/jsdom.ts';
+
+// ── Fixtures + fetch stub ────────────────────────────────────────────────────
+
+const SESSION_QR: Session = {
+  id: 'sess-qr-1',
+  name: 'new-device',
+  status: 'qr_ready',
+  engineLoaded: true,
+  phone: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+// `disconnected` is a status the pre-engineLoaded fallback rule treats as NOT started (Start would
+// be offered). engineLoaded: true overrides that — the gateway still holds a live engine (e.g. mid
+// automatic-reconnect backoff), so the card must offer Stop/Unlink/Kill Stuck instead. Pins that
+// the action gate reads session.engineLoaded, not session.status.
+const SESSION_STALE_ENGINE: Session = {
+  id: 'sess-stale-1',
+  name: 'stale-engine',
+  status: 'disconnected',
+  engineLoaded: true,
+  phone: '15550009999',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+const SESSIONS = [SESSION_QR, SESSION_STALE_ENGINE];
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+interface FetchCall {
+  method: string;
+  path: string;
+  body?: unknown;
+}
+
+const fetchCalls: FetchCall[] = [];
+
+function resetFetchCalls(): void {
+  fetchCalls.length = 0;
+}
+
+function findFetchCall(method: string, path: string): FetchCall | undefined {
+  return fetchCalls.find(c => c.method === method && c.path === path);
+}
+
+// URL router for every endpoint the page can reach. Anything else 404s loudly instead of resolving
+// into a confusing downstream failure. Lifecycle actions (start/stop/logout/force-kill/pairing-code)
+// are stubbed generically even though none of the three cases below trigger them, per the brief's
+// endpoint list — a future case exercising them should not need to touch this stub.
+function installFetchStub(): void {
+  globalThis.fetch = (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+    const method = init?.method ?? 'GET';
+    const path = url.replace(/^https?:\/\/[^/]+/, '');
+
+    let body: unknown;
+    if (typeof init?.body === 'string') {
+      try {
+        body = JSON.parse(init.body);
+      } catch {
+        body = init.body;
+      }
+    }
+    fetchCalls.push({ method, path, body });
+
+    if (method === 'GET' && path === '/api/sessions') return Promise.resolve(jsonResponse(SESSIONS));
+
+    if (method === 'POST' && path === '/api/sessions') {
+      const name = (body as { name?: string } | undefined)?.name ?? 'unnamed';
+      return Promise.resolve(
+        jsonResponse({
+          id: `sess-new-${name}`,
+          name,
+          status: 'created',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        }),
+      );
+    }
+
+    const sessionIdMatch = path.match(/^\/api\/sessions\/([^/]+)$/);
+    if (method === 'GET' && sessionIdMatch) {
+      const found = SESSIONS.find(s => s.id === sessionIdMatch[1]);
+      return found ? Promise.resolve(jsonResponse(found)) : Promise.resolve(jsonResponse({ message: 'not found' }, 404));
+    }
+    if (method === 'DELETE' && sessionIdMatch) {
+      return Promise.resolve(new Response(null, { status: 204 }));
+    }
+
+    const qrMatch = path.match(/^\/api\/sessions\/([^/]+)\/qr$/);
+    if (method === 'GET' && qrMatch) {
+      const found = SESSIONS.find(s => s.id === qrMatch[1]);
+      if (!found) return Promise.resolve(jsonResponse({ message: 'not found' }, 404));
+      return Promise.resolve(jsonResponse({ qrCode: 'data:image/png;base64,FAKE', status: found.status }));
+    }
+
+    const pairingMatch = path.match(/^\/api\/sessions\/([^/]+)\/pairing-code$/);
+    if (method === 'POST' && pairingMatch) {
+      return Promise.resolve(jsonResponse({ pairingCode: '12345678', status: 'qr_ready' }));
+    }
+
+    const lifecycleMatch = path.match(/^\/api\/sessions\/([^/]+)\/(start|stop|logout|force-kill)$/);
+    if (method === 'POST' && lifecycleMatch) {
+      const found = SESSIONS.find(s => s.id === lifecycleMatch[1]);
+      const base = found ?? SESSION_STALE_ENGINE;
+      return Promise.resolve(jsonResponse({ ...base, status: 'disconnected', engineLoaded: false }));
+    }
+
+    return Promise.resolve(jsonResponse({ message: `unstubbed ${method} ${path}` }, 404));
+  };
+}
+
+// ── Harness bootstrap ────────────────────────────────────────────────────────
+
+type RTL = typeof import('@testing-library/react');
+type SessionsModule = typeof import('./Sessions.tsx');
+type RoleModule = typeof import('../components/RoleProvider.tsx');
+type ToastModule = typeof import('../components/Toast.tsx');
+
+let rtl: RTL;
+let Sessions: SessionsModule['Sessions'];
+let RoleProvider: RoleModule['RoleProvider'];
+let ToastProvider: ToastModule['ToastProvider'];
+let installJsdomGlobals: typeof installJsdomGlobalsFn;
+let queryClient: QueryClient | undefined;
+
+before(async () => {
+  ({ installJsdomGlobals } = await import('../test-helpers/jsdom.ts'));
+  await installJsdomGlobals();
+  installFetchStub();
+  // RoleProvider seeds from localStorage; 'admin' makes canWrite true, or every action button
+  // (New Session, Stop/Start, Unlink, Delete, Kill Stuck) is hidden and there is nothing to test.
+  window.localStorage.setItem('openwa_user_role', 'admin');
+  // Deliberately NOT setting sessionStorage['openwa_api_key']: useWebSocket.connect() reads it and
+  // bails with a console.warn when it's absent. Setting it would make socket.io actually dial
+  // http://localhost/events and hit ECONNREFUSED in this environment.
+  await import('../i18n/index.ts');
+  rtl = await import('@testing-library/react');
+  ({ RoleProvider } = await import('../components/RoleProvider.tsx'));
+  ({ ToastProvider } = await import('../components/Toast.tsx'));
+  ({ Sessions } = await import('./Sessions.tsx'));
+});
+
+afterEach(() => {
+  rtl.cleanup();
+  queryClient?.clear();
+  queryClient = undefined;
+});
+
+function renderSessions(): { container: HTMLElement } {
+  queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 1_000 } } });
+  return rtl.render(
+    createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      createElement(RoleProvider, null, createElement(ToastProvider, null, createElement(Sessions))),
+    ),
+  );
+}
+
+// ── Smoke tests ──────────────────────────────────────────────────────────────
+
+test('the session list renders, and action buttons gate on engineLoaded rather than status', async () => {
+  const { screen, within } = rtl;
+  resetFetchCalls();
+  renderSessions();
+
+  await screen.findByText('new-device');
+  await screen.findByText('stale-engine');
+
+  // stale-engine is `disconnected` (a status the old fallback rule treats as not-started, offering
+  // Start) but engineLoaded: true — the card must offer Stop/Unlink/Kill Stuck instead, and never
+  // Start, proving the gate reads engineLoaded rather than inferring it from status.
+  const staleCard = screen.getByText('stale-engine').closest('.session-card') as HTMLElement;
+  within(staleCard).getByRole('button', { name: 'Stop' });
+  within(staleCard).getByRole('button', { name: 'Unlink' });
+  within(staleCard).getByRole('button', { name: 'Kill Stuck' });
+  assert.equal(within(staleCard).queryByRole('button', { name: 'Start' }), null);
+
+  const qrCard = screen.getByText('new-device').closest('.session-card') as HTMLElement;
+  within(qrCard).getByRole('button', { name: 'Show QR' });
+});
+
+test('creating a session issues POST /api/sessions with the entered name', async () => {
+  const { screen, fireEvent, waitFor, within } = rtl;
+  resetFetchCalls();
+  renderSessions();
+
+  await screen.findByText('new-device');
+  fireEvent.click(screen.getByRole('button', { name: 'New Session' }));
+
+  const dialog = await screen.findByRole('dialog');
+  fireEvent.change(within(dialog).getByPlaceholderText('e.g., marketing-bot'), { target: { value: 'backup-bot' } });
+  fireEvent.click(within(dialog).getByRole('button', { name: 'Create' }));
+
+  // The optimistic row alone would pass even if the POST body were wrong — assert the wire call.
+  await waitFor(() => {
+    const call = findFetchCall('POST', '/api/sessions');
+    assert.ok(call, 'expected a POST to /sessions');
+    assert.deepEqual(call!.body, { name: 'backup-bot' });
+  });
+
+  await screen.findByText('backup-bot');
+});
+
+test('a typed pairing phone number survives toggling to the QR tab and back', async () => {
+  const { screen, fireEvent, within } = rtl;
+  resetFetchCalls();
+  renderSessions();
+
+  await screen.findByText('new-device');
+  const qrCard = screen.getByText('new-device').closest('.session-card') as HTMLElement;
+  fireEvent.click(within(qrCard).getByRole('button', { name: 'Show QR' }));
+
+  // Wait for the eager GET .../qr fetch triggered by opening the modal to settle before driving
+  // tab interactions, so its async setQrData doesn't land in the middle of the sequence below.
+  await screen.findByAltText('QR');
+
+  fireEvent.click(screen.getByRole('tab', { name: 'Link with Phone Number' }));
+  const phoneInput = screen.getByLabelText('Phone Number') as HTMLInputElement;
+  fireEvent.change(phoneInput, { target: { value: '919876543210' } });
+  assert.equal(phoneInput.value, '919876543210');
+
+  fireEvent.click(screen.getByRole('tab', { name: 'QR Code' }));
+  fireEvent.click(screen.getByRole('tab', { name: 'Link with Phone Number' }));
+
+  assert.equal(
+    (screen.getByLabelText('Phone Number') as HTMLInputElement).value,
+    '919876543210',
+    'the typed pairing phone number was lost after toggling tabs',
+  );
+});

--- a/dashboard/src/pages/Sessions.tsx
+++ b/dashboard/src/pages/Sessions.tsx
@@ -28,13 +28,10 @@ import {
 import { invalidateSessionQueries, reconcileSessionCache } from '../utils/sessionMutation';
 import { canCreateSession, filterSessions, isValidPairingPhone, sessionNameIssues } from '../utils/sessionForm';
 import { useToast } from '../hooks/useToast';
-import { useWebSocket } from '../hooks/useWebSocket';
 import { useRole } from '../hooks/useRole';
-import {
-  createSessionFeedState,
-  noteSessionFeedError,
-  subscribeSessionFeed,
-} from '../utils/sessionFeedSubscription';
+import { useSessionPairing } from '../hooks/useSessionPairing';
+import { useSessionFeed } from '../hooks/useSessionFeed';
+import { useSessionCreateForm } from '../hooks/useSessionCreateForm';
 import { PageHeader } from '../components/PageHeader';
 import { CustomSelect } from '../components/CustomSelect';
 import { Modal } from '../components/Modal';
@@ -49,15 +46,6 @@ export function Sessions() {
   const [sessions, setSessions] = useState<Session[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [showCreateModal, setShowCreateModal] = useState(false);
-  const [newSessionName, setNewSessionName] = useState('');
-  const [creating, setCreating] = useState(false);
-  const [qrData, setQrData] = useState<{ sessionId: string; sessionName: string; qrCode: string } | null>(null);
-  const [pairingMode, setPairingMode] = useState(false);
-  const [phoneNumber, setPhoneNumber] = useState('');
-  const [pairingCode, setPairingCode] = useState<string | null>(null);
-  const [requestingPairing, setRequestingPairing] = useState(false);
-  const [pairingError, setPairingError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
   const [selectedSession, setSelectedSession] = useState<Session | null>(null);
@@ -96,39 +84,56 @@ export function Sessions() {
     sessionsRef.current = sessions;
   }, [sessions]);
 
+  const {
+    qrData,
+    pairingMode,
+    phoneNumber,
+    pairingCode,
+    requestingPairing,
+    pairingError,
+    setPhoneNumber,
+    selectPairingTab,
+    handleChangeNumber,
+    handleGeneratePairingCode,
+    handleShowQR,
+    handleCloseQRModal,
+    applyQrPush,
+    dismissQrForSession,
+  } = useSessionPairing({ sessions, sessionsRef, reloadSessions: fetchSessions });
+
+  const { showCreateModal, setShowCreateModal, newSessionName, setNewSessionName, creating, handleCreate } =
+    useSessionCreateForm({
+      onCreated: newSession => {
+        // Functional append: never capture a stale `sessions` (a WS or fetch between the await and the
+        // setState would otherwise drop a row). Then invalidate the prefix so stats/groups/chats refresh.
+        setSessions(current => [...current, newSession]);
+        void invalidateSessionQueries(queryClient, queryKeys.sessions);
+      },
+      onFailed: msg => setError(msg),
+    });
+
   // Reconcile the LOCAL view with an authoritative Session response. The previous handlers discarded
   // the response and fabricated `{ status: 'disconnected' }`, losing phone:null, timestamps, and other
   // server-owned fields; this keeps the card and the selected-session modal byte-for-byte with the
   // server. Functional updates (no captured stale `sessions`) feed both the list and the selected row,
   // and the shared cache is reconciled + invalidated so sibling views refetch. The QR modal is cleared
-  // when the session that owned it stops, so it never hangs on a disconnected session's stale code.
+  // (via the pairing hook's dismisser) when the session that owned it stops, so it never hangs on a
+  // disconnected session's stale code.
   const applySessionResponse = useCallback(
     async (updated: Session) => {
       sessionsRef.current = replaceSession(sessionsRef.current, updated);
       setSessions(sessionsRef.current);
       setSelectedSession(current => (current?.id === updated.id ? updated : current));
-      // Functional form deliberately: reading `qrData` here would make it a dependency, and this
-      // callback is held by three lifecycle handlers (start/stop/logout). Opening or closing the QR
-      // modal would then rotate all three for a reason none of them care about. The updater also sees
-      // the CURRENT modal rather than the one captured when this callback was built.
-      setQrData(current => (current?.sessionId === updated.id ? null : current));
+      dismissQrForSession(updated.id);
       await reconcileSessionCache(queryClient, queryKeys.sessions, updated);
     },
-    [queryClient],
+    [queryClient, dismissQrForSession],
   );
 
-  // Live session-feed subscription state: wildcard first, per-session fallback for scoped keys.
-  const feedStateRef = useRef(createSessionFeedState());
-  // Most recent server error frame; folded into feedStateRef by the effect below (kept as state
-  // so the fallback runs after `subscribe` exists — the handler can't reference it directly).
-  const [feedErrorFrame, setFeedErrorFrame] = useState<{ code: string } | null>(null);
-
-  const { isConnected, subscribe } = useWebSocket({
-    onQRCode: useCallback((event: { sessionId: string; qrCode: string }) => {
-      // Fill the open QR modal straight from the push — the REST endpoint 400s BY DESIGN until a QR
-      // exists, so fetching it eagerly just spams the console with expected failures.
-      setQrData(prev => (prev && prev.sessionId === event.sessionId ? { ...prev, qrCode: event.qrCode } : prev));
-    }, []),
+  useSessionFeed({
+    sessions,
+    sessionsRef,
+    onQRCode: applyQrPush,
     onSessionStatus: useCallback(
       (event: { sessionId: string; status: string }) => {
         const prev = sessionsRef.current.find(s => s.id === event.sessionId);
@@ -143,9 +148,7 @@ export function Sessions() {
         // authoritative response arrives — and for `disconnected`, where that fallback is knowingly
         // wrong, the branch below refetches.
         sessionsRef.current = sessionsRef.current.map(s =>
-          s.id === event.sessionId
-            ? { ...s, status: event.status as Session['status'], engineLoaded: undefined }
-            : s,
+          s.id === event.sessionId ? { ...s, status: event.status as Session['status'], engineLoaded: undefined } : s,
         );
         setSessions(sessionsRef.current);
         // Mark the shared session queries stale so sibling views refetch — but ONLY on a real
@@ -173,151 +176,12 @@ export function Sessions() {
       },
       [toast, t, fetchSessions, queryClient],
     ),
-    onServerError: useCallback((frame: { code: string }) => {
-      setFeedErrorFrame(frame);
-    }, []),
   });
-
-  // Fold a server error frame into the feed state: a session-scoped key may not join the '*'
-  // room — silently fall back to one subscription per listed session (the list endpoint is
-  // already scope-filtered server-side), otherwise no status/QR push ever arrives and the QR
-  // modal sits on "generating" forever.
-  useEffect(() => {
-    if (!feedErrorFrame) return;
-    if (noteSessionFeedError(feedStateRef.current, feedErrorFrame.code)) {
-      subscribeSessionFeed({ subscribe }, feedStateRef.current, sessionsRef.current.map(s => s.id));
-    }
-  }, [feedErrorFrame, subscribe]);
-
-  // Join the live session feed (wildcard attempt, or per-session rooms after a scope fallback).
-  useEffect(() => {
-    if (isConnected) {
-      subscribeSessionFeed({ subscribe }, feedStateRef.current, sessionsRef.current.map(s => s.id));
-    }
-  }, [isConnected, subscribe]);
-
-  // Rooms are per-socket on the backend: a reconnect lands on a fresh socket with no
-  // subscriptions, so the per-session dedup set must be forgotten or the join effect
-  // above would skip every already-listed id and no feed frame would arrive again.
-  useEffect(() => {
-    if (!isConnected) feedStateRef.current.subscribedIds.clear();
-  }, [isConnected]);
-
-  // In per-session mode, sessions loaded/created after the fallback still need their rooms.
-  useEffect(() => {
-    if (isConnected && feedStateRef.current.scope === 'per-session') {
-      subscribeSessionFeed({ subscribe }, feedStateRef.current, sessions.map(s => s.id));
-    }
-  }, [isConnected, sessions, subscribe]);
 
   useEffect(() => {
     fetchSessions();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  const qrRefreshInterval = useRef<ReturnType<typeof setInterval> | null>(null);
-  const currentSessionName = useRef<string>('');
-
-  const fetchQR = useCallback(
-    async (sessionId: string) => {
-      // Guard: if session is already connected, stop polling immediately. Read the ref (not `sessions`)
-      // so fetchQR keeps a stable identity — otherwise the polling interval is torn down and restarted on
-      // every sessions update.
-      const currentSession = sessionsRef.current.find(s => s.id === sessionId);
-      if (currentSession?.status === 'ready') {
-        setQrData(null);
-        currentSessionName.current = '';
-        return;
-      }
-      // Poll only while a QR actually exists to refresh (qr_ready): before that the endpoint 400s
-      // by design (the engine hasn't produced one), and the WS session.qr push covers first display.
-      if (currentSession?.status !== 'qr_ready') return;
-      try {
-        const qr = await sessionApi.getQR(sessionId);
-        setQrData({ sessionId, sessionName: currentSessionName.current, qrCode: qr.qrCode });
-        if (qr.status === 'ready') {
-          setQrData(null);
-          currentSessionName.current = '';
-          fetchSessions();
-        }
-      } catch {
-        // Keep qrData alive so the polling interval keeps retrying until the QR
-        // is ready. Only stop polling if the session itself has failed. 'authenticating' is included so
-        // the modal (and the pairing-code panel mounted in it) survives the brief post-link handshake
-        // instead of being torn down mid-pairing — it closes on the real 'ready'/'failed' transition.
-        const updated = await sessionApi.get(sessionId).catch(() => null);
-        const stillInitializing =
-          updated && ['initializing', 'qr_ready', 'authenticating'].includes(updated.status);
-        if (!stillInitializing) {
-          setQrData(null);
-          currentSessionName.current = '';
-          fetchSessions();
-        }
-      }
-    },
-    [fetchSessions],
-  );
-  useEffect(() => {
-    if (qrData) {
-      currentSessionName.current = qrData.sessionName;
-      qrRefreshInterval.current = setInterval(() => {
-        fetchQR(qrData.sessionId);
-      }, 5000);
-    }
-    return () => {
-      if (qrRefreshInterval.current) clearInterval(qrRefreshInterval.current);
-    };
-  }, [qrData, fetchQR]);
-
-  const handleCloseQRModal = useCallback(() => {
-    setQrData(null);
-    setPairingMode(false);
-    setPhoneNumber('');
-    setPairingCode(null);
-    setPairingError(null);
-  }, []);
-
-  const handleGeneratePairingCode = async () => {
-    // Guard against a second concurrent request: the button is disabled while in flight, but the
-    // input's Enter handler is not, so a rapid double-Enter would otherwise fire overlapping POSTs.
-    if (requestingPairing) return;
-    if (!qrData || !phoneNumber.trim()) return;
-    if (!isValidPairingPhone(phoneNumber)) {
-      setPairingError(t('sessions.pairing.invalidPhone'));
-      return;
-    }
-    try {
-      setRequestingPairing(true);
-      setPairingError(null);
-      const res = await sessionApi.requestPairingCode(qrData.sessionId, phoneNumber.trim());
-      setPairingCode(res.pairingCode);
-    } catch (err) {
-      setPairingError(err instanceof Error ? err.message : t('common.errorGeneric'));
-    } finally {
-      setRequestingPairing(false);
-    }
-  };
-
-  const handleCreate = async () => {
-    if (!newSessionName.trim()) return;
-    try {
-      setCreating(true);
-      const newSession = await sessionApi.create(newSessionName);
-      // Functional append: never capture a stale `sessions` (a WS or fetch between the await and the
-      // setState would otherwise drop a row). Then invalidate the prefix so stats/groups/chats refresh.
-      setSessions(current => [...current, newSession]);
-      await invalidateSessionQueries(queryClient, queryKeys.sessions);
-      setNewSessionName('');
-      setShowCreateModal(false);
-      toast.success(t('sessions.create.successTitle'), t('sessions.create.successDesc', { name: newSession.name }));
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : t('sessions.create.errorDefault');
-      setError(msg);
-      toast.error(t('sessions.create.errorTitle'), msg);
-    } finally {
-      setCreating(false);
-    }
-  };
 
   const handleDelete = async (id: string) => {
     const session = sessions.find(s => s.id === id);
@@ -373,36 +237,6 @@ export function Sessions() {
       const fresh = await fetchSessions();
       const current = fresh.find(s => s.id === id);
       if (current?.status !== 'ready') handleShowQR(id);
-    }
-  };
-
-  const handleShowQR = async (id: string) => {
-    const session = sessions.find(s => s.id === id);
-    // Nothing to show for an already-connected session.
-    if (session?.status === 'ready') return;
-    const sessionName = session?.name || '';
-    // Reset any pairing sub-state from a previous open so a freshly opened modal never shows a
-    // stale code/phone belonging to a different session.
-    setPairingMode(false);
-    setPhoneNumber('');
-    setPairingCode(null);
-    setPairingError(null);
-    // Show loading state immediately so the modal opens and polling starts
-    // even before Chromium has finished initializing.
-    setQrData({ sessionId: id, sessionName, qrCode: '' });
-    currentSessionName.current = sessionName;
-    // Eager-fetch only when a QR already exists (qr_ready): before that the endpoint 400s BY DESIGN
-    // (the engine hasn't produced one), and the WS session.qr push + gated 5s poll deliver it
-    // without spamming the console with expected failures.
-    if (session?.status === 'qr_ready') {
-      try {
-        const qr = await sessionApi.getQR(id);
-        setQrData({ sessionId: id, sessionName, qrCode: qr.qrCode });
-      } catch (err) {
-        console.error('Failed to get QR:', err);
-        // Do not clear qrData here — keep the loading modal open so the
-        // polling interval (every 5 s) retries until the QR becomes available.
-      }
     }
   };
 
@@ -606,10 +440,7 @@ export function Sessions() {
                   role="tab"
                   aria-selected={!pairingMode}
                   className={`pairing-tab-btn ${!pairingMode ? 'active' : ''}`}
-                  onClick={() => {
-                    setPairingMode(false);
-                    setPairingError(null);
-                  }}
+                  onClick={() => selectPairingTab(false)}
                 >
                   {t('sessions.pairing.tabQr')}
                 </button>
@@ -617,10 +448,7 @@ export function Sessions() {
                   role="tab"
                   aria-selected={pairingMode}
                   className={`pairing-tab-btn ${pairingMode ? 'active' : ''}`}
-                  onClick={() => {
-                    setPairingMode(true);
-                    setPairingError(null);
-                  }}
+                  onClick={() => selectPairingTab(true)}
                 >
                   {t('sessions.pairing.tabPhone')}
                 </button>
@@ -719,14 +547,7 @@ export function Sessions() {
                     </div>
 
                     <div style={{ marginTop: '1.5rem' }}>
-                      <button
-                        className="btn-secondary"
-                        onClick={() => {
-                          setPairingCode(null);
-                          setPhoneNumber('');
-                        }}
-                        style={{ width: '100%' }}
-                      >
+                      <button className="btn-secondary" onClick={handleChangeNumber} style={{ width: '100%' }}>
                         {t('sessions.pairing.changeNumber')}
                       </button>
                     </div>
@@ -938,8 +759,7 @@ export function Sessions() {
                     <Square size={16} />
                     {t('sessions.actions.stop')}
                   </button>
-                ) : canWrite &&
-                  (session.status === 'created' || session.status === 'disconnected') ? (
+                ) : canWrite && (session.status === 'created' || session.status === 'disconnected') ? (
                   <button className="btn-action" onClick={() => handleStart(session.id)}>
                     <Play size={16} />
                     {t('sessions.actions.start')}

--- a/dashboard/src/test-helpers/vite-shim-hooks.mjs
+++ b/dashboard/src/test-helpers/vite-shim-hooks.mjs
@@ -4,11 +4,13 @@
 //   - extensionless relative imports → resolved by trying .tsx/.ts/.js/.mjs/.json (and /index.*)
 //   - .json           → wrapped as `export default` (Node would demand import attributes)
 //   - .css            → stubbed as an empty module
+//   - .svg/.png/.jpg/.webp → stubbed as `export default '<url>'` (Vite resolves an asset import to
+//     its URL string; Node has no loader for these extensions at all)
 //   - .ts files reading import.meta.env → transpiled with a shim (import.meta.env is a Vite
 //     global Node does not provide); every other .ts falls through to --experimental-strip-types
 //
 // Registered via test-helpers/register-hooks.ts. node:test runs each test file in its own child
-// process, so these hooks only ever affect the component smoke-test process — the 261 pure-logic
+// process, so these hooks only ever affect the component smoke-test process — the pure-logic
 // tests never register them.
 import { readFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
@@ -43,6 +45,11 @@ export async function resolve(specifier, context, nextResolve) {
 export async function load(url, context, nextLoad) {
   if (url.endsWith('.css')) {
     return { format: 'module', source: 'export default {};', shortCircuit: true };
+  }
+  if (url.endsWith('.svg') || url.endsWith('.png') || url.endsWith('.jpg') || url.endsWith('.webp')) {
+    // Vite resolves an asset import to its URL string. The tests never read the bytes; they only
+    // need the import to succeed and the value to be a string an <img src> can take.
+    return { format: 'module', source: `export default ${JSON.stringify(url)};`, shortCircuit: true };
   }
   if (url.endsWith('.json')) {
     const source = await readFile(fileURLToPath(url), 'utf8');

--- a/dashboard/src/utils/restartPoll.test.ts
+++ b/dashboard/src/utils/restartPoll.test.ts
@@ -52,5 +52,5 @@ test('the restart poll targets readiness, not a ping that survives the drain', (
 });
 
 test('the poll deadline comes from the helper rather than a bare constant', () => {
-  assert.match(read('../pages/Infrastructure.tsx'), /const maxAttempts = restartPollAttempts\(/);
+  assert.match(read('../hooks/useRestartFlow.ts'), /const maxAttempts = restartPollAttempts\(/);
 });


### PR DESCRIPTION
`Infrastructure.tsx` held 17 pieces of mutable state in one component; `Sessions.tsx` held 20. This
moves cohesive clusters into custom hooks, leaving 1 and 10.

## Why hooks and not child components

Moving state into a child component changes its lifetime — the child unmounts and the state dies.
Moving state into a custom hook does not, because a hook's state lives in its caller. This project
learned that the hard way twice on the Chats page: first a typed message draft, then a staged file
attachment, both silently discarded when the room closed.

So the split is asymmetric on purpose. Hooks take state; components would take only JSX. In the end
**no child component was extracted at all**, which makes that failure mode unreachable here rather
than merely avoided.

## The tests came first

Neither page had a render test, and the same bug was reachable in `Sessions.tsx` today: the pairing
panel renders only while the Phone tab is active, so a typed number placed inside an extracted panel
would not survive a tab toggle. Six characterization cases were written against the current pages and
mutation-tested before any state moved — including that exact sequence.

The harness also needed unblocking: `Infrastructure.tsx` imports four SVG assets and the ESM loader
handled only `.css`, `.json`, `.tsx` and `.ts`, so the page could not be imported by the test runner
at all. The loader now resolves an asset import to its URL string, as Vite does.

## The hooks

`Infrastructure.tsx` → `useInfraConfigForm`, `useConfigSave`, `useRestartFlow`, `useDataBackup`.

The obvious grouping was wrong in two places and the reads and writes said so. The pending/previous
profile pair is produced by the save and consumed only by the restart call, so splitting it across two
hooks created a bidirectional edge; it belongs to the restart flow, handed over in one call. And the
datastore-switch flags are written by the save and read only by the restart modal's warning — they
never touch the migration flag, which the export/import handlers own. After the correction the only
edge between hooks is a one-way `onSaved(profiles)` callback.

`Sessions.tsx` → `useSessionPairing`, `useSessionFeed`, `useSessionCreateForm`.

The create flow and the pairing flow look like one feature and are not: the create handler never
touches the QR or pairing state and never opens the QR modal. A list hook was considered and rejected —
the session-response handler writes the list, the selection and the QR state in five lines, so
extracting it would have created a cycle with the pairing hook.

## What was deliberately left alone

`queueStats` is live state written by the status-refetch effect and rendered in the webhook-queue
tile; it stays. The four confirmation ids stay in the page — they share no invariant, all three can be
non-null at once today, and one of them is an in-flight guard rather than confirmation state.
Collapsing them would be a behaviour change, not a refactor.

## Verification

Dashboard suite 266 → 272, and the six new cases pass unedited against both the old and the new pages —
the same suite was run in a worktree at the pre-refactor commit to confirm it. Lint, typecheck, i18n
parity, build and unit tests all pass. No backend file is touched.
