### PR TITLE
feat(helm): add Helm chart for Kubernetes deployments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -66,3 +66,6 @@ temp/
 
 # Debug
 .pnpm-debug.log*
+
+# Helm chart — deployment artifact, not a build input
+charts/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `BAILEYS_MARK_ONLINE_ON_CONNECT=false` keeps phone push notifications alive while a Baileys gateway is connected (default `true`, prior behavior). (#871)
 
+- **Helm chart for Kubernetes deployments, under `charts/openwa/`.** A single-replica
+  StatefulSet with a PVC for `/app/data` (session auth, main DB, media, plugins), the
+  docker-compose hardening mirrored (read-only rootfs, dropped capabilities, writable
+  `emptyDir` at `/tmp`), free-form `env`/`secretEnv` maps covering every variable in
+  `.env.example`, and optional Ingress, PodDisruptionBudget and ServiceMonitor.
+  Datastores are not bundled — point `env` at your own or stay on the SQLite default.
+  Closes #695.
+
 ### Fixed
 
 - **A key pasted with a stray space now authenticates on the WebSocket, not just over REST.**

--- a/charts/openwa/Chart.yaml
+++ b/charts/openwa/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: openwa
+description: OpenWA — WhatsApp API. Single-instance StatefulSet (see values.yaml replicaCount warning).
+type: application
+version: 0.1.0
+appVersion: "0.12.5"
+keywords:
+  - whatsapp
+  - openwa
+  - api
+home: https://github.com/rmyndharis/OpenWA
+sources:
+  - https://github.com/rmyndharis/OpenWA

--- a/charts/openwa/README.md
+++ b/charts/openwa/README.md
@@ -1,0 +1,36 @@
+# openwa
+
+Helm chart for [OpenWA](https://github.com/rmyndharis/OpenWA) — WhatsApp API.
+
+> **Single instance only.** OpenWA is single-process with in-memory engine state.
+> Keep `replicaCount: 1`; scaling out corrupts WhatsApp session auth. See
+> [docs/13-horizontal-scaling.md](../../docs/13-horizontal-scaling.md).
+
+## Install
+
+```bash
+helm install openwa ./charts/openwa \
+  --set secretEnv.API_MASTER_KEY=$(openssl rand -base64 32)
+```
+
+With `secretEnv.API_MASTER_KEY` left empty the app bootstraps a key into
+`/app/data/.api-key` on the PVC; the post-install NOTES show how to read it.
+
+## Configuration
+
+`env` (→ ConfigMap) and `secretEnv` (→ Secret) are free-form maps: any variable
+from the repo's `.env.example` works, e.g.:
+
+```bash
+helm install openwa ./charts/openwa \
+  --set env.DATABASE_TYPE=postgres \
+  --set env.DATABASE_HOST=postgres.default.svc \
+  --set secretEnv.DATABASE_USERNAME=openwa \
+  --set secretEnv.DATABASE_PASSWORD=...
+```
+
+Or bring your own Secret: `--set existingSecret=my-openwa-secret`.
+
+All other values (`persistence`, `resources`, `ingress`, `serviceMonitor`, …) are
+documented inline in [values.yaml](values.yaml). The chart does NOT bundle
+PostgreSQL/Redis/MinIO — point `env` at your own, or stay on the SQLite default.

--- a/charts/openwa/README.md
+++ b/charts/openwa/README.md
@@ -21,6 +21,9 @@ With `secretEnv.API_MASTER_KEY` left empty the app bootstraps a key into
 `env` (→ ConfigMap) and `secretEnv` (→ Secret) are free-form maps: any variable
 from the repo's `.env.example` works, e.g.:
 
+The container port is fixed at 2785; do not set PORT in env (probes and the
+Service targetPort are pinned to it) — service.port changes the Service port.
+
 ```bash
 helm install openwa ./charts/openwa \
   --set env.DATABASE_TYPE=postgres \

--- a/charts/openwa/templates/NOTES.txt
+++ b/charts/openwa/templates/NOTES.txt
@@ -1,0 +1,18 @@
+OpenWA has been installed as release "{{ .Release.Name }}".
+
+  WARNING: replicaCount must stay 1. OpenWA holds live WhatsApp engine state in
+  memory; scaling out corrupts session auth. See docs/13-horizontal-scaling.md.
+
+1. Wait for the pod:
+     kubectl -n {{ .Release.Namespace }} rollout status statefulset/{{ include "openwa.fullname" . }}
+
+2. Get the API key. If secretEnv.API_MASTER_KEY was left empty, the app generated
+   one on first boot and stored it on the PVC:
+     kubectl -n {{ .Release.Namespace }} exec {{ include "openwa.fullname" . }}-0 -- cat /app/data/.api-key
+
+3. Reach the API + dashboard:
+     kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "openwa.fullname" . }} 2785:{{ .Values.service.port }}
+     then open http://localhost:2785 (dashboard) or call http://localhost:2785/api.
+{{- if .Values.ingress.enabled }}
+   Or via the ingress host: http{{ if .Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.host }}
+{{- end }}

--- a/charts/openwa/templates/_helpers.tpl
+++ b/charts/openwa/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{- define "openwa.name" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "openwa.fullname" -}}
+{{- if contains .Chart.Name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{- define "openwa.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "openwa.labels" -}}
+helm.sh/chart: {{ include "openwa.chart" . }}
+{{ include "openwa.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "openwa.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "openwa.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "openwa.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "openwa.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "openwa.secretName" -}}
+{{- if .Values.existingSecret }}
+{{- .Values.existingSecret }}
+{{- else }}
+{{- include "openwa.fullname" . }}
+{{- end }}
+{{- end }}

--- a/charts/openwa/templates/configmap.yaml
+++ b/charts/openwa/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "openwa.fullname" . }}
+  labels:
+    {{- include "openwa.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.env }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}

--- a/charts/openwa/templates/ingress.yaml
+++ b/charts/openwa/templates/ingress.yaml
@@ -18,7 +18,7 @@ spec:
       http:
         paths:
           {{- range .Values.ingress.paths }}
-          - path: {{ .path }}
+          - path: {{ .path | quote }}
             pathType: {{ .pathType }}
             backend:
               service:

--- a/charts/openwa/templates/ingress.yaml
+++ b/charts/openwa/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "openwa.fullname" . }}
+  labels:
+    {{- include "openwa.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          {{- range .Values.ingress.paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "openwa.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/openwa/templates/pdb.yaml
+++ b/charts/openwa/templates/pdb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "openwa.fullname" . }}
+  labels:
+    {{- include "openwa.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "openwa.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/openwa/templates/secret.yaml
+++ b/charts/openwa/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if not .Values.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "openwa.fullname" . }}
+  labels:
+    {{- include "openwa.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- range $key, $value := .Values.secretEnv }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/openwa/templates/service-headless.yaml
+++ b/charts/openwa/templates/service-headless.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "openwa.fullname" . }}-headless
+  labels:
+    {{- include "openwa.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  selector:
+    {{- include "openwa.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: 2785
+      targetPort: http

--- a/charts/openwa/templates/service.yaml
+++ b/charts/openwa/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "openwa.fullname" . }}
+  labels:
+    {{- include "openwa.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "openwa.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http

--- a/charts/openwa/templates/serviceaccount.yaml
+++ b/charts/openwa/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "openwa.serviceAccountName" . }}
+  labels:
+    {{- include "openwa.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/openwa/templates/servicemonitor.yaml
+++ b/charts/openwa/templates/servicemonitor.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "openwa.fullname" . }}
+  labels:
+    {{- include "openwa.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "openwa.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: /api/metrics
+      interval: {{ .Values.serviceMonitor.interval }}
+      {{- if .Values.serviceMonitor.bearerTokenSecret.name }}
+      bearerTokenSecret:
+        name: {{ .Values.serviceMonitor.bearerTokenSecret.name }}
+        key: {{ .Values.serviceMonitor.bearerTokenSecret.key }}
+      {{- end }}
+{{- end }}

--- a/charts/openwa/templates/servicemonitor.yaml
+++ b/charts/openwa/templates/servicemonitor.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "openwa.fullname" . }}
   labels:
     {{- include "openwa.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/openwa/templates/statefulset.yaml
+++ b/charts/openwa/templates/statefulset.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "openwa.fullname" . }}
+  labels:
+    {{- include "openwa.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "openwa.fullname" . }}-headless
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "openwa.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "openwa.selectorLabels" . | nindent 8 }}
+    spec:
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      serviceAccountName: {{ include "openwa.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 2785
+          envFrom:
+            - configMapRef:
+                name: {{ include "openwa.fullname" . }}
+            - secretRef:
+                name: {{ include "openwa.secretName" . }}
+          livenessProbe:
+            httpGet:
+              path: /api/health/live
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /api/health/ready
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /app/data
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          {{- include "openwa.labels" . | nindent 10 }}
+      spec:
+        accessModes:
+          {{- toYaml .Values.persistence.accessModes | nindent 10 }}
+        {{- if .Values.persistence.storageClass }}
+        storageClassName: {{ .Values.persistence.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size }}

--- a/charts/openwa/templates/statefulset.yaml
+++ b/charts/openwa/templates/statefulset.yaml
@@ -17,6 +17,8 @@ spec:
     spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       serviceAccountName: {{ include "openwa.serviceAccountName" . }}
+      # The app never calls the Kubernetes API — don't mount a token it can't use.
+      automountServiceAccountToken: false
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -70,10 +72,12 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
   volumeClaimTemplates:
+    # volumeClaimTemplates is immutable in the StatefulSet API — only ever put
+    # immutable labels here (selectorLabels), never the chart/app-version labels.
     - metadata:
         name: data
         labels:
-          {{- include "openwa.labels" . | nindent 10 }}
+          {{- include "openwa.selectorLabels" . | nindent 10 }}
       spec:
         accessModes:
           {{- toYaml .Values.persistence.accessModes | nindent 10 }}

--- a/charts/openwa/values.yaml
+++ b/charts/openwa/values.yaml
@@ -1,0 +1,108 @@
+# replicaCount MUST stay 1. OpenWA is a single-process application: live WhatsApp
+# engine state is in-memory, and two pods driving the same session data corrupt the
+# session auth (forced logout / ban). See docs/13-horizontal-scaling.md.
+replicaCount: 1
+
+image:
+  repository: ghcr.io/rmyndharis/openwa
+  # Defaults to the chart's appVersion when empty.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+# Non-secret application config, rendered into a ConfigMap and loaded via envFrom.
+# Any variable from .env.example is valid here — that file stays the canonical list.
+env:
+  NODE_ENV: production
+  LOG_LEVEL: info
+
+# Secret config, rendered into a chart-managed Secret (stringData). Leave
+# API_MASTER_KEY empty to let the app bootstrap a key into /app/data/.api-key
+# (persists on the PVC) — NOTES.txt after install shows how to read it.
+secretEnv:
+  API_MASTER_KEY: ""
+
+# Name of an existing, operator-managed Secret to load via envFrom instead of the
+# chart-managed one. When set, secretEnv is ignored and no Secret is created.
+existingSecret: ""
+
+service:
+  type: ClusterIP
+  port: 80
+
+persistence:
+  # /app/data holds session auth, the main SQLite DB, media and plugins — losing
+  # this volume loses the linked WhatsApp sessions and the API keys.
+  size: 10Gi
+  storageClass: ""
+  accessModes:
+    - ReadWriteOnce
+
+# Headless Chromium (whatsapp-web.js) is memory-heavy during QR/init; too-tight
+# limits show up as OOMKilled loops at session start.
+resources:
+  requests:
+    memory: 512Mi
+    cpu: 250m
+  limits:
+    memory: 2Gi
+    cpu: 1000m
+
+# Matches docker-compose stop_grace_period: graceful drain + per-engine Chromium
+# teardown can exceed the 30s k8s default.
+terminationGracePeriodSeconds: 45
+
+# Parity with docker-compose hardening. The image entrypoint STARTS AS ROOT to
+# chown /app/data + the XDG dirs, then drops to the openwa user via gosu — so do
+# NOT add runAsNonRoot here; it breaks that pattern.
+containerSecurityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+    add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER
+      - SETGID
+      - SETUID
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  host: openwa.example.com
+  paths:
+    - path: /
+      pathType: Prefix
+  tls: []
+  #  - secretName: openwa-tls
+  #    hosts:
+  #      - openwa.example.com
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+# With replicaCount 1, minAvailable: 1 blocks voluntary eviction (node drains hang
+# until the pod is rescheduled). Opt in only with a matching runbook.
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+
+# Requires METRICS_TOKEN set on the app (via secretEnv); without it /api/metrics
+# returns 404.
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  # Secret holding the METRICS_TOKEN value for bearer auth.
+  bearerTokenSecret:
+    name: ""
+    key: token
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/charts/openwa/values.yaml
+++ b/charts/openwa/values.yaml
@@ -13,6 +13,9 @@ imagePullSecrets: []
 
 # Non-secret application config, rendered into a ConfigMap and loaded via envFrom.
 # Any variable from .env.example is valid here — that file stays the canonical list.
+# NOTE: the container port is fixed at 2785 (containerPort, probes and the Service
+# targetPort are all pinned to it). Setting PORT here breaks the pod — use
+# service.port to change the Service port instead.
 env:
   NODE_ENV: production
   LOG_LEVEL: info
@@ -20,6 +23,7 @@ env:
 # Secret config, rendered into a chart-managed Secret (stringData). Leave
 # API_MASTER_KEY empty to let the app bootstrap a key into /app/data/.api-key
 # (persists on the PVC) — NOTES.txt after install shows how to read it.
+# If a key exists in both env and secretEnv, the secret value wins (envFrom ordering).
 secretEnv:
   API_MASTER_KEY: ""
 
@@ -34,6 +38,8 @@ service:
 persistence:
   # /app/data holds session auth, the main SQLite DB, media and plugins — losing
   # this volume loses the linked WhatsApp sessions and the API keys.
+  # Empty storageClass means the cluster's default StorageClass; the PVC pends if
+  # the cluster has none.
   size: 10Gi
   storageClass: ""
   accessModes:
@@ -98,6 +104,9 @@ podDisruptionBudget:
 serviceMonitor:
   enabled: false
   interval: 30s
+  # Extra labels for the ServiceMonitor — most Prometheus Operators select
+  # ServiceMonitors by a release label (e.g. release: kube-prometheus-stack).
+  additionalLabels: {}
   # Secret holding the METRICS_TOKEN value for bearer auth.
   bearerTokenSecret:
     name: ""

--- a/docs/10-devops-infrastructure.md
+++ b/docs/10-devops-infrastructure.md
@@ -273,6 +273,24 @@ volumes:
 > [13 - Horizontal Scaling Guide](./13-horizontal-scaling.md) for the `replicas: 1` stance and the
 > (unimplemented) session-claim design that would be required first.
 
+### Helm Chart (Kubernetes)
+
+The maintained way to deploy on Kubernetes is the Helm chart at `charts/openwa/`:
+
+```bash
+helm install openwa ./charts/openwa \
+  --set secretEnv.API_MASTER_KEY=$(openssl rand -base64 32)
+```
+
+It renders a single-replica StatefulSet (`replicaCount: 1` — the same constraint as
+the compose warning above) with a PVC for `/app/data`, the compose hardening mirrored
+(read-only rootfs, dropped capabilities, writable `emptyDir` at `/tmp`), and optional
+Ingress / PodDisruptionBudget / ServiceMonitor. Configuration goes through free-form
+`env` and `secretEnv` maps — any variable from `.env.example` works; see
+`charts/openwa/README.md` and the inline comments in `charts/openwa/values.yaml`.
+The k8s manifests in [13 - Horizontal Scaling Guide](./13-horizontal-scaling.md) are
+an illustrative design sketch; the chart is the authoritative artifact.
+
 ## 10.3 CI/CD Pipeline
 
 ### GitHub Actions Workflow


### PR DESCRIPTION
## Description

Adds an official Helm chart at `charts/openwa/`, implementing the request in #695 (the original issuer went quiet, so this picks it up with their stated goal: an official chart rather than a private one).

The chart deploys OpenWA as a **single-replica StatefulSet** with a PVC for `/app/data` (session auth, main DB, media, plugins) and an `emptyDir` for `/tmp`. The pod spec mirrors the docker-compose hardening exactly: the container starts as root so the entrypoint can chown the data volume, then drops to the `openwa` user via gosu — capabilities `drop: [ALL]` with only the five the entrypoint needs re-added, read-only root filesystem, `allowPrivilegeEscalation: false`, and no service-account token automount (the app never calls the Kubernetes API).

Configuration goes through free-form `env` / `secretEnv` maps (rendered into a ConfigMap / Secret, with an `existingSecret` escape hatch), so any variable from `.env.example` works without the chart mirroring each one. Optional Ingress, PodDisruptionBudget (off by default — `minAvailable: 1` on a single replica can hold node drains), and ServiceMonitor (with `additionalLabels` passthrough for Prometheus Operator release selectors and bearer-token support for `METRICS_TOKEN`).

Design decisions worth knowing:

- **`replicaCount` is pinned at 1** with warnings in values, NOTES, and the README — multi-replica corrupts WhatsApp session auth (docs/13).
- **Datastores are not bundled.** The app boots fine on SQLite with no Redis; operators point `env` at their own PostgreSQL/Redis/S3 or stay on the defaults.
- **The container port is fixed at 2785** (containerPort, probes, and the Service targetPort are all pinned); comments in values and the README steer operators to `service.port` instead of `env.PORT`.
- **`volumeClaimTemplates` carries only immutable selector labels** — chart/app-version labels there would make every future `helm upgrade` a forbidden mutation.
- Operational note: behind an Ingress, per-IP rate limiting sees the ingress controller's IP unless `TRUSTED_PROXIES` is set (available via `env`).

Verification (dockerized `alpine/helm`): `helm lint` clean; `helm template` rendered and asserted for default values, all optionals enabled, `existingSecret`, and a quoted `/*` ingress path. `npm run check:versions`, `check:dockerignore`, `lint`, `format:check`, `build` green; full Jest suite green (4073 passed).

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] Tests added/updated (helm lint + template render assertions; no runtime code changed)
- [x] Documentation updated (`docs/10-devops-infrastructure.md`, `charts/openwa/README.md`, CHANGELOG `[Unreleased]`)
- [x] Lint passes
- [x] Self-reviewed

## Related Issues
Closes #695