### PR TITLE
fix(session): clear stale lid->phone mapping on definitive null resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A contact who hides their number no longer keeps a stale `lid -> phone` mapping forever.**
+  `SessionLidResolver` only persisted positive resolutions, so once a `@lid` sender's phone became
+  unresolvable (e.g. username adoption) the stored mapping was never corrected — the message `from`
+  filter and the reverse lookup kept attributing that lid to the old number, and API responses kept
+  returning a phone the user chose to hide. A definitive `null` answer from the engine now overwrites
+  the mapping; transient failures (no live engine, call rejected) still never touch it. (#1058)
+
 - **A key pasted with a stray space now authenticates on the WebSocket, not just over REST.**
   `validateApiKey` hashed the raw string as given, and HTTP strips surrounding whitespace from header
   values in transit — so a padded key was accepted on every REST call while the Socket.IO handshake,

--- a/src/modules/session/session-lid-resolver.service.spec.ts
+++ b/src/modules/session/session-lid-resolver.service.spec.ts
@@ -63,10 +63,24 @@ describe('SessionLidResolver', () => {
     expect(remember).toHaveBeenCalledWith('111', '628111222333', 's1');
   });
 
-  it('does not persist a miss', async () => {
+  it('persists a definitive null resolution so a stale mapping converges (#1058)', async () => {
     resolveContactPhone.mockResolvedValue(null);
 
     await resolver.resolveSenderPhone('s1', '404@lid');
+
+    expect(remember).toHaveBeenCalledWith('404', null, 's1');
+  });
+
+  it('does not persist a transient failure (engine rejects) as a null mapping', async () => {
+    resolveContactPhone.mockRejectedValue(new Error('socket closed'));
+
+    await resolver.resolveSenderPhone('s1', '111@lid');
+
+    expect(remember).not.toHaveBeenCalled();
+  });
+
+  it('does not persist when there is no live engine (transient, not definitive)', async () => {
+    await resolver.resolveSenderPhone('not-started', '111@lid');
 
     expect(remember).not.toHaveBeenCalled();
   });

--- a/src/modules/session/session-lid-resolver.service.ts
+++ b/src/modules/session/session-lid-resolver.service.ts
@@ -41,8 +41,17 @@ export class SessionLidResolver {
       return cached;
     }
     let phone: string | null;
+    // `resolved` marks a definitive engine answer: a rejection or a missing engine is a transient
+    // unknown, NOT "this contact has no phone", and must never overwrite a stored mapping (#1058).
+    let resolved = false;
     try {
-      phone = (await this.engines.get(sessionId)?.resolveContactPhone(contactId)) ?? null;
+      const engine = this.engines.get(sessionId);
+      if (engine) {
+        phone = (await engine.resolveContactPhone(contactId)) ?? null;
+        resolved = true;
+      } else {
+        phone = null;
+      }
     } catch {
       phone = null;
     }
@@ -54,10 +63,12 @@ export class SessionLidResolver {
       }
     }
     this.cache.set(key, phone);
-    // Persist a real @lid -> phone resolution so the read-path can bridge this contact's `@lid` and
-    // `@c.us` rows even when the operator never sent to them (#583 R3 Phase 2). Reuses the resolution
-    // above — no extra network call — and is fire-and-forget so dispatch never blocks/fails on it.
-    if (phone) {
+    // Persist the resolution so the read-path can bridge this contact's `@lid` and `@c.us` rows even
+    // when the operator never sent to them (#583 R3 Phase 2). A definitive null is persisted too, so
+    // a phone that later becomes hidden overwrites its stale mapping instead of being served forever
+    // (#1058). Reuses the resolution above — no extra network call — and is fire-and-forget so
+    // dispatch never blocks/fails on it.
+    if (phone || resolved) {
       void this.lidMappingStore?.remember(userPart(contactId), phone, sessionId)?.catch(() => {});
     }
     return phone;


### PR DESCRIPTION
## Summary

- `SessionLidResolver` only wrote positive lid->phone resolutions through to `lid_mappings`. A definitive `null` (the contact hid their number) was cached in memory but never persisted, so the stale mapping survived indefinitely — the message `from` filter and the reverse lookup kept attributing that lid to the old phone, and API responses kept returning a number the user no longer exposes.
- A definitive `null` answer from the engine now overwrites the stored mapping, so the table converges. Transient failures (no live engine, rejected call) are distinguished from a definitive answer and still never touch the table.

## Test plan

- New spec: a definitive `null` resolution persists `remember(lid, null, sessionId)`.
- Guard specs: an engine rejection and a missing engine must not write a `null` mapping.
- Full suite green: 257 suites / 4075 tests, plus `npm run build`, ESLint and Prettier on the touched files.

Closes #1058