### PR TITLE
test(coverage): ratchet low-coverage modules to measured levels (contact/docker/mcp/agent-tools/template)

### DIFF
--- a/docs/09-testing-strategy.md
+++ b/docs/09-testing-strategy.md
@@ -214,7 +214,7 @@ authoritative gate. Current policy:
 | `src/modules/template/`     | 77%      | 99%       | 92%   | 89%        |
 | `src/modules/webhook/`      | 72%      | 89%       | 90%   | 87%        |
 
-Each floor sits roughly five points below that scope's measured coverage, so it catches a real
+Each floor sits a point or two below that scope's measured coverage, so it catches a real
 regression without failing on ordinary churn. Raise a floor when coverage rises; never lower one.
 
 Two behaviours of Jest's threshold matching are worth knowing before adding a scope:

--- a/docs/09-testing-strategy.md
+++ b/docs/09-testing-strategy.md
@@ -200,7 +200,7 @@ authoritative gate. Current policy:
 | `src/modules/group/`        | 64%      | 47%       | 67%   | 67%        |
 | `src/modules/infra/`        | 73%      | 71%       | 87%   | 86%        |
 | `src/modules/integration/`  | 76%      | 83%       | 90%   | 89%        |
-| `src/modules/mcp/`          | 45%      | 55%       | 53%   | 53%        |
+| `src/modules/mcp/`          | 62%      | 81%       | 78%   | 78%        |
 | `src/modules/media/`        | 71%      | 87%       | 89%   | 88%        |
 | `src/modules/message/`      | 57%      | 66%       | 81%   | 80%        |
 | `src/modules/metrics/`      | 61%      | 65%       | 68%   | 65%        |

--- a/docs/09-testing-strategy.md
+++ b/docs/09-testing-strategy.md
@@ -184,7 +184,7 @@ authoritative gate. Current policy:
 | `src/common/storage/`       | 75%      | 80%       | 80%   | 77%        |
 | `src/common/utils/`         | 86%      | 92%       | 92%   | 91%        |
 | `src/config/`               | 88%      | 92%       | 91%   | 91%        |
-| `src/core/agent-tools/`     | 80%      | 39%       | 58%   | 57%        |
+| `src/core/agent-tools/`     | 88%      | 87%       | 83%   | 83%        |
 | `src/core/hooks/`           | 81%      | 73%       | 85%   | 84%        |
 | `src/core/plugins/`         | 72%      | 74%       | 81%   | 80%        |
 | `src/database/`             | 69%      | 69%       | 72%   | 72%        |

--- a/docs/09-testing-strategy.md
+++ b/docs/09-testing-strategy.md
@@ -195,7 +195,7 @@ authoritative gate. Current policy:
 | `src/modules/automation/`   | 60%      | 55%       | 75%   | 70%        |
 | `src/modules/chat-media/`   | 78%      | 81%       | 92%   | 90%        |
 | `src/modules/contact/`      | 79%      | 90%       | 89%   | 88%        |
-| `src/modules/docker/`       | 29%      | 55%       | 40%   | 40%        |
+| `src/modules/docker/`       | 88%      | 99%       | 96%   | 96%        |
 | `src/modules/events/`       | 70%      | 84%       | 81%   | 80%        |
 | `src/modules/group/`        | 64%      | 47%       | 67%   | 67%        |
 | `src/modules/infra/`        | 73%      | 71%       | 87%   | 86%        |

--- a/docs/09-testing-strategy.md
+++ b/docs/09-testing-strategy.md
@@ -194,7 +194,7 @@ authoritative gate. Current policy:
 | `src/modules/auth/`         | 75%      | 85%       | 86%   | 85%        |
 | `src/modules/automation/`   | 60%      | 55%       | 75%   | 70%        |
 | `src/modules/chat-media/`   | 78%      | 81%       | 92%   | 90%        |
-| `src/modules/contact/`      | 39%      | 53%       | 50%   | 49%        |
+| `src/modules/contact/`      | 79%      | 90%       | 89%   | 88%        |
 | `src/modules/docker/`       | 29%      | 55%       | 40%   | 40%        |
 | `src/modules/events/`       | 70%      | 84%       | 81%   | 80%        |
 | `src/modules/group/`        | 64%      | 47%       | 67%   | 67%        |

--- a/docs/09-testing-strategy.md
+++ b/docs/09-testing-strategy.md
@@ -184,7 +184,7 @@ authoritative gate. Current policy:
 | `src/common/storage/`       | 75%      | 80%       | 80%   | 77%        |
 | `src/common/utils/`         | 86%      | 92%       | 92%   | 91%        |
 | `src/config/`               | 88%      | 92%       | 91%   | 91%        |
-| `src/core/agent-tools/`     | 77%      | 32%       | 49%   | 50%        |
+| `src/core/agent-tools/`     | 80%      | 39%       | 58%   | 57%        |
 | `src/core/hooks/`           | 81%      | 73%       | 85%   | 84%        |
 | `src/core/plugins/`         | 72%      | 74%       | 81%   | 80%        |
 | `src/database/`             | 69%      | 69%       | 72%   | 72%        |
@@ -194,13 +194,13 @@ authoritative gate. Current policy:
 | `src/modules/auth/`         | 75%      | 85%       | 86%   | 85%        |
 | `src/modules/automation/`   | 60%      | 55%       | 75%   | 70%        |
 | `src/modules/chat-media/`   | 78%      | 81%       | 92%   | 90%        |
-| `src/modules/contact/`      | 25%      | 48%       | 44%   | 43%        |
-| `src/modules/docker/`       | 26%      | 52%       | 37%   | 38%        |
+| `src/modules/contact/`      | 39%      | 53%       | 50%   | 49%        |
+| `src/modules/docker/`       | 29%      | 55%       | 40%   | 40%        |
 | `src/modules/events/`       | 70%      | 84%       | 81%   | 80%        |
 | `src/modules/group/`        | 64%      | 47%       | 67%   | 67%        |
 | `src/modules/infra/`        | 73%      | 71%       | 87%   | 86%        |
 | `src/modules/integration/`  | 76%      | 83%       | 90%   | 89%        |
-| `src/modules/mcp/`          | 33%      | 48%       | 45%   | 46%        |
+| `src/modules/mcp/`          | 45%      | 55%       | 53%   | 53%        |
 | `src/modules/media/`        | 71%      | 87%       | 89%   | 88%        |
 | `src/modules/message/`      | 57%      | 66%       | 81%   | 80%        |
 | `src/modules/metrics/`      | 61%      | 65%       | 68%   | 65%        |
@@ -211,7 +211,7 @@ authoritative gate. Current policy:
 | `src/modules/stats/`        | 67%      | 63%       | 71%   | 69%        |
 | `src/modules/status-store/` | 79%      | 83%       | 92%   | 91%        |
 | `src/modules/status/`       | 47%      | 45%       | 62%   | 60%        |
-| `src/modules/template/`     | 43%      | 52%       | 70%   | 67%        |
+| `src/modules/template/`     | 46%      | 55%       | 73%   | 72%        |
 | `src/modules/webhook/`      | 72%      | 89%       | 90%   | 87%        |
 
 Each floor sits roughly five points below that scope's measured coverage, so it catches a real

--- a/docs/09-testing-strategy.md
+++ b/docs/09-testing-strategy.md
@@ -211,7 +211,7 @@ authoritative gate. Current policy:
 | `src/modules/stats/`        | 67%      | 63%       | 71%   | 69%        |
 | `src/modules/status-store/` | 79%      | 83%       | 92%   | 91%        |
 | `src/modules/status/`       | 47%      | 45%       | 62%   | 60%        |
-| `src/modules/template/`     | 46%      | 55%       | 73%   | 72%        |
+| `src/modules/template/`     | 77%      | 99%       | 92%   | 89%        |
 | `src/modules/webhook/`      | 72%      | 89%       | 90%   | 87%        |
 
 Each floor sits roughly five points below that scope's measured coverage, so it catches a real

