### PR TITLE
fix(swagger): stop Try-it composing an invalid send-text body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Swagger "Try it out" called `http://localhost:2785` instead of the host that served the docs**, failing with `Failed to fetch` anywhere else — a relative server is now listed first, so it resolves to the serving origin.
 - **Sending to a number WhatsApp cannot resolve returned `500`** on the whatsapp-web.js engine — it now answers `400` naming the recipient and both possible causes. Callers that retried the old 500 should treat this as terminal.
+- **Swagger "Try it out" on `send-text` always returned `400`** — the sampled body paired `linkPreview: false` with a `customLinkPreview`, which the endpoint rejects; the operation now ships explicit request-body examples.
 
 ## [0.14.0] - 2026-08-05
 

--- a/openapi.json
+++ b/openapi.json
@@ -1787,6 +1787,25 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SendTextMessageDto"
+              },
+              "examples": {
+                "minimal": {
+                  "summary": "Plain text message",
+                  "value": {
+                    "chatId": "628123456789@c.us",
+                    "text": "Hello from OpenWA!"
+                  }
+                },
+                "withMentions": {
+                  "summary": "Group message with an @mention (the text must carry the @<number> token)",
+                  "value": {
+                    "chatId": "120363000000000000@g.us",
+                    "text": "Hello @62811",
+                    "mentions": [
+                      "62811@c.us"
+                    ]
+                  }
+                }
               }
             }
           }

--- a/src/modules/message/dto/send-message.dto.spec.ts
+++ b/src/modules/message/dto/send-message.dto.spec.ts
@@ -1,6 +1,6 @@
 import { plainToInstance } from 'class-transformer';
 import { validate } from 'class-validator';
-import { SendTextMessageDto, SendMediaMessageDto } from './send-message.dto';
+import { SendTextMessageDto, SendMediaMessageDto, SEND_TEXT_BODY_EXAMPLES } from './send-message.dto';
 
 // Mirror the global ValidationPipe (main.ts): whitelist + forbidNonWhitelisted strip/reject unknown props.
 const validateDto = (cls: new () => object, obj: unknown) =>
@@ -46,6 +46,28 @@ describe('SendTextMessageDto mentions', () => {
       mentions: ['a'.repeat(65) + '@c.us'],
     });
     expect(errors.length).toBeGreaterThan(0);
+  });
+});
+
+// These examples are what Swagger UI pre-fills into "Try it out", so a caller who changes nothing
+// submits them verbatim. Left to the schema sampler the body paired `linkPreview: false` with a
+// `customLinkPreview` and every Try-it click 400'd (#1068); these assertions are what keeps a new
+// optional field from quietly recreating an unusable default.
+describe('SEND_TEXT_BODY_EXAMPLES', () => {
+  const entries = Object.entries(SEND_TEXT_BODY_EXAMPLES);
+
+  it('declares at least one example', () => {
+    expect(entries.length).toBeGreaterThan(0);
+  });
+
+  it.each(entries)('%s passes DTO validation', async (_name, example) => {
+    const errors = await validateDto(SendTextMessageDto, example.value);
+    expect(errors).toHaveLength(0);
+  });
+
+  it.each(entries)('%s does not combine linkPreview:false with customLinkPreview', (_name, example) => {
+    const value = example.value as { linkPreview?: boolean; customLinkPreview?: unknown };
+    expect(value.linkPreview === false && value.customLinkPreview !== undefined).toBe(false);
   });
 });
 

--- a/src/modules/message/dto/send-message.dto.ts
+++ b/src/modules/message/dto/send-message.dto.ts
@@ -104,6 +104,33 @@ export class SendTextMessageDto {
   customLinkPreview?: CustomLinkPreviewDto;
 }
 
