### PR TITLE
fix(swagger): target the serving origin from Try-it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Swagger "Try it out" called `http://localhost:2785` instead of the host that served the docs**, failing with `Failed to fetch` anywhere else — a relative server is now listed first, so it resolves to the serving origin.
+
 ## [0.14.0] - 2026-08-05
 
 ### Added

--- a/openapi.json
+++ b/openapi.json
@@ -7206,8 +7206,12 @@
   ],
   "servers": [
     {
+      "url": "/",
+      "description": "This instance (the origin serving these docs)"
+    },
+    {
       "url": "http://{host}:{port}",
-      "description": "OpenWA instance",
+      "description": "Another instance (set host and port)",
       "variables": {
         "host": {
           "default": "localhost"

--- a/src/config/swagger.config.spec.ts
+++ b/src/config/swagger.config.spec.ts
@@ -25,14 +25,26 @@ describe('createSwaggerConfig', () => {
     expect(config.security).not.toContainEqual({ [METRICS_BEARER_SCHEME]: [] });
   });
 
-  it('declares a templated default server so published specs carry a base URL', () => {
+  // Swagger UI aims "Try it" at servers[0]. A relative URL resolves against whatever origin served
+  // the docs, so it works on localhost, a LAN address and behind a TLS proxy alike; anything
+  // absolute here would send the reader's browser somewhere else entirely (#1068).
+  it('lists a relative server FIRST so Try-it targets the origin serving the docs', () => {
     const config = createSwaggerConfig();
 
-    expect(config.servers).toHaveLength(1);
-    const [server] = config.servers ?? [];
-    expect(server.url).toBe('http://{host}:{port}');
-    expect(server.variables?.host.default).toBe('localhost');
-    expect(server.variables?.port.default).toBe('2785');
+    const [first] = config.servers ?? [];
+    expect(first.url).toBe('/');
+    expect(first.url.startsWith('http')).toBe(false);
+  });
+
+  it('keeps the templated absolute server so published specs still carry a concrete base URL', () => {
+    const config = createSwaggerConfig();
+
+    expect(config.servers).toHaveLength(2);
+    const templated = (config.servers ?? []).find(s => s.url.includes('{host}'));
+    expect(templated).toBeDefined();
+    expect(templated?.url).toBe('http://{host}:{port}');
+    expect(templated?.variables?.host.default).toBe('localhost');
+    expect(templated?.variables?.port.default).toBe('2785');
   });
 });
 

--- a/src/config/swagger.config.ts
+++ b/src/config/swagger.config.ts
@@ -96,11 +96,20 @@ export function createSwaggerConfig(): Omit<OpenAPIObject, 'paths'> {
       .addTag('audit', 'Audit log')
       .addTag('metrics', 'Prometheus metrics')
       .addTag('health', 'Health check endpoints')
-      // Templated server: defaults to the out-of-box local instance, and the {host}/{port}
-      // variables keep Swagger UI "Try it" usable on real deployments (a hardcoded
-      // localhost URL would break Try-it for anyone serving elsewhere). Static consumers
-      // of the spec (the docs site) also get a concrete base URL to display.
-      .addServer('http://{host}:{port}', 'OpenWA instance', {
+      // ORDER MATTERS. Swagger UI resolves "Try it" against servers[0], substituting the variable
+      // defaults — it does not consider the origin the page was served from. A templated server
+      // alone therefore aimed every request at `http://localhost:2785`, so on any deployment that
+      // is not exactly that (a LAN address, a different PORT, a TLS proxy) Try-it called the
+      // reader's own machine and failed with "Failed to fetch" — the browser's CSP `connect-src
+      // 'self'` rejects the cross-origin call before it is even sent (#1068). A relative URL is
+      // resolved against the document's own location, which is what OpenAPI 3 specifies and what
+      // the spec did implicitly before it declared any server at all.
+      //
+      // So: relative first, and keep the templated absolute one second. Static consumers of
+      // openapi.json still get a concrete base URL to display (#975), and the host/port editor
+      // stays in the Servers dropdown for anyone pointing the docs at a different instance.
+      .addServer('/', 'This instance (the origin serving these docs)')
+      .addServer('http://{host}:{port}', 'Another instance (set host and port)', {
         host: { default: 'localhost' },
         port: { default: '2785', description: 'PORT env var' },
       })


### PR DESCRIPTION
Swagger UI's **Try it out** called `http://localhost:2785` regardless of where the docs were actually served from, so on any other address Execute failed with `Failed to fetch`. Reported in #1068.

## Cause

The spec declared exactly one server:

```json
{ "url": "http://{host}:{port}", "variables": { "host": { "default": "localhost" }, "port": { "default": "2785" } } }
```

Swagger UI aims Try-it at `servers[0]` with the variable defaults substituted. It does **not** consider the origin the page was loaded from once a server is declared — that fallback only applies to a spec with no `servers` array, which is what this one had before the templated entry was added. The result resolves to `http://localhost:2785` for every reader, so anyone browsing the docs at a LAN address, a different `PORT`, or through a TLS proxy had Try-it call their own machine.

The request never even left the page: this app sends `connect-src 'self'`, so the browser rejects the cross-origin call outright — which is why the error is the generic `Failed to fetch` rather than anything mentioning the wrong host. In production `CORS_ORIGINS` defaults to same-origin only, so it would have been refused a second time had it got that far. Neither of those is the defect; both are pre-existing and correct, and both were already present in the last release where Try-it worked. The only thing that changed is the declared server.

## Fix

List a relative server first. A relative URL resolves against the document's own location, so Try-it works on localhost, a LAN address and behind a TLS proxy alike.

The templated entry stays, second, so static consumers of `openapi.json` still get a concrete base URL to display and the `{host}`/`{port}` editor remains in the Servers dropdown for anyone pointing the docs at another instance.

## Verification

Built and run locally, serving the docs on `127.0.0.1:2796` — deliberately neither the default host nor the default port:

- The Servers dropdown defaults to `/`, with the templated entry still offered.
- Pressing Execute drives Swagger UI's own request path; captured at the network layer it issued `GET http://127.0.0.1:2796/api/health → 200`, the serving origin rather than `localhost:2785`.
- `swagger.config.spec.ts` asserts the first server is relative and that the templated entry survives with its variables intact. Mutation-checked: restoring the old ordering fails the suite.
- `openapi.json` regenerated — the diff is the `servers` array alone; no path, schema or `operationId` changed.
- Full gate green: build, lint, `tsc --noEmit`, 4761 unit tests, 148 e2e tests, and the dashboard typecheck/lint/i18n/test/build.

Refs #1068. The other half of that report — the Try-it request body being rejected before it is sent — is #1074.