--- a/package.json
+++ b/package.json
@@ -265,10 +265,10 @@
         "statements": 90
       },
       "./src/modules/contact/": {
-        "branches": 39,
-        "functions": 53,
-        "lines": 50,
-        "statements": 49
+        "branches": 79,
+        "functions": 90,
+        "lines": 89,
+        "statements": 88
       },
       "./src/modules/docker/": {
         "branches": 29,

--- a/package.json
+++ b/package.json
@@ -367,10 +367,10 @@
         "statements": 60
       },
       "./src/modules/template/": {
-        "branches": 46,
-        "functions": 55,
-        "lines": 73,
-        "statements": 72
+        "branches": 77,
+        "functions": 99,
+        "lines": 92,
+        "statements": 89
       },
       "./src/modules/webhook/": {
         "branches": 72,

--- a/package.json
+++ b/package.json
@@ -205,10 +205,10 @@
         "statements": 91
       },
       "./src/core/agent-tools/": {
-        "branches": 80,
-        "functions": 39,
-        "lines": 58,
-        "statements": 57
+        "branches": 88,
+        "functions": 87,
+        "lines": 83,
+        "statements": 83
       },
       "./src/core/hooks/": {
         "branches": 81,

--- a/package.json
+++ b/package.json
@@ -205,10 +205,10 @@
         "statements": 91
       },
       "./src/core/agent-tools/": {
-        "branches": 77,
-        "functions": 32,
-        "lines": 49,
-        "statements": 50
+        "branches": 80,
+        "functions": 39,
+        "lines": 58,
+        "statements": 57
       },
       "./src/core/hooks/": {
         "branches": 81,
@@ -265,16 +265,16 @@
         "statements": 90
       },
       "./src/modules/contact/": {
-        "branches": 25,
-        "functions": 48,
-        "lines": 44,
-        "statements": 43
+        "branches": 39,
+        "functions": 53,
+        "lines": 50,
+        "statements": 49
       },
       "./src/modules/docker/": {
-        "branches": 26,
-        "functions": 52,
-        "lines": 37,
-        "statements": 38
+        "branches": 29,
+        "functions": 55,
+        "lines": 40,
+        "statements": 40
       },
       "./src/modules/events/": {
         "branches": 70,
@@ -301,10 +301,10 @@
         "statements": 89
       },
       "./src/modules/mcp/": {
-        "branches": 33,
-        "functions": 48,
-        "lines": 45,
-        "statements": 46
+        "branches": 45,
+        "functions": 55,
+        "lines": 53,
+        "statements": 53
       },
       "./src/modules/media/": {
         "branches": 71,
@@ -367,10 +367,10 @@
         "statements": 60
       },
       "./src/modules/template/": {
-        "branches": 43,
-        "functions": 52,
-        "lines": 70,
-        "statements": 67
+        "branches": 46,
+        "functions": 55,
+        "lines": 73,
+        "statements": 72
       },
       "./src/modules/webhook/": {
         "branches": 72,

--- a/package.json
+++ b/package.json
@@ -271,10 +271,10 @@
         "statements": 88
       },
       "./src/modules/docker/": {
-        "branches": 29,
-        "functions": 55,
-        "lines": 40,
-        "statements": 40
+        "branches": 88,
+        "functions": 99,
+        "lines": 96,
+        "statements": 96
       },
       "./src/modules/events/": {
         "branches": 70,

--- a/package.json
+++ b/package.json
@@ -301,10 +301,10 @@
         "statements": 89
       },
       "./src/modules/mcp/": {
-        "branches": 45,
-        "functions": 55,
-        "lines": 53,
-        "statements": 53
+        "branches": 62,
+        "functions": 81,
+        "lines": 78,
+        "statements": 78
       },
       "./src/modules/media/": {
         "branches": 71,

--- a/src/core/agent-tools/tools/contact.tools.spec.ts
+++ b/src/core/agent-tools/tools/contact.tools.spec.ts
@@ -1,0 +1,105 @@
+import { invokeTool } from '../tool-invoker';
+import { contactTools } from './contact.tools';
+import type { AnyToolDescriptor } from '../tool-descriptor';
+import type { ContactService } from '../../../modules/contact/contact.service';
+import type { AuthService } from '../../../modules/auth/auth.service';
+
+// Covers every contactTools execute() handler via the real invokeTool path (auth → zod → handler).
+// agent-tools.module.ts is pure Nest wiring, stays at 0% coverage, and is intentionally not a target.
+
+function makeAuth(): Pick<AuthService, 'validateApiKey' | 'hasPermission'> {
+  return {
+    validateApiKey: jest.fn().mockResolvedValue({ id: 'k1', allowedSessions: null }),
+    hasPermission: jest.fn().mockReturnValue(true),
+  };
+}
+
+function makeTools(svc: ContactService): Map<string, AnyToolDescriptor> {
+  return new Map(contactTools(svc).map(t => [t.name, t]));
+}
+
+async function run(tool: AnyToolDescriptor, input: unknown): Promise<unknown> {
+  return invokeTool(tool, input, 'key', makeAuth() as unknown as AuthService);
+}
+
+describe('contactTools', () => {
+  it('ContactFindAll delegates to getContacts with paging', async () => {
+    const getContacts = jest.fn().mockResolvedValue([{ id: 'c1' }]);
+    const out = await run(makeTools({ getContacts } as unknown as ContactService).get('ContactFindAll')!, {
+      sessionId: 's1',
+      limit: 10,
+      offset: 5,
+    });
+    expect(getContacts).toHaveBeenCalledWith('s1', { limit: 10, offset: 5 });
+    expect(out).toEqual([{ id: 'c1' }]);
+  });
+
+  it('ContactFindOne delegates to getContactById', async () => {
+    const getContactById = jest.fn().mockResolvedValue({ id: 'c1' });
+    const out = await run(makeTools({ getContactById } as unknown as ContactService).get('ContactFindOne')!, {
+      sessionId: 's1',
+      contactId: '628123@c.us',
+    });
+    expect(getContactById).toHaveBeenCalledWith('s1', '628123@c.us');
+    expect(out).toEqual({ id: 'c1' });
+  });
+
+  it('ContactCheckNumber maps a found JID to exists:true', async () => {
+    const getNumberId = jest.fn().mockResolvedValue('628123@c.us');
+    const out = await run(makeTools({ getNumberId } as unknown as ContactService).get('ContactCheckNumber')!, {
+      sessionId: 's1',
+      number: '628123',
+    });
+    expect(getNumberId).toHaveBeenCalledWith('s1', '628123');
+    expect(out).toEqual({ number: '628123', exists: true, whatsappId: '628123@c.us' });
+  });
+
+  it('ContactCheckNumber maps a null JID to exists:false', async () => {
+    const getNumberId = jest.fn().mockResolvedValue(null);
+    const out = await run(makeTools({ getNumberId } as unknown as ContactService).get('ContactCheckNumber')!, {
+      sessionId: 's1',
+      number: '628123',
+    });
+    expect(out).toEqual({ number: '628123', exists: false, whatsappId: null });
+  });
+
+  it('ContactResolvePhone delegates to resolveContactPhone', async () => {
+    const resolveContactPhone = jest.fn().mockResolvedValue('628123');
+    const out = await run(makeTools({ resolveContactPhone } as unknown as ContactService).get('ContactResolvePhone')!, {
+      sessionId: 's1',
+      contactId: '12345@lid',
+    });
+    expect(resolveContactPhone).toHaveBeenCalledWith('s1', '12345@lid');
+    expect(out).toEqual({ contactId: '12345@lid', phone: '628123' });
+  });
+
+  it('ContactGetProfilePicture maps the service result to a url field', async () => {
+    const getProfilePicture = jest.fn().mockResolvedValue('https://example.com/pic.jpg');
+    const out = await run(
+      makeTools({ getProfilePicture } as unknown as ContactService).get('ContactGetProfilePicture')!,
+      { sessionId: 's1', contactId: '628123@c.us' },
+    );
+    expect(getProfilePicture).toHaveBeenCalledWith('s1', '628123@c.us');
+    expect(out).toEqual({ url: 'https://example.com/pic.jpg' });
+  });
+
+  it('ContactBlock delegates to blockContact and reports success', async () => {
+    const blockContact = jest.fn().mockResolvedValue(undefined);
+    const out = await run(makeTools({ blockContact } as unknown as ContactService).get('ContactBlock')!, {
+      sessionId: 's1',
+      contactId: '628123@c.us',
+    });
+    expect(blockContact).toHaveBeenCalledWith('s1', '628123@c.us');
+    expect(out).toEqual({ success: true, message: 'Contact blocked' });
+  });
+
+  it('ContactUnblock delegates to unblockContact and reports success', async () => {
+    const unblockContact = jest.fn().mockResolvedValue(undefined);
+    const out = await run(makeTools({ unblockContact } as unknown as ContactService).get('ContactUnblock')!, {
+      sessionId: 's1',
+      contactId: '628123@c.us',
+    });
+    expect(unblockContact).toHaveBeenCalledWith('s1', '628123@c.us');
+    expect(out).toEqual({ success: true, message: 'Contact unblocked' });
+  });
+});

--- a/src/core/agent-tools/tools/group.tools.spec.ts
+++ b/src/core/agent-tools/tools/group.tools.spec.ts
@@ -71,3 +71,87 @@ describe('GroupAddParticipants', () => {
     expect(out).toEqual({ success: true, message: 'Participants added', results });
   });
 });
+
+describe('groupTools execute handlers', () => {
+  it('GroupFindAll delegates to getGroups with paging', async () => {
+    const getGroups = jest.fn().mockResolvedValue([{ id: 'g1' }]);
+    const tool = groupTools({ getGroups } as unknown as GroupService).find(t => t.name === 'GroupFindAll')!;
+    const out = await invokeTool(
+      tool,
+      { sessionId: 's1', limit: 10, offset: 5 },
+      'key',
+      makeAuth() as unknown as AuthService,
+    );
+    expect(getGroups).toHaveBeenCalledWith('s1', { limit: 10, offset: 5 });
+    expect(out).toEqual([{ id: 'g1' }]);
+  });
+
+  it('GroupFindOne delegates to getGroupInfo', async () => {
+    const getGroupInfo = jest.fn().mockResolvedValue({ id: 'g1' });
+    const tool = groupTools({ getGroupInfo } as unknown as GroupService).find(t => t.name === 'GroupFindOne')!;
+    const out = await invokeTool(
+      tool,
+      { sessionId: 's1', groupId: '120363@g.us' },
+      'key',
+      makeAuth() as unknown as AuthService,
+    );
+    expect(getGroupInfo).toHaveBeenCalledWith('s1', '120363@g.us');
+    expect(out).toEqual({ id: 'g1' });
+  });
+
+  it('GroupGetInviteCode maps the code to code + link', async () => {
+    const getGroupInviteCode = jest.fn().mockResolvedValue('abc123');
+    const tool = groupTools({ getGroupInviteCode } as unknown as GroupService).find(
+      t => t.name === 'GroupGetInviteCode',
+    )!;
+    const out = await invokeTool(
+      tool,
+      { sessionId: 's1', groupId: '120363@g.us' },
+      'key',
+      makeAuth() as unknown as AuthService,
+    );
+    expect(getGroupInviteCode).toHaveBeenCalledWith('s1', '120363@g.us');
+    expect(out).toEqual({ inviteCode: 'abc123', inviteLink: 'https://chat.whatsapp.com/abc123' });
+  });
+
+  it('GroupCreate delegates to createGroup', async () => {
+    const createGroup = jest.fn().mockResolvedValue({ id: 'g1' });
+    const tool = groupTools({ createGroup } as unknown as GroupService).find(t => t.name === 'GroupCreate')!;
+    const out = await invokeTool(
+      tool,
+      { sessionId: 's1', name: 'New group', participants: ['628111@c.us'] },
+      'key',
+      makeAuth() as unknown as AuthService,
+    );
+    expect(createGroup).toHaveBeenCalledWith('s1', 'New group', ['628111@c.us']);
+    expect(out).toEqual({ id: 'g1' });
+  });
+
+  it('GroupSetSubject delegates to setGroupSubject and reports success', async () => {
+    const setGroupSubject = jest.fn().mockResolvedValue(undefined);
+    const tool = groupTools({ setGroupSubject } as unknown as GroupService).find(t => t.name === 'GroupSetSubject')!;
+    const out = await invokeTool(
+      tool,
+      { sessionId: 's1', groupId: '120363@g.us', subject: 'Renamed' },
+      'key',
+      makeAuth() as unknown as AuthService,
+    );
+    expect(setGroupSubject).toHaveBeenCalledWith('s1', '120363@g.us', 'Renamed');
+    expect(out).toEqual({ success: true, message: 'Group subject updated' });
+  });
+
+  it('GroupSetDescription delegates to setGroupDescription and reports success', async () => {
+    const setGroupDescription = jest.fn().mockResolvedValue(undefined);
+    const tool = groupTools({ setGroupDescription } as unknown as GroupService).find(
+      t => t.name === 'GroupSetDescription',
+    )!;
+    const out = await invokeTool(
+      tool,
+      { sessionId: 's1', groupId: '120363@g.us', description: 'About us' },
+      'key',
+      makeAuth() as unknown as AuthService,
+    );
+    expect(setGroupDescription).toHaveBeenCalledWith('s1', '120363@g.us', 'About us');
+    expect(out).toEqual({ success: true, message: 'Group description updated' });
+  });
+});

