### PR TITLE
fix(infra): carry a session lease across an import by its remaining time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A long data import no longer expires the session claims it restores** — the ownership lease was written back with its original deadline, so a restore that ran longer than the lease had left committed an expiry that had already passed while the owning node was still recorded and still running the engine.
 - **A refused data import no longer offers a retry that stops live engines** — the one refusal whose retry is destructive now carries `IMPORT_WOULD_ORPHAN_ENGINES` and the dashboard matches it positively, so a refusal that only asks the operator to wait can no longer present a confirm whose OK re-runs the replace-all with `stopOrphans=true`.
 - **A data import is refused with `409` when another transaction holds the connection** — on SQLite it would otherwise nest inside that transaction and commit into it rather than to disk, so a restore reported as successful could vanish with that transaction's rollback.
 - **A second data import while one is running is now refused with `409`** — on SQLite both shared a single transaction, so the second one's rollback discarded a restore the first had already reported as successful.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **A long data import no longer expires the session claims it restores** — the ownership lease was written back with its original deadline, so a restore that ran longer than the lease had left committed an expiry that had already passed while the owning node was still recorded and still running the engine.
+- **A data import now carries each session's ownership lease by its remaining time instead of its original deadline** — a restore re-applied the deadline unchanged, so one that ran longer than a claim had left committed that claim as expired, including claims held by other nodes whose engines never stopped.
 - **A refused data import no longer offers a retry that stops live engines** — the one refusal whose retry is destructive now carries `IMPORT_WOULD_ORPHAN_ENGINES` and the dashboard matches it positively, so a refusal that only asks the operator to wait can no longer present a confirm whose OK re-runs the replace-all with `stopOrphans=true`.
 - **A data import is refused with `409` when another transaction holds the connection** — on SQLite it would otherwise nest inside that transaction and commit into it rather than to disk, so a restore reported as successful could vanish with that transaction's rollback.
 - **A second data import while one is running is now refused with `409`** — on SQLite both shared a single transaction, so the second one's rollback discarded a restore the first had already reported as successful.

--- a/src/modules/infra/infra-data.controller.spec.ts
+++ b/src/modules/infra/infra-data.controller.spec.ts
@@ -122,11 +122,19 @@ describe('InfraDataController.importData round-trips export-data (no silent mess
     expect(new Date(restored.leaseExpiresAt as unknown as string).toISOString()).toBe(leaseExpiresAt.toISOString());
   });
 
