### PR TITLE
feat(audit): record a WhatsApp-initiated unlink in the audit log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A WhatsApp-initiated unlink now leaves a durable audit record** — the disconnect reason previously reached only the log, the webhook and the socket, so once the process restarted an unlink was indistinguishable over the API from an ordinary network drop; transient drops stay unaudited, so a reconnect storm still writes nothing.
 - **The Go SDK has its first semantic version, `sdk/go/v0.2.0`** — until now the module proxy only served pseudo-versions, so callers could not pin a release at all.
 - **`rmyndharis-openwa` 0.2.0 on PyPI** — the first release through the trusted-publishing workflow, carrying everything the Python SDK gained since 0.1.0 in June.
 - **`rmyndharis/openwa` 0.2.0 on Packagist** — the first versioned PHP release since June; Composer users on a stable constraint were pinned to 0.1.0 while only `dev-main` moved.

--- a/src/modules/audit/intentionally-unemitted-actions.ts
+++ b/src/modules/audit/intentionally-unemitted-actions.ts
@@ -18,8 +18,6 @@ export const INTENTIONALLY_UNEMITTED_ACTIONS: Partial<Record<AuditAction, string
     'Not emitted: would fire on every authenticated request, which is too high-volume for the audit log. Authentication failures are audited (API_KEY_AUTH_FAILED); successful authentication is intentionally not.',
   [AuditAction.SESSION_CONNECTED]:
     'Not emitted: an engine-level lifecycle transition, redundant with sessions.status and the SessionEngineLifecycle lastDispatchedStatus map. User-initiated lifecycle (SESSION_STARTED / SESSION_STOPPED) is audited.',
-  [AuditAction.SESSION_DISCONNECTED]:
-    'Not emitted: an engine-level lifecycle transition, redundant with sessions.status and the SessionEngineLifecycle lastDispatchedStatus map; reconnect storms would flood the audit log.',
   [AuditAction.MESSAGE_SENT]:
     'Not emitted: per outbound message, fully redundant with the messages table, which persists every send with its outcome.',
   [AuditAction.MESSAGE_FAILED]:

--- a/src/modules/session/session-engine-lifecycle.service.ts
+++ b/src/modules/session/session-engine-lifecycle.service.ts
@@ -124,10 +124,15 @@ function isAuthTimeoutRejection(err: unknown): boolean {
  *
  * Deliberately not CONFLICT (another device took over, and takeover is recoverable), not
  * DEPRECATED_VERSION (our own client is too old), and not TIMEOUT (a fault, and the single most
- * common reconnect-storm reason). Mirrors how the whatsapp-web.js adapter classifies the same
- * states; the Baileys adapter reports its own logout through the same callback.
+ * common reconnect-storm reason). The first three mirror how the whatsapp-web.js adapter classifies
+ * the same states.
+ *
+ * BOTH engines are covered, and they spell it differently: `'logged out'` is the only reason the
+ * Baileys adapter ever passes to this callback, emitted for a WhatsApp-originated loggedOut (401)
+ * close — the same event, so it must audit the same way. Baileys' other two terminal closes (403
+ * forbidden, 440 connectionReplaced) report through onError instead and are not unlinks.
  */
