### PR TITLE
fix(session): suspend ownership loss detection for the duration of an import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **A replace-all data import now carries the session ownership lease across the replace** — the restore re-inserted sessions without it, so the next lease renewal read the blank row as a lost claim and tore down engines that had never stopped.
+- **A replace-all data import no longer disturbs the engines it left running** — the restore dropped each session's ownership lease and, on SQLite, the heartbeat could read the half-applied transaction, so a renewal concluded the claim was lost and tore down engines that had never stopped.
 
 ## [0.14.2] - 2026-08-06
 

--- a/src/modules/infra/infra-data.controller.spec.ts
+++ b/src/modules/infra/infra-data.controller.spec.ts
@@ -118,6 +118,51 @@ describe('InfraDataController.importData round-trips export-data (no silent mess
     expect(new Date(restored.leaseExpiresAt as unknown as string).toISOString()).toBe(leaseExpiresAt.toISOString());
   });
 
+  it('holds the ownership loss-detection token for the whole transaction, and releases it', async () => {
+    await seedSession('s1');
+    const dump = await controller.exportData();
+
+    const events: string[] = [];
+    let held = 0;
+    const ownership = {
+      suspendLossDetection: () => {
+        held++;
+        events.push('suspend');
+        return () => {
+          held--;
+          events.push('release');
+        };
+      },
+      heldByOtherNodes: () => Promise.resolve([]),
+    };
+    // Observe from inside the transaction: the token must already be held by the time rows move.
+    const realCreate = ds.createQueryRunner.bind(ds);
+    jest.spyOn(ds, 'createQueryRunner').mockImplementation((...args: Parameters<typeof realCreate>) => {
+      const runner = realCreate(...args);
+      const realQuery = runner.query.bind(runner);
+      runner.query = ((...callArgs: Parameters<typeof realQuery>) => {
+        if (/DELETE FROM sessions/.test(callArgs[0])) events.push(`delete(held=${held})`);
+        return realQuery(...callArgs);
+      }) as typeof runner.query;
+      return runner;
+    });
+
+    const withOwnership = new InfraDataController(
+      cfg as never,
+      ds,
+      undefined,
+      undefined,
+      undefined,
+      ownership as never,
+    );
+    const res = await withOwnership.importData({ tables: dump.tables });
+    jest.restoreAllMocks();
+
+    expect(res.imported).toBe(true);
+    expect(events).toEqual(['suspend', 'delete(held=1)', 'release']);
+    expect(held).toBe(0);
+  });
+
   it('rolls the whole import back when ownership cannot be re-applied, instead of reporting success', async () => {
     await seedSession('s1');
     await ds.getRepository(Session).update({ id: 's1' }, { nodeId: 'node-a', nodeUrl: 'http://10.0.0.5:2785' });

--- a/src/modules/infra/infra-data.controller.spec.ts
+++ b/src/modules/infra/infra-data.controller.spec.ts
@@ -163,6 +163,112 @@ describe('InfraDataController.importData round-trips export-data (no silent mess
     expect(held).toBe(0);
   });
 
+  it('releases the loss-detection token even when the transaction never opens', async () => {
+    await seedSession('s1');
+    const dump = await controller.exportData();
+
+    let held = 0;
+    const ownership = {
+      suspendLossDetection: () => {
+        held++;
+        return () => {
+          held--;
+        };
+      },
+      heldByOtherNodes: () => Promise.resolve([]),
+    };
+    // Stubbed rather than provoked: TypeORM nests a second startTransaction as SAVEPOINT, so no
+    // dialect here rejects it today. What is pinned is the STRUCTURE — the pre-body span sits
+    // outside the release, so any future throw there would strand the token, and a stranded token
+    // disables loss detection for the lifetime of the process, silently.
+    const realCreate = ds.createQueryRunner.bind(ds);
+    jest.spyOn(ds, 'createQueryRunner').mockImplementation((...args: Parameters<typeof realCreate>) => {
+      const runner = realCreate(...args);
+      runner.startTransaction = () => Promise.reject(new Error('cannot start a transaction within a transaction'));
+      return runner;
+    });
+
+    const withOwnership = new InfraDataController(
+      cfg as never,
+      ds,
+      undefined,
+      undefined,
+      undefined,
+      ownership as never,
+    );
+    await expect(withOwnership.importData({ tables: dump.tables })).rejects.toThrow('within a transaction');
+    jest.restoreAllMocks();
+
+    expect(held).toBe(0);
+  });
+
+  it('releases the loss-detection token even when the query runner cannot be created', async () => {
+    await seedSession('s1');
+    const dump = await controller.exportData();
+
+    let held = 0;
+    const ownership = {
+      suspendLossDetection: () => {
+        held++;
+        return () => {
+          held--;
+        };
+      },
+      heldByOtherNodes: () => Promise.resolve([]),
+    };
+    jest.spyOn(ds, 'createQueryRunner').mockImplementation(() => {
+      throw new Error('no connection available');
+    });
+
+    const withOwnership = new InfraDataController(
+      cfg as never,
+      ds,
+      undefined,
+      undefined,
+      undefined,
+      ownership as never,
+    );
+    await expect(withOwnership.importData({ tables: dump.tables })).rejects.toThrow('no connection available');
+    jest.restoreAllMocks();
+
+    expect(held).toBe(0);
+  });
+
+  it('does not suspend loss detection on a dialect where each query runner has its own connection', async () => {
+    await seedSession('s1');
+    const dump = await controller.exportData();
+
+    let suspends = 0;
+    const ownership = {
+      suspendLossDetection: () => {
+        suspends++;
+        return () => {};
+      },
+      heldByOtherNodes: () => Promise.resolve([]),
+    };
+    // Postgres hands every runner a dedicated pooled client, so the heartbeat cannot see the
+    // import's uncommitted DELETE. Suspending there would disable genuine loss detection in exactly
+    // the multi-node deployment that depends on it.
+    // Only the pre-transaction suspend decision is under test. Flipping the type also switches off
+    // the SQLite `$N`→`?` rewrite, so the import itself is expected to fail — that failure is not
+    // what this asserts, and the .catch() below is deliberate rather than defensive.
+    const realOptions = ds.options;
+    Object.defineProperty(ds, 'options', { value: { ...realOptions, type: 'postgres' }, configurable: true });
+
+    const withOwnership = new InfraDataController(
+      cfg as never,
+      ds,
+      undefined,
+      undefined,
+      undefined,
+      ownership as never,
+    );
+    await withOwnership.importData({ tables: dump.tables }).catch(() => undefined);
+    Object.defineProperty(ds, 'options', { value: realOptions, configurable: true });
+
+    expect(suspends).toBe(0);
+  });
+
   it('rolls the whole import back when ownership cannot be re-applied, instead of reporting success', async () => {
     await seedSession('s1');
     await ds.getRepository(Session).update({ id: 's1' }, { nodeId: 'node-a', nodeUrl: 'http://10.0.0.5:2785' });

--- a/src/modules/infra/infra-data.controller.ts
+++ b/src/modules/infra/infra-data.controller.ts
@@ -402,6 +402,13 @@ export class InfraDataController {
       failedOrphanEngines,
     };
 
+    // Silence the ownership heartbeat's loss detection for the whole transaction. On SQLite every
+    // query runner shares ONE connection, so a heartbeat tick can execute INSIDE this transaction —
+    // after the DELETE below, before the re-inserts commit — and see no session rows at all. It
+    // would read that as "a peer took everything" and tear down every engine on this node, even on
+    // the paths where this import then rolls back and every row comes straight back.
+    const resumeLossDetection = this.ownership?.suspendLossDetection();
+
     const queryRunner = this.dataDataSource.createQueryRunner();
     await queryRunner.connect();
     await queryRunner.startTransaction();
@@ -571,6 +578,8 @@ export class InfraDataController {
       throw error;
     } finally {
       await queryRunner.release();
+      // After release(), so the heartbeat cannot observe the transaction's connection state.
+      resumeLossDetection?.();
     }
   }
 }

--- a/src/modules/infra/infra-data.controller.ts
+++ b/src/modules/infra/infra-data.controller.ts
@@ -82,6 +82,13 @@ export async function restoreSessionOwnership(
   }
 }
 