-  it('carries a LIVE claim forward by its remaining time, not by its original expiry stamp', async () => {
+  it('carries LIVE claims forward by their remaining time, including a peer node’s', async () => {
     await seedSession('s1');
+    await seedSession('s2');
+    const dump = await controller.exportData();
+
+    // Seeded AFTER the export on purpose: the sessions importer writes 12 columns and none of them is
+    // ownership, so the dump cannot carry these values — and stamping them here keeps the assertion
+    // margin free of the export's cost. That margin is consumed by the import preamble and the
+    // commit, NOT by the stall below: a late timer moves the committed lease and `Date.now()` by the
+    // same amount, so lengthening the sleep buys nothing.
     const readAt = Date.now();
-    // A live claim whose remaining time the transaction below deliberately outlives. Scaled down from
-    // the real 60s TTL so the test costs a second, not a minute — the ordering is what matters.
+    // Scaled down from the real 60s TTL so the test costs a second, not a minute — the transaction
+    // outliving the remaining time is the property under test, not the size of either number.
     const remainingMs = 1_000;
     await ds.getRepository(Session).update(
       { id: 's1' },
@@ -137,7 +145,19 @@ describe('InfraDataController.importData round-trips export-data (no silent mess
         nodeUrl: 'http://10.0.0.5:2785',
       },
     );
-    const dump = await controller.exportData();
+    // A claim this node does NOT own. The import reads every row with a nodeId, so without the carry
+    // it commits a live peer's lease as expired — and `lapsedHeldByOthers` excludes only `nodeId =
+    // me`, so the importing node's own takeover sweep is what would then adopt a session whose engine
+    // never stopped on the peer.
+    await ds.getRepository(Session).update(
+      { id: 's2' },
+      {
+        nodeId: 'node-b',
+        claimedAt: new Date(readAt),
+        leaseExpiresAt: new Date(readAt + remainingMs * 2),
+        nodeUrl: 'http://10.0.0.9:2785',
+      },
+    );
 
     // Hold the transaction open past the original expiry, the way a large restore does. Re-binding
     // the stamp verbatim would then commit a lease this request already knows has expired: nodeId
@@ -162,14 +182,20 @@ describe('InfraDataController.importData round-trips export-data (no silent mess
     jest.restoreAllMocks();
     expect(res.imported).toBe(true);
 
-    const restored = await ds.getRepository(Session).findOneByOrFail({ id: 's1' });
-    const committed = new Date(restored.leaseExpiresAt as unknown as string).getTime();
-    expect(restored.nodeId).toBe('node-a');
-    // Still in the future: the claim was live when read, so it must be live when written back.
-    expect(committed).toBeGreaterThan(Date.now());
-    // Carried, not renewed: the remaining time is preserved rather than reset to a full TTL, so the
-    // restore cannot extend anyone's hold — least of all a peer's.
-    expect(committed).toBeLessThanOrEqual(Date.now() + remainingMs);
+    const own = await ds.getRepository(Session).findOneByOrFail({ id: 's1' });
+    const peer = await ds.getRepository(Session).findOneByOrFail({ id: 's2' });
+    const ownLease = new Date(own.leaseExpiresAt as unknown as string).getTime();
+    const peerLease = new Date(peer.leaseExpiresAt as unknown as string).getTime();
+
+    expect(own.nodeId).toBe('node-a');
+    expect(peer.nodeId).toBe('node-b');
+    // Both still in the future: they were live when read, so they must be live when written back.
+    expect(ownLease).toBeGreaterThan(Date.now());
+    expect(peerLease).toBeGreaterThan(Date.now());
+    // Carried, not renewed: each keeps its OWN remaining time rather than being reset to a full TTL,
+    // so the restore extends nobody's hold and the two do not collapse onto the same deadline.
+    expect(ownLease).toBeLessThanOrEqual(Date.now() + remainingMs);
+    expect(peerLease).toBeGreaterThan(ownLease);
   });
 
   it('holds the ownership loss-detection token for the whole transaction, and releases it', async () => {

--- a/src/modules/infra/infra-data.controller.spec.ts
+++ b/src/modules/infra/infra-data.controller.spec.ts
@@ -90,8 +90,12 @@ describe('InfraDataController.importData round-trips export-data (no silent mess
 
   it('keeps the session ownership lease across a replace, and never takes it from the payload', async () => {
     await seedSession('s1');
-    const claimedAt = new Date('2026-08-06T10:00:00.000Z');
-    const leaseExpiresAt = new Date('2026-08-06T10:05:00.000Z');
+    // Seeded far in the past ON PURPOSE, so the claim is unambiguously LAPSED whatever day the suite
+    // runs: a lapsed claim must survive verbatim, because shifting it would resurrect a dead node's
+    // hold on the session. (The previous fixture used a same-day stamp, so whether this exercised the
+    // lapsed or the live path depended on the wall clock.) The live path is covered below.
+    const claimedAt = new Date('2020-01-01T10:00:00.000Z');
+    const leaseExpiresAt = new Date('2020-01-01T10:05:00.000Z');
     // A live claim held by THIS node, exactly as SessionOwnershipService would have written it.
     await ds
       .getRepository(Session)
@@ -116,6 +120,56 @@ describe('InfraDataController.importData round-trips export-data (no silent mess
     expect(restored.nodeUrl).toBe('http://10.0.0.5:2785');
     expect(new Date(restored.claimedAt as unknown as string).toISOString()).toBe(claimedAt.toISOString());
     expect(new Date(restored.leaseExpiresAt as unknown as string).toISOString()).toBe(leaseExpiresAt.toISOString());
+  });
+
+  it('carries a LIVE claim forward by its remaining time, not by its original expiry stamp', async () => {
+    await seedSession('s1');
+    const readAt = Date.now();
+    // A live claim whose remaining time the transaction below deliberately outlives. Scaled down from
+    // the real 60s TTL so the test costs a second, not a minute — the ordering is what matters.
+    const remainingMs = 1_000;
+    await ds.getRepository(Session).update(
+      { id: 's1' },
+      {
+        nodeId: 'node-a',
+        claimedAt: new Date(readAt),
+        leaseExpiresAt: new Date(readAt + remainingMs),
+        nodeUrl: 'http://10.0.0.5:2785',
+      },
+    );
+    const dump = await controller.exportData();
+
+    // Hold the transaction open past the original expiry, the way a large restore does. Re-binding
+    // the stamp verbatim would then commit a lease this request already knows has expired: nodeId
+    // still names the live owner, so the row reads as an adoptable orphan to a peer's takeover sweep
+    // — a lapse manufactured by the restore, on a claim it observed live moments earlier.
+    const realCreate = ds.createQueryRunner.bind(ds);
+    let stalled = false;
+    jest.spyOn(ds, 'createQueryRunner').mockImplementation(() => {
+      const runner = realCreate();
+      const realQuery = runner.query.bind(runner) as (...args: unknown[]) => Promise<unknown>;
+      runner.query = (async (...args: unknown[]): Promise<unknown> => {
+        if (!stalled && typeof args[0] === 'string' && args[0].startsWith('DELETE FROM sessions')) {
+          stalled = true;
+          await new Promise(resolve => setTimeout(resolve, remainingMs * 1.5));
+        }
+        return realQuery(...args);
+      }) as typeof runner.query;
+      return runner;
+    });
+
+    const res = await controller.importData({ tables: dump.tables });
+    jest.restoreAllMocks();
+    expect(res.imported).toBe(true);
+
+    const restored = await ds.getRepository(Session).findOneByOrFail({ id: 's1' });
+    const committed = new Date(restored.leaseExpiresAt as unknown as string).getTime();
+    expect(restored.nodeId).toBe('node-a');
+    // Still in the future: the claim was live when read, so it must be live when written back.
+    expect(committed).toBeGreaterThan(Date.now());
+    // Carried, not renewed: the remaining time is preserved rather than reset to a full TTL, so the
+    // restore cannot extend anyone's hold — least of all a peer's.
+    expect(committed).toBeLessThanOrEqual(Date.now() + remainingMs);
   });
 
   it('holds the ownership loss-detection token for the whole transaction, and releases it', async () => {
@@ -1495,9 +1549,9 @@ describe('restoreSessionOwnership', () => {
     // Swallowing it would be worse than the bug: on PostgreSQL a failed statement aborts the
     // transaction, so the COMMIT that followed would execute as a ROLLBACK and the endpoint would
     // report a fully discarded import as a success.
-    await expect(restoreSessionOwnership([claim], () => Promise.reject(new Error('db went away')))).rejects.toThrow(
-      'db went away',
-    );
+    await expect(
+      restoreSessionOwnership([claim], () => Promise.reject(new Error('db went away')), new Date()),
+    ).rejects.toThrow('db went away');
   });
 
   it('does nothing when there is no ownership to carry', async () => {
@@ -1507,8 +1561,8 @@ describe('restoreSessionOwnership', () => {
       return Promise.resolve();
     };
 
-    await restoreSessionOwnership(null, insert);
-    await restoreSessionOwnership([], insert);
+    await restoreSessionOwnership(null, insert, new Date());
+    await restoreSessionOwnership([], insert, new Date());
 
     expect(calls).toEqual([]);
   });
@@ -1522,12 +1576,54 @@ describe('restoreSessionOwnership', () => {
       return Promise.resolve();
     };
 
-    await restoreSessionOwnership([claim], insert);
+    await restoreSessionOwnership([claim], insert, new Date());
 
+    // 'l' is not a parseable deadline, so it is written back untouched: a value this function cannot
+    // interpret is not one it may rewrite.
     expect(bound).toEqual([['node-a', 'c', 'l', 'u', 's1']]);
     expect(statements[0]).toContain('UPDATE sessions SET "nodeId"');
     expect(statements[0]).toContain('"claimedAt"');
     expect(statements[0]).toContain('"leaseExpiresAt"');
     expect(statements[0]).toContain('"nodeUrl"');
+  });
+
+  // The lease is a DEADLINE, and the transaction re-applying it can outlive what the deadline has
+  // left. These three cases pin which way each kind of claim moves.
+  const bindLease = async (leaseExpiresAt: unknown, readAt: Date, now: Date): Promise<unknown> => {
+    const bound: unknown[][] = [];
+    await restoreSessionOwnership(
+      [{ id: 's1', nodeId: 'node-a', claimedAt: 'c', leaseExpiresAt, nodeUrl: 'u' }],
+      (_sql, params) => {
+        bound.push(params);
+        return Promise.resolve();
+      },
+      readAt,
+      now,
+    );
+    return bound[0][2];
+  };
+
+  it('carries a live claim by its remaining time, so a long import cannot expire it', async () => {
+    const readAt = new Date('2026-08-06T10:00:00.000Z');
+    const commitAt = new Date('2026-08-06T10:02:00.000Z'); // a two-minute restore
+    // 30s left when read → 30s left when written, not an expiry two minutes in the past.
+    expect(await bindLease('2026-08-06T10:00:30.000Z', readAt, commitAt)).toBe('2026-08-06T10:02:30.000Z');
+  });
+
+  it('leaves an already-lapsed claim exactly where it was, so a dead node stays dead', async () => {
+    const readAt = new Date('2026-08-06T10:00:00.000Z');
+    const commitAt = new Date('2026-08-06T10:02:00.000Z');
+    // Shifting this one would resurrect a crashed peer's hold on the session.
+    expect(await bindLease('2026-08-06T09:59:00.000Z', readAt, commitAt)).toBe('2026-08-06T09:59:00.000Z');
+  });
+
+  it('preserves the stored shape — Date in, Date out (Postgres); text in, text out (SQLite)', async () => {
+    const readAt = new Date('2026-08-06T10:00:00.000Z');
+    const commitAt = new Date('2026-08-06T10:02:00.000Z');
+    const asDate = await bindLease(new Date('2026-08-06T10:00:30.000Z'), readAt, commitAt);
+    expect(asDate).toBeInstanceOf(Date);
+    expect((asDate as Date).toISOString()).toBe('2026-08-06T10:02:30.000Z');
+    expect(typeof (await bindLease('2026-08-06T10:00:30.000Z', readAt, commitAt))).toBe('string');
+    expect(await bindLease(null, readAt, commitAt)).toBeNull();
   });
 });

--- a/src/modules/infra/infra-data.controller.spec.ts
+++ b/src/modules/infra/infra-data.controller.spec.ts
@@ -1643,6 +1643,38 @@ describe('restoreSessionOwnership', () => {
     expect(await bindLease('2026-08-06T09:59:00.000Z', readAt, commitAt)).toBe('2026-08-06T09:59:00.000Z');
   });
 
+  it('refuses to carry text that is not the UTC form the writers emit', async () => {
+    const readAt = new Date('2026-08-06T10:00:00.000Z');
+    const commitAt = new Date('2026-08-06T10:02:00.000Z');
+    // `DateTransformer.to` and `leaseParam` both emit toISOString(), so a space-separated stamp can
+    // only come from somewhere that does not know this contract — e.g. a future migration DEFAULT of
+    // datetime('now'), the shape other columns in this repo already use. new Date() would read it as
+    // LOCAL time, and carrying it would write the host's UTC offset back into the column for good.
+    //
+    // Two days ahead, not seconds: parsed as local time this lands within ±14h of that instant, so it
+    // stays in the FUTURE under every timezone and would therefore be carried if the guard were gone.
+    // A near stamp would fall through to the already-lapsed branch on a positive-offset host and pass
+    // for the wrong reason — which is exactly what it did before this comment existed.
+    expect(await bindLease('2026-08-08 10:00:00', readAt, commitAt)).toBe('2026-08-08 10:00:00');
+  });
+
+  it('never carries a lease to an earlier instant than the one it read', async () => {
+    // A backward clock step between the read and the write-back. Without the clamp the carry would
+    // land before the original deadline — re-creating the expired-on-commit state it exists to avoid.
+    const readAt = new Date('2026-08-06T10:00:00.000Z');
+    const steppedBack = new Date('2026-08-06T09:58:00.000Z');
+    expect(await bindLease('2026-08-06T10:00:30.000Z', readAt, steppedBack)).toBe('2026-08-06T10:00:30.000Z');
+  });
+
+  it('falls back to the original value when the carry would overflow the Date range', async () => {
+    // A throw here would reach the caller's catch, which records a warning — and every claim after
+    // this row in the loop would silently never be re-applied.
+    const readAt = new Date('2026-08-06T10:00:00.000Z');
+    const commitAt = new Date('2026-08-06T10:02:00.000Z');
+    const nearMax = '+275760-09-13T00:00:00.000Z'; // the maximum representable Date
+    await expect(bindLease(nearMax, readAt, commitAt)).resolves.toBe(nearMax);
+  });
+
   it('preserves the stored shape — Date in, Date out (Postgres); text in, text out (SQLite)', async () => {
     const readAt = new Date('2026-08-06T10:00:00.000Z');
     const commitAt = new Date('2026-08-06T10:02:00.000Z');

--- a/src/modules/infra/infra-data.controller.ts
+++ b/src/modules/infra/infra-data.controller.ts
@@ -59,10 +59,37 @@ async function readSessionOwnership(queryRunner: QueryRunner): Promise<SessionOw
 }
 
 /**
- * Re-apply the claims verbatim for ids present in both the pre-import database and the restored set.
- * Values are re-bound exactly as they were read (ISO text on SQLite, Date on Postgres) rather than
- * reconstructed, and go through the caller's `insert` so the `$N`→`?` rewrite applies on SQLite. An
- * id the backup did not restore simply matches no row.
+ * Carry a lease across the transaction by its REMAINING time rather than its absolute stamp.
+ *
+ * The stamp is a deadline, and the transaction that re-applies it can run for longer than the
+ * deadline has left. Writing it back unchanged therefore commits an expiry this request already knows
+ * has passed, while `nodeId` still names the owner whose engine never stopped — a lapse manufactured
+ * by the restore, on a claim it observed live moments earlier.
+ *
+ * A claim that was ALREADY lapsed when read is re-bound untouched: shifting that one would resurrect
+ * a dead node's hold, which is the property the verbatim write was protecting. So is anything
+ * unparseable — a value this function does not understand is not one it should rewrite.
+ *
+ * The stored shape is preserved (ISO text on SQLite, Date on Postgres) because these values go back
+ * through raw SQL, bypassing the column transformer that would otherwise normalise them.
+ */
+function carryLease(raw: unknown, readAt: Date, now: Date): unknown {
+  // Only the two shapes these columns are actually stored in are interpreted; anything else is a
+  // value this function does not understand, and so not one it may rewrite.
+  if (!(raw instanceof Date) && typeof raw !== 'string') return raw;
+  const deadline = raw instanceof Date ? raw : new Date(raw);
+  const remainingMs = deadline.getTime() - readAt.getTime();
+  if (Number.isNaN(remainingMs) || remainingMs <= 0) return raw;
+  const carried = new Date(now.getTime() + remainingMs);
+  return raw instanceof Date ? carried : carried.toISOString();
+}
+
+/**
+ * Re-apply the claims for ids present in both the pre-import database and the restored set.
+ * `nodeId`/`claimedAt`/`nodeUrl` are re-bound exactly as they were read rather than reconstructed;
+ * only the lease deadline is carried forward (see {@link carryLease}). They go through the caller's
+ * `insert` so the `$N`→`?` rewrite applies on SQLite. An id the backup did not restore simply
+ * matches no row.
  *
  * Errors are NOT swallowed. On PostgreSQL a failed statement aborts the transaction, and the COMMIT
  * that followed would silently execute as a ROLLBACK — reporting a fully-discarded import as a
@@ -72,12 +99,14 @@ async function readSessionOwnership(queryRunner: QueryRunner): Promise<SessionOw
 export async function restoreSessionOwnership(
   preserved: SessionOwnershipRow[] | null,
   insert: (text: string, params: unknown[]) => Promise<unknown>,
+  readAt: Date,
+  now: Date = new Date(),
 ): Promise<void> {
   if (!preserved?.length) return;
   for (const row of preserved) {
     await insert(
       'UPDATE sessions SET "nodeId" = $1, "claimedAt" = $2, "leaseExpiresAt" = $3, "nodeUrl" = $4 WHERE id = $5',
-      [row.nodeId, row.claimedAt, row.leaseExpiresAt, row.nodeUrl, row.id],
+      [row.nodeId, row.claimedAt, carryLease(row.leaseExpiresAt, readAt, now), row.nodeUrl, row.id],
     );
   }
 }
@@ -567,6 +596,9 @@ export class InfraDataController {
         // deadlock on Postgres) and tolerate the columns being absent, so a database whose ownership
         // migration has been rolled back still imports.
         const preservedOwnership = await readSessionOwnership(queryRunner);
+        // Stamped AFTER the read, so the remaining lease time carried forward later is measured from
+        // the latest moment these values are known to have been true — never longer than they were.
+        const ownershipReadAt = new Date();
 
         await queryRunner.query('DELETE FROM sessions');
 
@@ -606,7 +638,7 @@ export class InfraDataController {
         // execute as a ROLLBACK and the endpoint would report a fully discarded import as a success,
         // with per-table counts, to an operator restoring after data loss.
         try {
-          await restoreSessionOwnership(preservedOwnership, insert);
+          await restoreSessionOwnership(preservedOwnership, insert, ownershipReadAt);
         } catch (error) {
           warnings.push(
             `Failed to restore session ownership: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/modules/infra/infra-data.controller.ts
+++ b/src/modules/infra/infra-data.controller.ts
@@ -72,15 +72,28 @@ async function readSessionOwnership(queryRunner: QueryRunner): Promise<SessionOw
  *
  * The stored shape is preserved (ISO text on SQLite, Date on Postgres) because these values go back
  * through raw SQL, bypassing the column transformer that would otherwise normalise them.
+ *
+ * Note the deliberate asymmetry with `claimedAt`, which stays verbatim because it is a historical
+ * fact. After a carry the pair therefore no longer spans a single TTL — `leaseExpiresAt - claimedAt`
+ * is the TTL plus the restore's duration — so it must not be used to derive a lease age.
  */
 function carryLease(raw: unknown, readAt: Date, now: Date): unknown {
-  // Only the two shapes these columns are actually stored in are interpreted; anything else is a
-  // value this function does not understand, and so not one it may rewrite.
+  // Only the two shapes these columns are actually stored in are interpreted, and for text only the
+  // UTC form the two writers emit (`DateTransformer.to` and `leaseParam`, both `toISOString()`).
+  // Anything else is left alone: rewriting a shape this function does not understand would be worse
+  // than not carrying it, because a local-time parse would bake the host's UTC offset into the
+  // column permanently — where the old verbatim write merely passed the odd value through.
   if (!(raw instanceof Date) && typeof raw !== 'string') return raw;
+  if (typeof raw === 'string' && !raw.endsWith('Z')) return raw;
   const deadline = raw instanceof Date ? raw : new Date(raw);
   const remainingMs = deadline.getTime() - readAt.getTime();
   if (Number.isNaN(remainingMs) || remainingMs <= 0) return raw;
-  const carried = new Date(now.getTime() + remainingMs);
+  // Never earlier than what was read: a backward clock step between the two stamps must not be able
+  // to commit an expiry sooner than the row already carried, which would re-create the very problem.
+  const carried = new Date(Math.max(now.getTime() + remainingMs, deadline.getTime()));
+  // A deadline that is representable but whose carry is not: fall back rather than throw, since the
+  // caller routes a throw into `warnings` and every later row in the loop would lose its claim.
+  if (!Number.isFinite(carried.getTime())) return raw;
   return raw instanceof Date ? carried : carried.toISOString();
 }
 


### PR DESCRIPTION
## Problem

A replace-all import preserves each session's ownership claim across the restore, re-binding the four columns exactly as they were read before the `DELETE`. For `nodeId`, `claimedAt` and `nodeUrl` that is right — they are facts, and re-deriving them from the payload is the anti-pattern the existing test guards against.

`leaseExpiresAt` is not a fact, it is a **deadline**, and the transaction re-applying it can run for longer than the deadline has left. When it does, the import commits an expiry it already knows has passed, while `nodeId` still names an owner whose engine never stopped.

The sharp part is whose claims those are. `readSessionOwnership` selects every row `WHERE "nodeId" IS NOT NULL` — **including claims held by other nodes**. So node A's import can commit node B's live lease as expired, and `lapsedHeldByOthers` excludes only `nodeId = me`, which means A's own takeover sweep is what then adopts a session whose engine is still running on B.

`docs/13` does describe a bounded overlap for a lapsed-then-adopted session ("a slow query is enough … bounded to roughly one heartbeat interval"), and the consequence here does fit that bound. But that paragraph is about a lease that genuinely went unrenewed on a healthy node, where the takeover is legitimate. It explains why an overlap is bounded; it does not license a third party manufacturing one.

The threshold is smaller than the surrounding comment implies: `leaseTtlMs - leaseHeartbeatMs`, so 40s of restore after the read at the defaults, with the importer inserting one row per awaited round-trip.

## Change

Carry the remaining time rather than the absolute stamp:

- **live when read** (30s left) → written with 30s left, wherever the commit lands;
- **already lapsed when read** → written verbatim. Shifting that one would resurrect a crashed node's hold, which is what the verbatim write was protecting;
- **text not in the UTC form the two writers emit** (`DateTransformer.to`, `leaseParam`) → verbatim. A non-ISO shape parses as *local* time, and where the old code passed it through byte-identical, carrying it would normalise the host's offset into the column permanently;
- **carry that overflows the Date range** → verbatim rather than throwing, since the caller turns a throw into a warning and every later row in the loop would lose its claim.

The carry is clamped so it can never precede the deadline it read — a backward clock step must not be able to commit an expiry earlier than the row already had.

## What this trades, stated rather than buried

The carried deadline is always later than the verbatim one, by the restore's duration. An owner that was alive at the read and died one second into a ten-minute restore therefore keeps a valid lease for up to a full TTL after commit, where the old code made that row instantly adoptable. That is the correct side to err on — the import cannot distinguish "dead" from "busy", and wrongly declaring a live claim dead is the failure with an engine on the other end of it — but it is a real change in failover latency for that case.

`claimedAt` deliberately stays verbatim (it is a historical fact), so after a carry the pair no longer spans a single TTL. Recorded in the docstring so nobody derives a lease age from it.

## Why here and not elsewhere

A post-commit `ownership.renew()` cannot cover this: it updates `WHERE id IN (live) AND nodeId = this.nodeId`, restricted to the in-memory `owned` set, so it structurally cannot touch a peer's claim — the case that matters most — and it would set a full TTL rather than carry what was left, extending a hold the restore has no business extending. Widening the sweep's grace only patches `lapsedHeldByOthers` and leaves `isHeldByOtherNode` (the stop/delete fence), the import's own orphan refusal and the proxy's `leaseLive` check all still reading the row as lapsed. The carry is the only point that holds every node's pre-DELETE claims and can preserve them without extending them.

## Tests

The end-to-end case holds the transaction open past a live claim's expiry and asserts both a claim owned by this node and one held by a **peer** come back in the future, each keeping its own remaining time. That also gives the multi-row loop its first coverage.

Mutation-verified, each mutation asserted present in the file before its run:

| Mutation | Result |
|---|---|
| `carryLease` writes the stamp verbatim | 3 of 51 fail |
| Drop the already-lapsed guard (would resurrect a dead node) | 2 of 51 fail |

Honest note on coverage: of the unit cases, only the live-carry one and the `Date`-branch shape leg discriminate against the old code. The lapsed-verbatim and null cases pass either way — they are non-regression guards, worth having, but not evidence the new behaviour is pinned.

The pre-existing lease test seeded a same-day stamp with no fake timers, so whether it exercised the lapsed or the live path depended on the wall clock the suite ran on — it would have failed under this change for any run before 10:05Z today. Re-seeded firmly in the past.

## Scope

Single node, the only supported topology (`replicas: 1 # MUST stay 1`), is unaffected: every reader of `leaseExpiresAt` either ORs in `nodeId = me` or excludes it before touching the lease.

## Gate

`format:check`, `lint`, `tsc --noEmit`, `openapi:check` (exit 0), `build`, `jest` (4929 passing), `test:e2e` (148 passing). Dashboard untouched.