### PR TITLE
fix(swagger): send a real media source from Try-it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Swagger "Try it out" called `http://localhost:2785` instead of the host that served the docs**, failing with `Failed to fetch` anywhere else — a relative server is now listed first, so it resolves to the serving origin.
 - **Sending to a number WhatsApp cannot resolve returned `500`** on the whatsapp-web.js engine — it now answers `400` naming the recipient and both possible causes. Callers that retried the old 500 should treat this as terminal.
 - **Swagger "Try it out" on `send-text` always returned `400`** — the sampled body paired `linkPreview: false` with a `customLinkPreview`, which the endpoint rejects; the operation now ships explicit request-body examples.
+- **Swagger "Try it out" on the media routes uploaded the literal string `"string"`** — the sampled body carried both `url` and `base64`, and base64 wins; each route now ships an explicit example with a single media source.
 
 ## [0.14.0] - 2026-08-05
 

--- a/openapi.json
+++ b/openapi.json
@@ -1902,6 +1902,16 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SendMediaMessageDto"
+              },
+              "examples": {
+                "fromUrl": {
+                  "summary": "Fetch the media from a URL",
+                  "value": {
+                    "chatId": "628123456789@c.us",
+                    "url": "https://example.com/image.jpg",
+                    "caption": "Check out this image!"
+                  }
+                }
               }
             }
           }
@@ -1947,6 +1957,15 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SendMediaMessageDto"
+              },
+              "examples": {
+                "fromUrl": {
+                  "summary": "Fetch the media from a URL",
+                  "value": {
+                    "chatId": "628123456789@c.us",
+                    "url": "https://example.com/video.mp4"
+                  }
+                }
               }
             }
           }
@@ -1992,6 +2011,16 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SendAudioMessageDto"
+              },
+              "examples": {
+                "fromUrl": {
+                  "summary": "Fetch the media from a URL",
+                  "value": {
+                    "chatId": "628123456789@c.us",
+                    "url": "https://example.com/audio.ogg",
+                    "ptt": true
+                  }
+                }
               }
             }
           }
@@ -2037,6 +2066,16 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SendMediaMessageDto"
+              },
+              "examples": {
+                "fromUrl": {
+                  "summary": "Fetch the media from a URL",
+                  "value": {
+                    "chatId": "628123456789@c.us",
+                    "url": "https://example.com/report.pdf",
+                    "filename": "report.pdf"
+                  }
+                }
               }
             }
           }
@@ -2166,6 +2205,15 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SendMediaMessageDto"
+              },
+              "examples": {
+                "fromUrl": {
+                  "summary": "Fetch the media from a URL",
+                  "value": {
+                    "chatId": "628123456789@c.us",
+                    "url": "https://example.com/sticker.png"
+                  }
+                }
               }
             }
           }

--- a/src/modules/message/dto/send-message.dto.spec.ts
+++ b/src/modules/message/dto/send-message.dto.spec.ts
@@ -1,6 +1,16 @@
 import { plainToInstance } from 'class-transformer';
 import { validate } from 'class-validator';
-import { SendTextMessageDto, SendMediaMessageDto, SEND_TEXT_BODY_EXAMPLES } from './send-message.dto';
+import {
+  SendTextMessageDto,
+  SendMediaMessageDto,
+  SendAudioMessageDto,
+  SEND_TEXT_BODY_EXAMPLES,
+  SEND_IMAGE_BODY_EXAMPLES,
+  SEND_VIDEO_BODY_EXAMPLES,
+  SEND_AUDIO_BODY_EXAMPLES,
+  SEND_DOCUMENT_BODY_EXAMPLES,
+  SEND_STICKER_BODY_EXAMPLES,
+} from './send-message.dto';
 
 // Mirror the global ValidationPipe (main.ts): whitelist + forbidNonWhitelisted strip/reject unknown props.
 const validateDto = (cls: new () => object, obj: unknown) =>
