### PR TITLE
fix(infra): refuse a second replace-all import while one is running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A second data import while one is running is now refused with `409`** — on SQLite both shared a single transaction, so the second one's rollback discarded a restore the first had already reported as successful.
 - **A replace-all data import no longer disturbs the engines it left running** — the restore dropped each session's ownership lease and, on SQLite, the heartbeat could read the half-applied transaction, so a renewal concluded the claim was lost and tore down engines that had never stopped.
 
 ## [0.14.2] - 2026-08-06

--- a/dashboard/src/hooks/useDataBackup.ts
+++ b/dashboard/src/hooks/useDataBackup.ts
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { shouldOfferStopOrphansRetry } from '../utils/importRefusal';
 import { useTranslation } from 'react-i18next';
 import { infraApi } from '../services/api';
 import { useToast } from './useToast';
@@ -42,11 +43,14 @@ export function useDataBackup(): DataBackup {
     }
   };
 
-  // POST the replace-all restore and fold the backend's orphan-engine contract into the UI. A 409
-  // means live engines exist for sessions the backup would remove (the server message lists them);
-  // the contract's preferred retry is stopOrphans=true, which stops those engines inside the
-  // request, so offer it as a confirm. force=true is deliberately not offered (the api client does
-  // not even send it): it leaves the engines running until a restart.
+  // POST the replace-all restore and fold the backend's orphan-engine contract into the UI. The route
+  // answers 409 for TWO different reasons and they need opposite handling, so branch on the machine
+  // code, never on the status alone: IMPORT_ALREADY_RUNNING means another restore is in flight and
+  // there is nothing to decide (retrying with stopOrphans would run a second destructive replace the
+  // operator never asked for). The orphan case does have a decision — live engines exist for sessions
+  // the backup would remove — and its preferred retry is stopOrphans=true, which stops them inside
+  // the request, so that one is offered as a confirm. force=true is deliberately not offered (the api
+  // client does not even send it): it leaves the engines running until a restart.
   const runImport = async (tables: Record<string, unknown[]>, stopOrphans = false): Promise<void> => {
     try {
       const res = await infraApi.importData(tables, stopOrphans ? { stopOrphans: true } : undefined);
@@ -66,7 +70,8 @@ export function useDataBackup(): DataBackup {
       }
     } catch (err) {
       const status = (err as { status?: number } | null)?.status;
-      if (status === 409 && !stopOrphans && err instanceof Error) {
+      const code = (err as { code?: string } | null)?.code;
+      if (shouldOfferStopOrphansRetry(status, code, stopOrphans) && err instanceof Error) {
         // The confirm doubles as the refusal display: OK retries with stopOrphans=true, Cancel
         // leaves the engines (and the current data) untouched. A 409 on the retry itself (an
         // engine started mid-import) falls through to the plain error toast — no confirm loop.

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -1073,10 +1073,12 @@ export const infraApi = {
       counts: Record<string, number>;
     }>('/infra/export-data'),
   // 200 contract includes the orphan-engine reconciliation result (restartRequired / notices /
-  // stopped+failed ids). A 409 (live engines exist for sessions the backup would remove; the error
-  // message lists them) is retried by the caller with stopOrphans=true, which stops those engines
-  // inside the request. force is deliberately NOT exposed: it leaves the engines writing into the
-  // restored tables until a restart — the window stopOrphans exists to close.
+  // stopped+failed ids). 409 has TWO causes and the error's `code` distinguishes them:
+  // IMPORT_ALREADY_RUNNING (another restore is in flight — nothing to retry), or the orphan case
+  // (live engines exist for sessions the backup would remove; the message lists them), which the
+  // caller retries with stopOrphans=true to stop those engines inside the request. force is
+  // deliberately NOT exposed: it leaves the engines writing into the restored tables until a
+  // restart — the window stopOrphans exists to close.
   importData: (tables: Record<string, unknown[]>, options?: { stopOrphans?: boolean }) =>
     request<{
       imported: boolean;

--- a/dashboard/src/utils/importRefusal.test.ts
+++ b/dashboard/src/utils/importRefusal.test.ts
@@ -1,0 +1,32 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { shouldOfferStopOrphansRetry } from './importRefusal.ts';
+
+// The retry this predicate gates is DESTRUCTIVE: it re-POSTs the replace-all with stopOrphans=true,
+// which tears down live engines. Branching on the 409 status alone offered that retry from a dialog
+// whose message says "another import is already running; wait for it" — so OK read as an
+// acknowledgement and ran a second full replace nobody asked for.
+
+test('offers the retry for the orphan-engine refusal, which is a real decision', () => {
+  assert.equal(shouldOfferStopOrphansRetry(409, undefined, false), true);
+});
+
+test('never offers the retry when another import is already running', () => {
+  assert.equal(shouldOfferStopOrphansRetry(409, 'IMPORT_ALREADY_RUNNING', false), false);
+});
+
+test('does not loop: a 409 on the retry itself is not offered again', () => {
+  assert.equal(shouldOfferStopOrphansRetry(409, undefined, true), false);
+});
+
+test('leaves every other status alone', () => {
+  assert.equal(shouldOfferStopOrphansRetry(413, undefined, false), false);
+  assert.equal(shouldOfferStopOrphansRetry(500, undefined, false), false);
+  assert.equal(shouldOfferStopOrphansRetry(undefined, undefined, false), false);
+});
+
+test('an unknown future 409 code still gets the orphan treatment, not silence', () => {
+  // Fail toward showing the operator something actionable rather than swallowing a refusal we do
+  // not recognise; only the code we know needs no decision is excluded.
+  assert.equal(shouldOfferStopOrphansRetry(409, 'SOME_FUTURE_CODE', false), true);
+});

--- a/dashboard/src/utils/importRefusal.ts
+++ b/dashboard/src/utils/importRefusal.ts
@@ -1,0 +1,22 @@
+/**
+ * POST /infra/import-data answers 409 for two unrelated reasons, and they need opposite handling.
+ *
+ * The orphan case is a DECISION: live engines exist for sessions the backup would remove, and the
+ * documented retry is `stopOrphans=true`, which stops them inside the request. Offering that as a
+ * confirm is right.
+ *
+ * IMPORT_ALREADY_RUNNING is not a decision — another restore is in flight and the caller can only
+ * wait. Retrying it with `stopOrphans` would run a second destructive replace-all the operator never
+ * asked for, from a dialog whose message says "wait". So the status alone must never drive the
+ * confirm; the machine code has to be read.
+ */
+export function shouldOfferStopOrphansRetry(
+  status: number | undefined,
+  code: string | undefined,
+  alreadyRetriedWithStopOrphans: boolean,
+): boolean {
+  if (status !== 409) return false;
+  // A 409 on the retry itself (an engine started mid-import) must not loop.
+  if (alreadyRetriedWithStopOrphans) return false;
+  return code !== 'IMPORT_ALREADY_RUNNING';
+}

--- a/openapi.json
+++ b/openapi.json
@@ -3410,7 +3410,7 @@
             "description": "Data imported successfully"
           },
           "409": {
-            "description": "Refused: live engines exist for sessions the backup would remove (retry with stopOrphans=true to stop them in-request, or force=true to proceed and restart after)"
+            "description": "Refused, for one of two reasons: another import is already running (code IMPORT_ALREADY_RUNNING — wait for it, do not retry immediately); or live engines exist for sessions the backup would remove (retry with stopOrphans=true to stop them in-request, or force=true to proceed and restart after)"
           }
         },
         "summary": "Import data to Data DB (replaces existing data)",

--- a/src/modules/infra/infra-data.controller.spec.ts
+++ b/src/modules/infra/infra-data.controller.spec.ts
@@ -163,6 +163,34 @@ describe('InfraDataController.importData round-trips export-data (no silent mess
     expect(held).toBe(0);
   });
 
+  it('refuses a second concurrent import instead of letting two share one transaction', async () => {
+    await seedSession('s1');
+    const dump = await controller.exportData();
+
+    // Why this matters on the default dialect: BetterSqlite3Driver.createQueryRunner() returns a
+    // SINGLETON runner, so two overlapping imports share one transaction. The second startTransaction
+    // nests as SAVEPOINT, its commit issues RELEASE SAVEPOINT rather than COMMIT, and a rollback at
+    // depth 1 issues a full ROLLBACK — discarding a restore the other call already reported as
+    // imported:true.
+    //
+    // No gating needed to make this deterministic: the first call runs synchronously up to its first
+    // await, so the guard must be set before any await for the second call to see it. That ordering
+    // is the property under test as much as the 409 is.
+    const first = controller.importData({ tables: dump.tables });
+    const second = controller.importData({ tables: dump.tables });
+
+    await expect(second).rejects.toMatchObject({ status: 409 });
+    await expect(first).resolves.toMatchObject({ imported: true });
+  });
+
+  it('accepts an import again once the previous one has finished', async () => {
+    await seedSession('s1');
+    const dump = await controller.exportData();
+
+    await expect(controller.importData({ tables: dump.tables })).resolves.toMatchObject({ imported: true });
+    await expect(controller.importData({ tables: dump.tables })).resolves.toMatchObject({ imported: true });
+  });
+
   it('releases the loss-detection token even when the transaction never opens', async () => {
     await seedSession('s1');
     const dump = await controller.exportData();

--- a/src/modules/infra/infra-data.controller.ts
+++ b/src/modules/infra/infra-data.controller.ts
@@ -99,6 +99,16 @@ const SHARED_CONNECTION_DIALECTS = new Set(['better-sqlite3', 'sqlite']);
 export class InfraDataController {
   private readonly logger = createLogger('InfraDataController');
 
+  /**
+   * Whether a replace-all import is already running in this process. Not a nicety: on better-sqlite3
+   * every query runner is a driver SINGLETON, so two overlapping imports share one transaction — the
+   * second nests as SAVEPOINT, its commit issues RELEASE SAVEPOINT rather than COMMIT, and a rollback
+   * at depth 1 issues a full ROLLBACK that discards a restore the other call already answered
+   * `imported: true` for. Serialising them is the only honest answer; queueing the second would still
+   * run a destructive replace nobody is waiting on.
+   */
+  private importInFlight = false;
+
   constructor(
     private readonly configService: ConfigService,
     @InjectDataSource('data')
@@ -278,7 +288,7 @@ export class InfraDataController {
   @ApiResponse({
     status: 409,
     description:
-      'Refused: live engines exist for sessions the backup would remove (retry with stopOrphans=true to stop them in-request, or force=true to proceed and restart after)',
+      'Refused, for one of two reasons: another import is already running (code IMPORT_ALREADY_RUNNING — wait for it, do not retry immediately); or live engines exist for sessions the backup would remove (retry with stopOrphans=true to stop them in-request, or force=true to proceed and restart after)',
   })
   async importData(
     @Body()
@@ -310,6 +320,37 @@ export class InfraDataController {
     /** Orphan engines stopped inside this request (only populated when stopOrphans=true was passed). */
     stoppedOrphanEngines: string[];
     /** Orphan engines whose teardown threw or timed out (Map reconciled regardless; investigate). */
+    failedOrphanEngines: string[];
+  }> {
+    // Check-and-set with NO await between them, so the single-threaded event loop makes this atomic:
+    // the first call reaches the assignment before the second call starts. It guards the whole method,
+    // including the pre-flight orphan teardown below — running that twice concurrently would stop
+    // engines on behalf of a restore that is about to be refused.
+    if (this.importInFlight) {
+      throw new ConflictException({
+        statusCode: 409,
+        error: 'Conflict',
+        message: 'A data import is already running; wait for it to finish before starting another.',
+        code: 'IMPORT_ALREADY_RUNNING',
+      });
+    }
+    this.importInFlight = true;
+    try {
+      return await this.runImport(data);
+    } finally {
+      this.importInFlight = false;
+    }
+  }
+
+  /** The replace-all restore itself. Only ever entered through importData's single-flight guard. */
+  private async runImport(data: { tables: Partial<MigrationTables>; force?: boolean; stopOrphans?: boolean }): Promise<{
+    imported: boolean;
+    counts: TableCounts;
+    warnings: string[];
+    notices: string[];
+    restartRequired: boolean;
+    orphanedEngines: string[];
+    stoppedOrphanEngines: string[];
     failedOrphanEngines: string[];
   }> {
     const warnings: string[] = [];


### PR DESCRIPTION
## Current limitation

`POST /infra/import-data` has no concurrency control, and on the default data store that is not a
tidiness problem.

`BetterSqlite3Driver.createQueryRunner()` returns a **driver singleton** — every caller gets the same
runner object. So two overlapping imports do not get a transaction each; they share one:

- the second `startTransaction()` sees `transactionDepth > 0` and issues `SAVEPOINT typeorm_1`, not a
  second `BEGIN` (it does not fail, and nothing warns);
- `commitTransaction()` at depth > 1 issues `RELEASE SAVEPOINT`, **not** `COMMIT`;
- `rollbackTransaction()` at depth 1 issues a full `ROLLBACK`.

Put together: import A can run to completion and answer `imported: true` with per-table counts, and
then import B — hitting the warnings gate or the empty-backup refusal — issues the `ROLLBACK` that
discards A's restore. The operator is told the restore succeeded and is left with an empty database.

The failure needs nothing exotic to trigger: a double-clicked button, or an HTTP client retrying a
slow request.

## Desired behaviour

One replace-all restore at a time per process. A second concurrent call is refused, not queued.

## Implementation

`importData` refuses a concurrent call with `409` and `code: IMPORT_ALREADY_RUNNING`.

Three details that are deliberate:

- **The check and the set have no `await` between them.** That is what makes them atomic on a
  single-threaded event loop: the first call reaches the assignment before the second call begins.
  The test depends on exactly that ordering rather than on any timing, so it also pins the property.
- **The guard wraps the whole method, including the pre-flight orphan teardown.** Running that
  concurrently would stop live engines on behalf of a restore that is about to be refused.
- **The body moved into a private `runImport`**, so the guard cannot be bypassed by a future early
  return added above it, and the flag is cleared in a `finally` that owns the entire call.

Refusing rather than queueing is the point. A queued second replace-all would still run destructively,
against data its caller never saw, with nobody waiting on the answer.

## The dashboard had to change with it

Worth reviewing closely, because the server change alone would have made the UI worse. The import
handler branched on the 409 **status alone** and answered it with a `window.confirm` whose OK
re-POSTs the restore with `stopOrphans: true` — a destructive retry that tears down live engines.

A new 409 whose message reads *"another import is already running; wait for it to finish"* would
therefore have rendered OK/Cancel buttons where OK means "stop my engines and replace everything
again". The operator opted into none of that.

The branch now reads the machine code the api client already carries, and the decision is a pure
predicate in `dashboard/src/utils/importRefusal.ts` with its own tests — matching how the other
extracted dashboard logic is covered. The stale comments in the hook and the api client, which both
asserted that a 409 always means the orphan case, are corrected.

## Scope, stated because the mechanism is broader than the fix

This is a pre-existing defect, not a regression: the same shape is present at the merge base.

It serialises **import against import only**. The same shared-runner hazard remains open between an
import and the other transactions on the `'data'` DataSource — session create
(`session.service.ts:216`) and session delete (`session-engine-controls.ts:490`). Closing that needs
a DataSource-wide lock with real deadlock and latency trade-offs against every session operation, and
is deliberately not attempted here.

## Validation

- Two concurrent `importData` calls: the second rejects with `409`, the first still resolves
  `imported: true`. Without the guard this test does not merely fail — the two calls corrupt the
  shared transaction badly enough that the SQLite connection closes and the runner dies, which is a
  fair picture of what the defect does to a live process.
- A sequential second import still succeeds, so the flag is released on the success path.
- Mutation-checked: disabling the guard reproduces the crash; removing the flag release fails the
  sequential-import test.
- The `409` response was already declared on this route for the orphan-engine refusal; its description
  now names both reasons rather than adding a second entry, and `openapi.json` is regenerated to match.
- Dashboard side: five cases on the refusal predicate — the orphan case still offers the retry,
  `IMPORT_ALREADY_RUNNING` never does, a 409 on the retry itself does not loop, other statuses are
  untouched, and an unrecognised future 409 code still surfaces something actionable rather than
  being swallowed.
- Full gate green — `lint`, `tsc --noEmit` over the whole program including specs, `format:check`,
  `openapi:check`, `build`, the unit suite (4,829 passing), the e2e suite (148 passing), and the
  dashboard's typecheck, lint, i18n check, build and 280 unit tests.