-const TERMINAL_UNLINK_REASONS = new Set(['LOGOUT', 'UNPAIRED', 'UNPAIRED_IDLE']);
+const TERMINAL_UNLINK_REASONS = new Set(['LOGOUT', 'UNPAIRED', 'UNPAIRED_IDLE', 'logged out']);
 
 /**
  * Owns the live WhatsApp engines and every state machine around them: start/stop/logout/forceKill,

--- a/src/modules/session/session-engine-lifecycle.service.ts
+++ b/src/modules/session/session-engine-lifecycle.service.ts
@@ -117,6 +117,19 @@ function isAuthTimeoutRejection(err: unknown): boolean {
 }
 
 /**
+ * Disconnect reasons that mean WhatsApp revoked this device, as opposed to a link that merely
+ * dropped. Only these are audited (#1107): they are one-shot and terminal — no reconnect can
+ * restore the link, only a fresh QR can — so they cannot produce the per-attempt flood that keeps
+ * the rest of the disconnect transitions out of the audit log.
+ *
+ * Deliberately not CONFLICT (another device took over, and takeover is recoverable), not
+ * DEPRECATED_VERSION (our own client is too old), and not TIMEOUT (a fault, and the single most
+ * common reconnect-storm reason). Mirrors how the whatsapp-web.js adapter classifies the same
+ * states; the Baileys adapter reports its own logout through the same callback.
+ */
+const TERMINAL_UNLINK_REASONS = new Set(['LOGOUT', 'UNPAIRED', 'UNPAIRED_IDLE']);
+
+/**
  * Owns the live WhatsApp engines and every state machine around them: start/stop/logout/forceKill,
  * delete's engine retirement, reconnect backoff, engine-event wiring, and the credential-teardown /
  * initial-status fences that keep concurrent lifecycle actions serialized. SessionService keeps the
@@ -759,6 +772,21 @@ export class SessionEngineLifecycle {
       reason,
       action: 'disconnected',
     });
+
+    // #1107: everything else this method does with `reason` is ephemeral — a log line, a webhook, a
+    // socket emit, a plugin hook — and the only DB write below is the status. So once the process
+    // restarts, a WhatsApp unlink is indistinguishable over the API from a network drop: both read
+    // `disconnected` with a null `lastError`. Audit the unlinks, and only those. That is the same
+    // test SESSION_RESTRICTED already passes next door — rare, not reconnect noise, no other durable
+    // record — and it keeps the objection that keeps the rest unemitted intact, since a flapping
+    // connection retries with TIMEOUT/NAVIGATION and never with one of these.
+    if (TERMINAL_UNLINK_REASONS.has(reason)) {
+      void this.auditService?.logWarn(AuditAction.SESSION_DISCONNECTED, {
+        sessionId: id,
+        metadata: { reason },
+        errorMessage: `WhatsApp unlinked this device (${reason}); the session must be re-paired with a fresh QR`,
+      });
+    }
 
     void this.webhookService.dispatch(id, 'session.disconnected', { sessionId: id, reason });
     this.eventsGateway.emitSessionDisconnected(id, { reason });

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -2648,7 +2648,11 @@ describe('SessionService', () => {
       await new Promise(resolve => setImmediate(resolve));
     };
 
-    it.each(['LOGOUT', 'UNPAIRED', 'UNPAIRED_IDLE'])(
+    // 'logged out' is the Baileys spelling: baileys-lifecycle reports a WhatsApp-originated
+    // loggedOut (401) close through this same callback with that exact string, and it is the ONLY
+    // reason that adapter ever passes here. Without it the audit row would exist for whatsapp-web.js
+    // sessions and silently not for Baileys ones — the engine asymmetry this test exists to prevent.
+    it.each(['LOGOUT', 'UNPAIRED', 'UNPAIRED_IDLE', 'logged out'])(
       'writes a durable audit record for a terminal unlink (%s)',
       async reason => {
         const callbacks = await startAndCapture();

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -2637,6 +2637,82 @@ describe('SessionService', () => {
       expect(eventsGateway.emitSessionDisconnected).toHaveBeenCalledWith('sess-uuid-1', { reason: 'socket closed' });
     });
 
+    // #1107: the reason reaches the log, the webhook, the socket and the plugin hook, and stops
+    // there — the only DB write on this path is the status. So an operator reading the session
+    // afterwards cannot tell a WhatsApp unlink from a network drop: both are `disconnected` with a
+    // null `lastError`. An unlink is rare, is not reconnect noise, and has no other durable record,
+    // which is the same test that already earns SESSION_RESTRICTED its audit row.
+    const disconnectAndFlush = async (callbacks: EngineEventCallbacks, reason: string): Promise<void> => {
+      callbacks.onDisconnected?.(reason);
+      // The handler re-reads the session row before publishing, so the audit lands after the findOne.
+      await new Promise(resolve => setImmediate(resolve));
+    };
+
+    it.each(['LOGOUT', 'UNPAIRED', 'UNPAIRED_IDLE'])(
+      'writes a durable audit record for a terminal unlink (%s)',
+      async reason => {
+        const callbacks = await startAndCapture();
+        jest
+          .spyOn(lifecycle as unknown as { scheduleReconnect: (id: string, s: unknown) => void }, 'scheduleReconnect')
+          .mockImplementation(() => {});
+        auditService.logWarn.mockClear();
+
+        await disconnectAndFlush(callbacks, reason);
+
+        // Assert the call before destructuring it: an absent call would otherwise surface as an
+        // unreadable TypeError on the array pattern rather than as the missing audit row.
+        expect(auditService.logWarn).toHaveBeenCalledTimes(1);
+        const [action, context] = auditCall(auditService.logWarn);
+        expect(action).toBe('session_disconnected');
+        expect(context.sessionId).toBe('sess-uuid-1');
+        expect(context.metadata).toMatchObject({ reason });
+      },
+    );
+
+    // The reason this action was left unemitted until now: a flapping connection retries forever,
+    // and a row per attempt would bury the one that matters. Filtering to the unlinks keeps that
+    // objection answered — a storm is TIMEOUT/NAVIGATION, never LOGOUT.
+    it.each(['TIMEOUT', 'NAVIGATION', 'socket closed'])('does not audit a transient drop (%s)', async reason => {
+      const callbacks = await startAndCapture();
+      jest
+        .spyOn(lifecycle as unknown as { scheduleReconnect: (id: string, s: unknown) => void }, 'scheduleReconnect')
+        .mockImplementation(() => {});
+      auditService.logWarn.mockClear();
+
+      await disconnectAndFlush(callbacks, reason);
+
+      expect(auditService.logWarn).not.toHaveBeenCalled();
+    });
+
+    // The audit row is a disconnect side effect like the webhook and the socket emit, so it belongs
+    // behind the SAME post-await identity fence. Superseding before the call would only exercise the
+    // wiring's entry check, which would pass wherever the emit sat — so supersede the engine while
+    // the handler is parked on its session reload, the one window that discriminates the placement.
+    it('does not audit an unlink from an engine superseded during the async session reload', async () => {
+      const callbacks = await startAndCapture();
+      jest
+        .spyOn(lifecycle as unknown as { scheduleReconnect: (id: string, s: unknown) => void }, 'scheduleReconnect')
+        .mockImplementation(() => {});
+      let resolveReload!: (value: Session | null) => void;
+      (repository.findOne as jest.Mock).mockImplementation(
+        () =>
+          new Promise<Session | null>(resolve => {
+            resolveReload = resolve;
+          }),
+      );
+      auditService.logWarn.mockClear();
+
+      // Still the live owner here, so the handler proceeds past its entry fence and parks.
+      const handled = Promise.resolve(callbacks.onDisconnected?.('LOGOUT'));
+      enginesOf().set('sess-uuid-1', { marker: 'engine-B' });
+      await Promise.resolve();
+      await Promise.resolve();
+      resolveReload(createMockSession({ status: SessionStatus.READY }));
+      await handled;
+
+      expect(auditService.logWarn).not.toHaveBeenCalled();
+    });
+
     it('ignores onReady from an engine that was torn down (post-stop window)', async () => {
       const callbacks = await startAndCapture();
       enginesOf().delete('sess-uuid-1'); // stop()/forceKill() removes the engine from the live map


### PR DESCRIPTION
Closes #1107.

## Problem

The disconnect reason reaches the log line, the `session.disconnected` webhook, the socket emit and the `session:disconnected` plugin hook — and stops there. The only database write on that path is the status:

```ts
void this.updateStatus(id, SessionStatus.DISCONNECTED);   // status, and nothing else
```

So the information survives only for as long as someone is watching a live channel. After a restart, a device WhatsApp revoked is indistinguishable over the API from a link that merely dropped: both read `disconnected` with a null `lastError`, because `lastError` is transient by design and is withheld for any status other than `FAILED` or `ACTION_REQUIRED`.

That is the gap #1072 ran into — the reporter could not tell from their own session row whether WhatsApp had unlinked the device or they had simply stopped the process, and neither could we.

## Why this action was unemitted, and why that no longer applies

`SESSION_DISCONNECTED` was registered as deliberately never emitted, on the grounds that *reconnect storms would flood the audit log*. That objection is about volume, and it is answered by narrowing the emission rather than by staying silent:

```ts
const TERMINAL_UNLINK_REASONS = new Set(['LOGOUT', 'UNPAIRED', 'UNPAIRED_IDLE', 'logged out']);
```

These are one-shot and terminal — no reconnect can restore the link, only a fresh QR can — so they cannot produce a row per attempt. A flapping connection retries with `TIMEOUT` or `NAVIGATION` and never with one of these. `CONFLICT` (another device took over, and takeover is recoverable) and `DEPRECATED_VERSION` (our own client is too old) stay out; neither is an unlink.

This is the same test `SESSION_RESTRICTED` already passes at the adjacent call site — rare, not reconnect noise, and no other durable record — and it reuses the mechanism rather than adding one: no migration, no schema change, and no change to the session response contract. It is read through the existing endpoint:

```
GET /audit?action=session_disconnected&sessionId=<id>
```

## Both engines

The first three tokens are the whatsapp-web.js spelling. `'logged out'` is the Baileys one: its adapter reports a WhatsApp-originated `loggedOut` (401) close through this same callback with that exact string, and it is the only reason it ever passes here. Same event, so it audits the same way. Baileys' other two terminal closes (403 forbidden, 440 connectionReplaced) report through `onError` and are not unlinks, so they stay out.

This was missed in the first commit — the set covered one engine and silently not the other — and was caught reviewing the change against both adapters before merge.

## Placement

The row is written behind the **post-await identity fence**, alongside the webhook, the socket emit and the status write — not in the event wiring. An engine superseded while the handler is parked on its session reload must publish no side effects, and the audit row is one.

The registry entry is removed, as that file's own instructions require. The coverage gate is honest in both directions — it fails for an unemitted action with no entry, and for an entry whose action is in fact emitted — so it validates both halves of this change.

## Verification

Eight tests added, watched to fail first, then mutation-tested:

| Mutation | Result |
|---|---|
| Add `TIMEOUT` to the terminal set | transient-drop test red |
| Move the emit above the post-await fence | superseded-engine test red |
| Restore the registry entry while still emitting | audit coverage gate red |
| Drop the Baileys spelling from the set | Baileys unlink test red |

Backend gate green: lint, `format:check`, build, `tsc --noEmit`, 4940 unit tests, 148 e2e tests. The dashboard is untouched.

## Note for review

This adds a new audit action to a log operators may have retention policies around. It is bounded — at most one row per unlink, and an unlink already requires a human to re-scan a QR — but it is a new write path worth a second opinion on.

