### PR TITLE
fix(engine): report an unreachable recipient as 400, not 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Swagger "Try it out" called `http://localhost:2785` instead of the host that served the docs**, failing with `Failed to fetch` anywhere else — a relative server is now listed first, so it resolves to the serving origin.
+- **Sending to a number WhatsApp cannot resolve returned `500`** on the whatsapp-web.js engine — it now answers `400` naming the recipient and both possible causes. Callers that retried the old 500 should treat this as terminal.
 
 ## [0.14.0] - 2026-08-05
 

--- a/src/common/errors/recipient-unreachable.error.ts
+++ b/src/common/errors/recipient-unreachable.error.ts
@@ -1,0 +1,30 @@
+import { BadRequestException } from '@nestjs/common';
+
+/**
+ * Thrown when WhatsApp Web cannot resolve an individual recipient to an addressable id, so the send
+ * can never leave the gateway. Since WhatsApp's LID migration the page reports this as a bare
+ * `Error: No LID for user` raised inside its own bundle — with no status, no recipient, and nothing
+ * that identifies it as a caller problem — which reached the client as `500 Internal server error`
+ * and left nothing to act on (#1068, and #156/#573 before it).
+ *
+ * The gateway already knows better by then: `getNumberId` returned null, which is exactly how
+ * whatsapp-web.js reports "this number is not reachable on WhatsApp". That verdict is now surfaced
+ * instead of discarded.
+ *
+ * Extends NestJS `BadRequestException` so it maps to **HTTP 400** through the built-in exception
+ * handler — no custom global filter required. 400 rather than 404: on these routes a 404 already
+ * means the *session* was not found, and reusing it for the recipient would be ambiguous. Mirrors
+ * how {@link EngineNotSupportedError} maps to 501 and {@link EngineRefusedError} to 403.
+ *
+ * Two distinct situations produce it, and the message names both because the gateway cannot tell
+ * them apart: the number genuinely is not on WhatsApp, or this account has never had a chat with it
+ * (the upstream whatsapp-web.js LID limitation, whatsapp-web.js#3834).
+ */
+export class RecipientUnreachableError extends BadRequestException {
+  constructor(chatId: string) {
+    super(
+      `WhatsApp could not resolve the recipient ${chatId}. Either the number is not on WhatsApp, or ` +
+        'this session has no existing chat with it — message it once from the phone, then retry.',
+    );
+  }
+}

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -23,6 +23,7 @@ import { MessageNotFoundError } from '../../common/errors/message-not-found.erro
 import { ChannelNotFoundError } from '../../common/errors/channel-not-found.error';
 import { ChannelMediaNotSupportedError } from '../../common/errors/channel-media-not-supported.error';
 import { EngineNotSupportedError } from '../../common/errors/engine-not-supported.error';
+import { RecipientUnreachableError } from '../../common/errors/recipient-unreachable.error';
 import { EditedMessage, EngineStatus, GroupEvent, IncomingCallEvent } from '../interfaces/whatsapp-engine.interface';
 import { CallNotFoundError } from '../../common/errors/call-not-found.error';
 import { EngineRefusedError } from '../../common/errors/engine-refused.error';
@@ -3658,12 +3659,29 @@ describe('LID resolution for individual sends (#573 — WhatsApp @c.us → @lid 
     expect(res.id).toBe('OUT1');
   });
 
