### PR TITLE
ci(sdk): publish the Python SDK to PyPI via trusted publishing

### DIFF
--- a/.github/workflows/python-sdk-release.yml
+++ b/.github/workflows/python-sdk-release.yml
@@ -1,0 +1,95 @@
+name: Python SDK Release
+
+# Publishes rmyndharis-openwa to PyPI from sdk/python.
+#
+# Authentication is PyPI Trusted Publishing (OIDC) — there is deliberately NO PyPI token in this
+# workflow or in the repository secrets. PyPI mints a short-lived credential from the GitHub OIDC
+# token, so nothing long-lived exists to leak or rotate. Same arrangement as js-sdk-release.yml.
+#
+# One-time setup on pypi.org (see sdk/python/README.md -> Releasing), required BEFORE the first tag:
+# project settings -> Publishing -> add a GitHub trusted publisher with owner `rmyndharis`,
+# repository `OpenWA`, and workflow `python-sdk-release.yml`.
+#
+# The SDK version is the pyproject.toml version on a dedicated tag (e.g. py-sdk-v0.2.0), NOT the
+# monorepo v* app tags.
+
+on:
+  push:
+    tags: ['py-sdk-v*']
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Mints the OIDC token PyPI exchanges for its short-lived upload credential. Without this the
+      # publish has no credential at all — it is the whole mechanism.
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      # Guards are textual and secret-free, so a misconfigured release fails BEFORE anything is built
+      # or published. Mirrors java-sdk-release.yml and js-sdk-release.yml. Textual also means they run
+      # before setup-python and depend on no interpreter.
+      - name: Guard — ref must be a py-sdk-v* release tag
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          # workflow_dispatch can start this workflow on ANY ref; publishing an arbitrary branch or a
+          # monorepo app tag to PyPI must not be possible.
+          case "$REF" in
+            refs/tags/py-sdk-v*) ;;
+            *)
+              echo "::error::This workflow publishes to PyPI and must run from a py-sdk-v* tag (got '$REF'). For workflow_dispatch, select the release tag as the run ref."
+              exit 1
+              ;;
+          esac
+
+      - name: Guard — tag version matches pyproject.toml version
+        working-directory: sdk/python
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          TAG_VERSION="${REF_NAME#py-sdk-v}"
+          # First `version = "..."` in the file is the [project] version; the build-system table above
+          # it pins requirements, not a version key.
+          PKG_VERSION="$(grep -m1 -E '^version[[:space:]]*=' pyproject.toml | sed -E 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')"
+          if [ -z "$PKG_VERSION" ]; then
+            echo "::error::could not read the project version from pyproject.toml"
+            exit 1
+          fi
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag '$REF_NAME' (version '$TAG_VERSION') does not match pyproject.toml version '$PKG_VERSION'. Bump the project or fix the tag before releasing."
+            exit 1
+          fi
+          echo "Tag $REF_NAME matches pyproject.toml $PKG_VERSION"
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          # One interpreter, not the SDK CI matrix: the wheel is pure Python (py3-none-any) and carries
+          # requires-python from the metadata, so the build interpreter does not shape the artifact.
+          # The 3.9/3.12 compatibility matrix already runs on every push to main.
+          python-version: '3.12'
+
+      # Same gate as SDK CI, and for the same reason the Java release runs its tests: the artifact
+      # that reaches the index must be the one that passed, not a rebuild nobody checked.
+      - name: Test
+        working-directory: sdk/python
+        run: |
+          pip install -e '.[dev]'
+          pytest
+
+      - name: Build sdist + wheel
+        working-directory: sdk/python
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+
+      - name: Publish to PyPI (trusted publishing)
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          packages-dir: sdk/python/dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **The JavaScript SDK now publishes to npm from CI** via Trusted Publishing (OIDC) on a `js-sdk-v*` tag — no npm token exists anywhere, and every release carries build provenance.
+- **The Python SDK now publishes to PyPI from CI** via Trusted Publishing (OIDC) on a `py-sdk-v*` tag — no PyPI token exists anywhere, matching the JavaScript SDK's release path.
 
 ### Fixed
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -88,6 +88,34 @@ except OpenWANotFoundError as e:
 - Escape hatch for endpoints the SDK does not wrap:
   `client.request(method, path, query=…, body=…)`.
 
+## Releasing
+
+Publishing to PyPI is done by the
+[`python-sdk-release.yml`](../../.github/workflows/python-sdk-release.yml)
+workflow, which authenticates with **PyPI Trusted Publishing (OIDC)**. There is
+no PyPI token in the workflow or in the repository secrets: PyPI mints a
+short-lived credential from the GitHub OIDC token, so nothing long-lived exists
+to leak or rotate.
+
+One-time setup, required **before** the first tag — on pypi.org, open the
+project's publishing settings and add a GitHub trusted publisher:
+
+- Owner: `rmyndharis`
+- Repository: `OpenWA`
+- Workflow name: `python-sdk-release.yml`
+
+There are no repository secrets to add. Until the trusted publisher exists PyPI
+rejects the upload, so configure it first.
+
+Cutting a release:
+
+1. Bump `version` in `pyproject.toml` and land it on `main`.
+2. Tag that commit `py-sdk-v<version>` (e.g. `py-sdk-v0.2.0`) and push the tag.
+   The SDK has its own version line — the monorepo's `v*` tags are the app
+   version and never trigger an SDK publish.
+3. The workflow re-runs the test suite, builds the sdist and wheel, and
+   uploads. The artifacts published are the ones those tests passed against.
+
 ## License
 
 MIT


### PR DESCRIPTION
`rmyndharis-openwa` reached PyPI once, manually, and has sat at 0.1.0 since. This adds a tag-triggered publish workflow matching `js-sdk-release.yml`.

## Change

Authentication is **PyPI Trusted Publishing (OIDC)**. No PyPI token exists in the workflow or in repository secrets — PyPI mints a short-lived credential from the GitHub OIDC token, so nothing long-lived exists to leak or rotate.

Details worth reviewing:

- **The version guard reads `pyproject.toml` textually**, not with `tomllib`. The guard runs before `setup-python` so it must not depend on an interpreter being present, and `tomllib` would rule out the 3.9 this package still supports. The Java and JavaScript guards are textual for the same reason. Verified against the real file: it extracts `0.1.0`.
- **One build interpreter, not the CI matrix.** The wheel is pure Python (`py3-none-any`) and carries `requires-python` from the metadata, so the build interpreter cannot shape the artifact, and the 3.9/3.12 compatibility matrix already runs on every push to `main`. The suite still re-runs here so the uploaded artifacts are the ones it passed against.
- **Guards run before anything is built.** `workflow_dispatch` is restricted to the same `py-sdk-v*` tag shape a push triggers on, so an arbitrary branch or a monorepo `v*` app tag cannot reach PyPI, and the tag version must match `pyproject.toml`.
- `pypa/gh-action-pypi-publish` is pinned to the commit SHA behind `v1.14.2`, matching how every other third-party action in this repository is pinned. Note the release ref is an annotated tag, so the tag object's SHA is not the commit SHA — the pin dereferences to the commit.

## One-time setup required before the first tag

The pypi.org side cannot be automated. In the project's publishing settings, add a GitHub trusted publisher: owner `rmyndharis`, repository `OpenWA`, workflow `python-sdk-release.yml`. Until that exists PyPI rejects the upload. Documented in `sdk/python/README.md` -> Releasing.

No repository secrets are needed.
