### PR TITLE
test(coverage): restore the floor-calibration note and ratchet two stale scopes

### DIFF
--- a/docs/09-testing-strategy.md
+++ b/docs/09-testing-strategy.md
@@ -214,7 +214,7 @@ authoritative gate. Current policy:
 | `src/modules/template/`     | 77%      | 99%       | 92%   | 89%        |
 | `src/modules/webhook/`      | 72%      | 89%       | 90%   | 87%        |
 
-Each floor sits a point or two below that scope's measured coverage, so it catches a real
+Set each floor about five points below that scope's measured coverage, so it catches a real
 regression without failing on ordinary churn. Raise a floor when coverage rises; never lower one.
 
 Two behaviours of Jest's threshold matching are worth knowing before adding a scope:

--- a/docs/09-testing-strategy.md
+++ b/docs/09-testing-strategy.md
@@ -192,7 +192,7 @@ authoritative gate. Current policy:
 | `src/engine/identity/`      | 85%      | 95%       | 94%   | 93%        |
 | `src/modules/audit/`        | 59%      | 45%       | 72%   | 68%        |
 | `src/modules/auth/`         | 75%      | 85%       | 86%   | 85%        |
-| `src/modules/automation/`   | 60%      | 55%       | 75%   | 70%        |
+| `src/modules/automation/`   | 67%      | 57%       | 83%   | 79%        |
 | `src/modules/chat-media/`   | 78%      | 81%       | 92%   | 90%        |
 | `src/modules/contact/`      | 79%      | 90%       | 89%   | 88%        |
 | `src/modules/docker/`       | 88%      | 99%       | 96%   | 96%        |
@@ -210,7 +210,7 @@ authoritative gate. Current policy:
 | `src/modules/session/`      | 75%      | 79%       | 88%   | 87%        |
 | `src/modules/stats/`        | 67%      | 63%       | 71%   | 69%        |
 | `src/modules/status-store/` | 79%      | 83%       | 92%   | 91%        |
-| `src/modules/status/`       | 47%      | 45%       | 62%   | 60%        |
+| `src/modules/status/`       | 70%      | 58%       | 79%   | 78%        |
 | `src/modules/template/`     | 77%      | 99%       | 92%   | 89%        |
 | `src/modules/webhook/`      | 72%      | 89%       | 90%   | 87%        |
 

--- a/package.json
+++ b/package.json
@@ -253,10 +253,10 @@
         "statements": 85
       },
       "./src/modules/automation/": {
-        "branches": 60,
-        "functions": 55,
-        "lines": 75,
-        "statements": 70
+        "branches": 67,
+        "functions": 57,
+        "lines": 83,
+        "statements": 79
       },
       "./src/modules/chat-media/": {
         "branches": 78,
@@ -361,10 +361,10 @@
         "statements": 91
       },
       "./src/modules/status/": {
-        "branches": 47,
-        "functions": 45,
-        "lines": 62,
-        "statements": 60
+        "branches": 70,
+        "functions": 58,
+        "lines": 79,
+        "statements": 78
       },
       "./src/modules/template/": {
         "branches": 77,


### PR DESCRIPTION
§9.5 of the testing-strategy document closes with a sentence describing how far each coverage floor sits below its scope's measured coverage. #1100 rewrote that sentence to "a point or two below" after tightening five scopes to roughly that margin. The sentence generalises over all thirty-five scopes, though, and measured against the merged tree it holds for seven of them.

The wording is now an instruction rather than a description. A sentence stating where floors currently sit is a claim about a distribution that changes every time any scope is ratcheted, so it is guaranteed to go stale; a sentence stating how to calibrate a new floor stays correct regardless of where the existing ones happen to be.

Two floors were also raised to match the rule the sentence now states. Both had drifted far enough below measured coverage that neither could fail on a realistic regression:

| Scope | Floor | Measured | Now |
|---|---|---|---|
| `src/modules/status/` | 47 / 45 / 62 / 60 | 75.3 / 62.9 / 83.6 / 83.3 | 70 / 58 / 79 / 78 |
| `src/modules/automation/` | 60 / 55 / 75 / 70 | 72.0 / 61.9 / 87.9 / 84.5 | 67 / 57 / 83 / 79 |

Order is branches / functions / lines / statements.

Eight further scopes sit six to ten points above their floor. They remain within the rule and are deliberately left alone — moving them would make this a second ratcheting pass rather than a correction.

No production code changes. The floors and the §9.5 table are kept in agreement by the existing gate in `src/common/docs-coverage-policy.spec.ts`, which compares them in both directions; changing the config alone makes it fail, which is how the table edit was driven. Both raised floors were confirmed enforced by setting one a point above its measured value and watching the suite reject it at 75.29% against a 76% threshold.
