### PR TITLE
docs(sdk): document how the Go SDK is released

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **The JavaScript SDK now publishes to npm from CI** via Trusted Publishing (OIDC) on a `js-sdk-v*` tag — no npm token exists anywhere, and every release carries build provenance.
 - **The Python SDK now publishes to PyPI from CI** via Trusted Publishing (OIDC) on a `py-sdk-v*` tag — no PyPI token exists anywhere, matching the JavaScript SDK's release path.
+- **The Go SDK documents how it is released** — tags must carry the `sdk/go/` module prefix, so a bare `v*` app tag never publishes it and callers can finally pin a version instead of a pseudo-version.
 
 ### Fixed
 

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -172,3 +172,34 @@ go vet ./...
 The `TestRouting` table asserts the exact method and path of every service call,
 so a wrong path (the historical `/messages/text` vs `/messages/send-text`) fails
 at test time.
+
+## Releasing
+
+There is no publish workflow, and none is possible: Go has no registry to push
+to. The module proxy serves whatever a repository tag points at, so **tagging
+is the release**.
+
+The tag must carry the module's directory prefix, because the module lives in a
+subdirectory rather than at the repository root:
+
+```bash
+# Correct — `sdk/go/` prefix, matching `module github.com/rmyndharis/OpenWA/sdk/go`
+git tag sdk/go/v0.2.0 && git push origin sdk/go/v0.2.0
+```
+
+A bare `v0.2.0` tag is the *app* version and does nothing for this module.
+Without a prefixed tag, `go get` resolves a pseudo-version
+(`v0.0.0-<date>-<commit>`) — usable, but callers cannot pin a release.
+
+Cutting a release:
+
+1. Bump `DefaultUserAgent` in `options.go` (it carries the SDK version and is
+   sent on every request, so it drifts silently if only the tag moves).
+2. Land that on `main`.
+3. Tag that commit `sdk/go/v<version>` and push the tag.
+
+> **A published version is immutable.** Once the module proxy has served
+> `sdk/go/vX.Y.Z` it caches it permanently — deleting or moving the tag does not
+> take it back, and the only remedy is to publish a higher version (and, if the
+> bad one must be discouraged, a `retract` directive in `go.mod`). Tag a commit
+> that is already green on `main`.


### PR DESCRIPTION
The Go SDK has no publish workflow and cannot have one — Go has no registry to push to, so **tagging is the release**. Nothing in the repository recorded that, which is why the module has only ever been resolvable as a pseudo-version.

## The load-bearing detail

The tag must carry the `sdk/go/` module prefix, because the module lives in a subdirectory rather than at the repository root.

This is empirically confirmed rather than asserted: the repo already has bare `v*` app tags, and `proxy.golang.org` still answers `v0.0.0-<date>-<commit>` for `github.com/rmyndharis/OpenWA/sdk/go` — a bare tag does not apply to a module in a subdirectory. So `go get` works today, but callers cannot pin a release.

## Also recorded

- `DefaultUserAgent` in `options.go` carries the SDK version (`openwa-go/0.1.0`) and is sent on every request. It drifts silently if only the tag moves.
- **A published module version is immutable.** Once the proxy has served it, deleting or moving the tag does not take it back; the remedy is a higher version plus, if needed, a `retract` directive. So tag a commit already green on `main`.

## Scope

Docs only, deliberately. There is no publish step to automate, and `sdk-ci.yml` already tests `sdk/go` on every push to `main`, so a tag-triggered test job would re-run a check that has already passed on the same commit — after the tag is public and immutable, when it can no longer prevent anything.

Not reformatted: the file is not Prettier-clean on `main` and markdown is not gated by CI.