@@ -68,6 +78,40 @@ describe('SEND_TEXT_BODY_EXAMPLES', () => {
   it.each(entries)('%s does not combine linkPreview:false with customLinkPreview', (_name, example) => {
     const value = example.value as { linkPreview?: boolean; customLinkPreview?: unknown };
     expect(value.linkPreview === false && value.customLinkPreview !== undefined).toBe(false);
+  });
+});
+
+// These are what Swagger UI pre-fills into "Try it out", so a caller who changes nothing submits them
+// verbatim. Left to the schema sampler the body carried `url` and `base64: "string"` together, and
+// base64 wins in buildMediaInput — so Execute uploaded four characters of garbage (#1068). Every
+// example must stay submittable as-is, which is what stops a new optional field from recreating that.
+describe('media route body examples', () => {
+  const suites: Array<[string, new () => object, Record<string, { value: unknown }>]> = [
+    ['send-image', SendMediaMessageDto, SEND_IMAGE_BODY_EXAMPLES],
+    ['send-video', SendMediaMessageDto, SEND_VIDEO_BODY_EXAMPLES],
+    ['send-audio', SendAudioMessageDto, SEND_AUDIO_BODY_EXAMPLES],
+    ['send-document', SendMediaMessageDto, SEND_DOCUMENT_BODY_EXAMPLES],
+    ['send-sticker', SendMediaMessageDto, SEND_STICKER_BODY_EXAMPLES],
+  ];
+
+  it.each(suites)('%s declares at least one example', (_route, _cls, examples) => {
+    expect(Object.keys(examples).length).toBeGreaterThan(0);
+  });
+
+  it.each(suites)('%s examples all pass DTO validation', async (_route, cls, examples) => {
+    for (const [name, example] of Object.entries(examples)) {
+      const errors = await validateDto(cls, example.value);
+      expect({ name, errors: errors.map(e => e.property) }).toEqual({ name, errors: [] });
+    }
+  });
+
+  // buildMediaInput prefers base64 over url, so an example carrying both would send the base64 —
+  // and no short placeholder is real media. Exactly one source per example, never both.
+  it.each(suites)('%s examples carry exactly one media source', (_route, _cls, examples) => {
+    for (const [name, example] of Object.entries(examples)) {
+      const v = example.value as { url?: string; base64?: string };
+      expect({ name, sources: [v.url, v.base64].filter(Boolean).length }).toEqual({ name, sources: 1 });
+    }
   });
 });
 

--- a/src/modules/message/dto/send-message.dto.ts
+++ b/src/modules/message/dto/send-message.dto.ts
@@ -194,6 +194,37 @@ export class SendMediaMessageDto {
   mentions?: string[];
 }
 