--- a/src/core/agent-tools/tools/message.tools.spec.ts
+++ b/src/core/agent-tools/tools/message.tools.spec.ts
@@ -1,0 +1,303 @@
+import { invokeTool } from '../tool-invoker';
+import { messageTools } from './message.tools';
+import type { AnyToolDescriptor } from '../tool-descriptor';
+import type { MessageService } from '../../../modules/message/message.service';
+import type { AuthService } from '../../../modules/auth/auth.service';
+
+// Covers every messageTools execute() handler via the real invokeTool path (auth → zod → handler).
+// agent-tools.module.ts is pure Nest wiring, stays at 0% coverage, and is intentionally not a target.
+
+function makeAuth(): Pick<AuthService, 'validateApiKey' | 'hasPermission'> {
+  return {
+    validateApiKey: jest.fn().mockResolvedValue({ id: 'k1', allowedSessions: null }),
+    hasPermission: jest.fn().mockReturnValue(true),
+  };
+}
+
+function makeTools(svc: MessageService): Map<string, AnyToolDescriptor> {
+  return new Map(messageTools(svc).map(t => [t.name, t]));
+}
+
+async function run(tool: AnyToolDescriptor, input: unknown): Promise<unknown> {
+  return invokeTool(tool, input, 'key', makeAuth() as unknown as AuthService);
+}
+
+describe('messageTools', () => {
+  it('MessageList delegates to getMessages with the filter fields', async () => {
+    const getMessages = jest.fn().mockResolvedValue([{ id: 'm1' }]);
+    const tools = makeTools({ getMessages } as unknown as MessageService);
+    const out = await run(tools.get('MessageList')!, {
+      sessionId: 's1',
+      chatId: '628111@c.us',
+      limit: 10,
+      offset: 5,
+    });
+    expect(getMessages).toHaveBeenCalledWith('s1', {
+      chatId: '628111@c.us',
+      from: undefined,
+      limit: 10,
+      offset: 5,
+    });
+    expect(out).toEqual([{ id: 'm1' }]);
+  });
+
+  it('MessageHistory delegates to getChatHistory', async () => {
+    const getChatHistory = jest.fn().mockResolvedValue([{ id: 'm1' }]);
+    const tools = makeTools({ getChatHistory } as unknown as MessageService);
+    const out = await run(tools.get('MessageHistory')!, {
+      sessionId: 's1',
+      chatId: '628111@c.us',
+      limit: 50,
+      includeMedia: true,
+      deep: true,
+    });
+    expect(getChatHistory).toHaveBeenCalledWith('s1', '628111@c.us', 50, true, true);
+    expect(out).toEqual([{ id: 'm1' }]);
+  });
+
+  it('MessageGetReactions delegates to getMessageReactions', async () => {
+    const getMessageReactions = jest.fn().mockResolvedValue([{ emoji: '👍' }]);
+    const tools = makeTools({ getMessageReactions } as unknown as MessageService);
+    const out = await run(tools.get('MessageGetReactions')!, {
+      sessionId: 's1',
+      chatId: '628111@c.us',
+      messageId: 'm1',
+    });
+    expect(getMessageReactions).toHaveBeenCalledWith('s1', '628111@c.us', 'm1');
+    expect(out).toEqual([{ emoji: '👍' }]);
+  });
+
+  it('MessageSendText delegates to sendText and forwards linkPreview when set', async () => {
+    const sendText = jest.fn().mockResolvedValue({ id: 'm1' });
+    const tools = makeTools({ sendText } as unknown as MessageService);
+    const out = await run(tools.get('MessageSendText')!, {
+      sessionId: 's1',
+      chatId: '628111@c.us',
+      text: 'hello',
+      linkPreview: false,
+    });
+    expect(sendText).toHaveBeenCalledWith('s1', { chatId: '628111@c.us', text: 'hello', linkPreview: false });
+    expect(out).toEqual({ id: 'm1' });
+  });
+
+  it('MessageSendText omits linkPreview when unset', async () => {
+    const sendText = jest.fn().mockResolvedValue({ id: 'm1' });
+    const tools = makeTools({ sendText } as unknown as MessageService);
+    await run(tools.get('MessageSendText')!, {
+      sessionId: 's1',
+      chatId: '628111@c.us',
+      text: 'hello',
+    });
+    expect(sendText).toHaveBeenCalledWith('s1', { chatId: '628111@c.us', text: 'hello' });
+  });
+
+  it('MessageSendImage delegates to sendImage with the media fields', async () => {
+    const sendImage = jest.fn().mockResolvedValue({ id: 'm1' });
+    const tools = makeTools({ sendImage } as unknown as MessageService);
+    const out = await run(tools.get('MessageSendImage')!, {
+      sessionId: 's1',
+      chatId: '628111@c.us',
+      url: 'https://example.com/pic.jpg',
+      filename: 'pic.jpg',
+      caption: 'look',
+    });
+    expect(sendImage).toHaveBeenCalledWith('s1', {
+      chatId: '628111@c.us',
+      url: 'https://example.com/pic.jpg',
+      base64: undefined,
+      mimetype: undefined,
+      filename: 'pic.jpg',
+      caption: 'look',
+    });
+    expect(out).toEqual({ id: 'm1' });
+  });
+
+  it('MessageSendVideo delegates to sendVideo with the media fields', async () => {
+    const sendVideo = jest.fn().mockResolvedValue({ id: 'm1' });
+    const tools = makeTools({ sendVideo } as unknown as MessageService);
+    const out = await run(tools.get('MessageSendVideo')!, {
+      sessionId: 's1',
+      chatId: '628111@c.us',
+      url: 'https://example.com/clip.mp4',
+      caption: 'watch',
+    });
+    expect(sendVideo).toHaveBeenCalledWith('s1', {
+      chatId: '628111@c.us',
+      url: 'https://example.com/clip.mp4',
+      base64: undefined,
+      mimetype: undefined,
+      filename: undefined,
+      caption: 'watch',
+    });
+    expect(out).toEqual({ id: 'm1' });
+  });
+
+  it('MessageSendAudio delegates to sendAudio including the ptt flag', async () => {
+    const sendAudio = jest.fn().mockResolvedValue({ id: 'm1' });
+    const tools = makeTools({ sendAudio } as unknown as MessageService);
+    const out = await run(tools.get('MessageSendAudio')!, {
+      sessionId: 's1',
+      chatId: '628111@c.us',
+      base64: 'QUJD',
+      mimetype: 'audio/ogg',
+      ptt: true,
+    });
+    expect(sendAudio).toHaveBeenCalledWith('s1', {
+      chatId: '628111@c.us',
+      url: undefined,
+      base64: 'QUJD',
+      mimetype: 'audio/ogg',
+      filename: undefined,
+      caption: undefined,
+      ptt: true,
+    });
+    expect(out).toEqual({ id: 'm1' });
+  });
+
+  it('MessageSendDocument delegates to sendDocument with the media fields', async () => {
+    const sendDocument = jest.fn().mockResolvedValue({ id: 'm1' });
+    const tools = makeTools({ sendDocument } as unknown as MessageService);
+    const out = await run(tools.get('MessageSendDocument')!, {
+      sessionId: 's1',
+      chatId: '628111@c.us',
+      base64: 'QUJD',
+      mimetype: 'application/pdf',
+      filename: 'doc.pdf',
+    });
+    expect(sendDocument).toHaveBeenCalledWith('s1', {
+      chatId: '628111@c.us',
+      url: undefined,
+      base64: 'QUJD',
+      mimetype: 'application/pdf',
+      filename: 'doc.pdf',
+      caption: undefined,
+    });
+    expect(out).toEqual({ id: 'm1' });
+  });
+
+  it('MessageSendLocation delegates to sendLocation', async () => {
+    const sendLocation = jest.fn().mockResolvedValue({ id: 'm1' });
+    const tools = makeTools({ sendLocation } as unknown as MessageService);
+    const out = await run(tools.get('MessageSendLocation')!, {
+      sessionId: 's1',
+      chatId: '628111@c.us',
+      latitude: -6.2,
+      longitude: 106.8,
+      description: 'Office',
+      address: 'Jl. Sudirman',
+    });
+    expect(sendLocation).toHaveBeenCalledWith('s1', {
+      chatId: '628111@c.us',
+      latitude: -6.2,
+      longitude: 106.8,
+      description: 'Office',
+      address: 'Jl. Sudirman',
+    });
+    expect(out).toEqual({ id: 'm1' });
+  });
+
+  it('MessageSendContact delegates to sendContact', async () => {
+    const sendContact = jest.fn().mockResolvedValue({ id: 'm1' });
+    const tools = makeTools({ sendContact } as unknown as MessageService);
+    const out = await run(tools.get('MessageSendContact')!, {
+      sessionId: 's1',
+      chatId: '628111@c.us',
+      contactName: 'Jane',
+      contactNumber: '628222',
+    });
+    expect(sendContact).toHaveBeenCalledWith('s1', {
+      chatId: '628111@c.us',
+      contactName: 'Jane',
+      contactNumber: '628222',
+    });
+    expect(out).toEqual({ id: 'm1' });
+  });
+
+  it('MessageSendSticker delegates to sendSticker with the media fields', async () => {
+    const sendSticker = jest.fn().mockResolvedValue({ id: 'm1' });
+    const tools = makeTools({ sendSticker } as unknown as MessageService);
+    const out = await run(tools.get('MessageSendSticker')!, {
+      sessionId: 's1',
+      chatId: '628111@c.us',
+      url: 'https://example.com/sticker.webp',
+    });
+    expect(sendSticker).toHaveBeenCalledWith('s1', {
+      chatId: '628111@c.us',
+      url: 'https://example.com/sticker.webp',
+      base64: undefined,
+      mimetype: undefined,
+      filename: undefined,
+      caption: undefined,
+    });
+    expect(out).toEqual({ id: 'm1' });
+  });
+
+  it('MessageSendTemplate delegates to sendTemplate', async () => {
+    const sendTemplate = jest.fn().mockResolvedValue({ id: 'm1' });
+    const tools = makeTools({ sendTemplate } as unknown as MessageService);
+    const out = await run(tools.get('MessageSendTemplate')!, {
+      sessionId: 's1',
+      chatId: '628111@c.us',
+      templateName: 'welcome',
+      vars: { name: 'Jane' },
+    });
+    expect(sendTemplate).toHaveBeenCalledWith('s1', {
+      chatId: '628111@c.us',
+      templateId: undefined,
+      templateName: 'welcome',
+      vars: { name: 'Jane' },
+    });
+    expect(out).toEqual({ id: 'm1' });
+  });
+
+  it('MessageReply delegates to reply', async () => {
+    const reply = jest.fn().mockResolvedValue({ id: 'm2' });
+    const tools = makeTools({ reply } as unknown as MessageService);
+    const out = await run(tools.get('MessageReply')!, {
+      sessionId: 's1',
+      chatId: '628111@c.us',
+      quotedMessageId: 'm1',
+      text: 'got it',
+    });
+    expect(reply).toHaveBeenCalledWith('s1', {
+      chatId: '628111@c.us',
+      quotedMessageId: 'm1',
+      text: 'got it',
+    });
+    expect(out).toEqual({ id: 'm2' });
+  });
+
+  it('MessageForward delegates to forward', async () => {
+    const forward = jest.fn().mockResolvedValue({ id: 'm2' });
+    const tools = makeTools({ forward } as unknown as MessageService);
+    const out = await run(tools.get('MessageForward')!, {
+      sessionId: 's1',
+      fromChatId: '628111@c.us',
+      toChatId: '628222@c.us',
+      messageId: 'm1',
+    });
+    expect(forward).toHaveBeenCalledWith('s1', {
+      fromChatId: '628111@c.us',
+      toChatId: '628222@c.us',
+      messageId: 'm1',
+    });
+    expect(out).toEqual({ id: 'm2' });
+  });
+
+  it('MessageReact delegates to reactToMessage and maps the void result to success', async () => {
+    const reactToMessage = jest.fn().mockResolvedValue(undefined);
+    const tools = makeTools({ reactToMessage } as unknown as MessageService);
+    const out = (await run(tools.get('MessageReact')!, {
+      sessionId: 's1',
+      chatId: '628111@c.us',
+      messageId: 'm1',
+      emoji: '👍',
+    })) as { success: boolean };
+    expect(reactToMessage).toHaveBeenCalledWith('s1', {
+      chatId: '628111@c.us',
+      messageId: 'm1',
+      emoji: '👍',
+    });
+    expect(out).toEqual({ success: true });
+  });
+});

