### PR TITLE
fix(scripts): prevent EALLOWSCRIPTS in nested dashboard install under npm 11

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -4,11 +4,13 @@
  * Three conditional steps, each skipped when its target is absent so the hook is a no-op where the
  * piece is missing (the Docker builder stage copies package*.json long before any source):
  *
- *   1. `npm run dashboard:ci` when dashboard/ exists — the dashboard carries its own lockfile and
- *      the root install would otherwise leave it without dependencies. A failure here MUST abort
- *      the install: the old inline hook swallowed spawnSync's exit status, so a red dashboard
- *      install still reported `npm install` success and the breakage surfaced only at build/run
- *      time.
+ *   1. `npm ci` inside dashboard/ when dashboard/ exists — the dashboard carries its own lockfile and
+ *      the root install would otherwise leave it without dependencies. We run `npm ci` directly in
+ *      dashboard/ with any `npm_config_allow_scripts` environment variable stripped so that npm 11
+ *      does not reject `allow-scripts=true` from user `.npmrc` with EALLOWSCRIPTS. A failure here
+ *      MUST abort the install: the old inline hook swallowed spawnSync's exit status, so a red
+ *      dashboard install still reported `npm install` success and the breakage surfaced only at
+ *      build/run time.
  *   2. `node scripts/patch-wwebjs-201832.js --best-effort` when the patcher exists. The patcher
  *      itself decides fatality: under --best-effort it warns and exits 0 for a pristine-but-
  *      unpatched tree (no `patch` binary, Baileys-only user), but exits 1 for a HALF-patched
@@ -27,14 +29,35 @@ const { spawnSync } = require('child_process');
 
 const ROOT = path.join(__dirname, '..');
 
+/**
+ * Sanitize an environment object for child invocations.
+ *
+ * npm 11 rejects `--allow-scripts` in project-scoped installs (`npm ci`, `npm install`) when it
+ * originates from the environment (`npm_config_allow_scripts`) rather than `.npmrc` or
+ * `package.json`. When a root install is invoked with `allow-scripts=true` in `.npmrc`, npm
+ * exports that setting to the lifecycle environment as `npm_config_allow_scripts`. Stripping it
+ * prevents nested npm executions (`npm run dashboard:ci` -> `cd dashboard && npm ci`) from
+ * failing with EALLOWSCRIPTS while preserving the user's `.npmrc` configuration.
+ */
+function sanitizeEnv(env = process.env) {
+  const clean = { ...env };
+  for (const key of Object.keys(clean)) {
+    if (/^npm_config_allow[_-]scripts$/i.test(key)) {
+      delete clean[key];
+    }
+  }
+  return clean;
+}
+
 /** The steps to run for a given repo root, in order. */
-function planSteps(root) {
+function planSteps(root, env = process.env) {
+  const cleanEnv = sanitizeEnv(env);
   const steps = [];
   if (fs.existsSync(path.join(root, 'dashboard'))) {
     steps.push({
-      name: 'dashboard dependencies (npm run dashboard:ci)',
-      command: 'npm run dashboard:ci',
-      options: { stdio: 'inherit', shell: true, cwd: root },
+      name: 'dashboard dependencies (npm ci)',
+      command: 'npm ci',
+      options: { stdio: 'inherit', shell: true, cwd: path.join(root, 'dashboard'), env: cleanEnv },
     });
   }
   const patcher = path.join(root, 'scripts', 'patch-wwebjs-201832.js');
@@ -43,7 +66,7 @@ function planSteps(root) {
       name: 'whatsapp-web.js backport (scripts/patch-wwebjs-201832.js --best-effort)',
       command: process.execPath,
       args: [patcher, '--best-effort'],
-      options: { stdio: 'inherit', cwd: root },
+      options: { stdio: 'inherit', cwd: root, env: cleanEnv },
     });
   }
   const previewPatcher = path.join(root, 'scripts', 'patch-wwebjs-newsletter-preview.js');