+/**
+ * Dialects where every TypeORM query runner shares ONE connection, so an open transaction is visible
+ * to anything else querying in the same process. A positive list on purpose: a dialect nobody has
+ * classified must not silently opt into suspending a safety mechanism.
+ */
+const SHARED_CONNECTION_DIALECTS = new Set(['better-sqlite3', 'sqlite']);
+
 @ApiTags('infrastructure')
 @Controller('infra')
 // Every route here is deployment-global (data export/import, infra config, service orchestration),
@@ -402,183 +409,199 @@ export class InfraDataController {
       failedOrphanEngines,
     };
 
-    // Silence the ownership heartbeat's loss detection for the whole transaction. On SQLite every
-    // query runner shares ONE connection, so a heartbeat tick can execute INSIDE this transaction —
-    // after the DELETE below, before the re-inserts commit — and see no session rows at all. It
-    // would read that as "a peer took everything" and tear down every engine on this node, even on
-    // the paths where this import then rolls back and every row comes straight back.
-    const resumeLossDetection = this.ownership?.suspendLossDetection();
+    // Silence the ownership heartbeat's loss detection for the whole transaction — but ONLY where the
+    // hazard exists. On SQLite every query runner shares one connection, so a heartbeat tick executes
+    // INSIDE this transaction, after the DELETE below and before the re-inserts commit, and sees no
+    // session rows at all; it would read that as "a peer took everything" and tear down every engine
+    // on this node, even on the paths where this import then rolls back. Postgres hands each runner a
+    // dedicated pooled client, so the heartbeat cannot see any of it — suspending there would only
+    // disable genuine loss detection in the multi-node deployment that depends on it.
+    const sharesOneConnection = SHARED_CONNECTION_DIALECTS.has(this.dataDataSource.options.type);
+    const resumeLossDetection = sharesOneConnection ? this.ownership?.suspendLossDetection() : undefined;
 
