### PR TITLE
fix(infra): refuse to report an import that was not made durable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A data import is refused with `409` when another transaction holds the connection** — on SQLite it would otherwise nest inside that transaction and commit into it rather than to disk, so a restore reported as successful could vanish with that transaction's rollback.
 - **A second data import while one is running is now refused with `409`** — on SQLite both shared a single transaction, so the second one's rollback discarded a restore the first had already reported as successful.
 - **A replace-all data import no longer disturbs the engines it left running** — the restore dropped each session's ownership lease and, on SQLite, the heartbeat could read the half-applied transaction, so a renewal concluded the claim was lost and tore down engines that had never stopped.
 

--- a/openapi.json
+++ b/openapi.json
@@ -3410,7 +3410,7 @@
             "description": "Data imported successfully"
           },
           "409": {
-            "description": "Refused, for one of two reasons: another import is already running (code IMPORT_ALREADY_RUNNING — wait for it, do not retry immediately); or live engines exist for sessions the backup would remove (retry with stopOrphans=true to stop them in-request, or force=true to proceed and restart after)"
+            "description": "Refused. code IMPORT_ALREADY_RUNNING: another import is running — wait for it. code IMPORT_NESTED_TRANSACTION: another database transaction holds this connection, so a restore could not be made durable — retry with nothing else in flight. Otherwise: live engines exist for sessions the backup would remove (retry with stopOrphans=true to stop them in-request, or force=true to proceed and restart after)"
           }
         },
         "summary": "Import data to Data DB (replaces existing data)",

--- a/src/modules/infra/infra-data.controller.spec.ts
+++ b/src/modules/infra/infra-data.controller.spec.ts
@@ -163,6 +163,42 @@ describe('InfraDataController.importData round-trips export-data (no silent mess
     expect(held).toBe(0);
   });
 
