### PR TITLE
ci(sdk): cut versioned PHP SDK releases by tagging the mirror

### DIFF
--- a/.github/workflows/php-sdk-release.yml
+++ b/.github/workflows/php-sdk-release.yml
@@ -1,0 +1,115 @@
+name: PHP SDK Release
+
+# Cuts a versioned release of the PHP SDK by pushing a tag to the mirror repo
+# rmyndharis/openwa-php, which is what Packagist reads versions from.
+#
+# Why a tag on the MIRROR and not here: Packagist installs from the mirror (it needs composer.json at
+# a repository root and does not support subdirectories), and it derives versions from that
+# repository's tags. A tag in this monorepo is invisible to it. split-php-sdk.yml already keeps the
+# mirror's `main` in sync on every push; this workflow adds the one thing it deliberately does not do.
+#
+# There is no version in sdk/php/composer.json — Composer takes the version from the tag, and a
+# hardcoded `version` field is discouraged precisely because it drifts. So the tag IS the version.
+#
+# One-time setup is the same secret split-php-sdk.yml already uses: PHP_SDK_SPLIT_TOKEN.
+#
+# The SDK version rides its own tag (e.g. php-sdk-v0.2.0), NOT the monorepo v* app tags.
+
+on:
+  push:
+    tags: ['php-sdk-v*']
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0 # full history is required for `git subtree split`
+          persist-credentials: false # stop the GITHUB_TOKEN extraheader from shadowing the PAT in the push URL
+
+      # Guards are textual and secret-free, so a misconfigured release fails BEFORE anything is
+      # pushed. Mirrors java/js/python-sdk-release.yml.
+      - name: Guard — ref must be a php-sdk-v* release tag
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          # workflow_dispatch can start this workflow on ANY ref; publishing an arbitrary branch or a
+          # monorepo app tag to Packagist must not be possible.
+          case "$REF" in
+            refs/tags/php-sdk-v*) ;;
+            *)
+              echo "::error::This workflow publishes to Packagist and must run from a php-sdk-v* tag (got '$REF'). For workflow_dispatch, select the release tag as the run ref."
+              exit 1
+              ;;
+          esac
+
+      - name: Guard — composer branch-alias tracks the release line
+        working-directory: sdk/php
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          VERSION="${REF_NAME#php-sdk-v}"
+          # dev-main's alias tells Composer which line the unreleased branch represents. It is easy to
+          # forget on a minor bump, and the result is silently wrong metadata for anyone requiring
+          # dev-main rather than an outright failure — so check it here, where it is still cheap to fix.
+          EXPECTED="$(echo "$VERSION" | cut -d. -f1-2).x-dev"
+          ACTUAL="$(jq -r '.extra["branch-alias"]["dev-main"] // ""' composer.json)"
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo "::error::composer.json extra.branch-alias.dev-main is '$ACTUAL' but tag '$REF_NAME' needs '$EXPECTED'. Update the alias and re-tag."
+            exit 1
+          fi
+          echo "branch-alias '$ACTUAL' matches $REF_NAME"
+
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+        with:
+          # Oldest version composer.json supports (php >=8.1). Nothing is built here — the release only
+          # moves a tag — so this run is purely a tripwire, and the oldest interpreter is the one that
+          # catches syntax the floor does not allow. The 8.1/8.2 matrix runs on every push to main.
+          php-version: '8.1'
+
+      - name: PHP SDK tests
+        working-directory: sdk/php
+        run: |
+          composer install --no-interaction --no-progress
+          ./vendor/bin/phpunit
+
+      - name: Tag the mirror repo
+        env:
+          SPLIT_TOKEN: ${{ secrets.PHP_SDK_SPLIT_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          # Unlike split-php-sdk.yml, a missing token is FATAL here rather than a green skip: that
+          # workflow re-runs on the next push, while a release that silently publishes nothing is
+          # indistinguishable from one that worked.
+          if [ -z "${SPLIT_TOKEN:-}" ]; then
+            echo "::error::PHP_SDK_SPLIT_TOKEN is not set — cannot tag the mirror. Configure it (see sdk/php/README.md -> Releasing) before tagging a release."
+            exit 1
+          fi
+          VERSION="${REF_NAME#php-sdk-v}"
+          MIRROR="https://x-access-token:${SPLIT_TOKEN}@github.com/rmyndharis/openwa-php.git"
+
+          # A published Composer version is effectively immutable: Packagist caches the tag's contents,
+          # so moving it does not reliably reach anyone who already resolved it. Refuse rather than
+          # force-push over a released version.
+          if git ls-remote --tags --exit-code "$MIRROR" "refs/tags/${VERSION}" >/dev/null 2>&1; then
+            echo "::error::rmyndharis/openwa-php already has tag '${VERSION}'. Released versions are immutable — bump the version instead of re-tagging."
+            exit 1
+          fi
+
+          git config user.name "rmyndharis"
+          git config user.email "yudhi@rmyndharis.com"
+          # Same split the mirror workflow performs, taken at THIS tag: subtree split is deterministic,
+          # so the commit this produces is the one mirror `main` already carries for the same tree.
+          SPLIT_SHA="$(git subtree split --prefix=sdk/php HEAD)"
+          echo "Split SHA: $SPLIT_SHA"
+          # Tag without the `v` prefix, matching the existing 0.1.0 tag on the mirror. Composer accepts
+          # both, but mixing the two in one repository makes the version list read as two series.
+          git push "$MIRROR" "${SPLIT_SHA}:refs/tags/${VERSION}"
+          echo "Tagged rmyndharis/openwa-php ${VERSION} -> ${SPLIT_SHA}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **The JavaScript SDK now publishes to npm from CI** via Trusted Publishing (OIDC) on a `js-sdk-v*` tag — no npm token exists anywhere, and every release carries build provenance.
 - **The Python SDK now publishes to PyPI from CI** via Trusted Publishing (OIDC) on a `py-sdk-v*` tag — no PyPI token exists anywhere, matching the JavaScript SDK's release path.
+- **The PHP SDK now cuts versioned releases from CI** on a `php-sdk-v*` tag — it tags the Packagist mirror, which previously only ever tracked `dev-main` because nothing propagated a version.
 - **The Go SDK documents how it is released** — tags must carry the `sdk/go/` module prefix, so a bare `v*` app tag never publishes it and callers can finally pin a version instead of a pseudo-version.
 
 ### Fixed

--- a/sdk/php/README.md
+++ b/sdk/php/README.md
@@ -75,6 +75,47 @@ try {
 - Escape hatch for endpoints the SDK does not wrap:
   `$client->request($method, $path, $query, $body)`.
 
+## Releasing
+
+Packagist installs this SDK from the mirror repository
+[`rmyndharis/openwa-php`](https://github.com/rmyndharis/openwa-php), not from the
+monorepo — Composer needs `composer.json` at a repository root and does not
+support subdirectories. Two workflows keep that mirror correct:
+
+- [`split-php-sdk.yml`](../../.github/workflows/split-php-sdk.yml) syncs the
+  mirror's `main` on every push that touches `sdk/php/**`, which is what
+  Packagist's `dev-main` follows.
+- [`php-sdk-release.yml`](../../.github/workflows/php-sdk-release.yml) cuts a
+  versioned release by pushing a **tag** to the mirror. Packagist derives
+  versions from that repository's tags, so a tag in this monorepo alone
+  publishes nothing.
+
+There is no `version` field in `composer.json`, and there should not be —
+Composer takes the version from the tag, and a hardcoded field drifts. **The tag
+is the version.**
+
+Cutting a release:
+
+1. If the minor line changes, update `extra.branch-alias.dev-main` in
+   `composer.json` (e.g. `0.1.x-dev` → `0.2.x-dev`) and land it on `main`. The
+   release workflow refuses to publish when the alias does not match the tag.
+2. Tag that commit `php-sdk-v<version>` (e.g. `php-sdk-v0.2.0`) and push the
+   tag. The SDK has its own version line — the monorepo's `v*` tags are the app
+   version and never trigger an SDK release.
+3. The workflow runs the test suite, then tags the mirror `<version>` (no `v`
+   prefix, matching the existing tags there). Packagist picks it up from its
+   GitHub hook within a minute or two.
+
+> **A released version is effectively immutable.** Packagist caches a tag's
+> contents, so moving one does not reliably reach anyone who already resolved
+> it. The workflow refuses to overwrite an existing mirror tag — bump the
+> version instead of re-tagging.
+
+Requires the `PHP_SDK_SPLIT_TOKEN` secret, the same one the mirror workflow
+uses. Unlike the mirror workflow, which skips with a notice when the token is
+absent, the release **fails**: a release that silently publishes nothing looks
+exactly like one that worked.
+
 ## License
 
 MIT


### PR DESCRIPTION
The PHP SDK was the last one whose versioned releases were manual — and the manual step was easy to miss, because it happens in a **different repository**. Packagist installs from `rmyndharis/openwa-php` and derives versions from *that* repo's tags, so a tag here publishes nothing.

`split-php-sdk.yml` has kept the mirror's `main` in sync all along, which is exactly why the symptom was quiet: Packagist's `dev-main` tracked `f2451f9e` (current) while the newest installable release stayed `0.1.0` from June. Anyone requiring a stable constraint has been getting June's code.

## Change

A `php-sdk-v*` tag workflow that runs the suite and then pushes the matching tag to the mirror.

**The tag is the version.** `composer.json` deliberately carries no `version` field — Composer reads it from the tag, and a hardcoded one drifts — so nothing else needs bumping for a patch release.

Three guards, all before anything is pushed:

- `workflow_dispatch` is restricted to the same tag shape a push triggers on, so an arbitrary branch or a monorepo `v*` app tag cannot reach Packagist.
- `extra.branch-alias.dev-main` must match the tag's minor line. This one is worth a guard because getting it wrong produces *silently wrong metadata* for `dev-main` consumers rather than a failure. Verified both ways against the real `composer.json`: `0.1.0` passes against the current `0.1.x-dev`, and `0.2.0` / `1.0.3` correctly fail.
- An existing mirror tag is refused. Packagist caches a tag's contents, so moving one does not reliably reach anyone who already resolved it.

## Deliberate differences from `split-php-sdk.yml`

- **A missing `PHP_SDK_SPLIT_TOKEN` is fatal here**, where the mirror workflow skips with a notice. That workflow re-runs on the next push; a release that silently publishes nothing is indistinguishable from one that worked. Same reasoning as the Java release guard.
- **Tests run on PHP 8.1**, the floor `composer.json` declares, rather than the mirror workflow's 8.2. Nothing is built — the release only moves a tag — so the run is purely a tripwire, and the oldest interpreter catches the most. The 8.1/8.2 matrix still runs on every push to `main`.
- **The mirror tag carries no `v` prefix** (`0.2.0`, not `v0.2.0`), matching the existing `0.1.0` tag there. Composer accepts both, but mixing them in one repository makes the version list read as two series.

The token-bearing remote URL is only ever passed to `git ls-remote` (output suppressed) and `git push`, never echoed — same handling as the existing mirror workflow.

## Result

All five SDKs now release from CI:

| SDK | Registry | Trigger |
| --- | --- | --- |
| JavaScript | npm | `js-sdk-v*` |
| Python | PyPI | `py-sdk-v*` |
| Java | Maven Central | `java-sdk-v*` |
| PHP | Packagist | `php-sdk-v*` |
| Go | module proxy | `sdk/go/v*` (tag only, no publish step exists) |
