### PR TITLE
feat(plugins): let a plugin ask for a link preview on a text send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Plugins can ask for a link preview.** `ConversationSendEnvelope` gained `linkPreview`, forwarded to the engine on a plain text send. Since 0.14.0 made Baileys previews opt-in, a plugin relaying a URL had no way to restore the preview card the REST API can already request — most visibly for a bot whose reply *is* a bare link. Ignored on media, location and quoted sends, whose engine paths take no preview option.
+
 ### Fixed
 
 - **Swagger "Try it out" called `http://localhost:2785` instead of the host that served the docs**, failing with `Failed to fetch` anywhere else — a relative server is now listed first, so it resolves to the serving origin.

--- a/src/core/plugins/conversation-send-facade.spec.ts
+++ b/src/core/plugins/conversation-send-facade.spec.ts
@@ -60,6 +60,63 @@ describe('conversation.send facade', () => {
     expect(res).toEqual({ id: 'm1' });
   });
 
+  it.each([true, false])('forwards an explicit linkPreview: %s to the text send', async choice => {
+    const sendText = jest.fn().mockResolvedValue({ id: 'm1' });
+    const facade = buildConversationSendFacade({
+      manifest: manifest(['conversation:send']) as never,
+      assertPermission: () => undefined,
+      assertSessionActive: jest.fn(),
+      resolveChatId: () => Promise.resolve('chat@c.us'),
+      runGuarded: (_events: string[], run: () => Promise<unknown>) => run(),
+      sendText,
+      reply: jest.fn(),
+    } as never);
+    await facade.send({
+      type: 'text',
+      text: 'see https://example.com',
+      sessionId: 's',
+      chatId: 'chat@c.us',
+      linkPreview: choice,
+    });
+    expect(sendText).toHaveBeenCalledWith('s', {
+      chatId: 'chat@c.us',
+      text: 'see https://example.com',
+      linkPreview: choice,
+    });
+  });
+
+  it('ignores linkPreview on a media envelope rather than rejecting the send', async () => {
+    // The engine media path takes no preview option, but a caption carrying a URL is ordinary — refusing
+    // the send over a hint the engine simply cannot act on would cost the message for nothing.
+    const sendMedia = jest.fn().mockResolvedValue({ id: 'm2' });
+    const sendText = jest.fn();
+    const facade = buildConversationSendFacade({
+      manifest: manifest(['conversation:send']) as never,
+      assertPermission: () => undefined,
+      assertSessionActive: jest.fn(),
+      resolveChatId: () => Promise.resolve('chat@c.us'),
+      runGuarded: (_events: string[], run: () => Promise<unknown>) => run(),
+      sendText,
+      reply: jest.fn(),
+      sendMedia,
+    } as never);
+    await facade.send({
+      type: 'image',
+      mediaUrl: 'https://cdn.example.com/x.jpg',
+      text: 'see https://example.com',
+      sessionId: 's',
+      chatId: 'chat@c.us',
+      linkPreview: true,
+    });
+    expect(sendMedia).toHaveBeenCalledWith('s', {
+      chatId: 'chat@c.us',
+      url: 'https://cdn.example.com/x.jpg',
+      type: 'image',
+      caption: 'see https://example.com',
+    });
+    expect(sendText).not.toHaveBeenCalled();
+  });
+
   it('routes a media envelope to sendMedia with the caption from text, not sendText', async () => {
     const sendMedia = jest.fn().mockResolvedValue({ id: 'm2' });
     const sendText = jest.fn();

--- a/src/core/plugins/conversation-send-facade.ts
+++ b/src/core/plugins/conversation-send-facade.ts
@@ -18,7 +18,7 @@ export interface ConversationSendDeps {
   // synchronously inside sendText/reply. 'message:sent' is emitted later by SessionEngineLifecycle's
   // engine callback (onMessageCreate), outside this call's async scope, so seeding it here would be a no-op.
   runGuarded: <T>(events: string[], run: () => Promise<T>) => Promise<T>;
-  sendText: (sessionId: string, opts: { chatId: string; text: string }) => Promise<unknown>;
+  sendText: (sessionId: string, opts: { chatId: string; text: string; linkPreview?: boolean }) => Promise<unknown>;
   reply: (sessionId: string, opts: { chatId: string; quotedMessageId: string; text: string }) => Promise<unknown>;
   // Media send by URL. The loader binds this to the per-type MessageService media methods
   // (sendImage/sendVideo/sendAudio/sendDocument) — the facade stays DTO-agnostic.
@@ -93,7 +93,14 @@ export function buildConversationSendFacade(deps: ConversationSendDeps) {
         if (env.replyTo) {
           return deps.reply(sessionId, { chatId, quotedMessageId: env.replyTo, text: env.text ?? '' });
         }
-        return deps.sendText(sessionId, { chatId, text: env.text ?? '' });
+        // Forwarded only when the plugin actually expressed a choice: MessageService widens the engine
+        // call whenever the key is present, so a blanket `linkPreview: undefined` would rewrite the call
+        // shape of every plugin send that never asked for a preview.
+        return deps.sendText(sessionId, {
+          chatId,
+          text: env.text ?? '',
+          ...(env.linkPreview === undefined ? {} : { linkPreview: env.linkPreview }),
+        });
       });
     },
   };