+  it('refuses outright when another transaction already holds the connection, before deleting anything', async () => {
+    await seedSession('s1');
+    const dump = await controller.exportData();
+
+    // better-sqlite3 hands out a SINGLETON runner, so an import started while a session create or
+    // delete holds a transaction becomes a SAVEPOINT inside it: its commit issues RELEASE SAVEPOINT,
+    // not COMMIT. The result is genuinely indeterminate — the enclosing transaction may commit (the
+    // replace lands) or roll back (it vanishes) — so detecting it afterwards cannot produce a
+    // truthful answer, and by then every row is already deleted. Refuse before touching anything.
+    const outer = ds.createQueryRunner();
+    await outer.connect();
+    await outer.startTransaction();
+
+    await expect(controller.importData({ tables: dump.tables })).rejects.toMatchObject({ status: 409 });
+
+    // The decisive assertion: nothing was destroyed on the way to the refusal.
+    const survived = await ds.getRepository(Session).findOneBy({ id: 's1' });
+    expect(survived).not.toBeNull();
+
+    await outer.rollbackTransaction();
+    await outer.release();
+  });
+
+  it('runs normally once no other transaction holds the connection', async () => {
+    await seedSession('s1');
+    const dump = await controller.exportData();
+
+    const outer = ds.createQueryRunner();
+    await outer.connect();
+    await outer.startTransaction();
+    await outer.rollbackTransaction();
+    await outer.release();
+
+    await expect(controller.importData({ tables: dump.tables })).resolves.toMatchObject({ imported: true });
+  });
+
   it('refuses a second concurrent import instead of letting two share one transaction', async () => {
     await seedSession('s1');
     const dump = await controller.exportData();

--- a/src/modules/infra/infra-data.controller.ts
+++ b/src/modules/infra/infra-data.controller.ts
@@ -288,7 +288,7 @@ export class InfraDataController {
   @ApiResponse({
     status: 409,
     description:
-      'Refused, for one of two reasons: another import is already running (code IMPORT_ALREADY_RUNNING — wait for it, do not retry immediately); or live engines exist for sessions the backup would remove (retry with stopOrphans=true to stop them in-request, or force=true to proceed and restart after)',
+      'Refused. code IMPORT_ALREADY_RUNNING: another import is running — wait for it. code IMPORT_NESTED_TRANSACTION: another database transaction holds this connection, so a restore could not be made durable — retry with nothing else in flight. Otherwise: live engines exist for sessions the backup would remove (retry with stopOrphans=true to stop them in-request, or force=true to proceed and restart after)',
   })
   async importData(
     @Body()
@@ -469,6 +469,29 @@ export class InfraDataController {
     try {
       const queryRunner = this.dataDataSource.createQueryRunner();
       await queryRunner.connect();
+
+      // Refuse BEFORE a single row is deleted, not after. On better-sqlite3 every query runner is a
+      // driver SINGLETON, so if anything else already holds a transaction on this DataSource — a
+      // session create or delete — this import would not get its own: it would become a SAVEPOINT
+      // inside theirs, and commitTransaction() would issue RELEASE SAVEPOINT rather than COMMIT.
+      //
+      // The outcome of that is genuinely indeterminate, which is why detecting it afterwards is not
+      // good enough: if the enclosing transaction commits, the replace lands; if it rolls back, the
+      // replace vanishes. Either way this request cannot report the truth, and it has already
+      // deleted every row — including any the enclosing transaction just wrote. Refusing up front is
+      // the only answer that is both honest and non-destructive. On Postgres each runner gets its own
+      // pooled client, so this is always false there and the check costs nothing.
+      if (queryRunner.isTransactionActive) {
+        throw new ConflictException({
+          statusCode: 409,
+          error: 'Conflict',
+          message:
+            'Another database transaction is in progress on this connection, so a restore could not be ' +
+            'made durable. Retry with no other data operation in flight.',
+          code: 'IMPORT_NESTED_TRANSACTION',
+        });
+      }
+
       // startTransaction is inside the runner's own try/finally, so a throw from it still releases
       // the runner instead of stranding it for the life of the process.
       await queryRunner.startTransaction();


### PR DESCRIPTION
## Current limitation

On better-sqlite3 — the default data store — `createQueryRunner()` returns a driver **singleton**, and
TypeORM nests transactions on it. So an import started while something else holds a transaction on the
`data` DataSource does not get its own: it becomes a `SAVEPOINT` inside theirs, and
`commitTransaction()` issues `RELEASE SAVEPOINT` instead of `COMMIT`.

Two callers can be that enclosing transaction: `session.service.ts:216` (session create) and
`session-engine-controls.ts:490` (session delete).

The outcome is then **indeterminate**, and that is the crux. Measured against a real DataSource:

- enclosing transaction **rolls back** → the whole restore vanishes, after the endpoint answered
  `imported: true` with per-table counts;
- enclosing transaction **commits** → the restore lands, including the `DELETE FROM sessions` that
  removed the row the session create had just written.

Either way the import has already destroyed every row and already answered, and it cannot know which
branch it is on.

## Desired behaviour

Do not start a replace-all restore that cannot be made durable.

## Implementation

`isTransactionActive` is already `true` after `connect()` and before `startTransaction()` when another
transaction owns the connection. The import refuses there with `409` and code
`IMPORT_NESTED_TRANSACTION`, **before a single row is deleted**.

On Postgres each query runner gets its own pooled client, so the flag is always false there and the
check costs nothing.

### The first attempt was wrong, and the reason is worth recording

It detected the condition *after* the commit and returned `imported: false`. That looked defensible —
until you ask which branch is common. A session create usually **succeeds**, so the enclosing
transaction usually **commits**, so the usual outcome is that the restore *lands* while the endpoint
reports failure and the dashboard toasts "import failed". An operator mid data-loss recovery would be
told nothing was restored, after every table had been wiped and rewritten.

That is not a smaller lie than the one being fixed; it is the same lie pointed the other way, on the
more frequent path. Refusing up front removes the indeterminacy instead of trying to report it, and it
is fewer lines than the check it replaces.

## Scope

This does not serialise the session paths against the import — a caller that loses the race simply
retries. Closing the window itself needs a lock spanning every session create and delete, with real
deadlock and latency trade-offs against ordinary traffic, and is a separate change. What this
guarantees is narrower and complete: an import either runs with the connection to itself, or does
nothing at all.

## Validation

- With another transaction open, the import now rejects with `409` **and the seeded session is still
  there** — the assertion is on the data state, not just the status, because "refused" is only
  meaningful if nothing was destroyed on the way.
- Negative control: once that transaction has ended, the same import succeeds.
- Mutation-checked: disabling the refusal fails the test.
- The existing import suite is unchanged and green — round-trip, ownership preservation,
  rollback-on-ownership-failure, and the concurrent-import refusal.
- The route's `409` description now names all three refusals, and `openapi.json` is regenerated.
- Full gate green — `lint`, `tsc --noEmit` over the whole program including specs, `format:check`,
  `openapi:check`, `build`, the unit suite (4,831 passing) and the e2e suite (148 passing).
