### PR TITLE
fix(config): refuse compressed request bodies at the in-flight body budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **A request body with a `Content-Encoding` other than `identity` is now refused with `415`** — the aggregate in-flight body cap counts wire bytes, so a compressed body was admitted on its compressed size and then inflated past the memory it was supposed to bound.
+- **An API request body with a `Content-Encoding` other than `identity` is now refused with `415`** — the aggregate in-flight body cap counts wire bytes, so a compressed body was admitted on its compressed size and then inflated past the memory it was supposed to bound.
 
 ## [0.14.2] - 2026-08-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`rmyndharis-openwa` 0.2.0 on PyPI** — the first release through the trusted-publishing workflow, carrying everything the Python SDK gained since 0.1.0 in June.
 - **`rmyndharis/openwa` 0.2.0 on Packagist** — the first versioned PHP release since June; Composer users on a stable constraint were pinned to 0.1.0 while only `dev-main` moved.
 
+### Changed
+
+- **A request body with a `Content-Encoding` other than `identity` is now refused with `415`** — the aggregate in-flight body cap counts wire bytes, so a compressed body was admitted on its compressed size and then inflated past the memory it was supposed to bound.
+
 ## [0.14.2] - 2026-08-06
 
 ### Added

--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -102,7 +102,7 @@ Validation failures (`statusCode: 400`) return `message` as an **array** of fiel
 | `404`       | Not Found             | The addressed resource (session, message, webhook, batch, …) does not exist                                                                                                                                             |
 | `409`       | Conflict              | A uniqueness constraint was violated (e.g. duplicate name), or a credential teardown for the same session name is still in flight on `start`/`delete` (retryable; body carries `code: 'SESSION_NAME_TEARDOWN_PENDING'`) |
 | `413`       | Payload Too Large     | Base64 media exceeds the media byte cap (see §6.3)                                                                                                                                                                      |
-| `415`       | Unsupported Media Type | The request carries a `Content-Encoding` other than `identity`. Compressed request bodies are not accepted: the aggregate body cap counts wire bytes, so an inflated body would exceed the memory it bounds            |
+| `415`       | Unsupported Media     | The request has a body carrying a `Content-Encoding` other than `identity`; compressed request bodies are not accepted, as the aggregate body cap counts wire bytes                                                     |
 | `500`       | Internal Server Error | Send failed at the WhatsApp engine or an unexpected server error                                                                                                                                                        |
 
 ### Timestamp Conventions

--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -102,6 +102,7 @@ Validation failures (`statusCode: 400`) return `message` as an **array** of fiel
 | `404`       | Not Found             | The addressed resource (session, message, webhook, batch, …) does not exist                                                                                                                                             |
 | `409`       | Conflict              | A uniqueness constraint was violated (e.g. duplicate name), or a credential teardown for the same session name is still in flight on `start`/`delete` (retryable; body carries `code: 'SESSION_NAME_TEARDOWN_PENDING'`) |
 | `413`       | Payload Too Large     | Base64 media exceeds the media byte cap (see §6.3)                                                                                                                                                                      |
+| `415`       | Unsupported Media Type | The request carries a `Content-Encoding` other than `identity`. Compressed request bodies are not accepted: the aggregate body cap counts wire bytes, so an inflated body would exceed the memory it bounds            |
 | `500`       | Internal Server Error | Send failed at the WhatsApp engine or an unexpected server error                                                                                                                                                        |
 
 ### Timestamp Conventions

--- a/docs/12-troubleshooting-faq.md
+++ b/docs/12-troubleshooting-faq.md
@@ -670,6 +670,10 @@ MEDIA_DOWNLOAD_MAX_BYTES=52428800
 # Default 25mb.
 BODY_SIZE_LIMIT=25mb
 
+# Note: send the body uncompressed. A request carrying Content-Encoding: gzip (or deflate/br)
+# is refused with 415 — the aggregate in-flight cap counts bytes on the wire, so a compressed
+# body would be admitted small and then inflated past the memory that cap exists to bound.
+
 # Supported formats
 # Images: jpg, jpeg, png, gif, webp
 # Videos: mp4, 3gp

--- a/src/config/inflight-body-budget.spec.ts
+++ b/src/config/inflight-body-budget.spec.ts
@@ -1,5 +1,8 @@
 import { EventEmitter } from 'events';
