### PR TITLE
docs: correct the MCP tool count and shipped tool domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Swagger "Try it out" called `http://localhost:2785` instead of the host that served the docs**, failing with `Failed to fetch` anywhere else — a relative server is now listed first, so it resolves to the serving origin.
 
+### Documentation
+
+- Documentation corrected where it understated the MCP surface: the tool count is 51 rather than ~39 (README and the architecture diagram), labels and automation-rule reads ship by default instead of being planned, and the Session row lists both presence tools.
+
 ## [0.14.0] - 2026-08-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ curl -X POST http://localhost:2785/api/sessions/{sessionId}/webhooks \
 
 OpenWA can expose a **curated set of tools over the [Model Context Protocol](https://modelcontextprotocol.io)** so AI agents (Claude, Cursor, …) can drive WhatsApp. It is **off by default** and **additive** — every REST route keeps working unchanged.
 
-Set `MCP_ENABLED=true` to mount a stateless Streamable-HTTP transport at **`POST /mcp`** on the existing server (same port, no extra process). It exposes ~39 curated tools (sessions, messaging, contacts, basic group ops, webhook reads) — a focused surface rather than the full API, so agents aren't overwhelmed and destructive operations stay off the agent path.
+Set `MCP_ENABLED=true` to mount a stateless Streamable-HTTP transport at **`POST /mcp`** on the existing server (same port, no extra process). It exposes 51 curated tools (sessions, messaging, contacts, basic group ops, webhook reads, labels, automation-rule reads) — a focused surface rather than the full API, so agents aren't overwhelmed and destructive operations stay off the agent path.
 
 ```bash
 MCP_ENABLED=true npm run start:prod   # or set MCP_ENABLED in your .env / compose

--- a/docs/24-mcp-integration.md
+++ b/docs/24-mcp-integration.md
@@ -26,7 +26,7 @@
 | **OAuth 2.1 (public exposure)**   | 🔜 Planned     | Static API key is used today (suitable for self-hosted/internal)        |
 | **Agent-action audit provenance** | 🔜 Planned     | Mark audited actions as agent-initiated                                 |
 | **Env-tunable rate limits**       | ✅ Implemented | `MCP_RATE_LIMIT_MAX` / `MCP_RATE_LIMIT_WINDOW_MS`                       |
-| **Additional tool domains**       | 🔜 Planned     | labels / templates / channels / catalog / status as an opt-in expansion |
+| **Additional tool domains**       | 🔜 Planned     | templates / channels / catalog / status (labels/automation now ship)    |
 
 ---
 
@@ -81,7 +81,7 @@ flowchart TB
 flowchart LR
     Client[MCP client] -->|POST /mcp| Adapter
     subgraph Core["src/core/agent-tools (SDK-free)"]
-        Registry[ToolRegistryService<br/>~39 ToolDescriptors]
+        Registry[ToolRegistryService<br/>51 ToolDescriptors]
         Invoker[invokeTool<br/>auth → validate → handler]
     end
     subgraph Adapter["src/modules/mcp (SDK, opt-in)"]
@@ -120,7 +120,7 @@ declares a `tier` (`read` | `write`) and, for writes, a required role.
 
 | Domain         | Read tools                                              | Write tools                                                                                   |
 | -------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| **Session**    | list, get, chats, stats                                 | mark read/unread, typing                                                                      |
+| **Session**    | list, get, chats, stats, presence                       | mark read/unread, typing, subscribe presence                                                  |
 | **Message**    | list, history, reactions                                | send text/image/video/audio/document/location/contact/sticker/template, reply, forward, react |
 | **Contact**    | list, get, check-number, resolve-phone, profile-picture | block, unblock                                                                                |
 | **Group**      | list, get, invite-code                                  | create, add participants, set subject, set description                                        |
@@ -244,8 +244,8 @@ Guidelines:
   intended for self-hosted/internal use).
 - **Agent-action audit provenance** — record that an audited action was agent-initiated
   and by which key.
-- **Expansion-pack tool domains** — labels, templates, channels, catalog, and status are
-  not in the default surface yet.
+- **Expansion-pack tool domains** — templates, channels, catalog, and status are not in the
+  default surface yet. Labels and automation-rule reads already are.
 - **Stateful MCP sessions / SSE reconnect, prompts, elicitation** — out of scope; the
   transport is intentionally stateless.
 


### PR DESCRIPTION
## What

The MCP documentation was left behind by the tools that shipped in v0.14.0, to the point where `docs/24-mcp-integration.md` contradicted itself: the component table reported **51 tools** while the architecture diagram a few sections below still said **~39**. The README repeated the old figure.

## Changes

- **Tool count is 51** in the README and in the `docs/24` architecture diagram. The figure matches the golden list asserted in `tool-registry.spec.ts` (`expect(expected).toHaveLength(51)`), so it cannot drift again without a failing test.
- **Labels and automation-rule reads are no longer described as planned.** Both the capability table and the roadmap listed labels as an upcoming "opt-in expansion", implying a gate that does not exist — `allAgentTools()` composes `labelTools()` and `automationTools()` unconditionally, and the only MCP knobs are `MCP_ENABLED`, `MCP_READONLY` and the two rate-limit pairs. The README's domain list now names them too.
- **The Session row of the tool-surface table** listed 7 of its 9 tools, omitting `SessionGetPresence` and `SessionSubscribePresence`.

## Verification

Counted from source at this base — automation 2, contact 7, group 7, label 8, message 15, session 9, webhook 3 = **51**, agreeing with the registry spec.

Documentation only: no source file is touched and no behaviour changes. Markdown is outside the `format:check` glob (`src/**/*.ts`, `test/**/*.ts`), so no formatter run applies; the edited table rows were kept within the existing column widths by hand.