--- a/src/core/agent-tools/tools/session.tools.spec.ts
+++ b/src/core/agent-tools/tools/session.tools.spec.ts
@@ -1,0 +1,117 @@
+import { invokeTool } from '../tool-invoker';
+import { sessionTools } from './session.tools';
+import type { AnyToolDescriptor } from '../tool-descriptor';
+import type { SessionService } from '../../../modules/session/session.service';
+import type { AuthService } from '../../../modules/auth/auth.service';
+
+// Covers every sessionTools execute() handler via the real invokeTool path (auth → zod → handler).
+// agent-tools.module.ts is pure Nest wiring, stays at 0% coverage, and is intentionally not a target.
+
+function makeAuth(): Pick<AuthService, 'validateApiKey' | 'hasPermission'> {
+  return {
+    validateApiKey: jest.fn().mockResolvedValue({ id: 'k1', allowedSessions: null }),
+    hasPermission: jest.fn().mockReturnValue(true),
+  };
+}
+
+function makeTools(svc: SessionService): Map<string, AnyToolDescriptor> {
+  return new Map(sessionTools(svc).map(t => [t.name, t]));
+}
+
+async function run(tool: AnyToolDescriptor, input: unknown): Promise<unknown> {
+  return invokeTool(tool, input, 'key', makeAuth() as unknown as AuthService);
+}
+
+describe('sessionTools', () => {
+  it('SessionFindAll scopes by the key allowedSessions and maps entities to DTOs', async () => {
+    const findAll = jest.fn().mockResolvedValue([{ id: 's1', name: 'main', status: 'ready' }]);
+    const isActive = jest.fn().mockReturnValue(true);
+    const out = (await run(makeTools({ findAll, isActive } as unknown as SessionService).get('SessionFindAll')!, {
+      limit: 5,
+    })) as Array<{ id: string; engineLoaded: boolean }>;
+    expect(findAll).toHaveBeenCalledWith(null, { limit: 5, offset: undefined });
+    expect(isActive).toHaveBeenCalledWith('s1');
+    expect(out).toEqual([expect.objectContaining({ id: 's1', engineLoaded: true })]);
+  });
+
+  it('SessionFindOne delegates to findOne and maps to the response DTO', async () => {
+    const findOne = jest.fn().mockResolvedValue({ id: 's1', name: 'main', status: 'ready' });
+    const isActive = jest.fn().mockReturnValue(false);
+    const out = (await run(makeTools({ findOne, isActive } as unknown as SessionService).get('SessionFindOne')!, {
+      sessionId: 's1',
+    })) as { id: string; engineLoaded: boolean };
+    expect(findOne).toHaveBeenCalledWith('s1');
+    expect(out.id).toBe('s1');
+    expect(out.engineLoaded).toBe(false);
+  });
+
+  it('SessionGetChats delegates to getChats with paging', async () => {
+    const getChats = jest.fn().mockResolvedValue([{ id: 'c1' }]);
+    const out = await run(makeTools({ getChats } as unknown as SessionService).get('SessionGetChats')!, {
+      sessionId: 's1',
+      limit: 20,
+      offset: 10,
+    });
+    expect(getChats).toHaveBeenCalledWith('s1', { limit: 20, offset: 10 });
+    expect(out).toEqual([{ id: 'c1' }]);
+  });
+
+  it('SessionGetStats scopes by the key allowedSessions', async () => {
+    const stats = { total: 2, active: 1, ready: 1, disconnected: 1 };
+    const getStats = jest.fn().mockResolvedValue(stats);
+    const out = await run(makeTools({ getStats } as unknown as SessionService).get('SessionGetStats')!, {});
+    expect(getStats).toHaveBeenCalledWith(null);
+    expect(out).toEqual(stats);
+  });
+
+  it('SessionSubscribePresence delegates to subscribeToPresence and reports success', async () => {
+    const subscribeToPresence = jest.fn().mockResolvedValue(undefined);
+    const out = await run(
+      makeTools({ subscribeToPresence } as unknown as SessionService).get('SessionSubscribePresence')!,
+      { sessionId: 's1', chatId: '628111@c.us' },
+    );
+    expect(subscribeToPresence).toHaveBeenCalledWith('s1', '628111@c.us');
+    expect(out).toEqual({ success: true });
+  });
+
+  it('SessionGetPresence delegates to getPresence and passes the result through', async () => {
+    const getPresence = jest.fn().mockResolvedValue({ presence: 'online' });
+    const out = await run(makeTools({ getPresence } as unknown as SessionService).get('SessionGetPresence')!, {
+      sessionId: 's1',
+      chatId: '628111@c.us',
+    });
+    expect(getPresence).toHaveBeenCalledWith('s1', '628111@c.us');
+    expect(out).toEqual({ presence: 'online' });
+  });
+
+  it('SessionMarkChatRead maps the sendSeen result to a success field', async () => {
+    const sendSeen = jest.fn().mockResolvedValue(true);
+    const out = await run(makeTools({ sendSeen } as unknown as SessionService).get('SessionMarkChatRead')!, {
+      sessionId: 's1',
+      chatId: '628111@c.us',
+    });
+    expect(sendSeen).toHaveBeenCalledWith('s1', '628111@c.us');
+    expect(out).toEqual({ success: true });
+  });
+
+  it('SessionMarkChatUnread maps the markUnread result to a success field', async () => {
+    const markUnread = jest.fn().mockResolvedValue(true);
+    const out = await run(makeTools({ markUnread } as unknown as SessionService).get('SessionMarkChatUnread')!, {
+      sessionId: 's1',
+      chatId: '628111@c.us',
+    });
+    expect(markUnread).toHaveBeenCalledWith('s1', '628111@c.us');
+    expect(out).toEqual({ success: true });
+  });
+
+  it('SessionSendChatState delegates to sendChatState and reports success', async () => {
+    const sendChatState = jest.fn().mockResolvedValue(undefined);
+    const out = await run(makeTools({ sendChatState } as unknown as SessionService).get('SessionSendChatState')!, {
+      sessionId: 's1',
+      chatId: '628111@c.us',
+      state: 'typing',
+    });
+    expect(sendChatState).toHaveBeenCalledWith('s1', '628111@c.us', 'typing');
+    expect(out).toEqual({ success: true });
+  });
+});