@@ -52,7 +75,7 @@ function planSteps(root) {
       name: 'whatsapp-web.js newsletter preview backport (scripts/patch-wwebjs-newsletter-preview.js --best-effort)',
       command: process.execPath,
       args: [previewPatcher, '--best-effort'],
-      options: { stdio: 'inherit', cwd: root },
+      options: { stdio: 'inherit', cwd: root, env: cleanEnv },
     });
   }
   return steps;
@@ -70,8 +93,8 @@ function failureReason(res) {
  * Run the planned steps, stopping at the first failure. Returns the process exit code (0 = all
  * steps ran clean or were absent). `spawn` is injectable for tests.
  */
-function run(root = ROOT, spawn = spawnSync) {
-  const steps = planSteps(root);
+function run(root = ROOT, spawn = spawnSync, env = process.env) {
+  const steps = planSteps(root, env);
   if (!steps.length) {
     console.log('postinstall: no dashboard/ or patch script present — nothing to do.');
     return 0;
@@ -94,4 +117,4 @@ if (require.main === module) {
   process.exit(run());
 }
 
-module.exports = { planSteps, failureReason, run, ROOT };
+module.exports = { sanitizeEnv, planSteps, failureReason, run, ROOT };

--- a/scripts/postinstall.spec.js
+++ b/scripts/postinstall.spec.js
@@ -13,7 +13,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const { planSteps, failureReason, run } = require('./postinstall.js');
+const { sanitizeEnv, planSteps, failureReason, run } = require('./postinstall.js');
 
 const OK = { status: 0, signal: null, error: null };
 
@@ -49,11 +49,13 @@ test('planSteps: empty root plans nothing', () => {
 });
 
 test('planSteps: dashboard only plans the dashboard install (shell, inherited stdio)', () => {
-  const steps = planSteps(makeRoot({ dashboard: true }));
+  const root = makeRoot({ dashboard: true });
+  const steps = planSteps(root);
   assert.equal(steps.length, 1);
-  assert.equal(steps[0].command, 'npm run dashboard:ci');
+  assert.equal(steps[0].command, 'npm ci');
   assert.equal(steps[0].options.shell, true);
   assert.equal(steps[0].options.stdio, 'inherit');
+  assert.equal(steps[0].options.cwd, path.join(root, 'dashboard'));
 });
 
 test('planSteps: patcher only plans the best-effort backport via the current node', () => {
@@ -75,14 +77,14 @@ test('planSteps: newsletter preview patcher plans its own best-effort backport',
 test('planSteps: both present plans dashboard first, patcher second', () => {
   const steps = planSteps(makeRoot({ dashboard: true, patcher: true }));
   assert.equal(steps.length, 2);
-  assert.equal(steps[0].command, 'npm run dashboard:ci');
+  assert.equal(steps[0].command, 'npm ci');
   assert.equal(steps[1].command, process.execPath);
 });
 
 test('planSteps: dashboard and both patchers run in stable order', () => {
   const steps = planSteps(makeRoot({ dashboard: true, patcher: true, previewPatcher: true }));
   assert.equal(steps.length, 3);
-  assert.equal(steps[0].command, 'npm run dashboard:ci');
+  assert.equal(steps[0].command, 'npm ci');
   assert.match(steps[1].args[0], /patch-wwebjs-201832\.js$/);
   assert.match(steps[2].args[0], /patch-wwebjs-newsletter-preview\.js$/);
 });
@@ -103,7 +105,7 @@ test('run: non-zero dashboard install exits 1 and never reaches the patcher (fai
   const { calls, spawn } = fakeSpawn([{ status: 1, signal: null, error: null }]);
   assert.equal(run(makeRoot({ dashboard: true, patcher: true }), spawn), 1);
   assert.equal(calls.length, 1);
-  assert.equal(calls[0].command, 'npm run dashboard:ci');
+  assert.equal(calls[0].command, 'npm ci');
 });
 
 test('run: spawn error (npm not found) exits 1', () => {
@@ -127,4 +129,45 @@ test('failureReason: maps each spawnSync outcome to a cause (null = success)', (
   assert.equal(failureReason({ status: 2, signal: null, error: null }), 'exit code 2');
   assert.equal(failureReason({ status: null, signal: 'SIGKILL', error: null }), 'killed by SIGKILL');
   assert.match(failureReason({ status: null, signal: null, error: new Error('boom') }), /failed to start — boom/);
+});
+
+test('sanitizeEnv: strips allow-scripts environment variables across case and separator variations', () => {
+  const input = {
+    PATH: '/usr/bin',
+    npm_config_allow_scripts: 'true',
+    NPM_CONFIG_ALLOW_SCRIPTS: 'true',
+    'npm_config_allow-scripts': 'true',
+    'NPM_CONFIG_ALLOW-SCRIPTS': 'true',
+    npm_config_allow_scripts_extra: 'keep',
+  };
+  const result = sanitizeEnv(input);
+  assert.deepEqual(result, {
+    PATH: '/usr/bin',
+    npm_config_allow_scripts_extra: 'keep',
+  });
+  assert.equal(input.npm_config_allow_scripts, 'true');
+});
+
+test('planSteps: strips npm_config_allow_scripts from step options.env to avoid EALLOWSCRIPTS in npm 11', () => {
+  const env = {
+    PATH: '/usr/bin',
+    npm_config_allow_scripts: 'true',
+    NPM_CONFIG_ALLOW_SCRIPTS: 'true',
+  };
+  const steps = planSteps(makeRoot({ dashboard: true, patcher: true, previewPatcher: true }), env);
+  assert.equal(steps.length, 3);
+  for (const step of steps) {
+    assert.equal('npm_config_allow_scripts' in step.options.env, false);
+    assert.equal('NPM_CONFIG_ALLOW_SCRIPTS' in step.options.env, false);
+    assert.equal(step.options.env.PATH, '/usr/bin');
+  }
+});
+
+test('run: passes sanitized environment to spawn calls', () => {
+  const { calls, spawn } = fakeSpawn([OK]);
+  const env = { PATH: '/usr/bin', npm_config_allow_scripts: 'true' };
+  run(makeRoot({ dashboard: true }), spawn, env);
+  assert.equal(calls.length, 1);
+  assert.equal('npm_config_allow_scripts' in calls[0].options.env, false);
+  assert.equal(calls[0].options.env.PATH, '/usr/bin');
 });


### PR DESCRIPTION
### Summary
Fixes a reproducible `EALLOWSCRIPTS` fatal error during the `postinstall` script execution under **npm 11** when `allow-scripts=true` is set in the user's `.npmrc`.

### Root Cause
1. When the root install (`npm ci`) reads `allow-scripts=true` from `.npmrc`, it exports this setting to the lifecycle environment as `npm_config_allow_scripts=true`.
2. Previously, `scripts/postinstall.js` executed `npm run dashboard:ci` (which runs `cd dashboard && npm ci`). That intermediate `npm run` process re-exported `.npmrc` settings to the nested `npm ci` command.
3. **npm 11** strictly forbids `--allow-scripts` originating from the CLI or environment variables (`npm_config_allow_scripts`) in project-scoped installs (`npm ci`, `npm i`), aborting the build with `EALLOWSCRIPTS`.

### Solution
- **`sanitizeEnv(env)`:** Added an environment sanitization helper in `scripts/postinstall.js` that strips any `npm_config_allow_scripts` variables (handling case and separator variations) from the inherited environment before spawning child processes.
- **Direct `npm ci` execution in `dashboard/`:** Replaced the indirect `'npm run dashboard:ci'` invocation with a direct `'npm ci'` call using `cwd: path.join(root, 'dashboard')` and the sanitized environment (`cleanEnv`), avoiding intermediate processes that re-export `.npmrc` options.
- **Project policy compliance:** Did NOT add any `"allowScripts": { "*": true }` entries to `package.json` nor modify user `.npmrc` configuration. Preserved fail-fast behavior for legitimate dashboard installation failures.

### Regression Tests
- Updated `scripts/postinstall.spec.js` assertions to match direct `'npm ci'` execution and explicit dashboard `cwd`.
- Added 3 dedicated unit regression tests for `sanitizeEnv`, environment stripping in `planSteps`, and `cleanEnv` injection in `run`.
- Verified cleanly against `npm run test:scripts` (20/20 passing), `npm run format:check`, and `npm run lint`.