### PR TITLE
chore(dashboard): add a formatting gate and bring the tree up to it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,12 @@ jobs:
       - name: Run ESLint
         run: cd dashboard && npm run lint
 
+      # ESLint here carries no Prettier plugin, and the root `format:check` globs `src/**/*.ts` from
+      # the repository root — it never reaches `dashboard/`. Without this step nothing in CI checks
+      # dashboard formatting, which is how 35 files drifted before this gate existed.
+      - name: Check formatting
+        run: cd dashboard && npm run format:check
+
       - name: Type-check dashboard tests
         run: cd dashboard && npm run typecheck
 

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -37,6 +37,7 @@
         "eslint-plugin-react-refresh": "^0.5.3",
         "globals": "^17.8.0",
         "jsdom": "^29.1.1",
+        "prettier": "^3.9.6",
         "typescript": "~6.0.3",
         "typescript-eslint": "^8.65.0",
         "vite": "^8.1.5"
@@ -3281,6 +3282,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -7,6 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "format": "prettier --write \"src/**/*.{ts,tsx,css}\"",
+    "format:check": "prettier --check \"src/**/*.{ts,tsx,css}\"",
     "typecheck": "tsc --noEmit -p tsconfig.test.json",
     "preview": "vite preview",
     "i18n:check": "node scripts/check-i18n-parity.mjs",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -45,6 +45,7 @@
     "eslint-plugin-react-refresh": "^0.5.3",
     "globals": "^17.8.0",
     "jsdom": "^29.1.1",
