### PR TITLE
docs(sdk): correct the Java release guide's missing-secret behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The Java SDK release guide described the opposite of what the workflow does** — it promised a missing publish secret makes the run a harmless no-op, while the guard has since been a hard failure by design.
 - **A whatsapp-web.js session failing with `Execution context was destroyed` showed a bare Puppeteer error with no next step** — the advisory naming the likely stale browser profile went only to the server log, so the session card now carries a short form of it too.
 - **Infrastructure reported "Pinned by an environment variable" for any unapplied change, without naming the variable** — the gateway now reports which settings a higher-precedence layer actually supplies, so a real pin names its variable, a saved-but-not-restarted change says so instead, and the Engine card gained the notice it never had.
 

--- a/sdk/java/README.md
+++ b/sdk/java/README.md
@@ -146,8 +146,10 @@ One-time setup (repository secrets):
 - `GPG_PRIVATE_KEY` — ASCII-armored signing key.
 - `GPG_PASSPHRASE` — passphrase for that key.
 
-Until the secrets exist the workflow cleanly no-ops (it prints a notice and
-skips the deploy), so tagging early is harmless.
+All four secrets are checked before anything is built, and a missing one **fails
+the run**. That is deliberate: skipping the deploy and reporting green is
+indistinguishable from a real release in the run list, so configure the secrets
+before tagging rather than tagging to see what happens.
 
 Cutting a release:
 


### PR DESCRIPTION
`sdk/java/README.md` -> Releasing promised that until the publish secrets exist the workflow "cleanly no-ops (it prints a notice and skips the deploy), so tagging early is harmless".

The workflow does the opposite, and deliberately so. The credential guard (`java-sdk-release.yml`) collects every missing secret and exits 1, with its own comment explaining why: a skipped deploy that reports green is indistinguishable from a real release in the run list.

Someone following the README would tag a release expecting a harmless run and get a red one instead — or, worse, trust the inverse promise while auditing why a release did not appear.

Noticed while auditing which SDKs actually publish automatically; unrelated to that work, so it is its own change.

Not reformatted: the file is not Prettier-clean on `main` and markdown is not gated by CI, so running the formatter here would bury a two-line correction in unrelated churn.