### PR TITLE
docs(troubleshooting): point the webhook diagnostic at the delivery-failure API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The API description now documents the two statuses middleware returns before routing** — `415` for a compressed request body and `503` with `Retry-After` when too much body data is already in flight, neither of which appeared anywhere in the OpenAPI document despite applying to every operation.
 - **The Helm chart now states the reason `replicaCount` must stay 1 that actually applies today** — the warning described two pods corrupting shared session auth, which a session lease and per-pod volumes already prevent, so an operator acting on it would mitigate the wrong thing.
 
+### Documentation
+
+- The webhook troubleshooting runbook told operators there was no webhook-delivery log API and to grep container logs instead; that was true when written but `GET /api/webhooks/delivery-failures` shipped four days later, so the one page reached when a webhook is silent denied the endpoint exists. It now carries the real call, names the fields that gate dispatch (`active`, `events`, `filters`), and notes that `lastTriggeredAt` is never set by the Test button.
+
 ## [0.14.4] - 2026-08-07
 
 ### Fixed

--- a/docs/12-troubleshooting-faq.md
+++ b/docs/12-troubleshooting-faq.md
@@ -713,11 +713,20 @@ curl -X POST http://localhost:2785/api/sessions/{id}/messages/send-image \
 **Diagnostic:**
 
 ```bash
-# Check webhook configuration
+# Check webhook configuration — `active` must be true, `events` must list the event (or "*"),
+# and `filters` must not exclude it. `lastTriggeredAt` stays null until a real 2xx delivery:
+# the Test button never sets it, so a green Test proves nothing about real events.
 curl -H "X-API-Key: $API_KEY" \
   http://localhost:2785/api/sessions/{sessionId}/webhooks
 
-# No webhook-delivery log API — check the server logs / audit trail instead
+# Abandoned deliveries, most recent first: those that exhausted every retry, plus those never
+# attempted at all (recorded with `attempts: 0`). Requires an ADMIN key — an OPERATOR key gets
+# a 403, which reads like the endpoint does not exist. Rows older than
+# WEBHOOK_FAILURE_RETENTION_DAYS (default 90) are pruned.
+curl -H "X-API-Key: $ADMIN_API_KEY" \
+  "http://localhost:2785/api/webhooks/delivery-failures?sessionId={sessionId}&limit=20"
+
+# Attempts still in flight (not yet exhausted) appear only in the server logs:
 docker compose logs openwa-api 2>&1 | grep -i webhook
 
 # Test webhook endpoint
@@ -727,6 +736,12 @@ curl -X POST http://your-webhook-url \
 ```
 
 **Solutions:**
+
+Read the two lists together before changing anything. A delivery-failure row carrying an HTTP
+`lastStatusCode` means the gateway delivered and your receiver rejected it — fix the receiver. An
+empty list with `lastTriggeredAt` still null means nothing has ever been delivered and nothing has
+permanently failed: the event either never matched this webhook (`active`, `events`, `filters`) or
+was never emitted for the session at all.
 
 Webhooks are rows created through the API — there is no webhook config file:
 


### PR DESCRIPTION
## Problem

`docs/12-troubleshooting-faq.md`, in **Issue: Webhook Not Receiving Messages**, told operators:

```bash
# No webhook-delivery log API — check the server logs / audit trail instead
```

That was accurate when written in `f96576aa` (25 Jun), which removed a documented-but-nonexistent
endpoint. `GET /api/webhooks/delivery-failures` then shipped in `5f5a6cdd` (#520, 29 Jun) — four days
later — and the sentence was never revisited.

The result is worse than a gap: the single page an operator reaches when a webhook is silent tells
them the diagnostic endpoint does not exist, so they stop looking. `docs/11-operational-runbooks.md`
has carried the correct call the whole time, which is where the replacement wording comes from.

## Changes

- Add the real `delivery-failures` call to the diagnostic block, carrying the caveats the operational
  runbook already proved out: rows cover retry-exhausted deliveries **and** those never attempted
  (`attempts: 0`), and rows older than `WEBHOOK_FAILURE_RETENTION_DAYS` (default 90) are pruned.
- Note that the endpoint is ADMIN-gated. An OPERATOR key gets a `403`, which is easy to misread as
  "the endpoint does not exist" — the same wrong conclusion the old line produced.
- Keep the log grep, rewritten as what it genuinely covers: attempts still in flight, which the
  dead-letter list does not record.
- Name the three fields that gate dispatch (`active`, `events`, `filters`) and point out that
  `lastTriggeredAt` is set only by a real 2xx delivery and never by the Test button.
- Add a short reading guide separating a row with an HTTP `lastStatusCode` (delivered, receiver
  rejected it) from an empty list (never dispatched) — two cases this section previously conflated.

## Verification

Every claim traced to source rather than carried over from the runbook:

| Claim | Source |
|---|---|
| Endpoint exists, ADMIN-gated, `sessionId`/`limit`/`offset` | `webhooks-list.controller.ts:14-19` |
| Retention default 90 days | `webhook.service.ts:159-160` |
| `attempts: 0` rows for never-attempted deliveries | `webhook.service.ts:466` |
| `lastStatusCode` is non-null only when an HTTP response returned | `record-delivery-failure.ts` — `/^HTTP (\d{3})\b/` |
| `active` / `events` / `filters` gate dispatch | `webhook.service.ts:436`, `:452` |
| `lastTriggeredAt` written only inside the 2xx branch | `webhook.service.ts:886` |
| Test never writes `lastTriggeredAt` | `webhook.service.ts:349-399` |

Docs-only; `npm run format` clean with no collateral reflow.