--- a/src/modules/contact/contact.controller.spec.ts
+++ b/src/modules/contact/contact.controller.spec.ts
@@ -1,0 +1,101 @@
+import { ContactController } from './contact.controller';
+import { ContactService } from './contact.service';
+
+describe('ContactController', () => {
+  const service = {
+    getContacts: jest.fn(),
+    getProfilePictures: jest.fn(),
+    getContactById: jest.fn(),
+    getNumberId: jest.fn(),
+    getProfilePicture: jest.fn(),
+    resolveContactPhone: jest.fn(),
+    upsertContact: jest.fn(),
+    deleteContact: jest.fn(),
+    blockContact: jest.fn(),
+    unblockContact: jest.fn(),
+  };
+  const controller = new ContactController(service as unknown as ContactService);
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('findAll parses limit/offset query strings', async () => {
+    service.getContacts.mockResolvedValue([]);
+    await controller.findAll('s1', '5', '10');
+    expect(service.getContacts).toHaveBeenCalledWith('s1', { limit: 5, offset: 10 });
+  });
+
+  it('findAll leaves paging undefined without query params', async () => {
+    service.getContacts.mockResolvedValue([]);
+    await controller.findAll('s1');
+    expect(service.getContacts).toHaveBeenCalledWith('s1', { limit: undefined, offset: undefined });
+  });
+
+  it('getProfilePictures splits, trims and drops empty ids', async () => {
+    service.getProfilePictures.mockResolvedValue([null, 'https://pps/2.jpg']);
+    const out = await controller.getProfilePictures('s1', ' a@c.us , ,b@c.us ');
+    expect(service.getProfilePictures).toHaveBeenCalledWith('s1', ['a@c.us', 'b@c.us']);
+    expect(out).toEqual({ pictures: [null, 'https://pps/2.jpg'] });
+  });
+
+  it('getProfilePictures defaults a missing ids param to an empty list', async () => {
+    service.getProfilePictures.mockResolvedValue([]);
+    await controller.getProfilePictures('s1');
+    expect(service.getProfilePictures).toHaveBeenCalledWith('s1', []);
+  });
+
+  it('findOne delegates to the service', async () => {
+    service.getContactById.mockResolvedValue({ id: 'c1' });
+    await controller.findOne('s1', 'c1');
+    expect(service.getContactById).toHaveBeenCalledWith('s1', 'c1');
+  });
+
+  it('checkNumber maps a null whatsappId to exists:false', async () => {
+    service.getNumberId.mockResolvedValue(null);
+    await expect(controller.checkNumber('s1', '628123')).resolves.toEqual({
+      number: '628123',
+      exists: false,
+      whatsappId: null,
+    });
+  });
+
+  it('checkNumber returns the canonical id when the number exists', async () => {
+    service.getNumberId.mockResolvedValue('628123@c.us');
+    await expect(controller.checkNumber('s1', '628123')).resolves.toEqual({
+      number: '628123',
+      exists: true,
+      whatsappId: '628123@c.us',
+    });
+  });
+
+  it('getProfilePicture wraps the url', async () => {
+    service.getProfilePicture.mockResolvedValue('https://pps/1.jpg');
+    await expect(controller.getProfilePicture('s1', 'c1')).resolves.toEqual({ url: 'https://pps/1.jpg' });
+  });
+
+  it('resolvePhone wraps contactId and phone', async () => {
+    service.resolveContactPhone.mockResolvedValue('628123456789');
+    await expect(controller.resolvePhone('s1', '123@lid')).resolves.toEqual({
+      contactId: '123@lid',
+      phone: '628123456789',
+    });
+  });
+
+  it('upsertContact passes first/last name from the DTO', async () => {
+    service.upsertContact.mockResolvedValue(undefined);
+    await expect(controller.upsertContact('s1', 'c1', { firstName: 'A', lastName: 'B' })).resolves.toEqual({
+      success: true,
+      message: 'Contact saved',
+    });
+    expect(service.upsertContact).toHaveBeenCalledWith('s1', 'c1', 'A', 'B');
+  });
+
+  it.each([
+    ['deleteContact', { success: true, message: 'Contact deleted' }],
+    ['blockContact', { success: true, message: 'Contact blocked' }],
+    ['unblockContact', { success: true, message: 'Contact unblocked' }],
+  ] as const)('%s delegates and returns its success body', async (method, body) => {
+    service[method].mockResolvedValue(undefined);
+    await expect(controller[method]('s1', 'c1')).resolves.toEqual(body);
+    expect(service[method]).toHaveBeenCalledWith('s1', 'c1');
+  });
+});