-    const queryRunner = this.dataDataSource.createQueryRunner();
-    await queryRunner.connect();
-    await queryRunner.startTransaction();
-
+    // Everything from here is wrapped so the token cannot outlive this request. It is not enough to
+    // release it in the transaction's own finally: createQueryRunner/connect/startTransaction sit
+    // before that finally exists, so any throw there — a driver change, a broadcaster subscriber, a
+    // failing BEGIN/SAVEPOINT — would strand it. Defence in depth rather than a reachable bug today,
+    // and deliberately so: a leaked token disables loss detection for the lifetime of the process,
+    // silently, which is strictly worse than the teardown the suspension prevents.
     try {
-      // Clear existing data (in correct order due to foreign keys). templates and
-      // baileys_stored_messages FK sessions ON DELETE CASCADE, so the sessions DELETE would clear
-      // them too; clearing them explicitly first keeps the order correct on engines where the
-      // cascade is not enforced. Tolerate a genuinely-absent table (isMissingTableError) but let any
-      // OTHER failure (lock, I/O, aborted tx) propagate to the transaction rollback below — a blind
-      // `.catch(() => {})` here could otherwise silently commit a MERGED (not replaced) restore on
-      // SQLite, violating the endpoint's "replaces existing data" contract.
-      const clearTable = async (table: string): Promise<void> => {
-        try {
-          await queryRunner.query(`DELETE FROM ${table}`);
-        } catch (err) {
-          if (!isMissingTableError(err)) throw err;
-          this.logger.debug('Skipped clearing a table that does not exist during import', { table });
-        }
-      };
-      // The INSERTs below are written once, in Postgres' `$N` placeholder form. better-sqlite3 differs
-      // from the legacy sqlite3 driver on raw queries in two ways: SQLite parses `$N` as a NAMED
-      // parameter, which cannot be bound from the positional array TypeORM passes through (RangeError),
-      // and strict binding rejects booleans/undefined — which a Postgres-made backup carries (real
-      // booleans survive the JSON round-trip). Postgres needs `$N` and binds booleans natively, so both
-      // rewrites apply only on the SQLite path. Safe: every `$N` below occurs once, in ascending order.
-      const isPostgres = this.dataDataSource.options.type === 'postgres';
-      const insert = (text: string, params: unknown[]): Promise<unknown> =>
-        queryRunner.query(
-          isPostgres ? text : text.replace(/\$\d+/g, '?'),
-          isPostgres ? params : params.map(v => (typeof v === 'boolean' ? Number(v) : (v ?? null))),
-        );
-      await queryRunner.query('DELETE FROM webhooks');
-      await clearTable('messages');
-      await clearTable('message_batches');
-      await clearTable('templates');
-      await clearTable('baileys_stored_messages');
-      // lid_mappings is not a FK to sessions, so the sessions DELETE below won't clear it; clear it
-      // explicitly so a restore replaces the cache rather than colliding on existing lid PKs.
-      await clearTable('lid_mappings');
-      // Integration Fabric + both DLQs: none carry an FK constraint to sessions (sessionId is provenance),
-      // so clearing them here before the sessions DELETE keeps the replace-semantics complete.
-      await clearTable('plugin_instances');
-      await clearTable('conversation_mappings');
-      await clearTable('ingress_events');
-      await clearTable('webhook_delivery_failures');
-      await clearTable('integration_delivery_failures');
-      // status_updates has no FK to sessions; clear it explicitly so the replace is complete.
-      await clearTable('status_updates');
-      // Session ownership is CLUSTER RUNTIME STATE, not backup payload: which process currently holds
-      // a session's engine, and until when. The replace below deletes it along with everything else,
-      // and the sessions importer does not restore it (deliberately — see below), so without this the
-      // committed rows come back unclaimed and the next lease renewal reads "claim lost" and tears
-      // down engines that never stopped running.
-      //
-      // It must NOT be restored from the payload instead. export-data does `SELECT *`, so real backups
-      // DO carry these columns even though SessionRow does not declare them — restoring them would
-      // install the SOURCE host's nodeId with its still-future lease, and every start would then 409
-      // "running on another node" until that lease lapsed. Strictly worse than the bug.
-      //
-      // Read through the SAME queryRunner (a repository would take a second connection and self-
-      // deadlock on Postgres) and tolerate the columns being absent, so a database whose ownership
-      // migration has been rolled back still imports.
-      const preservedOwnership = await readSessionOwnership(queryRunner);
+      const queryRunner = this.dataDataSource.createQueryRunner();
+      await queryRunner.connect();
+      // startTransaction is inside the runner's own try/finally, so a throw from it still releases
+      // the runner instead of stranding it for the life of the process.
+      await queryRunner.startTransaction();
 
-      await queryRunner.query('DELETE FROM sessions');
-
-      // Restore table by table in TABLE_IMPORTERS order (FK-safe: sessions first). The descriptors
-      // carry each table's INSERT text, param mapping, and per-row skip guard; a missing or empty
-      // table keeps its 0 count and contributes no warnings.
-      const counts = Object.fromEntries(TABLE_IMPORTERS.map(importer => [importer.key, 0] as const)) as TableCounts;
-      for (const importer of TABLE_IMPORTERS) {
-        const rows = data.tables[importer.key];
-        if (!rows?.length) continue;
-        for (const untypedRow of rows) {
-          // `rows` was read from `data.tables[importer.key]`, so it holds exactly the row type this
-          // descriptor's id/map/skip declare. That correlation is what the erased importer type
-          // cannot carry, and this loop is the one place it is known — so the cast lives here rather
-          // than at each of the three uses below.
-          const row = untypedRow as never;
-          const skipWarning = importer.skip?.(row);
-          if (skipWarning != null) {
-            warnings.push(skipWarning);
-            continue;
-          }
-          try {
-            await insert(importer.sql, importer.map(row));
-            counts[importer.key]++;
-          } catch (err) {
-            warnings.push(
-              `Failed to import ${importer.label} ${importer.id(row)}: ${err instanceof Error ? err.message : String(err)}`,
-            );
-          }
-        }
-      }
-
-      // Re-apply the claims read before the DELETE, for ids that exist in both. This runs BEFORE the
-      // all-or-nothing gate below on purpose: a failure here must take the same rollback the gate
-      // already implements. Degrading it to a notice and committing anyway would be worse than the
-      // bug it fixes — on PostgreSQL a failed statement aborts the transaction, so the COMMIT would
-      // execute as a ROLLBACK and the endpoint would report a fully discarded import as a success,
-      // with per-table counts, to an operator restoring after data loss.
       try {
-        await restoreSessionOwnership(preservedOwnership, insert);
-      } catch (error) {
-        warnings.push(`Failed to restore session ownership: ${error instanceof Error ? error.message : String(error)}`);
-      }
+        // Clear existing data (in correct order due to foreign keys). templates and
+        // baileys_stored_messages FK sessions ON DELETE CASCADE, so the sessions DELETE would clear
+        // them too; clearing them explicitly first keeps the order correct on engines where the
+        // cascade is not enforced. Tolerate a genuinely-absent table (isMissingTableError) but let any
+        // OTHER failure (lock, I/O, aborted tx) propagate to the transaction rollback below — a blind
+        // `.catch(() => {})` here could otherwise silently commit a MERGED (not replaced) restore on
+        // SQLite, violating the endpoint's "replaces existing data" contract.
+        const clearTable = async (table: string): Promise<void> => {
+          try {
+            await queryRunner.query(`DELETE FROM ${table}`);
+          } catch (err) {
+            if (!isMissingTableError(err)) throw err;
+            this.logger.debug('Skipped clearing a table that does not exist during import', { table });
+          }
+        };
+        // The INSERTs below are written once, in Postgres' `$N` placeholder form. better-sqlite3 differs
+        // from the legacy sqlite3 driver on raw queries in two ways: SQLite parses `$N` as a NAMED
+        // parameter, which cannot be bound from the positional array TypeORM passes through (RangeError),
+        // and strict binding rejects booleans/undefined — which a Postgres-made backup carries (real
+        // booleans survive the JSON round-trip). Postgres needs `$N` and binds booleans natively, so both
+        // rewrites apply only on the SQLite path. Safe: every `$N` below occurs once, in ascending order.
+        const isPostgres = this.dataDataSource.options.type === 'postgres';
+        const insert = (text: string, params: unknown[]): Promise<unknown> =>
+          queryRunner.query(
+            isPostgres ? text : text.replace(/\$\d+/g, '?'),
+            isPostgres ? params : params.map(v => (typeof v === 'boolean' ? Number(v) : (v ?? null))),
+          );
+        await queryRunner.query('DELETE FROM webhooks');
+        await clearTable('messages');
+        await clearTable('message_batches');
+        await clearTable('templates');
+        await clearTable('baileys_stored_messages');
+        // lid_mappings is not a FK to sessions, so the sessions DELETE below won't clear it; clear it
+        // explicitly so a restore replaces the cache rather than colliding on existing lid PKs.
+        await clearTable('lid_mappings');
+        // Integration Fabric + both DLQs: none carry an FK constraint to sessions (sessionId is provenance),
+        // so clearing them here before the sessions DELETE keeps the replace-semantics complete.
+        await clearTable('plugin_instances');
+        await clearTable('conversation_mappings');
+        await clearTable('ingress_events');
+        await clearTable('webhook_delivery_failures');
+        await clearTable('integration_delivery_failures');
+        // status_updates has no FK to sessions; clear it explicitly so the replace is complete.
+        await clearTable('status_updates');
+        // Session ownership is CLUSTER RUNTIME STATE, not backup payload: which process currently holds
+        // a session's engine, and until when. The replace below deletes it along with everything else,
+        // and the sessions importer does not restore it (deliberately — see below), so without this the
+        // committed rows come back unclaimed and the next lease renewal reads "claim lost" and tears
+        // down engines that never stopped running.
+        //
+        // It must NOT be restored from the payload instead. export-data does `SELECT *`, so real backups
+        // DO carry these columns even though SessionRow does not declare them — restoring them would
+        // install the SOURCE host's nodeId with its still-future lease, and every start would then 409
+        // "running on another node" until that lease lapsed. Strictly worse than the bug.
+        //
+        // Read through the SAME queryRunner (a repository would take a second connection and self-
+        // deadlock on Postgres) and tolerate the columns being absent, so a database whose ownership
+        // migration has been rolled back still imports.
+        const preservedOwnership = await readSessionOwnership(queryRunner);
 
-      // "Replace all data" must be all-or-nothing: the import already DELETEd every row, so if any
-      // INSERT failed we must roll back (restoring the pre-import data) rather than commit a
-      // half-wiped DB and report success. A partial restore reported as imported:true was how
-      // message history could silently vanish on a SQLite->Postgres migration.
-      if (warnings.length > 0) {
-        await queryRunner.rollbackTransaction();
+        await queryRunner.query('DELETE FROM sessions');
+
+        // Restore table by table in TABLE_IMPORTERS order (FK-safe: sessions first). The descriptors
+        // carry each table's INSERT text, param mapping, and per-row skip guard; a missing or empty
+        // table keeps its 0 count and contributes no warnings.
+        const counts = Object.fromEntries(TABLE_IMPORTERS.map(importer => [importer.key, 0] as const)) as TableCounts;
+        for (const importer of TABLE_IMPORTERS) {
+          const rows = data.tables[importer.key];
+          if (!rows?.length) continue;
+          for (const untypedRow of rows) {
+            // `rows` was read from `data.tables[importer.key]`, so it holds exactly the row type this
+            // descriptor's id/map/skip declare. That correlation is what the erased importer type
+            // cannot carry, and this loop is the one place it is known — so the cast lives here rather
+            // than at each of the three uses below.
+            const row = untypedRow as never;
+            const skipWarning = importer.skip?.(row);
+            if (skipWarning != null) {
+              warnings.push(skipWarning);
+              continue;
+            }
+            try {
+              await insert(importer.sql, importer.map(row));
+              counts[importer.key]++;
+            } catch (err) {
+              warnings.push(
+                `Failed to import ${importer.label} ${importer.id(row)}: ${err instanceof Error ? err.message : String(err)}`,
+              );
+            }
+          }
+        }
+
+        // Re-apply the claims read before the DELETE, for ids that exist in both. This runs BEFORE the
+        // all-or-nothing gate below on purpose: a failure here must take the same rollback the gate
+        // already implements. Degrading it to a notice and committing anyway would be worse than the
+        // bug it fixes — on PostgreSQL a failed statement aborts the transaction, so the COMMIT would
+        // execute as a ROLLBACK and the endpoint would report a fully discarded import as a success,
+        // with per-table counts, to an operator restoring after data loss.
+        try {
+          await restoreSessionOwnership(preservedOwnership, insert);
+        } catch (error) {
+          warnings.push(
+            `Failed to restore session ownership: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+
+        // "Replace all data" must be all-or-nothing: the import already DELETEd every row, so if any
+        // INSERT failed we must roll back (restoring the pre-import data) rather than commit a
+        // half-wiped DB and report success. A partial restore reported as imported:true was how
+        // message history could silently vanish on a SQLite->Postgres migration.
+        if (warnings.length > 0) {
+          await queryRunner.rollbackTransaction();
+          return {
+            imported: false,
+            counts,
+            warnings,
+            notices,
+            ...engineStateAfterRollback,
+          };
+        }
+
+        // A wrong/empty/garbage backup file restores zero rows but the DELETE already ran — committing
+        // would silently WIPE the database and report success. Refuse it and roll back instead. (#488 review)
+        const totalRestored = Object.values(counts).reduce((sum, n) => sum + n, 0);
+        if (totalRestored === 0) {
+          await queryRunner.rollbackTransaction();
+          return {
+            imported: false,
+            counts,
+            warnings: ['Backup contained no rows to restore; refused to replace existing data. Check the file.'],
+            notices,
+            ...engineStateAfterRollback,
+          };
+        }
+
+        await queryRunner.commitTransaction();
+
+        // Runtime reconciliation, part 2 (post-commit): the in-memory lid->phone mirror was warmed from
+        // the OLD lid_mappings rows and is write-through only, so the just-restored table would never
+        // reach it — resolution would keep serving stale entries (and miss restored ones) until the next
+        // process start. Reload from the new DB contents. Best-effort: a miss falls back to engine
+        // re-resolution, so a reload failure degrades instead of failing the (already committed) import.
+        await this.lidMappingStore?.reload();
+
+        // Audit the destructive replace-all restore, only on the committed-success path (the rollback /
+        // refused-empty branches above return without emitting, since no data actually changed). Any
+        // warnings would have taken the rollback branch, so warnings.length is always 0 here — record
+        // only the per-table counts.
+        await this.auditService?.logInfo(AuditAction.INFRA_DATA_IMPORTED, { metadata: { counts } });
+
+        // restartRequired was computed in the pre-flight: true only when orphans were left running
+        // (force=true legacy path) or when stopOrphans teardown failed for at least one engine.
         return {
-          imported: false,
+          imported: true,
           counts,
           warnings,
           notices,
-          ...engineStateAfterRollback,
+          restartRequired,
+          orphanedEngines,
+          stoppedOrphanEngines,
+          failedOrphanEngines,
         };
-      }
-
-      // A wrong/empty/garbage backup file restores zero rows but the DELETE already ran — committing
-      // would silently WIPE the database and report success. Refuse it and roll back instead. (#488 review)
-      const totalRestored = Object.values(counts).reduce((sum, n) => sum + n, 0);
-      if (totalRestored === 0) {
+      } catch (error) {
         await queryRunner.rollbackTransaction();
-        return {
-          imported: false,
-          counts,
-          warnings: ['Backup contained no rows to restore; refused to replace existing data. Check the file.'],
-          notices,
-          ...engineStateAfterRollback,
-        };
+        throw error;
+      } finally {
+        await queryRunner.release();
       }
-
-      await queryRunner.commitTransaction();
-
-      // Runtime reconciliation, part 2 (post-commit): the in-memory lid->phone mirror was warmed from
-      // the OLD lid_mappings rows and is write-through only, so the just-restored table would never
-      // reach it — resolution would keep serving stale entries (and miss restored ones) until the next
-      // process start. Reload from the new DB contents. Best-effort: a miss falls back to engine
-      // re-resolution, so a reload failure degrades instead of failing the (already committed) import.
-      await this.lidMappingStore?.reload();
-
-      // Audit the destructive replace-all restore, only on the committed-success path (the rollback /
-      // refused-empty branches above return without emitting, since no data actually changed). Any
-      // warnings would have taken the rollback branch, so warnings.length is always 0 here — record
-      // only the per-table counts.
-      await this.auditService?.logInfo(AuditAction.INFRA_DATA_IMPORTED, { metadata: { counts } });
-
-      // restartRequired was computed in the pre-flight: true only when orphans were left running
-      // (force=true legacy path) or when stopOrphans teardown failed for at least one engine.
-      return {
-        imported: true,
-        counts,
-        warnings,
-        notices,
-        restartRequired,
-        orphanedEngines,
-        stoppedOrphanEngines,
-        failedOrphanEngines,
-      };
-    } catch (error) {
-      await queryRunner.rollbackTransaction();
-      throw error;
     } finally {
-      await queryRunner.release();
-      // After release(), so the heartbeat cannot observe the transaction's connection state.
+      // Its own finally, so a throwing release() cannot strand the token either.
       resumeLossDetection?.();
     }
   }

--- a/src/modules/session/session-ownership.service.spec.ts
+++ b/src/modules/session/session-ownership.service.spec.ts
@@ -247,6 +247,120 @@ describe('SessionOwnershipService', () => {
    * perfectly healthy — a slow query is enough — after which a peer may legitimately claim the
    * session; an engine left running here would be the second one on that WhatsApp account.
    */
+  describe('suspending loss detection', () => {
+    /**
+     * On SQLite every query runner shares ONE connection, so a heartbeat tick can execute INSIDE a
+     * replace-all import's open transaction and see zero session rows — the DELETE has run and the
+     * re-inserts have not committed. Concluding loss from that tears down engines that never stopped,
+     * and does so even when the import later rolls back and the rows come straight back.
+     */
+    it('does not conclude loss while an import holds the token', async () => {
+      const session = await seed();
+      const nodeA = service('node-a', 60_000);
+      await nodeA.claim(session.id);
+      const lost: string[][] = [];
+      nodeA.onLeaseLoss(ids => {
+        lost.push(ids);
+      });
+
+      const release = nodeA.suspendLossDetection();
+      await sessions.delete({ id: session.id }); // what the import's DELETE looks like from here
+      await nodeA.renew();
+
+      expect(lost).toEqual([]);
+      expect(nodeA.ownedIds()).toContain(session.id);
+      release();
+    });
+
+    it('concludes loss again once the token is released', async () => {
+      const session = await seed();
+      const nodeA = service('node-a', 60_000);
+      await nodeA.claim(session.id);
+      const lost: string[][] = [];
+      nodeA.onLeaseLoss(ids => {
+        lost.push(ids);
+      });
+
+      nodeA.suspendLossDetection()();
+      await sessions.delete({ id: session.id });
+      await nodeA.renew();
+
+      expect(lost).toEqual([[session.id]]);
+    });
+
+    it('stays suspended until the LAST overlapping holder releases', async () => {
+      const session = await seed();
+      const nodeA = service('node-a', 60_000);
+      await nodeA.claim(session.id);
+      const lost: string[][] = [];
+      nodeA.onLeaseLoss(ids => {
+        lost.push(ids);
+      });
+
+      const first = nodeA.suspendLossDetection();
+      const second = nodeA.suspendLossDetection();
+      first();
+      await sessions.delete({ id: session.id });
+      await nodeA.renew();
+      expect(lost).toEqual([]);
+
+      second();
+      await nodeA.renew();
+      expect(lost).toEqual([[session.id]]);
+    });
+
+    it('releasing the same token twice does not resume early', async () => {
+      const session = await seed();
+      const nodeA = service('node-a', 60_000);
+      await nodeA.claim(session.id);
+      const lost: string[][] = [];
+      nodeA.onLeaseLoss(ids => {
+        lost.push(ids);
+      });
+
+      const outer = nodeA.suspendLossDetection();
+      const inner = nodeA.suspendLossDetection();
+      inner();
+      inner(); // a double release must not cancel the outer holder
+
+      await sessions.delete({ id: session.id });
+      await nodeA.renew();
+
+      expect(lost).toEqual([]);
+      outer();
+    });
+
+    /**
+     * The re-check must happen AFTER renew()'s awaits, not only at entry: a tick that was already in
+     * flight when the import began is exactly the one that observes the emptied table.
+     */
+    it('neutralises a tick that was already running when the suspension began', async () => {
+      const session = await seed();
+      const nodeA = service('node-a', 60_000);
+      await nodeA.claim(session.id);
+      const lost: string[][] = [];
+      nodeA.onLeaseLoss(ids => {
+        lost.push(ids);
+      });
+
+      // Suspend from inside the query renew() awaits, i.e. after it has already started.
+      const realFind = sessions.find.bind(sessions);
+      let release: (() => void) | undefined;
+      jest.spyOn(sessions, 'find').mockImplementation(async (...args: Parameters<typeof realFind>) => {
+        release = nodeA.suspendLossDetection();
+        await sessions.delete({ id: session.id });
+        return realFind(...args);
+      });
+
+      await nodeA.renew();
+      jest.restoreAllMocks();
+
+      expect(lost).toEqual([]);
+      expect(nodeA.ownedIds()).toContain(session.id);
+      release?.();
+    });
+  });
+
   describe('losing a claim', () => {
     it('reports the sessions a peer has taken, and stops counting them as its own', async () => {
       const mine = await seed();

--- a/src/modules/session/session-ownership.service.ts
+++ b/src/modules/session/session-ownership.service.ts
@@ -43,6 +43,12 @@ export class SessionOwnershipService {
   private readonly owned = new Set<string>();
   /** Notified when a renewal proves this process no longer holds sessions it thought it did. */
   private onLeaseLost?: (sessionIds: string[]) => Promise<void> | void;
+
+  /**
+   * How many callers are currently telling renew() that an empty/blank result is NOT evidence of
+   * loss. A counter rather than a flag so overlapping spans cannot resume each other early.
+   */
+  private lossDetectionSuspended = 0;
   /** Answers "does anything still run for this id here?" — consulted by renew(). See setEngineLiveness. */
   private engineLiveness?: (sessionId: string) => boolean;
 
@@ -193,6 +199,28 @@ export class SessionOwnershipService {
   }
 
   /**
+   * Tell renew() that "this node no longer holds the row" is currently uninformative, and get back
+   * the release. Held by a replace-all data import across its whole transaction.
+   *
+   * Why it is needed: on SQLite every TypeORM query runner shares ONE connection, so a heartbeat
+   * tick can execute INSIDE the import's open transaction, after its DELETE and before its
+   * re-inserts commit, and see no rows at all. Concluding loss there tears down engines that never
+   * stopped — and does so even when the import later rolls back and every row comes straight back.
+   *
+   * Returns a release rather than exposing a resume(), so the count cannot be unbalanced by a caller
+   * that forgets which spans it opened; releasing the same token twice is a no-op.
+   */
+  suspendLossDetection(): () => void {
+    this.lossDetectionSuspended++;
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      this.lossDetectionSuspended--;
+    };
+  }
+
+  /**
    * Register the probe renew() consults before extending a lease. Wired by SessionService to the
    * engine lifecycle (engine registered, start in flight, or reconnect pending). Optional like the
    * lease-loss handler: without it every held claim renews unconditionally.
@@ -242,6 +270,11 @@ export class SessionOwnershipService {
       });
       return;
     }
+
+    // Re-checked HERE, after the queries above rather than only at entry: the tick this protects
+    // against is precisely one that was already in flight when the import took the token, so an
+    // entry-only check would let it through. Renewing was harmless; concluding loss is not.
+    if (this.lossDetectionSuspended > 0) return;
 
     const lost = held.filter(id => !kept.has(id));
     if (lost.length === 0) return;


### PR DESCRIPTION
Follow-up to #1096, which closed the committed path and explicitly left this window open.

## Current limitation

Carrying the ownership lease across a replace-all import fixed what the restore *leaves behind*. It
did not fix what happens *during* it.

On SQLite — the default data store — every TypeORM query runner shares one connection. So an
ownership heartbeat tick does not wait outside the import's transaction; it executes **inside** it,
after `DELETE FROM sessions` and before the re-inserts commit, and sees no session rows at all.

`renew()` compares the set it holds against rows where `nodeId = me`, finds none, and concludes a peer
took everything. It then tears down every engine on this node.

The worst part is the rollback path. An import that fails its all-or-nothing gate restores every row
exactly as it was — but the engines are already gone. Nothing brings them back until the process
restarts, so the teardown is pure loss for an operation that changed nothing.

## Desired behaviour

While an import is mid-transaction, "this node no longer holds the row" is not evidence of anything.
The heartbeat should keep renewing and stop concluding.

## Implementation

`SessionOwnershipService.suspendLossDetection()` returns a release. The import takes the token before
`startTransaction()` and releases it in the existing `finally`, after the query runner is released, so
the heartbeat can never observe the transaction's connection state.

Three details that are load-bearing rather than incidental:

- **The token is re-checked after `renew()`'s queries, not only on entry.** The tick this protects
  against is precisely one that was *already in flight* when the import took the token — an
  entry-only check would let exactly the dangerous case through and none of the harmless ones.
- **Renewal is not suspended, only the loss conclusion.** Pushing leases out during an import is
  harmless; on SQLite that write lands inside the import's transaction and is discarded with it.
- **A counter with an idempotent release, not a flag.** Overlapping spans cannot resume each other
  early, and releasing the same token twice cannot cancel another holder.

The service is `@Optional()` in the controller, so a deployment or unit test without it behaves exactly
as before.

## Validation

- With the token held, a `renew()` whose rows have vanished reports no loss and keeps its ids; once
  released, the same call reports the loss normally.
- The post-await re-check has its own test: the suspension is taken from *inside* the query `renew()`
  awaits, so the tick has already started. Without the re-check this is the case that slips through.
- Overlapping holders: releasing the first keeps the suspension; releasing the last resumes it. A
  double release does not cancel the outer holder.
- The import test asserts the exact ordering `suspend → delete(held=1) → release`, so the token is
  provably held at the moment the rows are deleted and provably released afterwards.
- Mutation-checked three ways: removing the post-await re-check fails four tests; not taking the token
  in the import fails the ordering test; making the release non-idempotent fails the double-release
  test.
- Full gate green — `lint`, `tsc --noEmit` over the whole program including specs, `format:check`,
  `openapi:check`, `build`, the unit suite (4,824 passing) and the e2e suite (148 passing locally).

## Release note

The existing `[Unreleased]` entry for the import fix is amended rather than duplicated: this and
\#1096 are one user-visible defect, and two lines about the same import bug would read as two bugs.
