### PR TITLE
fix(engine): carry the stale-profile advisory into the session error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A whatsapp-web.js session failing with `Execution context was destroyed` showed a bare Puppeteer error with no next step** — the advisory naming the likely stale browser profile went only to the server log, so the session card now carries a short form of it too.
+
 ## [0.14.1] - 2026-08-05
 
 ### Added

--- a/docs/12-troubleshooting-faq.md
+++ b/docs/12-troubleshooting-faq.md
@@ -438,7 +438,8 @@ flavours; loading the stale profile destroys the page context during `Client.inj
 trigger today is the **v0.8.12** amd64 switch from Debian's `chromium` package to Chrome for Testing
 (#663), but the same symptom can follow any future change to the bundled browser binary. The error
 reads like a Puppeteer bug and gives no hint that the profile is the cause — the adapter now logs an
-advisory when it detects this error.
+advisory when it detects this error, and the session's `lastError` (the message the dashboard shows on
+the session card) carries a short form of it, so the pointer survives without reading the container log.
 
 **Fix:** delete the affected session's profile dir and start the session again to scan a new QR. The
 profile cannot be salvaged — clearing only the cache subdirs (`Cache`, `GPUCache`, `Code Cache`, …) is

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -128,6 +128,65 @@ describe('isExecutionContextDestroyedError (#708 — Puppeteer context loss duri
   );
 });
 
+// #1081: the advisory naming the stale profile dir went only to the server log, so the dashboard —
+// which renders nothing but onError's text as `lastError` — showed a bare Puppeteer error with no
+// next step. The hint has to travel WITH the reason, not beside it.
+describe('WhatsAppWebJsAdapter initialize() failure reason (#1081)', () => {
+  const newAdapter = (): WhatsAppWebJsAdapter =>
+    new WhatsAppWebJsAdapter({ sessionId: 'sess-advisory', sessionDataPath: './data/sessions', puppeteer: {} });
+
+  let rmSpy: jest.SpyInstance;
+  let clientInitSpy: jest.SpyInstance;
+  let savedWebVersion: string | undefined;
+
+  beforeEach(() => {
+    // 'off' keeps initialize() offline (no wa-version registry fetch); rm is stubbed so the real
+    // data dir is never touched by the pre-launch Singleton cleanup.
+    savedWebVersion = process.env.WWEBJS_WEB_VERSION;
+    process.env.WWEBJS_WEB_VERSION = 'off';
+    rmSpy = jest.spyOn(fs.promises, 'rm').mockResolvedValue(undefined);
+    clientInitSpy = jest.spyOn(Client.prototype as unknown as { initialize: () => Promise<void> }, 'initialize');
+  });
+
+  afterEach(() => {
+    rmSpy.mockRestore();
+    clientInitSpy.mockRestore();
+    if (savedWebVersion === undefined) {
+      delete process.env.WWEBJS_WEB_VERSION;
+    } else {
+      process.env.WWEBJS_WEB_VERSION = savedWebVersion;
+    }
+  });
+
+  /** Drive initialize() to the catch with `message`, and hand back what onError actually received. */
+  const reasonFor = async (message: string): Promise<string> => {
+    clientInitSpy.mockRejectedValue(new Error(message));
+    let surfaced = '';
+    const onError = jest.fn((reason: string) => {
+      surfaced = reason;
+    });
+    await expect(newAdapter().initialize({ onError })).rejects.toThrow(message);
+    expect(onError).toHaveBeenCalledTimes(1);
+    return surfaced;
+  };
+
+  it('appends the stale-profile remedy to the reason the dashboard shows', async () => {
+    const raw = 'Protocol error (Runtime.callFunctionOn): Execution context was destroyed.';
+    const surfaced = await reasonFor(raw);
+
+    // The raw Puppeteer text stays FIRST: it is what operators search for and what issue reports quote.
+    expect(surfaced.startsWith(raw)).toBe(true);
+    expect(surfaced).toMatch(/browser profile/i);
+    expect(surfaced).toMatch(/docs\/12-troubleshooting-faq\.md/);
+  });
+
+  it('leaves an unrelated initialize failure byte-identical', async () => {
+    const raw = 'Failed to launch the browser process:  Code: null';
+
+    expect(await reasonFor(raw)).toBe(raw);
+  });
+});
+
 describe('buildProxyLaunchConfig (#628 — proxy credentials must not go into --proxy-server)', () => {
   it('strips credentials from an HTTP proxy and returns them as proxyAuthentication', () => {
     expect(buildProxyLaunchConfig('http://user:pass@proxy.example.com:8080')).toEqual({

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -473,6 +473,10 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     } catch (error) {
       this.setStatus(EngineStatus.FAILED);
       const reason = error instanceof Error ? error.message : String(error);
+      // What the dashboard renders as `lastError` is exactly this string and nothing else — the log
+      // below never reaches it. Carry a one-line remedy with the reason for the one failure we can
+      // actually advise on, so the session card stops being a dead end (#1081).
+      let surfacedReason = reason;
       if (isExecutionContextDestroyedError(reason)) {
         // #708: Puppeteer's "Execution context was destroyed" during inject reads like a Puppeteer bug.
         // During initialize() its dominant cause is a browser profile left stale by an upgrade that
@@ -490,8 +494,15 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
             `navigation or renderer crash (check for memory pressure or a WhatsApp Web reload). ` +
             `See docs/12-troubleshooting-faq.md.`,
         );
+        // Kept short and with the raw Puppeteer text FIRST: operators search on that string, and the
+        // dashboard truncates a long reason. The profile path stays in the log above — it is too long
+        // for a card, and naming the wrong remedy is worse than pointing at the FAQ, since deleting a
+        // profile forces an irreversible re-pair.
+        surfacedReason =
+          `${reason} WhatsApp Web's page context was destroyed during startup. If this followed an ` +
+          `upgrade, the session's browser profile is likely stale — see docs/12-troubleshooting-faq.md.`;
       }
-      this.callbacks.onError?.(reason);
+      this.callbacks.onError?.(surfacedReason);
       throw error;
     }
   }


### PR DESCRIPTION
A whatsapp-web.js session that fails to initialize with `Execution context was destroyed` is marked failed with the raw Puppeteer message as its `lastError`. The adapter already detects this specific error and logs an advisory naming the browser profile directory to remove — but that text only ever reaches the server log. The dashboard renders `lastError` and nothing else, so the session card showed an opaque protocol error with no next step, which is exactly how it was reported in #1081.

## Change

Append a short form of the advisory to the reason handed to `onError`, which is what becomes `lastError`.

Two deliberate choices:

- **The raw Puppeteer text stays first.** Operators search on that string and issue reports quote it verbatim; burying it behind our own prose would make the card harder to match against search results.
- **The profile path stays in the log, not on the card.** It is too long for the field, and deleting a profile forces an irreversible re-pair — so the card points at the FAQ instead of naming a remedy that may not apply. The binary-change trigger only affects some upgrade paths, so asserting it on every occurrence would send operators to destroy a working pairing.

Unrelated initialize failures are passed through byte-identical.

## Verification

Two tests: one pins the appended remedy and that the raw text still leads, the other pins that a non-matching failure reaches `onError` unchanged. Both were confirmed to fail before the change. Full adapter suite (468) and backend suite (4799) pass.

`docs/12-troubleshooting-faq.md` said the advisory is logged; it now also records that the session card carries it, so the entry stays accurate.

Refs #1081.
