### PR TITLE
fix(session): force-kill a wedged engine browser before the reconnect relaunch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A reconnect now force-kills a wedged browser before relaunching** — when a Chromium that stopped responding also refused to shut down, the automatic reconnect launched its replacement against the same browser profile while the old process could still be holding it, so the retry could fail on the very condition it was recovering from.
 - **A WhatsApp-initiated unlink now clears a session's stored credentials once rather than twice** — whatsapp-web.js can raise the logout event more than once for a single unlink and nothing deduplicated it, so the repeats raced each other and a still-open browser into the `ENOTEMPTY` failure the removal now carries the retry budget to survive.
 - **A reaction to a message the gateway never stored no longer vanishes** — the `message.reaction` webhook and the dashboard stream were both gated on the stored row, so a reaction to an ephemeral message, or to one that arrived before the session went live, was dropped with no error and no log.
 - **`MEDIA_DOWNLOAD_ENABLED` is now validated at boot** — it is read as "anything that is not `false`/`0`/`no`", so a typo left inbound media being decrypted and base64-inlined into every message row instead of disabling it. Only `true`/`false`/`1`/`0`/`yes`/`no` are accepted now, so a spelling like `on` that used to work will fail startup until it is changed.

--- a/src/modules/session/session-engine-lifecycle.service.ts
+++ b/src/modules/session/session-engine-lifecycle.service.ts
@@ -952,7 +952,14 @@ export class SessionEngineLifecycle {
       // (after 10s on a hang), so reconnection proceeds either way.
       const oldEngine = this.engines.get(id);
       if (oldEngine) {
-        await this.teardownEngineSafely(id, oldEngine, e => e.destroy(), 'destroy');
+        const destroyed = await this.teardownEngineSafely(id, oldEngine, e => e.destroy(), 'destroy');
+        if (!destroyed) {
+          // A timed-out destroy() leaves the wedged Chromium process alive (the raced promise never
+          // kills it — see start()'s catch), and this path relaunches on the SAME profile dir in the
+          // same tick. Escalate to a SIGKILL so the replacement browser can't collide with the
+          // orphan (#1081); bounded again by teardownEngineSafely, so it can't wedge a second time.
+          await this.teardownEngineSafely(id, oldEngine, e => e.forceDestroy(), 'force-destroy');
+        }
         this.engines.deleteIfLive(id, oldEngine);
       }
 

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -1277,6 +1277,38 @@ describe('SessionService', () => {
       expect(intern().engines.has('sess-uuid-1')).toBe(false);
       expect(mockEngine.forceDestroy).toHaveBeenCalled();
     });
+
+    it('executeReconnect escalates a timed-out destroy() to forceDestroy() before relaunching (a wedged Chromium must not survive into the relaunch)', async () => {
+      (repository.update as jest.Mock).mockResolvedValue({ affected: 1 });
+      (repository.findOne as jest.Mock).mockResolvedValue(createMockSession());
+      // Register the old engine the way a live session would have.
+      await intern().initializeEngine('sess-uuid-1', createMockSession());
+      const initCallsBeforeReconnect = mockEngine.initialize.mock.calls.length;
+      // The wedge: graceful destroy() never settles, so the teardown race can only time out.
+      mockEngine.destroy.mockReturnValue(new Promise<void>(() => undefined));
+
+      jest.useFakeTimers();
+      try {
+        const run = intern().executeReconnect('sess-uuid-1', createMockSession(), {
+          attempts: 1,
+          timer: null,
+          maxAttempts: 5,
+          baseDelay: 5000,
+        });
+        await jest.advanceTimersByTimeAsync(10_000); // the graceful-destroy teardown race is lost
+        await run;
+
+        // The wedged browser must be reaped before a replacement launches against the same profile
+        // dir — the invariant start()'s catch and the init-timeout path already enforce.
+        expect(mockEngine.forceDestroy).toHaveBeenCalledTimes(1);
+        expect(mockEngine.initialize.mock.calls.length).toBe(initCallsBeforeReconnect + 1); // relaunch happened
+        const killOrder = mockEngine.forceDestroy.mock.invocationCallOrder[0];
+        const relaunchOrder = mockEngine.initialize.mock.invocationCallOrder[initCallsBeforeReconnect];
+        expect(killOrder).toBeLessThan(relaunchOrder);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
   });
 
   // ── initializeEngine init-timeout race (#667 follow-up) ───────────
@@ -1777,7 +1809,12 @@ describe('SessionService', () => {
       try {
         const i = internals();
         // A wedged Chromium: destroy() never resolves — the exact condition that triggers a reconnect.
-        const stuck = { destroy: jest.fn(() => new Promise<void>(() => undefined)) };
+        // The timed-out destroy escalates to a SIGKILL before the relaunch, so the stuck engine needs
+        // the forceDestroy the real interface guarantees.
+        const stuck = {
+          destroy: jest.fn(() => new Promise<void>(() => undefined)),
+          forceDestroy: jest.fn().mockResolvedValue(undefined),
+        };
         i.engines.set('sess-uuid-1', stuck);
 
         const done = i.executeReconnect('sess-uuid-1', createMockSession(), reconnectState);


### PR DESCRIPTION
## Problem

When the automatic reconnect tears down the old engine, the graceful `destroy()` is raced against a 10s deadline (`teardownEngineSafely`) so a wedged Chromium cannot stall the reconnect forever. Losing that race, however, leaves the wedged browser process alive — the raced promise never kills the OS process — and `executeReconnect` proceeds to relaunch a replacement browser against the same profile directory in the same tick. The retry can then trip over the very state it is recovering from (a startup "Execution context was destroyed" is one signature of two browsers contending for one profile).

Every other path that anticipates a wedged browser already reaps it with `forceDestroy()` (SIGKILL): `start()`'s catch, the init-timeout path ("so a retry doesn't collide with an orphaned browser"), `delete()`, and reconnect-exhaustion. The pre-relaunch teardown in `executeReconnect` was the one exception — and the only one of those paths that immediately relaunches on the same profile.

Surfaced by the investigation in #1081, where the log shows the sequence directly: `engine.destroy() timed out` → immediate re-init → "Execution context was destroyed" → terminal `failed`.

## Fix

If the graceful `destroy()` teardown reports failure (timeout or rejection), escalate to a second bounded teardown with `forceDestroy()` before evicting the engine and re-initializing. `forceDestroy()` SIGKILLs that client's own Chromium child process directly and is a safe no-op when the process is already gone. The teardown-before-evict ordering is unchanged, and the escalation is itself time-bounded, so a hang cannot stall the reconnect a second time.

## Testing

- New spec: a hung `destroy()` must escalate to `forceDestroy()` **before** the relaunch — call order asserted via `invocationCallOrder`. Mutation-tested both ways: removing the escalation and moving it after the re-init each fail the spec.
- The existing "still re-initializes when the old engine destroy() hangs" spec keeps passing; its stuck-engine mock now carries the `forceDestroy` the real interface guarantees.
- Full gate: lint, build, `tsc --noEmit`, unit suite, e2e, dashboard build.

Refs #1081
