### PR TITLE
test(auth): make the query-param session-scope guard see every handler

### DIFF
--- a/src/modules/auth/query-session-scope-coverage.spec.ts
+++ b/src/modules/auth/query-session-scope-coverage.spec.ts
@@ -11,14 +11,29 @@ import { readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 
 /**
+ * Match a 2-space-indented method declaration and capture its parameter list: `name( <params> )`
+ * followed by either a return type (`:`) or the body (`{`). Decorators (`@Get(...)`) start with `@`,
+ * so they are not matched as method names.
+ *
+ * The `{` alternative is load-bearing rather than cosmetic. Requiring a return type made the checker
+ * skip every handler declared without one — 83 of 181 at the time it was widened, so a clean result
+ * described less than half the surface it appeared to cover. The coverage test below now fails if
+ * that ever becomes true again.
+ *
+ * Returned fresh on each call: the `g` flag makes `lastIndex` stateful, so a shared instance would
+ * resume mid-source for the second caller.
+ */
+export function methodPattern(): RegExp {
+  return /^ {2}(?:async\s+)?([a-zA-Z0-9_]+)\s*\(([\s\S]*?)\)\s*[:{]/gm;
+}
+
+/**
  * Return the names of handlers in `source` that take a `sessionId` query param but do NOT inject
  * `@CurrentApiKey` in the same parameter list — i.e. that bypass the guard fence without re-scoping.
  */
 export function handlersMissingSessionScope(source: string): string[] {
   const offenders: string[] = [];
-  // Match a 2-space-indented method declaration and capture its parameter list: `name( <params> ):`.
-  // Decorators (`@Get(...)`) start with `@`, so they are not matched as method names.
-  const methodRe = /^ {2}(?:async\s+)?([a-zA-Z0-9_]+)\s*\(([\s\S]*?)\)\s*:/gm;
+  const methodRe = methodPattern();
   for (let m = methodRe.exec(source); m !== null; m = methodRe.exec(source)) {
     const [, name, params] = m;
     const takesSessionIdQuery = /@Query\(\s*['"]sessionId['"]\s*\)/.test(params);
@@ -52,6 +67,19 @@ describe('query-param sessionId endpoints are session-scoped', () => {
     expect(handlersMissingSessionScope(vulnerable)).toEqual(['findAll']);
   });
 
+  it('flags a vulnerable handler that declares no return type', () => {
+    // The guard is only worth what it can see. A handler written without an explicit return type is
+    // just as exposed, and for most of this file's life the checker skipped every one of them.
+    const vulnerable = `
+  async findAll(
+    @Query('sessionId') sessionId?: string,
+  ) {
+    return this.svc.findAll(sessionId);
+  }
+`;
+    expect(handlersMissingSessionScope(vulnerable)).toEqual(['findAll']);
+  });
+
   it('clears a handler that injects @CurrentApiKey alongside the query param', () => {
     const fixed = `
   async findAll(
@@ -62,6 +90,36 @@ describe('query-param sessionId endpoints are session-scoped', () => {
   }
 `;
     expect(handlersMissingSessionScope(fixed)).toEqual([]);
+  });
+
+  // A structural guard that silently stops covering things is worse than no guard, because the green
+  // result reads as "no endpoint leaks" rather than "no endpoint I looked at leaks". This pairs every
+  // HTTP-verb decorator with the method the checker would examine for it, and fails if any decorator
+  // has none — which is what a matcher that cannot parse a handler's shape looks like from outside.
+  it('examines every decorated handler, so a clean result means the whole surface', () => {
+    const modulesDir = join(__dirname, '..');
+    const blind: string[] = [];
+    let decorated = 0;
+    for (const file of listControllerFiles(modulesDir)) {
+      const source = readFileSync(file, 'utf8');
+      const decorators = [...source.matchAll(/^ {2}@(?:Get|Post|Put|Patch|Delete|All|Head|Options)\(/gm)];
+      const methods = [...source.matchAll(methodPattern())].map(m => m.index ?? 0);
+      for (let i = 0; i < decorators.length; i++) {
+        decorated++;
+        const from = decorators[i].index ?? 0;
+        const until = decorators[i + 1]?.index ?? Number.MAX_SAFE_INTEGER;
+        // The handler a decorator belongs to is the first method starting before the next decorator.
+        if (methods.some(at => at > from && at < until)) continue;
+        blind.push(
+          `${file.replace(/.*\/src\//, 'src/')} :: ${source
+            .slice(from, from + 40)
+            .split('\n')[0]
+            .trim()}`,
+        );
+      }
+    }
+    expect(decorated).toBeGreaterThan(100); // the count itself must not silently collapse to zero
+    expect(blind).toEqual([]);
   });
 
   it('no real controller takes @Query(sessionId) without scoping to the calling key', () => {


### PR DESCRIPTION
## Problem

`query-session-scope-coverage.spec.ts` is a structural guard against a cross-tenant scoping class of bug: the API-key guard resolves a scoped session id from **route params only**, so a handler taking `sessionId` as a **query** param bypasses that fence and must re-scope from the calling key itself. The spec fails if any controller handler takes `@Query('sessionId')` without also injecting `@CurrentApiKey`.

It matched a method declaration only when it was followed by an explicit return type:

```ts
/^ {2}(?:async\s+)?([a-zA-Z0-9_]+)\s*\(([\s\S]*?)\)\s*:/gm
```

Handlers written without one were skipped. Measured against the TypeScript AST rather than by inspection: **98 of 181 handlers were visible; 83 were not.** A green result described 54% of the surface while reading as though it covered all of it — which is the worse half of the problem, because the failure mode of a structural guard is silence.

The same pattern also captured the wrong parameter list for three handlers, two of them in the invisible set. A truncated capture is precisely the shape that would hide a `@Query`.

To be clear about the exposure: **no endpoint is currently leaking.** Only two handlers in the whole tree take `@Query('sessionId')`, both already scoped. What was broken is the guard's reach, not the scoping it guards.

## Change

Accept a body brace as well as a return type — `\)\s*[:{]`. Against the AST: 181 of 181 handlers visible, and the three parameter-capture mismatches gone. Zero handlers use a destructuring parameter, the one shape that would have made the widened pattern stop early.

Widening alone would not stop this recurring, so the spec now audits its own reach: a coverage test pairs every HTTP-verb decorator with the method the checker would examine for it, and fails if any decorator has none. Against the previous pattern it reports exactly the 83 blind handlers; against this one, zero. It also asserts the decorator count has not collapsed to zero, so the guard cannot pass by finding nothing at all.

The pattern is returned from a single function used by both the checker and the coverage test, so the test audits the matcher that actually runs rather than a copy that can drift from it.

## Tests

Two new cases, both confirmed failing against the old pattern and passing against the new one by reverting the pattern in place (the mutation was asserted present in the file before the run):

| Case | Old pattern | New pattern |
|---|---|---|
| flags a vulnerable handler declaring no return type | fails | passes |
| examines every decorated handler | fails (83 blind) | passes |

The existing self-check — that the checker can actually detect a leak — is unchanged and still the first thing the file asserts.

## Scope

Test-only; no `src/` behaviour changes, so no CHANGELOG entry (matching the convention of the last test-only change). `jest` 4934 passing, `test:e2e` 148 passing, `lint`, `tsc --noEmit`, `build` all clean.