+/**
+ * Request-body examples for `POST send-text`, applied with `@ApiBody` on the controller.
+ *
+ * Swagger UI does NOT pre-fill "Try it out" from the required properties — its sampler walks EVERY
+ * property in the schema, skipping only `deprecated`/`readOnly`/`writeOnly`. So an optional field is
+ * always present in the generated body; a property's `example` only decides the VALUE it is given,
+ * never whether it appears. Left to the sampler this endpoint offers `linkPreview: false` together
+ * with a `customLinkPreview` object — the one combination `MessageService.sendText` rejects outright
+ * — so every Try-it click returned `400 linkPreview: false cannot be combined with customLinkPreview`
+ * without the caller having typed anything (#1068). An explicit example overrides the sampler
+ * entirely, which is the only way to stop an optional property from reaching the default body.
+ *
+ * Keep every entry here a payload the API actually accepts: `send-message.dto.spec.ts` validates each
+ * one against the DTO and asserts it does not trip that guard, so a future field cannot silently
+ * reintroduce an unusable default.
+ */
+export const SEND_TEXT_BODY_EXAMPLES = {
+  minimal: {
+    summary: 'Plain text message',
+    value: { chatId: '628123456789@c.us', text: 'Hello from OpenWA!' },
+  },
+  withMentions: {
+    summary: 'Group message with an @mention (the text must carry the @<number> token)',
+    value: { chatId: '120363000000000000@g.us', text: 'Hello @62811', mentions: ['62811@c.us'] },
+  },
+};
+
 export class SendMediaMessageDto {
   @ApiProperty({
     description: 'WhatsApp chat ID',

--- a/src/modules/message/message.controller.ts
+++ b/src/modules/message/message.controller.ts
@@ -1,9 +1,15 @@
 import { Controller, Post, Get, Param, Body, Query, Res, HttpCode, HttpStatus, StreamableFile } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiQuery } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiQuery, ApiBody } from '@nestjs/swagger';
 import type { Response } from 'express';
 import { MessageService } from './message.service';
 import { BulkMessageService } from './bulk-message.service';
-import { SendTextMessageDto, SendMediaMessageDto, SendAudioMessageDto, MessageResponseDto } from './dto';
+import {
+  SendTextMessageDto,
+  SendMediaMessageDto,
+  SendAudioMessageDto,
+  MessageResponseDto,
+  SEND_TEXT_BODY_EXAMPLES,
+} from './dto';
 import { SendTemplateMessageDto } from './dto/send-template.dto';
 import { SendBulkMessageDto, BulkMessageResponseDto } from './dto/bulk-message.dto';
 import {
@@ -66,6 +72,9 @@ export class MessageController {
   @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Send a text message' })
   @ApiParam({ name: 'sessionId', description: 'Session ID' })
+  // Without an explicit example Swagger UI samples the body from EVERY property, which pairs
+  // `linkPreview: false` with a `customLinkPreview` — the combination sendText rejects (#1068).
+  @ApiBody({ type: SendTextMessageDto, examples: SEND_TEXT_BODY_EXAMPLES })
   @ApiResponse({
     status: 201,
     description: 'Message sent',


### PR DESCRIPTION
Opening the API docs and pressing **Execute** on `POST /api/sessions/{sessionId}/messages/send-text` returned `400 linkPreview: false cannot be combined with customLinkPreview` without the caller having typed anything. Reported in #1068.

## Cause

Swagger UI does not build its "Try it out" body from the required properties. Its schema sampler walks **every** property, skipping only `deprecated`, `readOnly` and `writeOnly` — so an optional field is always present in the generated body, and a property's `example` only decides the value it is filled with, never whether it appears.

Since `linkPreview` (`example: false`) and `customLinkPreview` were added, the generated body was:

```json
{
  "chatId": "628123456789@c.us",
  "text": "Hello from OpenWA!",
  "mentions": ["628123456789@c.us"],
  "linkPreview": false,
  "customLinkPreview": { "url": "https://example.com/launch", "title": "We just launched", "description": "Read the announcement." }
}
```

`linkPreview: false` together with a `customLinkPreview` is the one combination `MessageService.sendText` rejects outright, so the failure was deterministic — independent of the engine, the session state, and the chat id.

## Fix

Declare explicit request-body examples with `@ApiBody`. An explicit example overrides the sampler entirely, which is the only way to keep an optional property out of the default body — removing the property examples would merely change the values it is filled with (`linkPreview` would become `true` and `customLinkPreview` would arrive as placeholder strings, which whatsapp-web.js answers with `501`).

Two examples are offered:

- **minimal** — a plain text message, the default.
- **withMentions** — a group message in the shape `mentions` actually requires: a group chat id, and the `@<number>` token present in the text. The previous sampled body mentioned the recipient of a 1:1 chat with no token in the text, which contradicted both the field description and `docs/06-api-specification.md`.

## Verification

- Built and run locally: the Try-it body is now `{ "chatId": ..., "text": ... }`; posting it clears the guard and fails only on session validation, while the previous sampled body still returns the guard's 400.
- `SEND_TEXT_BODY_EXAMPLES` is exported so `send-message.dto.spec.ts` validates every entry against the DTO and asserts none reproduces the rejected combination — a future optional field cannot silently restore an unusable default. Mutation-checked: re-adding the old body as an example fails the suite.
- `openapi.json` regenerated; the diff is 19 added lines under the send-text request body. No path, schema or `operationId` changed.
- Full gate green: build, lint, `tsc --noEmit`, 4765 unit tests, 148 e2e tests, and the dashboard typecheck/lint/i18n/test/build.

Closes #1068 only in part — the Swagger server-URL problem reported in the same issue is handled separately.