--- a/src/core/plugins/plugin.interfaces.ts
+++ b/src/core/plugins/plugin.interfaces.ts
@@ -274,6 +274,13 @@ export interface ConversationSendEnvelope {
   text?: string;
   mediaUrl?: string;
   replyTo?: string;
+  /**
+   * Ask the engine for a link preview on a plain text send. Baileys generates one only when this is
+   * `true`, so a plugin relaying a URL gets a bare link without it; whatsapp-web.js previews by
+   * default and takes `false` to suppress. Ignored on media, location and quoted sends, which route
+   * through engine paths that take no preview option.
+   */
+  linkPreview?: boolean;
   /** WGS84 coordinates; required for type 'location', ignored otherwise. `text` doubles as the
    *  location description. */
   latitude?: number;


### PR DESCRIPTION
## The gap

0.14.0 made Baileys link previews opt-in — a send carrying a URL no longer renders a preview card unless the caller asks for it. `SendTextMessageDto` gained `linkPreview` and `customLinkPreview` in that release, so REST callers can ask.

`ConversationSendEnvelope` did not, and nothing downstream fills the gap:

| Layer | Can express a preview choice? |
| --- | --- |
| `SendTextMessageDto` (REST) | yes, since 0.14.0 |
| `MessageService.sendText` | yes — widens the engine call when the DTO carries a choice |
| Baileys adapter | yes — `linkPreview === true ? {} : { linkPreview: null }` |
| **`ConversationSendEnvelope`** (plugins) | **no** |

So a plugin send reaches `engine.sendTextMessage` with `options === undefined`, and the adapter hands Baileys an explicit "no preview". The plugin surface is the only one that cannot ask.

It matters most where the link *is* the message. A flow connector that renders a link step or a redirect step sends the bare URL and nothing else — the preview card carried the title and image, and there is no way to get it back from inside a plugin.

whatsapp-web.js is unaffected either way: it previews by default and only reads an explicit `false`.

## The change

`ConversationSendEnvelope.linkPreview?: boolean`, forwarded to `MessageService.sendText` on the plain-text branch of the send facade.

Forwarded only when the plugin expressed a choice. `MessageService` widens the engine call whenever the key is present, so passing a blanket `linkPreview: undefined` would rewrite the call shape of every plugin send that never asked — the existing spec asserting `sendText` is called with exactly `{ chatId, text }` pins that and still passes unchanged.

Media, location and quoted sends ignore the field. Those engine paths take no preview option, and unlike `replyTo` — which is rejected because a caller who asked for a quote and silently got none has lost something they can see — a preview is a hint the engine simply cannot act on. Refusing the send would cost the message for nothing. The behaviour is documented on the field and covered by a test.

`customLinkPreview` is deliberately not included. It is Baileys-only, answers `501` on whatsapp-web.js, and carries a nested DTO; no plugin needs it today, and it can be added later without disturbing this field.

## Verification

- `npx tsc --noEmit` clean
- `npx jest src/core/plugins` — 321 passing across 26 suites
- `npx eslint src/core/plugins/` clean
- The two `linkPreview` forwarding cases were checked against a reverted `conversation-send-facade.ts` and both fail there, so they pin the change rather than restating it. The media case passes either way by design — it is a guard against a future regression, not a proof of new behaviour.

No REST surface changed, so `openapi.json` is untouched.

## Scope

Touches only `src/core/plugins/` plus a `CHANGELOG.md` entry. No other open PR touches those files, so the only possible conflict is the changelog line.

Follow-up, once this ships: `types/openwa.d.ts` in the plugins repo needs the same field, and typebot-connector can then restore its preview cards. That change is deliberately held until this merges — vendoring a field the host does not have yet would advertise a capability that is not there.