+/**
+ * Request-body examples for the media send routes, applied with `@ApiBody` on the controller.
+ *
+ * Same reason as the text route: Swagger UI's sampler emits EVERY property, so the generated body
+ * carried `url` AND `base64` together. `base64` has no `example`, so it arrived as the literal string
+ * `"string"` — and `MessageService.buildMediaInput` deliberately lets base64 win over url (a stale
+ * example url must never be fetched in place of real bytes), so pressing Execute uploaded four
+ * characters of garbage instead of the example image. An explicit example is the only way to keep an
+ * optional property out of the body.
+ *
+ * Only the URL form is offered, and every entry must be submittable as-is: a base64 example would
+ * need real bytes pasted in, which is the "click Execute, get an error" trap this exists to remove.
+ * `base64` and its `mimetype` requirement stay documented in the schema.
+ */
+const mediaBodyExample = (url: string, extra: Record<string, unknown> = {}) => ({
+  fromUrl: {
+    summary: 'Fetch the media from a URL',
+    value: { chatId: '628123456789@c.us', url, ...extra },
+  },
+});
+
+export const SEND_IMAGE_BODY_EXAMPLES = mediaBodyExample('https://example.com/image.jpg', {
+  caption: 'Check out this image!',
+});
+export const SEND_VIDEO_BODY_EXAMPLES = mediaBodyExample('https://example.com/video.mp4');
+export const SEND_AUDIO_BODY_EXAMPLES = mediaBodyExample('https://example.com/audio.ogg', { ptt: true });
+export const SEND_DOCUMENT_BODY_EXAMPLES = mediaBodyExample('https://example.com/report.pdf', {
+  filename: 'report.pdf',
+});
+export const SEND_STICKER_BODY_EXAMPLES = mediaBodyExample('https://example.com/sticker.png');
+
 export class SendAudioMessageDto extends SendMediaMessageDto {
   @ApiPropertyOptional({
     description:

--- a/src/modules/message/message.controller.ts
+++ b/src/modules/message/message.controller.ts
@@ -9,6 +9,11 @@ import {
   SendAudioMessageDto,
   MessageResponseDto,
   SEND_TEXT_BODY_EXAMPLES,
+  SEND_IMAGE_BODY_EXAMPLES,
+  SEND_VIDEO_BODY_EXAMPLES,
+  SEND_AUDIO_BODY_EXAMPLES,
+  SEND_DOCUMENT_BODY_EXAMPLES,
+  SEND_STICKER_BODY_EXAMPLES,
 } from './dto';
 import { SendTemplateMessageDto } from './dto/send-template.dto';
 import { SendBulkMessageDto, BulkMessageResponseDto } from './dto/bulk-message.dto';
@@ -114,6 +119,9 @@ export class MessageController {
   @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Send an image message' })
   @ApiParam({ name: 'sessionId', description: 'Session ID' })
+  // Without an explicit example Swagger UI samples `url` AND `base64` into the body, and base64 wins
+  // in buildMediaInput — so Execute uploaded the literal string "string" instead of the URL (#1068).
+  @ApiBody({ type: SendMediaMessageDto, examples: SEND_IMAGE_BODY_EXAMPLES })
   @ApiResponse({
     status: 201,
     description: 'Image sent',
@@ -134,6 +142,7 @@ export class MessageController {
   @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Send a video message' })
   @ApiParam({ name: 'sessionId', description: 'Session ID' })
+  @ApiBody({ type: SendMediaMessageDto, examples: SEND_VIDEO_BODY_EXAMPLES })
   @ApiResponse({
     status: 201,
     description: 'Video sent',
@@ -154,6 +163,7 @@ export class MessageController {
   @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Send an audio/voice message' })
   @ApiParam({ name: 'sessionId', description: 'Session ID' })
+  @ApiBody({ type: SendAudioMessageDto, examples: SEND_AUDIO_BODY_EXAMPLES })
   @ApiResponse({
     status: 201,
     description: 'Audio sent',
@@ -174,6 +184,7 @@ export class MessageController {
   @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Send a document/file' })
   @ApiParam({ name: 'sessionId', description: 'Session ID' })
+  @ApiBody({ type: SendMediaMessageDto, examples: SEND_DOCUMENT_BODY_EXAMPLES })
   @ApiResponse({
     status: 201,
     description: 'Document sent',
@@ -222,6 +233,7 @@ export class MessageController {
   @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Send a sticker message' })
   @ApiParam({ name: 'sessionId', description: 'Session ID' })
+  @ApiBody({ type: SendMediaMessageDto, examples: SEND_STICKER_BODY_EXAMPLES })
   @ApiResponse({
     status: 201,
     description: 'Sticker sent',


### PR DESCRIPTION
Pressing **Execute** on `send-image`, `send-video`, `send-audio`, `send-document` or `send-sticker` in the API docs uploaded the literal string `"string"` rather than the example media. Same root cause as #1074, different consequence.

## Cause

Swagger UI builds its sample body from **every** property in the schema, not just the required ones. `SendMediaMessageDto` declares both `url` and `base64`, so both landed in the body — and `base64` carries no `example`, so it arrived as the string `"string"`:

```json
{ "chatId": "628123456789@c.us", "url": "https://example.com/image.jpg", "base64": "string", "mimetype": "image/jpeg", ... }
```

`buildMediaInput` prefers `base64` over `url` when a request supplies both, and deliberately so — its own comment calls out "a stale `url` (e.g. a Swagger/example default left in the body)" as the case it is guarding against. That is the correct precedence for a real caller; it just means the docs' own default body sent four bytes of garbage.

## Fix

Give each media route an explicit request-body example, which replaces the sampled body outright.

Each example now also fits its own route. Every one of them previously proposed `https://example.com/image.jpg`, inherited from the shared `SendMediaMessageDto` — so `send-video` suggested an image, and `send-document` suggested a JPEG. They now carry a video, an audio file, a PDF and a sticker respectively.

Only the URL form is offered. A base64 example would need real bytes pasted in before it could be submitted, which is the same "click Execute, get an error" trap this PR removes; `base64` and its `mimetype` requirement remain documented in the schema.

## Verification

Built and run locally, reading the generated body straight from the served spec through Swagger UI's own sampler:

| route | before | after |
|---|---|---|
| `send-image` | `url: image.jpg` + `base64: "string"` | `url: image.jpg`, `caption` |
| `send-video` | `url: image.jpg` + `base64: "string"` | `url: video.mp4` |
| `send-audio` | `url: image.jpg` + `base64: "string"` | `url: audio.ogg`, `ptt: true` |
| `send-document` | `url: image.jpg` + `base64: "string"` | `url: report.pdf`, `filename` |
| `send-sticker` | `url: image.jpg` + `base64: "string"` | `url: sticker.png` |

- The spec asserts every example validates against its DTO and carries exactly one media source. Mutation-checked: re-adding `base64` alongside `url` fails all five routes.
- `openapi.json` regenerated; the diff is 48 added lines of examples. No path, schema or `operationId` changed.
- Full gate green: build, lint, `tsc --noEmit`, 4775 unit tests, 148 e2e tests, dashboard typecheck/lint/i18n/test/build.

Refs #1068, alongside #1074 (the text route) and #1075 (the server URL).