### PR TITLE
fix(message): validate the WID shape of mentions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Sending to a number WhatsApp cannot resolve returned `500`** on the whatsapp-web.js engine — it now answers `400` naming the recipient and both possible causes. Callers that retried the old 500 should treat this as terminal.
 - **Swagger "Try it out" on `send-text` always returned `400`** — the sampled body paired `linkPreview: false` with a `customLinkPreview`, which the endpoint rejects; the operation now ships explicit request-body examples.
 - **Swagger "Try it out" on the media routes uploaded the literal string `"string"`** — the sampled body carried both `url` and `base64`, and base64 wins; each route now ships an explicit example with a single media source.
+- **A malformed `mentions` entry returned an undiagnosable `500`** — only type and length were checked, so junk reached WhatsApp Web's WID parser; entries are now validated as individual WIDs (`@c.us`, `@s.whatsapp.net`, `@lid`) and rejected with a `400`.
 
 ## [0.14.0] - 2026-08-05
 

--- a/src/modules/message/dto/is-mention-wid.validator.ts
+++ b/src/modules/message/dto/is-mention-wid.validator.ts
@@ -1,0 +1,35 @@
+import { ValidatorConstraint, ValidatorConstraintInterface } from 'class-validator';
+import { parseWaId } from '../../../engine/identity/wa-id';
+
+/**
+ * Whether a string can address an individual in a `mentions` array.
+ *
+ * A mention names a person, so only the two individual dialects are accepted: `<phone>@c.us` (and
+ * its raw-protocol twin `<phone>@s.whatsapp.net`) and `<lid>@lid`. A `:<device>` suffix is fine —
+ * {@link parseWaId} strips it.
+ *
+ * Rejecting the rest is what keeps a malformed entry out of the engine. Nothing validated the shape
+ * before, so a bare number or any other junk string reached WhatsApp Web's `createWid` inside
+ * `window.WWebJS.sendMessage`, where the unguarded `mentionedJidList.map(createWid)` threw. The page
+ * bundle is minified, so the throw arrived as `Error: t: t` and the caller received
+ * `500 Internal server error` — undiagnosable from either end (#1068).
+ *
+ * Group ids are rejected too: `mentions` is the participant list, and mentioning a group is a
+ * separate WhatsApp feature (`groupMentions`) that this API does not expose. A `@g.us` here was
+ * never honoured — it just failed later and less clearly.
+ */
+export function isMentionWid(value: unknown): boolean {
+  if (typeof value !== 'string') return false;
+  const kind = parseWaId(value).kind;
+  return kind === 'user' || kind === 'lid';
+}
+
+@ValidatorConstraint({ name: 'isMentionWid', async: false })
+export class IsMentionWidConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown): boolean {
+    return isMentionWid(value);
+  }
+  defaultMessage(): string {
+    return 'each mentions entry must be an individual WID — <phone>@c.us or <lid>@lid';
+  }
+}

--- a/src/modules/message/dto/send-message.dto.spec.ts
+++ b/src/modules/message/dto/send-message.dto.spec.ts
@@ -115,6 +115,55 @@ describe('media route body examples', () => {
   });
 });
 