-import { Request, Response } from 'express';
+import { createServer, request as httpRequest, Server } from 'http';
+import { AddressInfo } from 'net';
+import { gzipSync } from 'zlib';
+import express, { Request, Response, json } from 'express';
 import {
   createInflightBodyBudget,
   parseBodyLimitBytes,
@@ -388,5 +391,120 @@ describe('stall reaper', () => {
     jest.advanceTimersByTime(120_000);
     expect(destroyMock(getReq)).not.toHaveBeenCalled();
     expect(destroyMock(emptyReq)).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Compressed bodies, exercised over a REAL server with a RAW http client. The doubles above hand the
+ * middleware a header bag and never move a byte, so they cannot show what a compressed body costs
+ * once the parser inflates it. A raw client (rather than an assertion library) is deliberate: the
+ * exact bytes on the wire are the subject here, and a serializer that helpfully re-encodes a Buffer
+ * would test itself instead of the middleware.
+ */
+describe('compressed request bodies', () => {
+  const BUDGET = 64 * 1024;
+  /** Compresses ~1000:1, so its declared length is a small fraction of what inflating it costs. */
+  const INFLATED_PAYLOAD = Buffer.from(JSON.stringify({ data: 'a'.repeat(2 * MB) }));
+
+  let server: Server | undefined;
+  let budget: InflightBodyBudget;
+  let port = 0;
+
+  const listen = async (): Promise<void> => {
+    budget = createInflightBodyBudget(BUDGET);
+    const app = express();
+    app.use(budget.middleware);
+    app.use(json({ limit: '25mb' }));
+    app.post('/echo', (_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+    server = createServer(app);
+    await new Promise<void>(resolve => server!.listen(0, '127.0.0.1', resolve));
+    port = (server.address() as AddressInfo).port;
+  };
+
+  interface Reply {
+    status: number;
+    body: string;
+  }
+
+  /**
+   * Resolves on the response even when the server drops the socket mid-upload — which is exactly
+   * what a refusal does here (it answers, sets Connection: close and never reads the body), so a
+   * client that treated the reset as fatal could not observe the status it is meant to assert.
+   */
+  const send = (headers: Record<string, string>, body: Buffer): Promise<Reply> =>
+    new Promise((resolve, reject) => {
+      let reply: Reply | undefined;
+      const req = httpRequest({ host: '127.0.0.1', port, path: '/echo', method: 'POST', headers }, res => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk: Buffer) => chunks.push(chunk));
+        res.on('end', () => {
+          reply = { status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString() };
+          resolve(reply);
+        });
+      });
+      req.on('error', (error: NodeJS.ErrnoException) => {
+        if (reply) return;
+        if (error.code === 'ECONNRESET' || error.code === 'EPIPE') return;
+        reject(error);
+      });
+      req.end(body);
+    });
+
+  beforeEach(() => jest.useRealTimers());
+  afterEach(async () => {
+    if (server) await new Promise<void>(resolve => server!.close(() => resolve()));
+    server = undefined;
+  });
+
+  it('refuses a gzip-encoded body with 415 instead of admitting it on its compressed length', async () => {
+    await listen();
+    const gzipped = gzipSync(INFLATED_PAYLOAD);
+    // The premise: compressed, this body is small enough to sail through admission control.
+    expect(gzipped.length).toBeLessThan(BUDGET);
+    expect(INFLATED_PAYLOAD.length).toBeGreaterThan(BUDGET);
+
+    const reply = await send(
+      {
+        'Content-Type': 'application/json',
+        'Content-Encoding': 'gzip',
+        'Content-Length': String(gzipped.length),
+      },
+      gzipped,
+    );
+
+    expect(reply.status).toBe(415);
+    expect(JSON.parse(reply.body)).toEqual({
+      statusCode: 415,
+      message: 'Compressed request bodies are not supported',
+      error: 'Unsupported Media Type',
+    });
+    expect(budget.currentBytes()).toBe(0);
+  });
+
+  it('refuses an oversized UNCOMPRESSED body through the budget, not the encoding guard', async () => {
+    await listen();
+    const plain = Buffer.alloc(BUDGET + 1, 0x20);
+
+    const reply = await send({ 'Content-Type': 'application/json', 'Content-Length': String(plain.length) }, plain);
+
+    expect(reply.status).toBe(503);
+  });
+
+  it('admits an ordinary body declaring Content-Encoding: identity', async () => {
+    await listen();
+    const plain = Buffer.from(JSON.stringify({ data: 'small' }));
+
+    const reply = await send(
+      {
+        'Content-Type': 'application/json',
+        'Content-Encoding': 'identity',
+        'Content-Length': String(plain.length),
+      },
+      plain,
+    );
+
+    expect(reply.status).toBe(200);
   });
 });

--- a/src/config/inflight-body-budget.spec.ts
+++ b/src/config/inflight-body-budget.spec.ts
@@ -1,4 +1,6 @@
 import { EventEmitter } from 'events';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
 import { createServer, request as httpRequest, Server } from 'http';
 import { AddressInfo } from 'net';
 import { gzipSync } from 'zlib';
@@ -446,7 +448,13 @@ describe('compressed request bodies', () => {
       });
       req.on('error', (error: NodeJS.ErrnoException) => {
         if (reply) return;
-        if (error.code === 'ECONNRESET' || error.code === 'EPIPE') return;
+        // A refusal answers and drops the socket without reading the body, so the reset can beat
+        // the parsed response. Settle with a sentinel rather than swallowing it: a bare timeout
+        // would report as "test timed out" instead of "expected 415, got a connection reset".
+        if (error.code === 'ECONNRESET' || error.code === 'EPIPE') {
+          resolve({ status: 0, body: '' });
+          return;
+        }
         reject(error);
       });
       req.end(body);
@@ -492,6 +500,59 @@ describe('compressed request bodies', () => {
     expect(reply.status).toBe(503);
   });
 
+  it('refuses a compressed body whose Content-Length is zero', async () => {
+    await listen();
+
+    // `reserved` is 0 here, so a gate keyed on the reservation would wave this through to the
+    // parser and the client would get body-parser's HTML error instead of the documented shape.
+    const reply = await send(
+      { 'Content-Type': 'application/json', 'Content-Encoding': 'gzip', 'Content-Length': '0' },
+      Buffer.alloc(0),
+    );
+
+    expect(reply.status).toBe(415);
+    expect((JSON.parse(reply.body) as { error?: string }).error).toBe('Unsupported Media Type');
+  });
+
+  it('refuses a compressed body whose Content-Length is not a safe integer', async () => {
+    await listen();
+    const gzipped = gzipSync(INFLATED_PAYLOAD);
+
+    // parseDeclaredLength refuses to reserve for this, but type-is `hasBody` still hands it to the
+    // parser — the one shape that escaped both the reservation AND admission control.
+    const reply = await send(
+      {
+        'Content-Type': 'application/json',
+        'Content-Encoding': 'gzip',
+        'Content-Length': String(Number.MAX_SAFE_INTEGER + 2),
+      },
+      gzipped,
+    );
+
+    expect(reply.status).toBe(415);
+    expect((JSON.parse(reply.body) as { error?: string }).error).toBe('Unsupported Media Type');
+  });
+
+  it('refuses an encoding LIST, matching what the parser would do with it', async () => {
+    await listen();
+    const plain = Buffer.from(JSON.stringify({ data: 'small' }));
+
+    // "identity, identity" transforms nothing, but body-parser compares the whole header against
+    // 'identity' and refuses it — so the middleware refuses it too and both layers answer the same
+    // documented shape instead of disagreeing about who rejects it.
+    const reply = await send(
+      {
+        'Content-Type': 'application/json',
+        'Content-Encoding': 'identity, identity',
+        'Content-Length': String(plain.length),
+      },
+      plain,
+    );
+
+    expect(reply.status).toBe(415);
+    expect((JSON.parse(reply.body) as { error?: string }).error).toBe('Unsupported Media Type');
+  });
+
   it('admits an ordinary body declaring Content-Encoding: identity', async () => {
     await listen();
     const plain = Buffer.from(JSON.stringify({ data: 'small' }));
@@ -506,5 +567,24 @@ describe('compressed request bodies', () => {
     );
 
     expect(reply.status).toBe(200);
+  });
+});
+
+/**
+ * The `inflate: false` backstop is unreachable while the guard above stands, so no behavioural test
+ * can lock it — yet it is the only thing standing if the guard is ever bypassed. Assert it in the
+ * source instead, the way load-env.spec.ts locks main.ts's import order.
+ */
+describe('body-parser inflate backstop', () => {
+  const read = (relative: string): string => readFileSync(resolve(__dirname, relative), 'utf8');
+
+  it('disables inflate on both global parsers in main.ts', () => {
+    const source = read('../main.ts');
+
+    expect(source.match(/^\s+inflate: false,$/gm)).toHaveLength(2);
+  });
+
+  it('disables inflate on the MCP route-level fallback parser', () => {
+    expect(read('../modules/mcp/mcp.server.ts')).toContain('express.json({ inflate: false })');
   });
 });

--- a/src/config/inflight-body-budget.ts
+++ b/src/config/inflight-body-budget.ts
@@ -163,8 +163,20 @@ export function createInflightBodyBudget(budgetBytes: number, options?: Inflight
     // orders of magnitude larger than the whole budget can be buffered without the accounting ever
     // seeing it. Refusing here — before admission, before a byte is read — keeps the invariant
     // true rather than trying to price an expansion that is not knowable in advance.
+    //
+    // The predicate is body-parser's, NOT `reserved > 0`. They disagree on exactly the cases that
+    // matter: `parseDeclaredLength` rejects a Content-Length that is not a safe integer (reserving
+    // nothing), while type-is `hasBody` accepts anything non-NaN — so `Content-Length: 2**53 + 1`
+    // with a gzip body reserves 0 here yet is still handed to the parser. Mirroring hasBody keeps
+    // the two layers from disagreeing about whether a body exists.
+    const bodyIndicated =
+      req.headers['transfer-encoding'] !== undefined || !Number.isNaN(Number(req.headers['content-length']));
+    // The accepted set is body-parser's, deliberately: it compares the WHOLE header against
+    // 'identity', so even a technically-uncompressed list ("identity, identity") is refused there.
+    // Accepting more here would only move the refusal to the parser, which answers a different
+    // shape — the two layers agreeing matters more than honouring an encoding list nobody sends.
     const encoding = (req.headers['content-encoding'] ?? '').trim().toLowerCase();
-    if (reserved > 0 && encoding !== '' && encoding !== 'identity') {
+    if (bodyIndicated && encoding !== '' && encoding !== 'identity') {
       rejectCompressed(req, res);
       return;
     }

--- a/src/config/inflight-body-budget.ts
+++ b/src/config/inflight-body-budget.ts
@@ -11,7 +11,16 @@
  * This middleware closes the gap. It tracks the aggregate body bytes currently in flight across
  * ALL connections — the declared Content-Length where present, one budget slot otherwise — and
  * refuses NEW requests with 503 + Retry-After once the budget is exhausted, without reading a
- * single byte of the rejected body. A stalled sender (headers, then silence) holds its
+ * single byte of the rejected body.
+ *
+ * The bound is on WIRE bytes, and it holds as heap only while a body is stored as it arrives.
+ * A compressed body would break that — admitted at its compressed length, then inflated by the
+ * parser into memory nothing accounted for — so a non-identity Content-Encoding is refused with
+ * 415 outright rather than priced. The one remaining looseness is deliberate and bounded: a
+ * chunked identity body reserves a placeholder and is reconciled against socket.bytesRead on the
+ * poll interval, so it can briefly under-report by the bytes that arrive within one interval.
+ *
+ * A stalled sender (headers, then silence) holds its
  * reservation only until the stall reaper drops the socket after STALL_TIMEOUT_MS without any
  * new body bytes, so a handful of silent connections cannot pin the whole budget. The request
  * stream itself is never tapped — no 'data' listener — so downstream consumers (the body
@@ -127,12 +136,38 @@ export function createInflightBodyBudget(budgetBytes: number, options?: Inflight
       .json({ statusCode: 503, message: 'Too much request body data in flight; retry later' });
   };
 
+  /** Same never-read-the-body disposal as rejectBusy; only the reason and status differ. */
+  const rejectCompressed = (req: Request, res: Response): void => {
+    if (res.headersSent || res.writableEnded) {
+      req.destroy();
+      return;
+    }
+    res.status(415).set('Connection', 'close').json({
+      statusCode: 415,
+      message: 'Compressed request bodies are not supported',
+      error: 'Unsupported Media Type',
+    });
+  };
+
   const middleware = (req: Request, res: Response, next: NextFunction): void => {
     const declared = parseDeclaredLength(req.headers['content-length']);
     // A body with no declared length is expected only when the request is chunk-encoded (Node
     // ignores close-delimited request bodies on keep-alive HTTP/1.1). Anything else — GETs,
     // health checks, Content-Length: 0 — reserves nothing and is never reaped.
     let reserved = declared ?? (req.headers['transfer-encoding'] !== undefined ? undeclaredReservation : 0);
+
+    // Every quantity this budget works with — the declared length, and socket.bytesRead in the
+    // reconciler below — is a WIRE measurement, while what the budget exists to bound is HEAP. The
+    // two are the same size only while the body is stored as it arrives. A compressed body breaks
+    // that: it is admitted on its compressed length and then inflated by the parser, so a payload
+    // orders of magnitude larger than the whole budget can be buffered without the accounting ever
+    // seeing it. Refusing here — before admission, before a byte is read — keeps the invariant
+    // true rather than trying to price an expansion that is not knowable in advance.
+    const encoding = (req.headers['content-encoding'] ?? '').trim().toLowerCase();
+    if (reserved > 0 && encoding !== '' && encoding !== 'identity') {
+      rejectCompressed(req, res);
+      return;
+    }
 
     // Admission control on the RESERVED size: a request that would push the aggregate past the
     // budget is refused before a single byte of its body is buffered.

--- a/src/config/inflight-body-budget.ts
+++ b/src/config/inflight-body-budget.ts
@@ -16,9 +16,12 @@
  * The bound is on WIRE bytes, and it holds as heap only while a body is stored as it arrives.
  * A compressed body would break that — admitted at its compressed length, then inflated by the
  * parser into memory nothing accounted for — so a non-identity Content-Encoding is refused with
- * 415 outright rather than priced. The one remaining looseness is deliberate and bounded: a
- * chunked identity body reserves a placeholder and is reconciled against socket.bytesRead on the
- * poll interval, so it can briefly under-report by the bytes that arrive within one interval.
+ * 415 outright rather than priced. The remaining looseness in the wire-byte ACCOUNTING is
+ * deliberate and bounded: a chunked identity body reserves a placeholder and is reconciled against
+ * socket.bytesRead on the poll interval, so it can briefly under-report by the bytes that arrive
+ * within one interval. Separately, and by design, an admitted identity body still costs a constant
+ * multiple of its wire size once parsed (the raw Buffer pinned on rawBody, plus the decoded string
+ * and the parsed object) — the budget bounds the input, not the parse.
  *
  * A stalled sender (headers, then silence) holds its
  * reservation only until the stall reaper drops the socket after STALL_TIMEOUT_MS without any

--- a/src/main.ts
+++ b/src/main.ts
@@ -125,9 +125,11 @@ async function bootstrap() {
   // what a provider signed, so the @Public ingress controller can HMAC-verify over the raw body
   // (JSON.stringify(req.body) is NOT byte-identical). Cheap for every route; non-ingress routes ignore it.
   // `inflate: false` is a backstop, not the guard: the budget middleware above already refuses a
-  // compressed body with 415 before a byte is read. It sits here so a future middleware reordering,
-  // or a route-level parser mounted past that middleware, cannot silently reopen the gap — an
-  // inflated body is charged to the budget at its compressed size and bounded by nothing.
+  // compressed body with 415 before a byte is read. It sits here so a future reordering of these
+  // parsers relative to that middleware cannot silently reopen the gap — an inflated body is
+  // charged to the budget at its compressed size and bounded by nothing. Every other parser in the
+  // process must carry the same flag for that argument to hold; the MCP route-level fallback
+  // (src/modules/mcp/mcp.server.ts) does.
   app.use(
     json({
       limit: bodyLimit,

--- a/src/main.ts
+++ b/src/main.ts
@@ -124,9 +124,14 @@ async function bootstrap() {
   // The `verify` callback stashes the EXACT bytes json() received on req.rawBody, byte-identical to
   // what a provider signed, so the @Public ingress controller can HMAC-verify over the raw body
   // (JSON.stringify(req.body) is NOT byte-identical). Cheap for every route; non-ingress routes ignore it.
+  // `inflate: false` is a backstop, not the guard: the budget middleware above already refuses a
+  // compressed body with 415 before a byte is read. It sits here so a future middleware reordering,
+  // or a route-level parser mounted past that middleware, cannot silently reopen the gap — an
+  // inflated body is charged to the budget at its compressed size and bounded by nothing.
   app.use(
     json({
       limit: bodyLimit,
+      inflate: false,
       verify: (req: Request & { rawBody?: Buffer }, _res, buf) => {
         req.rawBody = buf;
       },
@@ -136,6 +141,7 @@ async function bootstrap() {
     urlencoded({
       extended: true,
       limit: bodyLimit,
+      inflate: false,
       // Form-encoded webhook providers also sign the exact wire bytes. Use the same capture contract
       // as json(); other content types remain unsupported rather than installing a global catch-all.
       verify: (req: Request & { rawBody?: Buffer }, _res, buf) => {

--- a/src/modules/mcp/mcp.server.ts
+++ b/src/modules/mcp/mcp.server.ts
@@ -244,5 +244,8 @@ export function mountMcpServer(
   // The route throttle gates the auth DB lookup and per-request MCP server/transport construction. The
   // process-wide capped json() in main.ts runs first for all routes; this route-level parser is a
   // defensive fallback and no-ops once the global parser has consumed the body.
-  adapter.post(basePath, createIpThrottle(ipRateLimiter), express.json(), handler);
+  // `inflate: false` matches the global parsers: a compressed body is refused by the budget
+  // middleware long before this runs, and this keeps the fallback from becoming the one parser that
+  // would still gunzip an unaccounted body if that ordering ever changed.
+  adapter.post(basePath, createIpThrottle(ipRateLimiter), express.json({ inflate: false }), handler);
 }


### PR DESCRIPTION
## Current limitation

The aggregate in-flight body budget (`src/config/inflight-body-budget.ts`) exists to bound how much
request-body memory the process holds across all connections at once — the per-request
`BODY_SIZE_LIMIT` bounds one upload, but says nothing about how many are buffered simultaneously.

Every quantity that budget works with is a **wire** measurement: the declared `Content-Length` at
admission, and `socket.bytesRead` in the stall reconciler. Those equal heap only while a body is
stored as it arrives.

A compressed body breaks that equality. It is admitted on its compressed length and then inflated by
the body parser, so a payload orders of magnitude larger than the entire budget can be buffered
without the accounting ever seeing it. The middleware is a deliberate pre-guard that runs before Nest
routing, so neither the throttler nor the auth guards can compensate — by the time they run, the
memory is already held.

Measured on a real socket: a 2 MiB JSON body (2,097,163 bytes), gzipped to 2,080 bytes, was admitted
against a **64 KiB** budget and answered `200`.

## Desired behaviour

A request that has a body and declares a `Content-Encoding` other than `identity` is refused with
`415 Unsupported Media Type` before admission control and before a byte of it is read.

Refusing is preferable to pricing the request: the expansion ratio is not knowable in advance, so
there is no honest reservation to take.

## Implementation

- **`src/config/inflight-body-budget.ts`** — check `Content-Encoding` ahead of the admission test and
  refuse with the same never-read-the-body disposal the existing 503 path uses (`Connection: close`,
  nothing reserved, `next()` never called).

  The "does this request have a body?" test is **body-parser's own predicate**, not the budget's
  reservation. They are not the same question: `parseDeclaredLength` declines to reserve for a
  `Content-Length` that is not a safe integer, while type-is `hasBody` accepts anything non-NaN. So
  `Content-Length: 2**53 + 1` with a gzip body reserved nothing, skipped the refusal, skipped
  admission control, and was still handed to the parser. `Content-Length: 0` escaped the same way and
  landed on express's `finalhandler`, answering an HTML page instead of the JSON shape the status
  table documents. Keying on the parser's predicate keeps the two layers agreeing about whether a
  body exists at all.

  The accepted set matches body-parser exactly for the same reason: it compares the whole header
  against `identity`, so an encoding **list** (even `identity, identity`) is refused here too rather
  than being waved through to a different error shape.

- **`src/main.ts`** and **`src/modules/mcp/mcp.server.ts`** — `inflate: false` on every parser in the
  process. This is a backstop, not the guard: it exists so a reordering of the parsers relative to the
  budget middleware cannot silently reopen the gap. `NestFactory.create(..., { bodyParser: false })`
  disables Nest's own parsers, so the two globals plus the MCP route-level fallback are the complete
  set.

- The module docstring claimed the aggregate bound unconditionally. It now states that the bound is
  on wire bytes, why compressed bodies are refused rather than priced, and names the remaining bounded
  looseness in the accounting (a chunked identity body reconciles against `socket.bytesRead` on the
  poll interval, so it can briefly under-report by one interval's arrivals).

## Compatibility and operator impact

This refuses requests that previously succeeded, so it is a gateway request-acceptance change. **The
release carrying it should be a MINOR, not a patch.**

The exposure is small. The API is JSON, and no first-party client compresses request bodies — checked
at the library-defaults level, which is where this could have gone wrong: the dashboard uses browser
`fetch`, the JS SDK `globalThis.fetch`, and the Python, PHP, Java and Go SDKs all leave their HTTP
clients' request-side compression off (Go's `http.Transport` only negotiates *response* gzip). The
node-to-node session forwarder is also clean — it re-serialises the parsed body and forwards a
four-header allowlist that excludes `content-encoding`.

The one third-party surface worth naming is the `@Public` ingress endpoint, which exists to receive
provider webhooks. No provider integration in this repository sends or documents compressed
deliveries, but a provider that did would now be refused with `415` **before** signature verification.
Worth knowing when reading `/ingress` traffic: previously `req.rawBody` held the *inflated* bytes for
such a delivery, so its HMAC was computed over inflated content.

`Content-Encoding: identity`, an empty header value, and an absent header all continue to work
unchanged; an encoding *list* is the one previously-accepted shape that is now refused. Multipart
uploads are unaffected — multer/busboy never decompress. `Transfer-Encoding: gzip` is not a bypass:
nothing in Node or body-parser decodes a transfer coding. The gateway has no response-compression
middleware at all, so nothing on the response side is involved.

No new configuration knob is introduced. A flag would need coordinated edits across `.env.example`,
env validation, precedence, both compose files, the chart and the docs, and would carry the
blank-forward shadowing failure mode — to serve a consumer that does not demonstrably exist. If real
demand appears, the right shape is a separate sub-budget for compressed bodies rather than a switch
that reopens the shared one.

## Validation

- New coverage in `src/config/inflight-body-budget.spec.ts` drives genuine payloads over a real socket
  into a real `express` app. The existing doubles in that file hand the middleware a header bag and
  never move a byte, so they cannot demonstrate what inflation costs — this needed a real server to
  reproduce at all. A raw `http` client rather than an assertion library, because the exact bytes on
  the wire are the subject.
- The headline test failed before the change (`200`, body admitted) and passes after (`415`).
- Mutation-checked, three ways: reverting the gate to the reservation-based test fails the two
  header-shape cases; deleting `inflate: false` from `main.ts` fails the source assertion; deleting it
  from the MCP parser fails its own.
- The backstop is unreachable while the guard stands, so no behavioural test can lock it. It is
  asserted in the source instead, the way `load-env.spec.ts` locks `main.ts`'s import order.
- Controls keep the guard from being over-broad: an oversized **uncompressed** body is still refused
  by the budget with `503` (not by the new path), and `identity` is still admitted with `200`.
- Full gate green: `lint`, `tsc --noEmit` over the whole program including specs, `format:check`,
  `check:versions`, `check:dockerignore`, `openapi:check`, `build`, the unit suite (4,812 passing) and
  the e2e suite (148 passing locally; the 3 Redis-gated tests in `test/queue-on.e2e-spec.ts` are
  skipped without a local Redis and run in CI).
- `openapi.json` is byte-identical, because the status is emitted by pre-routing middleware that the
  Nest document generator cannot see — the same reason the budget's own `503` has never appeared there
  either. The status table in `docs/06` is the client-facing record.

## Documentation

`415` is added to the status-code table in `docs/06-api-specification.md`, and the `BODY_SIZE_LIMIT`
FAQ in `docs/12-troubleshooting-faq.md` notes that request bodies must be sent uncompressed.