+    "prettier": "^3.9.6",
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.65.0",
     "vite": "^8.1.5"

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -103,28 +103,32 @@ function AppContent() {
   );
 
   if (!isAuthenticated) {
-    return <Suspense fallback={loadingFallback}><Login onLogin={handleLogin} /></Suspense>;
+    return (
+      <Suspense fallback={loadingFallback}>
+        <Login onLogin={handleLogin} />
+      </Suspense>
+    );
   }
 
   return (
     <ToastProvider>
       <BrowserRouter>
         <Suspense fallback={loadingFallback}>
-        <Routes>
-          <Route path="/" element={<Layout onLogout={handleLogout} userRole={role} />}>
-            <Route index element={<Dashboard />} />
-            <Route path="sessions" element={<Sessions />} />
-            <Route path="chats" element={<Chats />} />
-            <Route path="webhooks" element={<Webhooks />} />
-            <Route path="templates" element={<Templates />} />
-            {role === 'admin' && <Route path="api-keys" element={<ApiKeys />} />}
-            <Route path="logs" element={<Logs />} />
-            <Route path="message-tester" element={<MessageTester />} />
-            {role === 'admin' && <Route path="infrastructure" element={<Infrastructure />} />}
-            {role === 'admin' && <Route path="plugins" element={<Plugins />} />}
-            <Route path="*" element={<Navigate to="/" replace />} />
-          </Route>
-        </Routes>
+          <Routes>
+            <Route path="/" element={<Layout onLogout={handleLogout} userRole={role} />}>
+              <Route index element={<Dashboard />} />
+              <Route path="sessions" element={<Sessions />} />
+              <Route path="chats" element={<Chats />} />
+              <Route path="webhooks" element={<Webhooks />} />
+              <Route path="templates" element={<Templates />} />
+              {role === 'admin' && <Route path="api-keys" element={<ApiKeys />} />}
+              <Route path="logs" element={<Logs />} />
+              <Route path="message-tester" element={<MessageTester />} />
+              {role === 'admin' && <Route path="infrastructure" element={<Infrastructure />} />}
+              {role === 'admin' && <Route path="plugins" element={<Plugins />} />}
+              <Route path="*" element={<Navigate to="/" replace />} />
+            </Route>
+          </Routes>
         </Suspense>
       </BrowserRouter>
     </ToastProvider>

--- a/dashboard/src/components/CustomSelect.tsx
+++ b/dashboard/src/components/CustomSelect.tsx
@@ -95,10 +95,10 @@ export function CustomSelect({ value, onChange, options, ariaLabel }: CustomSele
           if (e.key.length === 1) {
             typeAheadBuffer.current += e.key.toLowerCase();
             clearTimeout(typeAheadTimer.current);
-            typeAheadTimer.current = setTimeout(() => { typeAheadBuffer.current = ''; }, 500);
-            const match = options.findIndex(opt =>
-              opt.label.toLowerCase().startsWith(typeAheadBuffer.current),
-            );
+            typeAheadTimer.current = setTimeout(() => {
+              typeAheadBuffer.current = '';
+            }, 500);
+            const match = options.findIndex(opt => opt.label.toLowerCase().startsWith(typeAheadBuffer.current));
             if (match >= 0) setFocusedIndex(match);
           }
           break;

--- a/dashboard/src/components/DashboardCharts.css
+++ b/dashboard/src/components/DashboardCharts.css
@@ -44,7 +44,9 @@
   font-size: 0.8125rem;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.15s ease, color 0.15s ease;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease;
 }
 
 .dashboard-charts .period-tab.active {

--- a/dashboard/src/components/ErrorBoundary.tsx
+++ b/dashboard/src/components/ErrorBoundary.tsx
@@ -32,11 +32,18 @@ export class ErrorBoundary extends Component<Props, State> {
   render() {
     if (this.state.hasError) {
       return (
-        <div style={{
-          display: 'flex', flexDirection: 'column', alignItems: 'center',
-          justifyContent: 'center', minHeight: '100vh', padding: '2rem',
-          fontFamily: 'system-ui, sans-serif', color: 'var(--text-primary)',
-        }}>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            minHeight: '100vh',
+            padding: '2rem',
+            fontFamily: 'system-ui, sans-serif',
+            color: 'var(--text-primary)',
+          }}
+        >
           <AlertCircle size={48} style={{ color: 'var(--error)', marginBottom: '1rem' }} />
           <h1 style={{ fontSize: '1.5rem', marginBottom: '0.5rem' }}>{i18n.t('errorBoundary.title')}</h1>
           <p style={{ color: 'var(--text-muted)', marginBottom: '1.5rem', textAlign: 'center' }}>
@@ -45,10 +52,16 @@ export class ErrorBoundary extends Component<Props, State> {
           <button
             onClick={this.handleReload}
             style={{
-              display: 'flex', alignItems: 'center', gap: '0.5rem',
-              padding: '0.75rem 1.5rem', backgroundColor: 'var(--primary)',
-              color: 'white', border: 'none', borderRadius: '0.5rem',
-              cursor: 'pointer', fontSize: '1rem',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.5rem',
+              padding: '0.75rem 1.5rem',
+              backgroundColor: 'var(--primary)',
+              color: 'white',
+              border: 'none',
+              borderRadius: '0.5rem',
+              cursor: 'pointer',
+              fontSize: '1rem',
             }}
           >
             <RefreshCw size={18} />

--- a/dashboard/src/components/GlobalSearch.tsx
+++ b/dashboard/src/components/GlobalSearch.tsx
@@ -26,36 +26,63 @@ export function GlobalSearch({ onHit, currentSessionId }: GlobalSearchProps) {
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const blurTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const run = useCallback(async (query: string, offset: number, append: boolean) => {
-    const params = buildSearchParams(query, scopeCurrent && currentSessionId ? { sessionId: currentSessionId } : undefined, { limit: PAGE_SIZE, offset });
-    if (!params) { setHits([]); setTotal(0); setError(null); setLoading(false); return; }
-    setLoading(true); setError(null);
-    try {
-      const res = await searchApi.search(params);
-      setHits(prev => append ? [...prev, ...res.hits] : res.hits);
-      setTotal(res.total);
-    } catch (e: unknown) {
-      const status = (e as { status?: number }).status;
-      if (status === 501) setError(t('search.unavailable'));
-      else if (status === 503) setError(t('search.error'));
-      else setError(t('search.error'));
-      setHits([]); setTotal(0);
-    } finally {
-      setLoading(false);
-    }
-  }, [scopeCurrent, currentSessionId, t]);
+  const run = useCallback(
+    async (query: string, offset: number, append: boolean) => {
+      const params = buildSearchParams(
+        query,
+        scopeCurrent && currentSessionId ? { sessionId: currentSessionId } : undefined,
+        { limit: PAGE_SIZE, offset },
+      );
+      if (!params) {
+        setHits([]);
+        setTotal(0);
+        setError(null);
+        setLoading(false);
+        return;
+      }
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await searchApi.search(params);
+        setHits(prev => (append ? [...prev, ...res.hits] : res.hits));
+        setTotal(res.total);
+      } catch (e: unknown) {
+        const status = (e as { status?: number }).status;
+        if (status === 501) setError(t('search.unavailable'));
+        else if (status === 503) setError(t('search.error'));
+        else setError(t('search.error'));
+        setHits([]);
+        setTotal(0);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [scopeCurrent, currentSessionId, t],
+  );
 
   // Debounce on input change.
   useEffect(() => {
     if (timer.current) clearTimeout(timer.current);
-    if (!q.trim()) { setHits([]); setTotal(0); setError(null); return; }
-    timer.current = setTimeout(() => { setOpen(true); void run(q, 0, false); }, DEBOUNCE_MS);
-    return () => { if (timer.current) clearTimeout(timer.current); };
+    if (!q.trim()) {
+      setHits([]);
+      setTotal(0);
+      setError(null);
+      return;
+    }
+    timer.current = setTimeout(() => {
+      setOpen(true);
+      void run(q, 0, false);
+    }, DEBOUNCE_MS);
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
   }, [q, run]);
 
   // Clear any pending blur timeout on unmount so it can't fire setState after teardown.
   useEffect(() => {
-    return () => { if (blurTimer.current) clearTimeout(blurTimer.current); };
+    return () => {
+      if (blurTimer.current) clearTimeout(blurTimer.current);
+    };
   }, []);
 
   const loadMore = () => void run(q, hits.length, true);
@@ -67,14 +94,16 @@ export function GlobalSearch({ onHit, currentSessionId }: GlobalSearchProps) {
         type="text"
         placeholder={t('search.placeholder')}
         value={q}
-        onChange={(e) => setQ(e.target.value)}
+        onChange={e => setQ(e.target.value)}
         onFocus={() => q.trim() && setOpen(true)}
-        onBlur={() => { blurTimer.current = setTimeout(() => setOpen(false), 150); }}
+        onBlur={() => {
+          blurTimer.current = setTimeout(() => setOpen(false), 150);
+        }}
         aria-label={t('search.placeholder')}
       />
       {currentSessionId && (
         <label className="global-search-scope">
-          <input type="checkbox" checked={scopeCurrent} onChange={(e) => setScopeCurrent(e.target.checked)} />
+          <input type="checkbox" checked={scopeCurrent} onChange={e => setScopeCurrent(e.target.checked)} />
           {t('search.scope.current')}
         </label>
       )}
@@ -83,16 +112,24 @@ export function GlobalSearch({ onHit, currentSessionId }: GlobalSearchProps) {
           {loading && <div className="global-search-state">{t('search.loading')}</div>}
           {!loading && error && <div className="global-search-state">{error}</div>}
           {!loading && !error && hits.length === 0 && <div className="global-search-state">{t('search.empty')}</div>}
-          {!loading && !error && hits.map((h) => (
-            <button key={h.messageId} className="global-search-hit" role="option" onMouseDown={() => onHit(h)}>
-              <div className="global-search-hit-meta">{h.chatId} · {new Date(h.timestamp * 1000).toLocaleString()}</div>
-              <div className="global-search-hit-snippet">
-                {renderHighlightedSnippet(h.snippet).map((seg, i) => seg.marked ? <mark key={i}>{seg.text}</mark> : <span key={i}>{seg.text}</span>)}
-              </div>
-            </button>
-          ))}
+          {!loading &&
+            !error &&
+            hits.map(h => (
+              <button key={h.messageId} className="global-search-hit" role="option" onMouseDown={() => onHit(h)}>
+                <div className="global-search-hit-meta">
+                  {h.chatId} · {new Date(h.timestamp * 1000).toLocaleString()}
+                </div>
+                <div className="global-search-hit-snippet">
+                  {renderHighlightedSnippet(h.snippet).map((seg, i) =>
+                    seg.marked ? <mark key={i}>{seg.text}</mark> : <span key={i}>{seg.text}</span>,
+                  )}
+                </div>
+              </button>
+            ))}
           {!loading && !error && hits.length < total && (
-            <button className="global-search-more" onClick={loadMore}>{t('search.results', { count: total })}</button>
+            <button className="global-search-more" onClick={loadMore}>
+              {t('search.results', { count: total })}
+            </button>
           )}
         </div>
       )}

--- a/dashboard/src/components/PluginInstances.tsx
+++ b/dashboard/src/components/PluginInstances.tsx
@@ -183,16 +183,28 @@ export function PluginInstances({ pluginId }: { pluginId: string }) {
                 {inst.enabled ? t('plugins.instances.enabled') : t('plugins.instances.disabled')}
               </span>
               <div className="pi-actions">
-                <button className="icon-btn" onClick={() => void toggleEnabled(inst)} title={t(`plugins.instances.actions.${inst.enabled ? 'disable' : 'enable'}`)}>
+                <button
+                  className="icon-btn"
+                  onClick={() => void toggleEnabled(inst)}
+                  title={t(`plugins.instances.actions.${inst.enabled ? 'disable' : 'enable'}`)}
+                >
                   <Power size={16} />
                 </button>
-                <button className="icon-btn" onClick={() => setConfirm({ type: 'regenerate', inst })} title={t('plugins.instances.actions.regenerate')}>
+                <button
+                  className="icon-btn"
+                  onClick={() => setConfirm({ type: 'regenerate', inst })}
+                  title={t('plugins.instances.actions.regenerate')}
+                >
                   <RefreshCw size={16} />
                 </button>
                 <button className="icon-btn" onClick={() => openEdit(inst)} title={t('plugins.instances.actions.edit')}>
                   <Pencil size={16} />
                 </button>
-                <button className="icon-btn danger" onClick={() => setConfirm({ type: 'delete', inst })} title={t('plugins.instances.actions.delete')}>
+                <button
+                  className="icon-btn danger"
+                  onClick={() => setConfirm({ type: 'delete', inst })}
+                  title={t('plugins.instances.actions.delete')}
+                >
                   <Trash2 size={16} />
                 </button>
               </div>
@@ -213,7 +225,11 @@ export function PluginInstances({ pluginId }: { pluginId: string }) {
               <button className="btn-secondary" onClick={() => setShowForm(false)}>
                 {t('common.cancel')}
               </button>
-              <button className="btn-primary" onClick={() => void submitCreate()} disabled={createM.isPending || !form.instanceId}>
+              <button
+                className="btn-primary"
+                onClick={() => void submitCreate()}
+                disabled={createM.isPending || !form.instanceId}
+              >
                 {createM.isPending ? <Loader2 className="animate-spin" size={16} /> : t('common.create')}
               </button>
             </>
@@ -264,7 +280,11 @@ export function PluginInstances({ pluginId }: { pluginId: string }) {
         <Modal
           open
           onClose={() => setMinted(null)}
-          title={mintedKind === 'regenerated' ? t('plugins.instances.regenerate.title') : t('plugins.instances.created.title')}
+          title={
+            mintedKind === 'regenerated'
+              ? t('plugins.instances.regenerate.title')
+              : t('plugins.instances.created.title')
+          }
           closeLabel={t('common.close')}
           footer={
             <button className="btn-secondary" onClick={() => setMinted(null)}>
@@ -305,7 +325,11 @@ export function PluginInstances({ pluginId }: { pluginId: string }) {
                 {t('common.cancel')}
               </button>
               <button className="btn-primary" onClick={() => void submitEdit()} disabled={updateM.isPending}>
-                {updateM.isPending ? <Loader2 className="animate-spin" size={16} /> : t('plugins.instances.actions.save')}
+                {updateM.isPending ? (
+                  <Loader2 className="animate-spin" size={16} />
+                ) : (
+                  t('plugins.instances.actions.save')
+                )}
               </button>
             </>
           }

--- a/dashboard/src/components/chats/ChatComposer.tsx
+++ b/dashboard/src/components/chats/ChatComposer.tsx
@@ -303,9 +303,7 @@ function ChatComposer({
             <div className="replying-to-title">
               {t('chats.replyingTo', {
                 name:
-                  replyingTo.direction === 'outgoing'
-                    ? t('chats.you')
-                    : activeChat.name || activeChat.id.split('@')[0],
+                  replyingTo.direction === 'outgoing' ? t('chats.you') : activeChat.name || activeChat.id.split('@')[0],
               })}
             </div>
             <div className="replying-to-body">

--- a/dashboard/src/components/chats/ChatSidebar.tsx
+++ b/dashboard/src/components/chats/ChatSidebar.tsx
@@ -66,7 +66,11 @@ function ChatSidebar({
   const renderChatRow = (chat: Chat) => {
     const isActive = chatsTab.activeChatId === chat.id;
     return (
-      <div key={chat.id} className={`chat-item-card ${isActive ? 'active' : ''}`} onClick={() => chatsTab.onSelectChat(chat)}>
+      <div
+        key={chat.id}
+        className={`chat-item-card ${isActive ? 'active' : ''}`}
+        onClick={() => chatsTab.onSelectChat(chat)}
+      >
         <ChatAvatar pictureUrl={chatsTab.pictures?.[chat.id]} kind={chat.kind} />
 
         <div className="chat-item-info">

--- a/dashboard/src/components/chats/ChatThread.tsx
+++ b/dashboard/src/components/chats/ChatThread.tsx
@@ -115,9 +115,7 @@ function ChatThread({
       ) : (
         messages.map((msg, index) => {
           const isMe = msg.direction === 'outgoing';
-          const formattedTime = formatTime(
-            msg.timestamp || Math.floor(new Date(msg.createdAt).getTime() / 1000),
-          );
+          const formattedTime = formatTime(msg.timestamp || Math.floor(new Date(msg.createdAt).getTime() / 1000));
 
           // Label who posted, WhatsApp-style: only in groups, only on incoming messages,
           // and only on the first of a consecutive run from the same sender (so a burst
@@ -125,11 +123,11 @@ function ChatThread({
           const prev = messages[index - 1];
           const showSender = Boolean(
             activeChat?.isGroup &&
-              !isMe &&
-              msg.chatName &&
-              // Key the run on the stable sender id (participant JID), not the display
-              // name — two participants who share a pushName must still start a new run.
-              (!prev || prev.direction === 'outgoing' || senderKey(prev) !== senderKey(msg)),
+            !isMe &&
+            msg.chatName &&
+            // Key the run on the stable sender id (participant JID), not the display
+            // name — two participants who share a pushName must still start a new run.
+            (!prev || prev.direction === 'outgoing' || senderKey(prev) !== senderKey(msg)),
           );
 
           const isMediaMessage = msg.type !== 'text';
@@ -195,12 +193,7 @@ function ChatThread({
               case 'video':
                 return (
                   <div className="message-media-video">
-                    <video
-                      src={mediaSrc}
-                      controls
-                      className="chat-video-media"
-                      onLoadedData={onMediaLoad}
-                    />
+                    <video src={mediaSrc} controls className="chat-video-media" onLoadedData={onMediaLoad} />
                   </div>
                 );
               case 'audio':
@@ -214,11 +207,7 @@ function ChatThread({
               default:
                 return (
                   <div className="message-media-document">
-                    <a
-                      href={mediaSrc}
-                      download={mediaInfo.filename || 'document'}
-                      className="chat-document-media"
-                    >
+                    <a href={mediaSrc} download={mediaInfo.filename || 'document'} className="chat-document-media">
                       📎 {mediaInfo.filename || t('chats.downloadDocument')}
                     </a>
                   </div>
@@ -316,11 +305,7 @@ function ChatThread({
                     </button>
 
                     <div className="reaction-trigger-wrapper">
-                      <button
-                        type="button"
-                        className="action-btn reaction-btn"
-                        title={t('chats.actions.react')}
-                      >
+                      <button type="button" className="action-btn reaction-btn" title={t('chats.actions.react')}>
                         <Smile size={14} />
                       </button>
                       <div className="reaction-quick-popover">

--- a/dashboard/src/components/chats/MessageBody.tsx
+++ b/dashboard/src/components/chats/MessageBody.tsx
@@ -31,7 +31,11 @@ function renderNode(node: MessageNode, key: number): ReactNode {
     case 'code':
       return <code key={key}>{node.value}</code>;
     case 'codeblock':
-      return <pre key={key}><code>{node.value}</code></pre>;
+      return (
+        <pre key={key}>
+          <code>{node.value}</code>
+        </pre>
+      );
   }
 }
 
@@ -39,9 +43,7 @@ function MessageBodyBase({ text, className, enableLinks = true }: Props) {
   const nodes = parseMessageBody(text);
   const rendered = <>{nodes.map(renderNode)}</>;
   return (
-    <div className={className}>
-      {enableLinks ? <Linkify options={linkifyOptions}>{rendered}</Linkify> : rendered}
-    </div>
+    <div className={className}>{enableLinks ? <Linkify options={linkifyOptions}>{rendered}</Linkify> : rendered}</div>
   );
 }
 

--- a/dashboard/src/components/chats/StatusComposeModal.tsx
+++ b/dashboard/src/components/chats/StatusComposeModal.tsx
@@ -86,11 +86,7 @@ function StatusComposeModal({ sessionId, onClose, onPosted }: Props) {
 
   const toggleComposeRecipient = (id: string) => {
     setComposeRecipients(prev =>
-      prev.includes(id)
-        ? prev.filter(r => r !== id)
-        : prev.length >= STATUS_RECIPIENTS_MAX
-          ? prev
-          : [...prev, id],
+      prev.includes(id) ? prev.filter(r => r !== id) : prev.length >= STATUS_RECIPIENTS_MAX ? prev : [...prev, id],
     );
   };
 
@@ -234,12 +230,7 @@ function StatusComposeModal({ sessionId, onClose, onPosted }: Props) {
           </div>
           <p className="compose-image-or">{t('chats.status.orLabel')}</p>
           <div className="compose-field">
-            <input
-              type="file"
-              accept="image/*"
-              ref={composeFileInputRef}
-              onChange={handleComposeImageFile}
-            />
+            <input type="file" accept="image/*" ref={composeFileInputRef} onChange={handleComposeImageFile} />
           </div>
           <div className="compose-field">
             <label>{t('chats.status.caption')}</label>

--- a/dashboard/src/hooks/queries.ts
+++ b/dashboard/src/hooks/queries.ts
@@ -27,8 +27,7 @@ export const queryKeys = {
   webhooks: ['webhooks'] as const,
   templates: (sessionId: string) => ['sessions', sessionId, 'templates'] as const,
   apiKeys: ['apiKeys'] as const,
-  logs: (params: { severity?: string; page: number; limit: number }) =>
-    ['logs', params] as const,
+  logs: (params: { severity?: string; page: number; limit: number }) => ['logs', params] as const,
   infraStatus: ['infra', 'status'] as const,
   plugins: ['plugins'] as const,
   pluginInstances: (pluginId: string) => ['plugins', pluginId, 'instances'] as const,
@@ -123,8 +122,7 @@ export function useUpdateWebhookMutation() {
 export function useDeleteWebhookMutation() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (params: { sessionId: string; id: string }) =>
-      webhookApi.delete(params.sessionId, params.id),
+    mutationFn: (params: { sessionId: string; id: string }) => webhookApi.delete(params.sessionId, params.id),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: queryKeys.webhooks });
     },
@@ -167,8 +165,7 @@ export function useUpdateTemplateMutation() {
 export function useDeleteTemplateMutation() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (params: { sessionId: string; id: string }) =>
-      templateApi.delete(params.sessionId, params.id),
+    mutationFn: (params: { sessionId: string; id: string }) => templateApi.delete(params.sessionId, params.id),
     onSuccess: (_template, params) => {
       void queryClient.invalidateQueries({ queryKey: queryKeys.templates(params.sessionId) });
     },
@@ -188,8 +185,13 @@ export function useApiKeysQuery() {
 export function useCreateApiKeyMutation() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (data: { name: string; role: string; allowedIps?: string[]; allowedSessions?: string[]; expiresAt?: string }) =>
-      apiKeyApi.create(data),
+    mutationFn: (data: {
+      name: string;
+      role: string;
+      allowedIps?: string[];
+      allowedSessions?: string[];
+      expiresAt?: string;
+    }) => apiKeyApi.create(data),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: queryKeys.apiKeys });
     },

--- a/dashboard/src/hooks/useContactStatuses.ts
+++ b/dashboard/src/hooks/useContactStatuses.ts
@@ -1,10 +1,7 @@
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import { sessionApi, type StatusUpdate } from '../services/api';
 
-export function useContactStatuses(
-  sessionId: string | null,
-  enabled = true,
-): UseQueryResult<StatusUpdate[], Error> {
+export function useContactStatuses(sessionId: string | null, enabled = true): UseQueryResult<StatusUpdate[], Error> {
   return useQuery<StatusUpdate[], Error>({
     queryKey: ['contact-statuses', sessionId],
     queryFn: async () => (await sessionApi.getContactStatuses(sessionId!)).statuses,

--- a/dashboard/src/i18n/index.ts
+++ b/dashboard/src/i18n/index.ts
@@ -14,7 +14,20 @@ import it from './locales/it.json';
 import ptBR from './locales/pt-BR.json';
 import ko from './locales/ko.json';
 
-export const supportedLanguages = ['en', 'de', 'es', 'he', 'zh-CN', 'zh-HK', 'ar', 'te', 'fr', 'it', 'pt-BR', 'ko'] as const;
+export const supportedLanguages = [
+  'en',
+  'de',
+  'es',
+  'he',
+  'zh-CN',
+  'zh-HK',
+  'ar',
+  'te',
+  'fr',
+  'it',
+  'pt-BR',
+  'ko',
+] as const;
 export type SupportedLanguage = (typeof supportedLanguages)[number];
 
 export const rtlLanguages: SupportedLanguage[] = ['he', 'ar'];

--- a/dashboard/src/i18n/locales.test.ts
+++ b/dashboard/src/i18n/locales.test.ts
@@ -107,7 +107,10 @@ test('sessionStatus.failed and sessionStatus.authenticating resolve in every loc
     for (const status of ['failed', 'authenticating']) {
       const key = `sessionStatus.${status}`;
       const value = i18n.t(key, { lng });
-      assert.ok(value && value !== key && value !== status, `${lng}: ${key} missing — status pill would render raw "${status}"`);
+      assert.ok(
+        value && value !== key && value !== status,
+        `${lng}: ${key} missing — status pill would render raw "${status}"`,
+      );
     }
   }
   assert.equal(i18n.t('sessionStatus.failed'), 'Failed');

--- a/dashboard/src/pages/ApiKeys.tsx
+++ b/dashboard/src/pages/ApiKeys.tsx
@@ -383,7 +383,9 @@ export function ApiKeys() {
           </div>
           <p className="confirm-message">
             <Trans
-              i18nKey={confirmAction.type === 'delete' ? 'apiKeys.confirm.deleteMessage' : 'apiKeys.confirm.revokeMessage'}
+              i18nKey={
+                confirmAction.type === 'delete' ? 'apiKeys.confirm.deleteMessage' : 'apiKeys.confirm.revokeMessage'
+              }
               values={{ name: confirmAction.name }}
               components={{ strong: <strong /> }}
             />

--- a/dashboard/src/pages/Chats.test.ts
+++ b/dashboard/src/pages/Chats.test.ts
@@ -200,11 +200,7 @@ function renderChats(): { container: HTMLElement } {
     createElement(
       QueryClientProvider,
       { client: queryClient },
-      createElement(
-        RoleProvider,
-        null,
-        createElement(ToastProvider, null, createElement(Chats)),
-      ),
+      createElement(RoleProvider, null, createElement(ToastProvider, null, createElement(Chats))),
     ),
   );
 }

--- a/dashboard/src/pages/Chats.tsx
+++ b/dashboard/src/pages/Chats.tsx
@@ -4,14 +4,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { nextReconnectState } from '../utils/reconnectState';
 import { applyIncomingToChatList } from '../utils/chatList';
 import { filterChats, filterChannels, groupStatusesByContact } from '../utils/chatFilters';
-import {
-  ArrowLeft,
-  Loader2,
-  Megaphone,
-  CircleDashed,
-  AlertCircle,
-  MessageSquare,
-} from 'lucide-react';
+import { ArrowLeft, Loader2, Megaphone, CircleDashed, AlertCircle, MessageSquare } from 'lucide-react';
 import { useProfilePicture } from '../hooks/useProfilePicture';
 import { useProfilePictures } from '../hooks/useProfilePictures';
 import { useResolvedPhone } from '../hooks/useResolvedPhone';
@@ -937,11 +930,7 @@ export function Chats() {
               // subscribed channels are a broadcast feed, not a two-way conversation.
               <div key={activeChannel.id} className="channel-room">
                 <header className="chats-room-header">
-                  <button
-                    className="room-back"
-                    onClick={() => setActiveChannel(null)}
-                    aria-label={t('common.back')}
-                  >
+                  <button className="room-back" onClick={() => setActiveChannel(null)} aria-label={t('common.back')}>
                     <ArrowLeft size={20} />
                   </button>
                   <Megaphone size={20} />
@@ -987,7 +976,11 @@ export function Chats() {
                     <ArrowLeft size={20} />
                   </button>
                   <CircleDashed size={20} />
-                  <h2>{activeStatusGroup.contact.name ?? activeStatusGroup.contact.pushName ?? activeStatusGroup.contact.id}</h2>
+                  <h2>
+                    {activeStatusGroup.contact.name ??
+                      activeStatusGroup.contact.pushName ??
+                      activeStatusGroup.contact.id}
+                  </h2>
                 </header>
                 <div className="messages-list" ref={statusFeedRef}>
                   {activeStatusGroup.items.map(item => (
@@ -1000,9 +993,7 @@ export function Chats() {
                       style={
                         item.type === 'text' && (item.backgroundColor || item.font)
                           ? {
-                              ...(item.backgroundColor
-                                ? { backgroundColor: item.backgroundColor, color: '#fff' }
-                                : {}),
+                              ...(item.backgroundColor ? { backgroundColor: item.backgroundColor, color: '#fff' } : {}),
                               ...statusFontStyle(item.font),
                             }
                           : undefined

--- a/dashboard/src/pages/Plugins.tsx
+++ b/dashboard/src/pages/Plugins.tsx
@@ -587,9 +587,7 @@ export default function Plugins() {
         plugin.status === 'enabled' ? await pluginsApi.disable(plugin.id) : await pluginsApi.enable(plugin.id);
       if (!res.success) {
         toast.warning(
-          plugin.status === 'enabled'
-            ? t('plugins.toasts.disableFailedTitle')
-            : t('plugins.toasts.enableFailedTitle'),
+          plugin.status === 'enabled' ? t('plugins.toasts.disableFailedTitle') : t('plugins.toasts.enableFailedTitle'),
           res.message,
         );
       }
@@ -1180,7 +1178,7 @@ export default function Plugins() {
                   {/* The Sessions and Instances tabs have their own actions; the footer Save is config-tab
                       only. A plugin with its own editor saves through that editor, so the footer Save is
                       omitted rather than left to save a form the operator cannot see. */}
-                  {showTabs && (configTab === 'sessions' || configTab === 'instances') ||
+                  {(showTabs && (configTab === 'sessions' || configTab === 'instances')) ||
                   configPlugin.configUi ? null : lz.configSchema &&
                     Object.keys(lz.configSchema.properties).length > 0 ? (
                     <button className="btn-primary" onClick={handleSaveSchemaConfig} disabled={savingConfig}>

--- a/dashboard/src/pages/Templates.tsx
+++ b/dashboard/src/pages/Templates.tsx
@@ -64,7 +64,10 @@ export function Templates() {
   const [previewValues, setPreviewValues] = useState<Record<string, string>>({});
   const [searchTerm, setSearchTerm] = useState('');
 
-  const { data: templates = [], isLoading: loadingTemplates } = useTemplatesQuery(selectedSessionId, !!selectedSessionId);
+  const { data: templates = [], isLoading: loadingTemplates } = useTemplatesQuery(
+    selectedSessionId,
+    !!selectedSessionId,
+  );
   const createMutation = useCreateTemplateMutation();
   const updateMutation = useUpdateTemplateMutation();
   const deleteMutation = useDeleteTemplateMutation();
@@ -371,7 +374,9 @@ export function Templates() {
                   type="button"
                 >
                   {isSaving ? <Loader2 size={18} className="animate-spin" /> : <Plus size={18} />}
-                  {canWrite ? t(editingTemplate ? 'templates.saveChanges' : 'templates.createTemplate') : t('templates.viewOnly')}
+                  {canWrite
+                    ? t(editingTemplate ? 'templates.saveChanges' : 'templates.createTemplate')
+                    : t('templates.viewOnly')}
                 </button>
               </div>
             </div>

--- a/dashboard/src/pages/Webhooks.tsx
+++ b/dashboard/src/pages/Webhooks.tsx
@@ -135,7 +135,7 @@ export function Webhooks() {
   const [toast, setToast] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
 
   // Single source for the contact/group autocomplete in whichever modal is open.
-  const activeSessionId = showEditModal ? editWebhook?.sessionId ?? '' : newWebhook.sessionId;
+  const activeSessionId = showEditModal ? (editWebhook?.sessionId ?? '') : newWebhook.sessionId;
   const { data: chats = [] } = useSessionChatsQuery(activeSessionId, showCreateModal || showEditModal);
 
   const eventDescription = (name: string) => {
@@ -484,7 +484,8 @@ export function Webhooks() {
           ) : (
             <div className="webhooks-card-list">
               {webhooks.map(webhook => {
-                const sessionName = sessions.find(s => s.id === webhook.sessionId)?.name || webhook.sessionId.substring(0, 12);
+                const sessionName =
+                  sessions.find(s => s.id === webhook.sessionId)?.name || webhook.sessionId.substring(0, 12);
                 return (
                   <div key={webhook.id} className="webhook-card">
                     <div className="webhook-card-header">
@@ -499,11 +500,19 @@ export function Webhooks() {
                           onClick={() => handleTest(webhook.sessionId, webhook.id)}
                           disabled={testingId === webhook.id}
                         >
-                          {testingId === webhook.id ? <Loader2 size={16} className="animate-spin" /> : <Play size={16} />}
+                          {testingId === webhook.id ? (
+                            <Loader2 size={16} className="animate-spin" />
+                          ) : (
+                            <Play size={16} />
+                          )}
                         </button>
                         {canWrite && (
                           <>
-                            <button className="icon-btn" title={t('webhooks.actions.edit')} onClick={() => openEdit(webhook)}>
+                            <button
+                              className="icon-btn"
+                              title={t('webhooks.actions.edit')}
+                              onClick={() => openEdit(webhook)}
+                            >
                               <Edit size={16} />
                             </button>
                             <button

--- a/dashboard/src/styles.scope.test.ts
+++ b/dashboard/src/styles.scope.test.ts
@@ -25,17 +25,30 @@ function selectors(css: string): string[] {
     let j = i;
     while (j < n && css[j] !== '{' && css[j] !== '}') j++;
     if (j >= n) break;
-    if (css[j] === '}') { i = j + 1; continue; }
+    if (css[j] === '}') {
+      i = j + 1;
+      continue;
+    }
     const header = css.slice(i, j).trim();
-    let depth = 1, k = j + 1;
-    while (k < n && depth) { if (css[k] === '{') depth++; else if (css[k] === '}') depth--; k++; }
+    let depth = 1,
+      k = j + 1;
+    while (k < n && depth) {
+      if (css[k] === '{') depth++;
+      else if (css[k] === '}') depth--;
+      k++;
+    }
     const body = css.slice(j + 1, k - 1);
     if (/^@keyframes|^@font-face|^@page/.test(header)) {
       /* keyframe/font selectors are not class-scoped — skip */
     } else if (/^@media|^@supports|^@container/.test(header)) {
       out.push(...selectors(body)); // recurse: inner rules must still be scoped
     } else if (header) {
-      out.push(...header.split(',').map(s => s.trim()).filter(Boolean));
+      out.push(
+        ...header
+          .split(',')
+          .map(s => s.trim())
+          .filter(Boolean),
+      );
     }
     i = k;
   }

--- a/dashboard/src/utils/authLifecycle.ts
+++ b/dashboard/src/utils/authLifecycle.ts
@@ -22,10 +22,7 @@ export function clearActorState(...caches: ClearableCache[]): void {
   for (const cache of caches) cache.clear();
 }
 
-export type StartupValidation =
-  | { action: 'role'; role: UserRole }
-  | { action: 'logout' }
-  | { action: 'keep' };
+export type StartupValidation = { action: 'role'; role: UserRole } | { action: 'logout' } | { action: 'keep' };
 
 /**
  * Fold the startup /auth/validate answer into an auth decision:

--- a/dashboard/src/utils/chatList.test.ts
+++ b/dashboard/src/utils/chatList.test.ts
@@ -27,7 +27,11 @@ test('an arriving message moves its chat to the top and refreshes the snippet', 
   );
   assert.equal(chats[0].lastMessage, 'hi');
   assert.equal(chats[0].timestamp, 200);
-  assert.deepEqual(before.map(c => c.id), ['a@c.us', 'b@c.us'], 'input is not mutated');
+  assert.deepEqual(
+    before.map(c => c.id),
+    ['a@c.us', 'b@c.us'],
+    'input is not mutated',
+  );
 });
 
 test('a location message shows the label, never its base64 body', () => {
@@ -110,7 +114,11 @@ test('promoteChatWithSnippet moves the sent-into chat to the top', () => {
   );
   assert.equal(after[0].lastMessage, '[image]');
   assert.equal(after[0].timestamp, 999);
-  assert.deepEqual(before.map(c => c.id), ['a@c.us', 'b@c.us'], 'input is not mutated');
+  assert.deepEqual(
+    before.map(c => c.id),
+    ['a@c.us', 'b@c.us'],
+    'input is not mutated',
+  );
 });
 
 test('promoteChatWithSnippet leaves an unknown chat alone rather than inventing a row', () => {

--- a/dashboard/src/utils/chatMessages.test.ts
+++ b/dashboard/src/utils/chatMessages.test.ts
@@ -348,10 +348,7 @@ test('capMediaPayloads: past the limit the OLDEST payloads strip to the omitted 
   assert.equal(capped[1].metadata?.media?.data, 'PAYLOAD_1');
   assert.equal(capped[MEDIA_PAYLOAD_CACHE_LIMIT].metadata?.media?.data, `PAYLOAD_${MEDIA_PAYLOAD_CACHE_LIMIT}`);
   // The retained payload count is exactly the cap.
-  assert.equal(
-    capped.filter(m => m.metadata?.media?.data).length,
-    MEDIA_PAYLOAD_CACHE_LIMIT,
-  );
+  assert.equal(capped.filter(m => m.metadata?.media?.data).length, MEDIA_PAYLOAD_CACHE_LIMIT);
   // Input is not mutated.
   assert.equal(list[0].metadata?.media?.data, 'PAYLOAD_0');
 });

--- a/dashboard/src/utils/chatMessages.ts
+++ b/dashboard/src/utils/chatMessages.ts
@@ -105,7 +105,13 @@ export const senderKey = (m: Pick<ChatMessage, 'author' | 'chatName'>): string |
 
 // ChatMessageView extends ChatMessage with the view-only fields the chat page renders.
 // Lifted from Chats.tsx so hooks/utils can share the same shape.
-export type MessageMedia = { mimetype: string; filename?: string; data?: string; omitted?: boolean; sizeBytes?: number };
+export type MessageMedia = {
+  mimetype: string;
+  filename?: string;
+  data?: string;
+  omitted?: boolean;
+  sizeBytes?: number;
+};
 
 export const getMediaSrc = (media?: MessageMedia): string => {
   if (!media || !media.data) return '';

--- a/dashboard/src/utils/messageFormatter.test.ts
+++ b/dashboard/src/utils/messageFormatter.test.ts
@@ -21,45 +21,31 @@ test('*bold* wraps with bold', () => {
 });
 
 test('_italic_ wraps with italic', () => {
-  assert.deepEqual(parseMessageBody('_em_'), [
-    { type: 'italic', children: [text('em')] },
-  ]);
+  assert.deepEqual(parseMessageBody('_em_'), [{ type: 'italic', children: [text('em')] }]);
 });
 
 test('~strike~ wraps with strike', () => {
-  assert.deepEqual(parseMessageBody('~gone~'), [
-    { type: 'strike', children: [text('gone')] },
-  ]);
+  assert.deepEqual(parseMessageBody('~gone~'), [{ type: 'strike', children: [text('gone')] }]);
 });
 
 test('`inline` produces a code node with literal value', () => {
-  assert.deepEqual(parseMessageBody('use `npm i` now'), [
-    text('use '),
-    { type: 'code', value: 'npm i' },
-    text(' now'),
-  ]);
+  assert.deepEqual(parseMessageBody('use `npm i` now'), [text('use '), { type: 'code', value: 'npm i' }, text(' now')]);
 });
 
 test('```block``` produces a codeblock node with literal value', () => {
-  assert.deepEqual(parseMessageBody('```line1\nline2```'), [
-    { type: 'codeblock', value: 'line1\nline2' },
-  ]);
+  assert.deepEqual(parseMessageBody('```line1\nline2```'), [{ type: 'codeblock', value: 'line1\nline2' }]);
 });
 
 test('code segments do not get formatted inside', () => {
   // The `*not*` inside the code segment stays literal.
-  assert.deepEqual(parseMessageBody('`*not*`'), [
-    { type: 'code', value: '*not*' },
-  ]);
+  assert.deepEqual(parseMessageBody('`*not*`'), [{ type: 'code', value: '*not*' }]);
 });
 
 test('nesting: *_a_* -> bold(italic(a))', () => {
   assert.deepEqual(parseMessageBody('*_a_*'), [
     {
       type: 'bold',
-      children: [
-        { type: 'italic', children: [text('a')] },
-      ],
+      children: [{ type: 'italic', children: [text('a')] }],
     },
   ]);
 });
@@ -88,9 +74,7 @@ test('multiple consecutive formats: *a* _b_', () => {
 test('marker without outside boundary stays literal (no over-formatting)', () => {
   // 'word*bold*end' has no boundary char before the opening '*' nor after the closer.
   // Per WhatsApp rules this is literal text — the boundary guard prevents over-formatting.
-  assert.deepEqual(parseMessageBody('word*bold*end'), [
-    { type: 'text', value: 'word*bold*end' },
-  ]);
+  assert.deepEqual(parseMessageBody('word*bold*end'), [{ type: 'text', value: 'word*bold*end' }]);
 });
 
 // Deepest bold/italic/strike nesting in a parsed tree; text/code leaves count as 0.
@@ -104,8 +88,7 @@ test('hostile input: deep marker nesting is capped instead of overflowing the st
   const nodes = parseMessageBody(evil);
   assert.ok(treeDepth(nodes) <= 20, `nesting depth ${treeDepth(nodes)} exceeds the cap`);
   // Beyond the cap the leftover markers degrade to literal text — nothing is dropped.
-  const flat = (ns: MessageNode[]): string =>
-    ns.map(n => ('children' in n ? flat(n.children) : n.value)).join('');
+  const flat = (ns: MessageNode[]): string => ns.map(n => ('children' in n ? flat(n.children) : n.value)).join('');
   const rendered = flat(nodes);
   assert.ok(rendered.includes('a'));
   assert.ok(rendered.includes('*_'), 'unparsed markers must survive as literal text');

--- a/dashboard/src/utils/messageFormatter.ts
+++ b/dashboard/src/utils/messageFormatter.ts
@@ -15,7 +15,7 @@ export type MessageNode =
 
 const FORMATS: Record<string, 'bold' | 'italic' | 'strike'> = {
   '*': 'bold',
-  '_': 'italic',
+  _: 'italic',
   '~': 'strike',
 };
 

--- a/dashboard/src/utils/reconnectState.test.ts
+++ b/dashboard/src/utils/reconnectState.test.ts
@@ -3,36 +3,41 @@ import assert from 'node:assert/strict';
 import { nextReconnectState } from './reconnectState.ts';
 
 test('initial connect (never connected before): no invalidate', () => {
-  assert.deepEqual(
-    nextReconnectState({ isConnected: true, hadConnected: false, wasDisconnected: false }),
-    { invalidate: false, hadConnected: true, wasDisconnected: false },
-  );
+  assert.deepEqual(nextReconnectState({ isConnected: true, hadConnected: false, wasDisconnected: false }), {
+    invalidate: false,
+    hadConnected: true,
+    wasDisconnected: false,
+  });
 });
 
 test('disconnect before any connect (noise): no gap marked, no invalidate', () => {
-  assert.deepEqual(
-    nextReconnectState({ isConnected: false, hadConnected: false, wasDisconnected: false }),
-    { invalidate: false, hadConnected: false, wasDisconnected: false },
-  );
+  assert.deepEqual(nextReconnectState({ isConnected: false, hadConnected: false, wasDisconnected: false }), {
+    invalidate: false,
+    hadConnected: false,
+    wasDisconnected: false,
+  });
 });
 
 test('disconnect after the first connect: mark a gap, no invalidate', () => {
-  assert.deepEqual(
-    nextReconnectState({ isConnected: false, hadConnected: true, wasDisconnected: false }),
-    { invalidate: false, hadConnected: true, wasDisconnected: true },
-  );
+  assert.deepEqual(nextReconnectState({ isConnected: false, hadConnected: true, wasDisconnected: false }), {
+    invalidate: false,
+    hadConnected: true,
+    wasDisconnected: true,
+  });
 });
 
 test('reconnect after a gap (wasDisconnected): invalidate', () => {
-  assert.deepEqual(
-    nextReconnectState({ isConnected: true, hadConnected: true, wasDisconnected: true }),
-    { invalidate: true, hadConnected: true, wasDisconnected: false },
-  );
+  assert.deepEqual(nextReconnectState({ isConnected: true, hadConnected: true, wasDisconnected: true }), {
+    invalidate: true,
+    hadConnected: true,
+    wasDisconnected: false,
+  });
 });
 
 test('stays connected: no invalidate, stays hadConnected', () => {
-  assert.deepEqual(
-    nextReconnectState({ isConnected: true, hadConnected: true, wasDisconnected: false }),
-    { invalidate: false, hadConnected: true, wasDisconnected: false },
-  );
+  assert.deepEqual(nextReconnectState({ isConnected: true, hadConnected: true, wasDisconnected: false }), {
+    invalidate: false,
+    hadConnected: true,
+    wasDisconnected: false,
+  });
 });

--- a/dashboard/src/utils/scrollDecision.test.ts
+++ b/dashboard/src/utils/scrollDecision.test.ts
@@ -3,7 +3,9 @@ import assert from 'node:assert/strict';
 import { decideScroll, type ScrollGeometry } from './scrollDecision.ts';
 
 const at = (scrollTop: number, scrollHeight = 1000, clientHeight = 500): ScrollGeometry => ({
-  scrollTop, scrollHeight, clientHeight,
+  scrollTop,
+  scrollHeight,
+  clientHeight,
 });
 
 test('outgoing message always scrolls to bottom', () => {

--- a/dashboard/src/utils/search-highlight.ts
+++ b/dashboard/src/utils/search-highlight.ts
@@ -5,9 +5,7 @@
  * text-node content, the unescaped body becomes inert characters. NEVER use `dangerouslySetInnerHTML`
  * on the raw snippet.
  */
-export function renderHighlightedSnippet(
-  snippet: string,
-): { text: string; marked: boolean }[] {
+export function renderHighlightedSnippet(snippet: string): { text: string; marked: boolean }[] {
   if (!snippet) return [{ text: '', marked: false }];
   // Split on <mark>/</mark>; odd indices (1, 3, …) were between the tags → highlighted.
   // The marked flag is derived from the pre-filter index, then empty boundary segments
@@ -16,7 +14,7 @@ export function renderHighlightedSnippet(
   return snippet
     .split(/<\/?mark>/)
     .map((text, i) => ({ text, marked: i % 2 === 1 }))
-    .filter((seg) => seg.text.length > 0);
+    .filter(seg => seg.text.length > 0);
 }
 
 /** Build the SearchParams for a debounced query (trims, drops empty). */

--- a/dashboard/src/utils/sessionActions.test.ts
+++ b/dashboard/src/utils/sessionActions.test.ts
@@ -119,7 +119,10 @@ test('replaceSession: unrelated rows keep their identity and order', () => {
   const updated = makeSession({ id: 'b', status: 'disconnected' });
   const result = replaceSession([a, b, c], updated);
 
-  assert.deepEqual(result.map(s => s.id), ['a', 'b', 'c']);
+  assert.deepEqual(
+    result.map(s => s.id),
+    ['a', 'b', 'c'],
+  );
   assert.equal(result[0], a, 'unrelated row keeps identity');
   assert.equal(result[2], c, 'unrelated row keeps identity');
   assert.equal(result[1], updated, 'matching row is the exact response object');
@@ -138,7 +141,10 @@ test('replaceSession: a response whose id is absent does not drop other rows (no
   const b = makeSession({ id: 'b' });
   const orphan = makeSession({ id: 'zzz', status: 'disconnected' });
   const result = replaceSession([a, b], orphan);
-  assert.deepEqual(result.map(s => s.id), ['a', 'b']);
+  assert.deepEqual(
+    result.map(s => s.id),
+    ['a', 'b'],
+  );
   assert.equal(result[0], a);
   assert.equal(result[1], b);
 });

--- a/dashboard/src/utils/sessionActions.ts
+++ b/dashboard/src/utils/sessionActions.ts
@@ -13,13 +13,7 @@ import type { Session } from '../services/api.ts';
 // The fallback below is for a dashboard talking to a gateway that predates the field. It reproduces
 // the old status set, whose known wrong answer is exactly that `disconnected` case — a stale
 // dashboard keeps the old behaviour instead of guessing differently.
-const STARTED_STATUSES_FALLBACK = new Set([
-  'initializing',
-  'qr_ready',
-  'authenticating',
-  'ready',
-  'action_required',
-]);
+const STARTED_STATUSES_FALLBACK = new Set(['initializing', 'qr_ready', 'authenticating', 'ready', 'action_required']);
 
 export function isSessionStarted(session: Pick<Session, 'status' | 'engineLoaded'>): boolean {
   return session.engineLoaded ?? STARTED_STATUSES_FALLBACK.has(session.status);

--- a/dashboard/src/utils/sessionForm.test.ts
+++ b/dashboard/src/utils/sessionForm.test.ts
@@ -78,8 +78,21 @@ test('filterSessions combines the search box and the status group', () => {
     { id: 'u3', name: 'sales-backup', status: 'disconnected' },
   ];
 
-  assert.deepEqual(filterSessions(sessions, 'sales', 'all').map(s => s.id), ['u1', 'u3']);
-  assert.deepEqual(filterSessions(sessions, 'sales', 'inactive').map(s => s.id), ['u3']);
-  assert.deepEqual(filterSessions(sessions, '', 'active').map(s => s.id), ['u1']);
-  assert.deepEqual(filterSessions(sessions, 'u2', 'all').map(s => s.id), ['u2'], 'id matches too');
+  assert.deepEqual(
+    filterSessions(sessions, 'sales', 'all').map(s => s.id),
+    ['u1', 'u3'],
+  );
+  assert.deepEqual(
+    filterSessions(sessions, 'sales', 'inactive').map(s => s.id),
+    ['u3'],
+  );
+  assert.deepEqual(
+    filterSessions(sessions, '', 'active').map(s => s.id),
+    ['u1'],
+  );
+  assert.deepEqual(
+    filterSessions(sessions, 'u2', 'all').map(s => s.id),
+    ['u2'],
+    'id matches too',
+  );
 });


### PR DESCRIPTION
Nothing in CI checked dashboard formatting.

The Dashboard job runs ESLint, which carries no Prettier plugin, and the repository's
`format:check` script globs `src/**/*.ts` from the root — a pattern that never reaches `dashboard/`.
So the dashboard has been outside every formatting gate since it was added, and 35 files had drifted
from the repository's own `.prettierrc`. The gap surfaced during a recent refactor: a review round was
spent on width violations that no gate would ever have caught, in files that were "clean" by every
check the project runs.

## What this does

- Adds `format` and `format:check` to `dashboard/package.json`, covering `src/**/*.{ts,tsx,css}`.
  All three extensions, deliberately — a gate that skips a file type invites the same drift back.
- Reformats the tree to satisfy it (34 files).
- Runs `format:check` in the Dashboard CI job, immediately after ESLint.

The dashboard has no Prettier config of its own, so this applies the repository's existing
`.prettierrc` where it was previously unenforced. No new dependency: `prettier` is already present.

## Why this is safe to read quickly

Prettier is an AST-preserving printer, so the 34-file diff is line-wrapping and nothing else. The
verification that matters is that the suite is unchanged: **272 passing before and after**, with
`lint`, `typecheck`, `i18n:check` and `build` all still green.

The diff is large but shallow. The two files worth actually reading are `dashboard/package.json` and
`.github/workflows/ci.yml`; the rest is the formatter's output.