+// Nothing checked the shape before, so a malformed entry reached WhatsApp Web's createWid and threw
+// from the minified bundle as `Error: t: t` — the caller got a 500 that named neither the field nor
+// the value (#1068). These cases are the contract: what an individual WID looks like, and what does not.
+describe('mentions WID shape', () => {
+  const accepted: Array<[string, string]> = [
+    ['phone @c.us (the documented form)', '628123456789@c.us'],
+    ['raw protocol @s.whatsapp.net (the #156 workaround)', '628123456789@s.whatsapp.net'],
+    ['privacy id @lid (phone genuinely unknown)', '148004841455867@lid'],
+    ['multi-device suffix', '628123456789:12@c.us'],
+  ];
+
+  const rejected: Array<[string, string]> = [
+    ['bare number, no domain', '628123456789'],
+    ['garbage', 'not-a-wid!!'],
+    ['empty string', ''],
+    ['group id (mentions is the participant list, not groupMentions)', '120363000000000000@g.us'],
+    ['status pseudo-JID', 'status@broadcast'],
+    ['unknown domain', '628123456789@example.com'],
+  ];
+
+  it.each(accepted)('accepts %s', async (_label, wid) => {
+    const errors = await validateDto(SendTextMessageDto, { chatId: 'g@g.us', text: 'hi', mentions: [wid] });
+    expect(errors).toHaveLength(0);
+  });
+
+  it.each(rejected)('rejects %s', async (_label, wid) => {
+    const errors = await validateDto(SendTextMessageDto, { chatId: 'g@g.us', text: 'hi', mentions: [wid] });
+    expect(errors.map(e => e.property)).toEqual(['mentions']);
+  });
+
+  it('rejects a bad entry even when another entry is valid', async () => {
+    const errors = await validateDto(SendTextMessageDto, {
+      chatId: 'g@g.us',
+      text: 'hi',
+      mentions: ['628123456789@c.us', 'not-a-wid!!'],
+    });
+    expect(errors.map(e => e.property)).toEqual(['mentions']);
+  });
+
+  it('applies to media captions too', async () => {
+    const errors = await validateDto(SendMediaMessageDto, {
+      chatId: 'g@g.us',
+      url: 'https://example.com/a.jpg',
+      mentions: ['not-a-wid!!'],
+    });
+    expect(errors.map(e => e.property)).toEqual(['mentions']);
+  });
+});
+
 describe('SendMediaMessageDto mentions', () => {
   it('accepts an optional array of mention WIDs', async () => {
     const errors = await validateDto(SendMediaMessageDto, {

--- a/src/modules/message/dto/send-message.dto.ts
+++ b/src/modules/message/dto/send-message.dto.ts
@@ -10,8 +10,10 @@ import {
   IsArray,
   ArrayMaxSize,
   IsBoolean,
+  Validate,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+import { IsMentionWidConstraint } from './is-mention-wid.validator';
 import { ToStrictBoolean } from '../../../common/utils/strict-boolean';
 
 const MENTIONS_DESCRIPTION =
@@ -73,6 +75,7 @@ export class SendTextMessageDto {
   @ArrayMaxSize(1024)
   @IsString({ each: true })
   @MaxLength(64, { each: true })
+  @Validate(IsMentionWidConstraint, { each: true })
   mentions?: string[];
 
   @ApiPropertyOptional({
@@ -191,6 +194,7 @@ export class SendMediaMessageDto {
   @ArrayMaxSize(1024)
   @IsString({ each: true })
   @MaxLength(64, { each: true })
+  @Validate(IsMentionWidConstraint, { each: true })
   mentions?: string[];
 }
 


### PR DESCRIPTION
A malformed `mentions` entry returned `500 Internal server error`, with a server log that was no more use than the response. Surfaced while investigating #1068.

## Cause

`mentions` was checked for type and length only — `@IsString({ each: true })` and `@MaxLength(64, { each: true })` — so any string got through. It then reached WhatsApp Web's `createWid` inside `window.WWebJS.sendMessage`:

```js
options.mentionedJidList = options.mentionedJidList.map(id => window.require("WAWebWidFactory").createWid(id));
options.mentionedJidList = options.mentionedJidList.filter(Boolean);
```

There is no `try`/`catch` there, and the `.filter(Boolean)` only rescues a falsy *return* — a throw rejects the whole `pupPage.evaluate`. Because the page bundle is minified, the error arrives with its class and message both mangled. Measured on the test server:

```
POST …/send-text  {"mentions":["628123456789"]}   → 500 {"statusCode":500,"message":"Internal server error"}
   log: ERROR [ExceptionsHandler] t: t
```

`t: t` names neither the field nor the value, so the failure was undiagnosable from either end.

## Fix

Validate each entry as an individual WID: `<phone>@c.us`, its raw-protocol twin `<phone>@s.whatsapp.net`, or `<lid>@lid`, each with an optional `:<device>` suffix.

The validator reuses `parseWaId` rather than introducing a regex, so the set of accepted dialects stays defined in one place — the same function the engine boundary already uses to classify ids.

Group ids are rejected too. `mentions` is the participant list; mentioning a group is a separate WhatsApp feature (`groupMentions`) this API does not expose, so a `@g.us` entry was never honoured — it only failed later and less clearly.

## Verification

Live, through the real HTTP stack on a locally built instance:

| entry | before | after |
|---|---|---|
| `628123456789` (bare) | `500` / log `t: t` | `400` "each mentions entry must be an individual WID…" |
| `not-a-wid!!` | `500` / log `t: t` | `400` same |
| `12036@g.us` | reached the engine | `400` same |
| `628123456789@c.us` | accepted | accepted (reaches the session check) |
| `628123456789@s.whatsapp.net` | accepted | accepted |
| `148004841455867@lid` | accepted | accepted |

The three accepted forms are asserted explicitly, not just the rejected ones — the risk in tightening a previously-anything-goes field is over-rejecting, and `@s.whatsapp.net` in particular is the workaround suggested on #156.

- Mutation-checked: removing the decorator from both DTOs fails 8 of the 18 cases.
- `openapi.json` regenerated and unchanged — `@Validate` contributes no schema metadata.
- Full gate green: build, lint, `tsc --noEmit`, 4772 unit tests, 148 e2e tests, dashboard typecheck/lint/i18n/test/build.

Refs #1068.