--- a/src/modules/docker/docker.service.spec.ts
+++ b/src/modules/docker/docker.service.spec.ts
@@ -342,17 +342,19 @@ describe('DockerService.getContainerByService label match and guard rails', () =
 
   it('resolves the container by its com.openwa.service label', async () => {
     const service = new DockerService();
+    const listContainers = jest.fn().mockResolvedValue([{ Id: 'label-hit-1', Names: ['/openwa-postgres'] }]);
     const getContainer = jest.fn((id: string) => ({ id }));
     Object.assign(service as unknown as Record<string, unknown>, {
-      docker: {
-        listContainers: jest.fn().mockResolvedValue([{ Id: 'label-hit-1', Names: ['/openwa-postgres'] }]),
-        getContainer,
-      },
+      docker: { listContainers, getContainer },
       isAvailable: true,
     });
 
     const result = await service.getContainerByService('database');
 
+    expect(listContainers).toHaveBeenCalledWith({
+      all: true,
+      filters: { label: ['com.openwa.service=database'] },
+    });
     expect(getContainer).toHaveBeenCalledWith('label-hit-1');
     expect(result).toEqual({ id: 'label-hit-1' });
   });
@@ -565,7 +567,7 @@ describe('DockerService.orchestrateProfiles', () => {
 
   it('collects per-profile failures and still succeeds when at least one started', async () => {
     const service = availableService();
-    jest.spyOn(service, 'startService').mockImplementation(async (svc: string) => svc === 'database');
+    jest.spyOn(service, 'startService').mockImplementation((svc: string) => Promise.resolve(svc === 'database'));
 
     const result = await service.orchestrateProfiles(['postgres', 'redis']);
 

--- a/src/modules/docker/docker.service.spec.ts
+++ b/src/modules/docker/docker.service.spec.ts
@@ -1,7 +1,12 @@
+import Docker from 'dockerode';
 import { DockerService } from './docker.service';
 
 // Prevent actual Docker connections on module init during tests
 jest.mock('dockerode');
+
+// The auto-mocked constructor: initializeDocker does `new Docker(...)` internally, so the
+// onModuleInit/isDockerAvailable tests steer the daemon by replacing its implementation.
+const DockerMock = Docker as unknown as jest.Mock;
 
 describe('DockerService.getRunningBuiltinServices', () => {
   const container = (name: string, service: string, state: string) => ({
@@ -168,5 +173,467 @@ describe('DockerService.getContainerByService exact-name fallback', () => {
     const result = await service.getContainerByService('redis');
     expect(getContainer).toHaveBeenCalledWith('r');
     expect(result).toEqual({ id: 'r' });
+  });
+});
+
+describe('DockerService.onModuleInit', () => {
+  // The probe runs against whatever buildDockerOptions() points at, but the dockerode
+  // constructor is the auto-mock — the "daemon" is whatever the test's fake says it is,
+  // so no real socket is ever touched.
+  const ENV_KEYS = ['DOCKER_HOST', 'REDIS_BUILTIN', 'POSTGRES_BUILTIN', 'MINIO_BUILTIN'];
+  let savedEnv: Record<string, string | undefined> = {};
+
+  const happyDocker = () => ({
+    ping: jest.fn().mockResolvedValue(undefined),
+    listContainers: jest.fn().mockResolvedValue([]),
+    pull: (_image: string, cb: (err: Error | null, stream: null) => void) => cb(null, null),
+    modem: { followProgress: (_stream: null, cb: (err: Error | null) => void) => cb(null) },
+    createVolume: jest.fn().mockResolvedValue({}),
+    createContainer: jest.fn().mockResolvedValue({ start: jest.fn().mockResolvedValue(undefined) }),
+  });
+
+  beforeEach(() => {
+    savedEnv = {};
+    for (const k of ENV_KEYS) {
+      savedEnv[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k];
+    }
+    DockerMock.mockReset();
+  });
+
+  it('does not throw when the Docker socket is absent — orchestration is disabled and bootstrap is skipped', async () => {
+    DockerMock.mockImplementation(() => ({
+      ping: jest.fn().mockRejectedValue(new Error('connect ENOENT /var/run/docker.sock')),
+    }));
+    const service = new DockerService();
+
+    await expect(service.onModuleInit()).resolves.toBeUndefined();
+    expect(service.isDockerAvailable()).toBe(false);
+  });
+
+  it('bootstraps the env-configured built-in profiles when the daemon is reachable', async () => {
+    process.env.REDIS_BUILTIN = 'true';
+    const docker = happyDocker();
+    DockerMock.mockImplementation(() => docker);
+    const service = new DockerService();
+
+    await expect(service.onModuleInit()).resolves.toBeUndefined();
+
+    expect(service.isDockerAvailable()).toBe(true);
+    expect(docker.createContainer).toHaveBeenCalledWith(expect.objectContaining({ name: 'openwa-redis' }));
+  });
+
+  it('logs a warning but still resolves when bootstrap orchestration fails', async () => {
+    process.env.REDIS_BUILTIN = 'true';
+    DockerMock.mockImplementation(() => ({
+      ...happyDocker(),
+      pull: (_image: string, cb: (err: Error | null, stream: null) => void) => cb(new Error('pull denied'), null),
+    }));
+    const service = new DockerService();
+
+    await expect(service.onModuleInit()).resolves.toBeUndefined();
+    expect(service.isDockerAvailable()).toBe(true);
+  });
+});
+
+describe('DockerService.isDockerAvailable', () => {
+  const originalDockerHost = process.env.DOCKER_HOST;
+
+  afterEach(() => {
+    if (originalDockerHost === undefined) delete process.env.DOCKER_HOST;
+    else process.env.DOCKER_HOST = originalDockerHost;
+    DockerMock.mockReset();
+  });
+
+  it('returns the live availability flag', () => {
+    delete process.env.DOCKER_HOST; // no re-probe: the flag is reported as-is
+    const service = new DockerService();
+    expect(service.isDockerAvailable()).toBe(false);
+    Object.assign(service as unknown as Record<string, unknown>, { isAvailable: true });
+    expect(service.isDockerAvailable()).toBe(true);
+  });
+
+  it('re-probes once in the background when DOCKER_HOST is set and the first probe failed', async () => {
+    process.env.DOCKER_HOST = 'tcp://docker-proxy:2375';
+    const ping = jest.fn().mockResolvedValue(undefined);
+    DockerMock.mockImplementation(() => ({ ping }));
+    const service = new DockerService();
+
+    // The first call reports the stale false and kicks off the one-shot re-probe...
+    expect(service.isDockerAvailable()).toBe(false);
+    // ...and the in-flight guard stops a second probe from piling up.
+    expect(service.isDockerAvailable()).toBe(false);
+    expect(DockerMock).toHaveBeenCalledTimes(1);
+
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(ping).toHaveBeenCalledTimes(1);
+    expect(service.isDockerAvailable()).toBe(true);
+  });
+});
+
+describe('DockerService.listContainers', () => {
+  const makeService = (listContainers: jest.Mock) => {
+    const service = new DockerService();
+    Object.assign(service as unknown as Record<string, unknown>, {
+      docker: { listContainers },
+      isAvailable: true,
+    });
+    return service;
+  };
+
+  it('returns an empty list when Docker is unavailable', async () => {
+    expect(await new DockerService().listContainers()).toEqual([]);
+  });
+
+  it('maps only OpenWA containers (label or /openwa- name) to ContainerInfo', async () => {
+    const service = makeService(
+      jest.fn().mockResolvedValue([
+        {
+          Id: 'aabbccddeeff00112233',
+          Names: ['/openwa-postgres'],
+          State: 'running',
+          Status: 'Up 2 hours',
+          Labels: { 'com.openwa.service': 'database', 'com.openwa.builtin': 'true' },
+        },
+        { Id: '11223344556677889900', Names: ['/openwa-redis'], State: 'exited', Status: 'Exited (0) yesterday' },
+        // Label-only match with sparse fields: falls back to 'unknown' placeholders.
+        { Id: 'ffee0011223344556677', Labels: { 'com.openwa.service': 'cache' } },
+        { Id: 'deadbeef0011', Names: ['/unrelated'], State: 'running', Status: 'Up', Labels: {} },
+      ]),
+    );
+
+    expect(await service.listContainers()).toEqual([
+      {
+        id: 'aabbccddeeff',
+        name: 'openwa-postgres',
+        state: 'running',
+        status: 'Up 2 hours',
+        labels: { 'com.openwa.service': 'database', 'com.openwa.builtin': 'true' },
+      },
+      { id: '112233445566', name: 'openwa-redis', state: 'exited', status: 'Exited (0) yesterday', labels: {} },
+      {
+        id: 'ffee00112233',
+        name: 'unknown',
+        state: 'unknown',
+        status: 'unknown',
+        labels: { 'com.openwa.service': 'cache' },
+      },
+    ]);
+  });
+
+  it('returns an empty list when the daemon listing fails', async () => {
+    const service = makeService(jest.fn().mockRejectedValue(new Error('daemon gone')));
+    expect(await service.listContainers()).toEqual([]);
+  });
+});
+
+describe('DockerService.getContainerByService label match and guard rails', () => {
+  it('returns null when Docker is unavailable', async () => {
+    expect(await new DockerService().getContainerByService('database')).toBeNull();
+  });
+
+  it('resolves the container by its com.openwa.service label', async () => {
+    const service = new DockerService();
+    const getContainer = jest.fn((id: string) => ({ id }));
+    Object.assign(service as unknown as Record<string, unknown>, {
+      docker: {
+        listContainers: jest.fn().mockResolvedValue([{ Id: 'label-hit-1', Names: ['/openwa-postgres'] }]),
+        getContainer,
+      },
+      isAvailable: true,
+    });
+
+    const result = await service.getContainerByService('database');
+
+    expect(getContainer).toHaveBeenCalledWith('label-hit-1');
+    expect(result).toEqual({ id: 'label-hit-1' });
+  });
+
+  it('returns null when the daemon lookup fails', async () => {
+    const service = new DockerService();
+    Object.assign(service as unknown as Record<string, unknown>, {
+      docker: { listContainers: jest.fn().mockRejectedValue(new Error('daemon gone')) },
+      isAvailable: true,
+    });
+    expect(await service.getContainerByService('database')).toBeNull();
+  });
+});
+
+describe('DockerService.createService', () => {
+  const withDocker = (docker: unknown) => {
+    const service = new DockerService();
+    Object.assign(service as unknown as Record<string, unknown>, { docker, isAvailable: true });
+    return service;
+  };
+
+  it('returns false when Docker is unavailable', async () => {
+    expect(await new DockerService().createService('redis')).toBe(false);
+  });
+
+  it('returns false for an unknown profile', async () => {
+    expect(await withDocker({}).createService('not-a-profile')).toBe(false);
+  });
+
+  it('returns true without pulling when the container already exists and is running', async () => {
+    const service = withDocker({});
+    const container = { inspect: jest.fn().mockResolvedValue({ State: { Running: true } }), start: jest.fn() };
+    jest.spyOn(service, 'getContainerByService').mockResolvedValue(container as never);
+
+    await expect(service.createService('postgres')).resolves.toBe(true);
+    expect(container.start).not.toHaveBeenCalled();
+  });
+
+  it('starts the retained container when it exists but is stopped', async () => {
+    const service = withDocker({});
+    const container = {
+      inspect: jest.fn().mockResolvedValue({ State: { Running: false } }),
+      start: jest.fn().mockResolvedValue(undefined),
+    };
+    jest.spyOn(service, 'getContainerByService').mockResolvedValue(container as never);
+
+    await expect(service.createService('redis')).resolves.toBe(true);
+    expect(container.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('pulls, creates the volume and container, and starts it (a pre-existing volume is fine)', async () => {
+    const start = jest.fn().mockResolvedValue(undefined);
+    const docker = {
+      pull: (_image: string, cb: (err: Error | null, stream: null) => void) => cb(null, null),
+      modem: { followProgress: (_stream: null, cb: (err: Error | null) => void) => cb(null) },
+      // EEXIST races are normal — the volume may survive from an earlier run.
+      createVolume: jest.fn().mockRejectedValue(new Error('volume already exists')),
+      createContainer: jest.fn().mockResolvedValue({ start }),
+    };
+    const service = withDocker(docker);
+    jest.spyOn(service, 'getContainerByService').mockResolvedValue(null);
+
+    await expect(service.createService('redis')).resolves.toBe(true);
+
+    expect(docker.createVolume).toHaveBeenCalledWith({ Name: 'openwa_redis-data' });
+    expect(docker.createContainer).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'openwa-redis', Image: 'redis:7-alpine' }),
+    );
+    expect(start).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns false when the daemon rejects the image pull', async () => {
+    const docker = {
+      pull: (_image: string, cb: (err: Error | null, stream: null) => void) =>
+        cb(new Error('pull access denied'), null),
+    };
+    const service = withDocker(docker);
+    jest.spyOn(service, 'getContainerByService').mockResolvedValue(null);
+
+    await expect(service.createService('redis')).resolves.toBe(false);
+  });
+});
+
+describe('DockerService.startService', () => {
+  it('creates the mapped profile when no container exists yet', async () => {
+    const service = new DockerService();
+    jest.spyOn(service, 'getContainerByService').mockResolvedValue(null);
+    const createService = jest.spyOn(service, 'createService').mockResolvedValue(true);
+
+    await expect(service.startService('database')).resolves.toBe(true);
+    expect(createService).toHaveBeenCalledWith('postgres');
+  });
+
+  it('passes an unmapped service name through as its own profile', async () => {
+    const service = new DockerService();
+    jest.spyOn(service, 'getContainerByService').mockResolvedValue(null);
+    const createService = jest.spyOn(service, 'createService').mockResolvedValue(false);
+
+    await expect(service.startService('custom-service')).resolves.toBe(false);
+    expect(createService).toHaveBeenCalledWith('custom-service');
+  });
+
+  it('returns true when the container is already running', async () => {
+    const service = new DockerService();
+    const container = { inspect: jest.fn().mockResolvedValue({ State: { Running: true } }), start: jest.fn() };
+    jest.spyOn(service, 'getContainerByService').mockResolvedValue(container as never);
+
+    await expect(service.startService('cache')).resolves.toBe(true);
+    expect(container.start).not.toHaveBeenCalled();
+  });
+
+  it('starts a stopped container', async () => {
+    const service = new DockerService();
+    const container = {
+      inspect: jest.fn().mockResolvedValue({ State: { Running: false } }),
+      start: jest.fn().mockResolvedValue(undefined),
+    };
+    jest.spyOn(service, 'getContainerByService').mockResolvedValue(container as never);
+
+    await expect(service.startService('cache')).resolves.toBe(true);
+    expect(container.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns false when the daemon rejects the start', async () => {
+    const service = new DockerService();
+    const container = {
+      inspect: jest.fn().mockResolvedValue({ State: { Running: false } }),
+      start: jest.fn().mockRejectedValue(new Error('daemon gone')),
+    };
+    jest.spyOn(service, 'getContainerByService').mockResolvedValue(container as never);
+
+    await expect(service.startService('cache')).resolves.toBe(false);
+  });
+});
+
+describe('DockerService.stopService', () => {
+  const makeService = (container: unknown) => {
+    const service = new DockerService();
+    jest.spyOn(service, 'getContainerByService').mockResolvedValue(container as never);
+    return service;
+  };
+
+  it('stops a running container and retains it', async () => {
+    const container = {
+      inspect: jest.fn().mockResolvedValue({ State: { Running: true } }),
+      stop: jest.fn().mockResolvedValue(undefined),
+    };
+    await expect(makeService(container).stopService('database')).resolves.toBe(true);
+    expect(container.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns true when the container is already stopped', async () => {
+    const container = {
+      inspect: jest.fn().mockResolvedValue({ State: { Running: false } }),
+      stop: jest.fn(),
+    };
+    await expect(makeService(container).stopService('database')).resolves.toBe(true);
+    expect(container.stop).not.toHaveBeenCalled();
+  });
+
+  it('returns true when the container does not exist', async () => {
+    await expect(makeService(null).stopService('database')).resolves.toBe(true);
+  });
+
+  it('returns false when the daemon rejects the stop', async () => {
+    const container = {
+      inspect: jest.fn().mockResolvedValue({ State: { Running: true } }),
+      stop: jest.fn().mockRejectedValue(new Error('daemon gone')),
+    };
+    await expect(makeService(container).stopService('database')).resolves.toBe(false);
+  });
+});
+
+describe('DockerService.orchestrateProfiles', () => {
+  const availableService = () => {
+    const service = new DockerService();
+    Object.assign(service as unknown as Record<string, unknown>, { docker: {}, isAvailable: true });
+    return service;
+  };
+
+  it('fails fast when Docker is unavailable, keeping the estimated restart time', async () => {
+    const result = await new DockerService().orchestrateProfiles(['postgres', 'redis', 'minio']);
+    expect(result).toEqual({
+      success: false,
+      message: 'Docker is not available',
+      containersStarted: [],
+      containersStopped: [],
+      errors: [],
+      estimatedTime: 15 + 20 + 13 + 15,
+    });
+  });
+
+  it('starts each mapped profile in order and reports the success message', async () => {
+    const service = availableService();
+    const startService = jest.spyOn(service, 'startService').mockResolvedValue(true);
+
+    const result = await service.orchestrateProfiles(['postgres', 'redis']);
+
+    expect(startService).toHaveBeenNthCalledWith(1, 'database');
+    expect(startService).toHaveBeenNthCalledWith(2, 'cache');
+    expect(result).toEqual({
+      success: true,
+      message: 'Successfully orchestrated 2 service(s)',
+      containersStarted: ['postgres', 'redis'],
+      containersStopped: [],
+      errors: [],
+      estimatedTime: 15 + 20 + 13,
+    });
+  });
+
+  it('collects per-profile failures and still succeeds when at least one started', async () => {
+    const service = availableService();
+    jest.spyOn(service, 'startService').mockImplementation(async (svc: string) => svc === 'database');
+
+    const result = await service.orchestrateProfiles(['postgres', 'redis']);
+
+    expect(result.success).toBe(true);
+    expect(result.containersStarted).toEqual(['postgres']);
+    expect(result.errors).toEqual([
+      "Service 'redis' container not found. It may need to be created first with docker-compose.",
+    ]);
+    expect(result.message).toBe(result.errors.join('; '));
+  });
+
+  it('captures a thrown start error instead of rejecting, and fails when nothing started', async () => {
+    const service = availableService();
+    jest.spyOn(service, 'startService').mockRejectedValue(new Error('boom'));
+
+    const result = await service.orchestrateProfiles(['postgres']);
+
+    expect(result.success).toBe(false);
+    expect(result.containersStarted).toEqual([]);
+    expect(result.errors).toEqual(['Failed to start postgres: boom']);
+    expect(result.message).toBe('Failed to start postgres: boom');
+  });
+});
+
+describe('DockerService.getSystemInfo', () => {
+  it('reports unavailable when Docker is not connected', async () => {
+    expect(await new DockerService().getSystemInfo()).toEqual({ available: false });
+  });
+
+  it('maps the daemon info into the public shape', async () => {
+    const service = new DockerService();
+    Object.assign(service as unknown as Record<string, unknown>, {
+      docker: {
+        info: jest.fn().mockResolvedValue({
+          Containers: 5,
+          ContainersRunning: 2,
+          ContainersPaused: 1,
+          ContainersStopped: 2,
+          Images: 9,
+          ServerVersion: '27.0.3',
+          OperatingSystem: 'Docker Desktop',
+          Architecture: 'aarch64',
+        }),
+      },
+      isAvailable: true,
+    });
+
+    expect(await service.getSystemInfo()).toEqual({
+      available: true,
+      info: {
+        containers: 5,
+        containersRunning: 2,
+        containersPaused: 1,
+        containersStopped: 2,
+        images: 9,
+        serverVersion: '27.0.3',
+        operatingSystem: 'Docker Desktop',
+        architecture: 'aarch64',
+      },
+    });
+  });
+
+  it('reports unavailable when the daemon info call fails', async () => {
+    const service = new DockerService();
+    Object.assign(service as unknown as Record<string, unknown>, {
+      docker: { info: jest.fn().mockRejectedValue(new Error('daemon gone')) },
+      isAvailable: true,
+    });
+    expect(await service.getSystemInfo()).toEqual({ available: false });
   });
 });

--- a/src/modules/mcp/mcp.server.spec.ts
+++ b/src/modules/mcp/mcp.server.spec.ts
@@ -1,8 +1,44 @@
 import { BadRequestException, ForbiddenException, UnauthorizedException } from '@nestjs/common';
 import type { Request, Response } from 'express';
-import { auditMcpAuthFailure, createIpThrottle, resolveMcpReadOnly } from './mcp.server';
+import { z } from 'zod';
+import { auditMcpAuthFailure, createIpThrottle, mountMcpServer, resolveMcpReadOnly } from './mcp.server';
 import { KeyRateLimiter } from './mcp-rate-limit';
 import { AuditAction } from '../audit/entities/audit-log.entity';
+import type { AnyToolDescriptor } from '../../core/agent-tools/tool-descriptor';
+import type { ToolRegistryService } from '../../core/agent-tools/tool-registry.service';
+import type { AuthService } from '../auth/auth.service';
+import type { AuditService } from '../audit/audit.service';
+
+// The request-handling path news up an McpServer + StreamableHTTPServerTransport per POST. Both SDK
+// classes are mocked so tests can observe the per-request transport (handleRequest args) and invoke
+// the registered tool callbacks exactly as the SDK would — no sockets, no MCP protocol traffic.
+// The closures dereference the mock handles lazily, so the factories stay valid before module init.
+type ToolCallback = (input: Record<string, unknown>, extra: unknown) => Promise<unknown>;
+const mockRegisteredTools: Array<{ name: string; callback: ToolCallback }> = [];
+const mockServerConnect = jest.fn<Promise<void>, unknown[]>();
+const mockServerClose = jest.fn<Promise<void>, unknown[]>();
+jest.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+  McpServer: jest.fn().mockImplementation(() => ({
+    registerTool: (
+      name: string,
+      _config: unknown,
+      callback: (input: Record<string, unknown>, extra: unknown) => Promise<unknown>,
+    ) => {
+      mockRegisteredTools.push({ name, callback });
+    },
+    connect: (...args: unknown[]) => mockServerConnect(...args),
+    close: () => mockServerClose(),
+  })),
+}));
+
+const mockHandleRequest = jest.fn<Promise<void>, unknown[]>();
+const mockTransportClose = jest.fn<Promise<void>, unknown[]>();
+jest.mock('@modelcontextprotocol/sdk/server/streamableHttp.js', () => ({
+  StreamableHTTPServerTransport: jest.fn().mockImplementation(() => ({
+    handleRequest: (...args: unknown[]) => mockHandleRequest(...args),
+    close: () => mockTransportClose(),
+  })),
+}));
 
 describe('resolveMcpReadOnly (secure-by-default MCP read-only flag)', () => {
   const prev = process.env.MCP_READONLY;
@@ -133,5 +169,183 @@ describe('auditMcpAuthFailure (MCP auth-failure audit trail, mirrors REST ApiKey
     // a non-401/403 throw to confirm the success-equivalent (no auth failure) is not audited.
     auditMcpAuthFailure(auditService, new BadRequestException('not an auth failure'), reqContext);
     expect(auditService.logWarn).not.toHaveBeenCalled();
+  });
+});
+
+// mountMcpServer is raw Express: every POST builds a fresh McpServer + transport and dispatches via
+// transport.handleRequest(req, res, req.body). These tests drive that route handler directly with
+// mock req/res. Auth is NOT a mount gate — it runs per tool call inside invokeTool (via the callback
+// registered with the per-request server), so a bad key is refused as a tool error result during the
+// dispatch, not as a rejected POST: transport.handleRequest is always reached once the IP throttle
+// and body parser have passed the request through.
+// mcp.module.ts is pure Nest wiring (module registration + the raw-Express mount call), stays at 0%
+// coverage, and is intentionally not a target.
+describe('mountMcpServer (raw-Express request-handling path)', () => {
+  const prevTrustedProxies = process.env.TRUSTED_PROXIES;
+
+  beforeEach(() => {
+    delete process.env.TRUSTED_PROXIES; // resolveClientIp then uses the socket IP, deterministically
+    mockRegisteredTools.length = 0;
+    mockServerConnect.mockReset().mockResolvedValue(undefined);
+    mockServerClose.mockReset().mockResolvedValue(undefined);
+    mockHandleRequest.mockReset().mockResolvedValue(undefined);
+    mockTransportClose.mockReset().mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    if (prevTrustedProxies === undefined) delete process.env.TRUSTED_PROXIES;
+    else process.env.TRUSTED_PROXIES = prevTrustedProxies;
+  });
+
+  interface Harness {
+    routeHandler: (req: Request, res: Response) => Promise<void>;
+    tool: AnyToolDescriptor;
+    authService: { validateApiKey: jest.Mock; hasPermission: jest.Mock };
+    auditService: { logWarn: jest.Mock };
+  }
+
+  const mount = (): Harness => {
+    const tool = {
+      name: 'MessageSendText',
+      description: 'Send a text message (session-scoped write tool)',
+      inputSchema: z.object({ sessionId: z.string(), to: z.string(), text: z.string() }),
+      tier: 'write',
+      sessionScoped: true,
+      handler: jest.fn().mockResolvedValue({ sent: true }),
+    } as unknown as AnyToolDescriptor;
+    const registry = { list: jest.fn(() => [tool]) };
+    const authService = { validateApiKey: jest.fn(), hasPermission: jest.fn(() => true) };
+    const auditService = { logWarn: jest.fn() };
+    let routeHandlers: unknown[] = [];
+    const adapter = {
+      post: jest.fn((_path: string, ...handlers: unknown[]) => {
+        routeHandlers = handlers;
+      }),
+    };
+    mountMcpServer(
+      adapter as unknown as Parameters<typeof mountMcpServer>[0],
+      registry as unknown as ToolRegistryService,
+      authService as unknown as AuthService,
+      new KeyRateLimiter(1000, 60_000),
+      new KeyRateLimiter(1000, 60_000),
+      { readOnly: false },
+      auditService as unknown as AuditService,
+    );
+    // adapter.post received [createIpThrottle(...), express.json(...), mcpHandler]; the tests drive
+    // the terminal handler directly with a pre-parsed body, as the file's middleware harness does.
+    const routeHandler = routeHandlers[routeHandlers.length - 1] as Harness['routeHandler'];
+    return { routeHandler, tool, authService, auditService };
+  };
+
+  type ResMock = { on: jest.Mock; status: jest.Mock; json: jest.Mock; headersSent: boolean };
+  const makeRes = (): ResMock => {
+    const res: ResMock = { on: jest.fn(), status: jest.fn(), json: jest.fn(), headersSent: false };
+    res.status.mockReturnValue(res);
+    res.json.mockReturnValue(res);
+    return res;
+  };
+
+  const post = async (
+    h: Harness,
+    body: unknown,
+    headers: Record<string, string> = {},
+  ): Promise<{ req: Request; res: ResMock }> => {
+    const req = {
+      method: 'POST',
+      path: '/mcp',
+      headers,
+      body,
+      socket: { remoteAddress: '203.0.113.7' },
+    } as unknown as Request;
+    const res = makeRes();
+    await h.routeHandler(req, res as unknown as Response);
+    return { req, res };
+  };
+
+  // The single registered tool callback, captured when the driven POST built its per-request server.
+  const toolCallback = (): ToolCallback => {
+    expect(mockRegisteredTools).toHaveLength(1);
+    return mockRegisteredTools[0].callback;
+  };
+
+  it('dispatches the request to transport.handleRequest with the parsed body', async () => {
+    const h = mount();
+    const body = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'MessageSendText', arguments: { sessionId: 's1', to: '123', text: 'hi' } },
+    };
+    const { req, res } = await post(h, body, { 'x-api-key': 'good-key' });
+
+    expect(mockServerConnect).toHaveBeenCalledTimes(1); // fresh server+transport wired per request
+    expect(mockHandleRequest).toHaveBeenCalledWith(req, res, body);
+    expect(res.on).toHaveBeenCalledWith('close', expect.any(Function)); // per-request teardown wired
+    expect(res.status).not.toHaveBeenCalled(); // no error fallback
+  });
+
+  it('refuses an invalid API key inside the dispatch: tool error result, tool handler never runs', async () => {
+    const h = mount();
+    h.authService.validateApiKey.mockRejectedValue(new UnauthorizedException('API key is invalid'));
+    await post(h, { jsonrpc: '2.0', id: 1 }, { 'x-api-key': 'bad-key' });
+
+    // Invoke the registered tool callback exactly as the SDK would while handling a tools/call.
+    const result = (await toolCallback()(
+      { sessionId: 's1', to: '123', text: 'hi' },
+      { requestInfo: { headers: { 'x-api-key': 'bad-key' } } },
+    )) as { isError?: boolean; content: Array<{ text: string }> };
+
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text)).toMatchObject({
+      success: false,
+      name: 'UnauthorizedException',
+      message: 'API key is invalid',
+    });
+    expect(h.authService.validateApiKey).toHaveBeenCalledWith('bad-key', undefined, 's1');
+    expect(h.tool.handler).not.toHaveBeenCalled(); // refused before the tool runs
+    // ...and the auth failure hits the audit trail with the real request context (mirrors REST).
+    expect(h.auditService.logWarn).toHaveBeenCalledWith(
+      AuditAction.API_KEY_AUTH_FAILED,
+      expect.objectContaining({
+        ipAddress: '203.0.113.7',
+        method: 'POST',
+        path: '/mcp',
+        errorMessage: 'API key is invalid',
+      }),
+    );
+  });
+
+  it('fails closed on a session-scoped tool call without sessionId (guard fires before the auth lookup)', async () => {
+    const h = mount();
+    await post(h, { jsonrpc: '2.0', id: 1 }, { authorization: 'Bearer good-key' });
+
+    const result = (await toolCallback()(
+      { to: '123', text: 'hi' }, // no sessionId
+      { requestInfo: { headers: { authorization: 'Bearer good-key' } } },
+    )) as { isError?: boolean; content: Array<{ text: string }> };
+
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text)).toMatchObject({
+      success: false,
+      message: 'sessionId is required for this tool',
+    });
+    // Fenced at the runtime boundary before the auth DB lookup, so a session-restricted key can
+    // never ride an undefined scope past validateApiKey's allowedSessions check.
+    expect(h.authService.validateApiKey).not.toHaveBeenCalled();
+    expect(h.tool.handler).not.toHaveBeenCalled();
+    expect(h.auditService.logWarn).not.toHaveBeenCalled(); // 400 parity with REST: not an auth failure
+  });
+
+  it('answers a JSON-RPC 500 when the transport throws', async () => {
+    const h = mount();
+    mockHandleRequest.mockRejectedValueOnce(new Error('boom'));
+    const { res } = await post(h, { jsonrpc: '2.0', id: 1 });
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      jsonrpc: '2.0',
+      error: { code: -32603, message: 'Internal server error' },
+      id: null,
+    });
   });
 });

