### PR TITLE
fix(docker): chown only /app/data instead of the whole /app tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   REST, the WebSocket gateway and the MCP mount all route through, so every surface agrees on what the
   credential is. Whitespace is never part of a key, so no legitimate credential changes meaning.
 
+- **Image builds no longer walk all of `node_modules` to chown it.** The production stage ended with
+  `chown -R openwa:openwa /app`, which touched every installed dependency file — over half an hour on
+  a small VPS, the slowest step of the build — and duplicated their metadata into a new image layer.
+  It was redundant: runtime writes only happen under `/app/data` and `/tmp`, the entrypoint re-chowns
+  `/app/data` at every container start, and the app tree only needs read access. The chown now covers
+  `./data` only, so the step is instant and the layer is gone. (#1045)
+
 ## [0.12.5] - 2026-08-03
 
 The follow-up to 0.12.4, and the end of the decomposition work. **Nothing here is visible to a user or

--- a/Dockerfile
+++ b/Dockerfile
@@ -151,9 +151,13 @@ COPY --from=builder /app/dist ./dist
 # (app.module.ts resolves dashboard/dist relative to dist/). Single container, single port.
 COPY --from=builder /app/dashboard/dist ./dashboard/dist
 
-# Create data directories with correct ownership
-RUN mkdir -p ./data/sessions ./data/media && \
-    chown -R openwa:openwa /app
+# Create data directories with correct ownership. Only ./data is chowned, NOT all of /app: the app
+# tree (node_modules, dist) only needs read access, which root-owned files already grant, and the
+# entrypoint re-chowns /app/data at every container start for the mounted-volume case. A full
+# /app chown walks every production dependency file (issue #1045: ~35 minutes on a small VPS) and
+# duplicates their metadata into a new image layer.
+RUN mkdir -p ./data/sessions ./data/media ./data/plugins && \
+    chown -R openwa:openwa ./data
 
 # The non-root openwa user has no home of its own (`useradd -r`, no -m). Chromium resolves the home
 # dir from the passwd entry via glib's getpwuid() — it IGNORES $HOME — so it tries to read/write


### PR DESCRIPTION
## Description

The production stage ended with `chown -R openwa:openwa /app`, which walks every file of the production `node_modules` at image build time — 2,130s (~35 minutes) on the reporter's 2 vCPU / 2 GB VPS, the single slowest step of the build — and duplicates the metadata of all of those files into a new image layer (the following `exporting layers` took another 124s).

The full-tree chown is redundant:

- Runtime writes happen only under `/app/data` (sessions, media, plugins, SQLite, `.env.generated`) and `/tmp` (XDG dirs).
- `docker-entrypoint.sh` already runs `mkdir -p` + `chown -R openwa:openwa /app/data` as root at **every** container start, which covers bind mounts and named volumes on first boot.
- The app tree (`node_modules`, `dist`, `dashboard/dist`) only needs read access, which root-owned files already grant; both compose files run a `read_only` rootfs anyway.

The chown is narrowed to `./data`, and `./data/plugins` is added to the `mkdir` to match the entrypoint.

Verified locally against the built image:

- `[production 12/14]` drops from minutes to **0.1s**; `exporting layers` 123.6s → 18.2s.
- Container booted from the image: health endpoint 200, node process runs as `openwa`, `/app/data` is `openwa:openwa` on a fresh volume, app tree readable, data dir writable.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] Tests added/updated — verified by a full image build + container boot (see above); no unit-testable surface
- [x] Documentation updated — `CHANGELOG.md` `[Unreleased]`; Dockerfile comment explains the narrowed scope
- [x] Lint passes
- [x] Self-reviewed

## Related Issues
Closes #1045