-  it('does not retry when re-resolution yields the same id (no pointless second send)', async () => {
+  // An unreachable recipient is a caller-visible fact, not a server fault: getNumberId already
+  // returned null. The bare page-side `No LID for user` carries no status, so letting it through
+  // surfaced as `500 Internal server error` with nothing to act on (#1068).
+  it('does not retry when re-resolution yields the same id, and reports a 400 (no pointless second send)', async () => {
     const getNumberId = jest.fn().mockResolvedValue(null); // unresolvable → fallback stays @c.us
     const sendMessage = jest.fn().mockRejectedValue(new Error('No LID for user'));
     const adapter = ready({ getNumberId, sendMessage });
-    await expect(adapter.sendTextMessage('628@c.us', 'x')).rejects.toThrow('No LID for user');
-    expect(sendMessage).toHaveBeenCalledTimes(1);
+    await expect(adapter.sendTextMessage('628@c.us', 'x')).rejects.toBeInstanceOf(RecipientUnreachableError);
+    await expect(adapter.sendTextMessage('628@c.us', 'x')).rejects.toMatchObject({ status: 400 });
+    // The raw engine wording must not reach the caller — it named neither the recipient nor the cause.
+    await expect(adapter.sendTextMessage('628@c.us', 'x')).rejects.not.toThrow('No LID for user');
+    expect(sendMessage).toHaveBeenCalledTimes(3); // one per attempt above, never a retry within one
+  });
+
+  it('reports a 400 when the RETRY against a re-resolved id is also unreachable', async () => {
+    const getNumberId = jest
+      .fn()
+      .mockResolvedValueOnce({ _serialized: '628@c.us' })
+      .mockResolvedValueOnce({ _serialized: '999@lid' });
+    const sendMessage = jest.fn().mockRejectedValue(new Error('No LID for user'));
+    const adapter = ready({ getNumberId, sendMessage });
+    await expect(adapter.sendTextMessage('628@c.us', 'x')).rejects.toBeInstanceOf(RecipientUnreachableError);
+    expect(sendMessage).toHaveBeenCalledTimes(2); // original + the one re-resolved retry
   });
 
   it('does not retry on a non-LID send error', async () => {

--- a/src/engine/adapters/wwebjs-messaging.ts
+++ b/src/engine/adapters/wwebjs-messaging.ts
@@ -20,6 +20,7 @@ import { chatHistoryMediaBudgetBytes, coerceDeclaredSize, ingestMediaBudgetBytes
 import { buildIncomingMessageBase } from './message-mapper';
 import { buildVCard } from './vcard';
 import { EngineNotSupportedError } from '../../common/errors/engine-not-supported.error';
+import { RecipientUnreachableError } from '../../common/errors/recipient-unreachable.error';
 import { type WwebjsEngineHost } from './wwebjs-host';
 
 /**
@@ -240,6 +241,11 @@ export class WwebjsMessaging {
    * — the signature of a contact whose cached/resolved id is stale (typically a `@c.us` for a contact
    * that has since migrated to `@lid`) — drop the mapping, re-resolve once, and retry only if the
    * fresh id differs, so a genuinely unreachable recipient surfaces its error instead of looping.
+   *
+   * When re-resolution cannot help, the recipient is unreachable rather than stale, and the raw
+   * `No LID for user` is replaced with {@link RecipientUnreachableError} (400). The bare page-side
+   * Error carries no status and no recipient, so letting it through produced an opaque 500 for what
+   * is really a caller-visible fact the gateway already established: `getNumberId` returned null.
    */
   private async sendResolved<T>(chatId: string, send: (to: string) => Promise<T>): Promise<T> {
     const to = await this.resolveSendId(chatId);
@@ -255,7 +261,7 @@ export class WwebjsMessaging {
       this.resolvedSendIds.delete(chatId);
       const fresh = await this.resolveSendId(chatId);
       if (fresh === to) {
-        throw err;
+        throw new RecipientUnreachableError(chatId);
       }
       // The first send threw, but wwjs can throw after the message is already on the wire — so this
       // retry may produce a duplicate. Log it: without this the second copy is invisible.
@@ -264,7 +270,16 @@ export class WwebjsMessaging {
         staleId: to,
         freshId: fresh,
       });
-      return send(fresh);
+      try {
+        return await send(fresh);
+      } catch (retryErr) {
+        // The re-resolved id is no better than the stale one — same unreachable recipient, and the
+        // raw error would 500 exactly as the first one did.
+        if (isNoLidForUserError(retryErr)) {
+          throw new RecipientUnreachableError(chatId);
+        }
+        throw retryErr;
+      }
     }
   }
 


### PR DESCRIPTION
Sending to a number WhatsApp cannot resolve answered `500 Internal server error` with an empty body, leaving the caller nothing to act on. Surfaced while investigating #1068, and reported twice before as #156 and #573.

## Cause

Since WhatsApp's LID migration, whatsapp-web.js raises a bare `Error: No LID for user` from inside the WhatsApp Web bundle. It carries no status, no recipient, and nothing marking it a caller problem — and there is no exception filter in the app, so NestJS classifies it as a server fault.

It is not one. By the time it is thrown the gateway has already established the cause: `resolveSendId` calls `getNumberId`, which returned `null` — which is precisely how whatsapp-web.js reports that a number is not reachable on WhatsApp. That verdict was discarded and the raw page error thrown in its place.

Observed on the test server:

```
POST …/messages/send-text  {"chatId":"628123456789@c.us","text":"…"}
→ 500 {"statusCode":500,"message":"Internal server error"}
   log: ERROR [ExceptionsHandler] Error: No LID for user
```

## Fix

Throw `RecipientUnreachableError` (400) on the two paths that cannot make progress: when re-resolution yields the same id, and when the single retry against a re-resolved id fails the same way. The second path was previously left raw and 500'd exactly as the first did.

The message names the recipient and both causes the gateway genuinely cannot tell apart:

> WhatsApp could not resolve the recipient 628123456789@c.us. Either the number is not on WhatsApp, or this session has no existing chat with it — message it once from the phone, then retry.

That second cause is the upstream whatsapp-web.js LID limitation (whatsapp-web.js#3834) that #156 was closed against; it is now stated in the response instead of only in a closed issue.

Sends that *can* make progress are untouched — a stale `@c.us` for a contact that has migrated to `@lid` still re-resolves and retries exactly as before.

`400` rather than `404` because on these routes a 404 already means the *session* was not found; reusing it for the recipient would be ambiguous. The class follows the existing pattern (`EngineNotSupportedError` → 501, `EngineRefusedError` → 403), so no global filter is needed.

## Contract note

This changes a response **status** on an error path: an unresolvable recipient goes `500` → `400`. Flagged deliberately — a caller that treated the old 500 as retryable should treat this 400 as terminal. Noted in the changelog under `[Unreleased]`. No response *shape* changes and `openapi.json` is byte-identical, since 400 was already documented on these routes.

## Verification

- The trigger is live-observed: on the test server a send to a number not on WhatsApp produced exactly that `No LID for user` → 500, with the retry path confirmed not to help because `getNumberId` keeps returning null.
- Unit tests assert the new error, its 400 status, and that the raw `No LID for user` wording no longer reaches the caller, plus a new case covering the retry path. Mutation-checked: restoring the raw `throw err` fails the suite.
- The pre-existing "does not retry when re-resolution yields the same id" test is updated rather than removed — it documented the old behaviour deliberately, and still asserts no pointless second send.
- Full gate green: build, lint, `tsc --noEmit`, 4761 unit tests, 148 e2e tests, dashboard typecheck/lint/i18n/test/build. `openapi.json` regenerated and unchanged.

**Verification boundary:** the mapping itself is unit-verified, not re-observed end to end on a paired session — that would mean deploying this branch over a live WhatsApp session on the test box, which I did not want to disturb for a three-line error mapping. The 500 it replaces *was* observed live.

Refs #1068.