--- a/src/modules/template/template.controller.spec.ts
+++ b/src/modules/template/template.controller.spec.ts
@@ -1,0 +1,47 @@
+import { TemplateController } from './template.controller';
+import { TemplateService } from './template.service';
+
+describe('TemplateController', () => {
+  const service = {
+    create: jest.fn(),
+    findBySession: jest.fn(),
+    findOne: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  };
+  const controller = new TemplateController(service as unknown as TemplateService);
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('create delegates with the session id and DTO', async () => {
+    const dto = { name: 'welcome', content: 'Hi {{name}}' };
+    service.create.mockResolvedValue({ id: 't1' });
+    await controller.create('s1', dto as never);
+    expect(service.create).toHaveBeenCalledWith('s1', dto);
+  });
+
+  it('findBySession delegates', async () => {
+    service.findBySession.mockResolvedValue([]);
+    await controller.findBySession('s1');
+    expect(service.findBySession).toHaveBeenCalledWith('s1');
+  });
+
+  it('findOne delegates with session + id', async () => {
+    service.findOne.mockResolvedValue({ id: 't1' });
+    await controller.findOne('s1', 't1');
+    expect(service.findOne).toHaveBeenCalledWith('s1', 't1');
+  });
+
+  it('update delegates with session, id and DTO', async () => {
+    const dto = { content: 'bye' };
+    service.update.mockResolvedValue({ id: 't1' });
+    await controller.update('s1', 't1', dto as never);
+    expect(service.update).toHaveBeenCalledWith('s1', 't1', dto);
+  });
+
+  it('delete delegates and resolves void', async () => {
+    service.delete.mockResolvedValue(undefined);
+    await expect(controller.delete('s1', 't1')).resolves.toBeUndefined();
+    expect(service.delete).toHaveBeenCalledWith('s1', 't1');
+  });
+});


### PR DESCRIPTION
## Summary

Five backend directories sat far below the rest of the codebase with ratchet thresholds that had fossilized well under their actual coverage (e.g. `contact` branches gated at 25%, `docker` at 26%, `mcp` at 33%, `agent-tools` functions at 32%), letting those modules regress without tripping CI. This branch locks the measured baseline first, then raises each module with real tests — every threshold now sits 1 point below its measured coverage, and `docs/09-testing-strategy.md` §9.5 stays in lockstep (enforced by `docs-coverage-policy.spec.ts`).

No production code changes.

## Measured coverage (lines, before → after)

| Directory | Before | After | New floor (B/F/L/S) |
|---|---|---|---|
| `src/modules/contact` | 52.0% | 90.8% | 79/90/89/88 |
| `src/modules/docker` | 42.8% | 97.9% | 88/99/96/96 |
| `src/modules/mcp` | 55.6% | 79.7% | 62/81/78/78 |
| `src/core/agent-tools` | 60.1% (functions 41.9%) | 84.8% (functions 88.4%) | 88/87/83/83 |
| `src/modules/template` | 75.5% | 93.4% | 77/99/92/89 |

## What changed

- **`contact`**: new `contact.controller.spec.ts` — all 10 handlers (query parsing, CSV id handling, exists-mapping, DTO forwarding, success bodies). The controller was at 0%.
- **`template`**: new `template.controller.spec.ts` — all 5 delegation handlers. The controller was at 0%.
- **`agent-tools`**: new specs for message/contact/session tools + extended group tools — all 37 tool `execute()` handlers driven through the real `invokeTool` path (auth → zod → handler), asserting service delegation and output mapping.
- **`docker`**: extended `docker.service.spec.ts` to every public method (orchestration paths, daemon-failure → `false`, socket-absent init), plus `isDockerAvailable`. Hermetic: dockerode mocked throughout.
- **`mcp`**: extended `mcp.server.spec.ts` — request-dispatch auth behavior (refusal is per-tool-call inside `invokeTool`, not a mount gate; asserted at that real boundary), valid-key dispatch, session-scoped fail-closed, transport-error render. `mcp.module.ts` (pure wiring) stays excluded, documented in the spec.
- **Docs**: §9.5 threshold rows updated per module in the same commits; prose corrected to match the new floor margin.

Module/wiring files (`*.module.ts`) are deliberately excluded from the new targets — noted in the spec headers.

## Verification

- `npm test -- --coverage` — 285 suites, 4906 tests passing, zero threshold violations
- `npm run lint` and `npx tsc --noEmit -p tsconfig.json` — clean
- Every threshold verified arithmetically: never lowered, always ≤ floor(measured) − 1