### PR TITLE
docs(n8n): flag the Baileys-only call outcomes and the test-URL trap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Documentation
 
 - The webhook troubleshooting runbook told operators there was no webhook-delivery log API and to grep container logs instead; that was true when written but `GET /api/webhooks/delivery-failures` shipped four days later, so the one page reached when a webhook is silent denied the endpoint exists. It now carries the real call, names the fields that gate dispatch (`active`, `events`, `filters`), and notes that `lastTriggeredAt` is never set by the Test button.
+- The n8n trigger event table advertised `call.accepted` / `call.rejected` / `call.missed` with no engine caveat, so a whatsapp-web.js user could build a missed-call workflow on events that engine never emits; they are now marked Baileys only, and the troubleshooting section names n8n's test-versus-production webhook URL, which silently delivers a single event and then stops.
 
 ## [0.14.4] - 2026-08-07
 

--- a/docs/22-n8n-integration.md
+++ b/docs/22-n8n-integration.md
@@ -90,11 +90,17 @@ Start workflows when WhatsApp events occur.
 | `session.reconnect_loop`                          | Every 5th consecutive reconnect attempt       | Stuck-session alerting                       |
 | `session.restriction`                             | WhatsApp restricted the account, or lifted it | Pausing outreach while an account is limited |
 | `presence.update`                                 | A watched chat's online/typing state changed  | Live agent hand-off, presence-aware routing  |
-| `call.accepted` / `call.rejected` / `call.missed` | A ringing call ended                          | Missed-call follow-up, call logging          |
+| `call.accepted` / `call.rejected` / `call.missed` | A ringing call ended — **Baileys only**       | Missed-call follow-up, call logging          |
 | `group.join`                                      | Participant(s) joined a group                 | Welcome messages                             |
 | `group.leave`                                     | Participant(s) left a group                   | Churn tracking                               |
 | `group.update`                                    | Group subject/description/settings changed    | Group administration                         |
 | `call.received`                                   | Incoming call started ringing                 | Auto-reject + auto-reply bots                |
+
+> [!NOTE]
+> The three call-outcome events fire on Baileys only. whatsapp-web.js hooks the call collection's
+> insert and sees no status at all, so it can report the ring but never how the call ended — a
+> workflow triggered on `call.missed` will simply never run on a whatsapp-web.js session.
+> `call.received` fires on both engines.
 
 #### How It Works
 
@@ -261,10 +267,20 @@ Always use the correct format for chat IDs:
 
 ### Trigger Not Receiving Events
 
-1. Check webhook was created in OpenWA dashboard
-2. Verify n8n webhook URL is accessible from OpenWA server
-3. Check firewall/proxy settings
-4. Ensure session is connected and active
+1. **Confirm you registered the production webhook URL, not the test one.** n8n gives every Webhook
+   node two URLs: a test URL (`https://your-n8n/webhook-test/…`) and a production URL
+   (`https://your-n8n/webhook/…`). The test URL is registered only while the editor is listening and
+   stops after a single request, so a workflow wired to it receives one event and then goes silent.
+   Activate the workflow and point OpenWA at the production URL.
+2. Check webhook was created in OpenWA dashboard
+3. Verify n8n webhook URL is accessible from OpenWA server
+4. Check firewall/proxy settings
+5. Ensure session is connected and active
+6. For a call-outcome trigger, confirm the session runs Baileys — see the note under the trigger
+   event table above
+7. Ask OpenWA which side dropped the event:
+   `GET /api/webhooks/delivery-failures?sessionId={sessionId}` (ADMIN key). A row means OpenWA
+   delivered and n8n rejected it; an empty list means the event never reached delivery at all
 
 ### Message Not Sending
 


### PR DESCRIPTION
## Problem

Two gaps on the n8n integration page, both of which present as "the integration is broken" rather
than as a documented limitation.

**1. The trigger event table promised events one engine never emits.**

`call.accepted` / `call.rejected` / `call.missed` were listed with the use case "Missed-call
follow-up, call logging" and no engine caveat. They are Baileys-only: `onCallOutcome` appears zero
times in `whatsapp-web-js.adapter.ts` and is invoked only at `baileys-events.ts:522`. whatsapp-web.js
patches the call collection's `set` and receives no status field at all, so it can report the ring
but never how the call ended.

`docs/06-api-specification.md` and `docs/12-troubleshooting-faq.md` both carry the **Baileys only**
marker for these three events. This page was the outlier, so a whatsapp-web.js user could build a
workflow on a trigger that can never fire and get no signal explaining why.

**2. The troubleshooting section omitted the most common n8n webhook mistake.**

n8n gives every Webhook node two URLs: a test URL (`/webhook-test/…`), registered only while the
editor is listening and deregistered after a single request, and a production URL (`/webhook/…`),
live while the workflow is active. A workflow left on the test URL receives one event — typically the
one triggered by a manual test — and then goes permanently silent.

The four existing checks (webhook created, URL reachable, firewall, session active) all pass in that
state, so the section led operators away from the actual cause.

## Changes

- Mark the three call-outcome events **Baileys only** in the table, with a note explaining the
  mechanism and confirming `call.received` fires on both engines.
- Add the production-vs-test URL check as the first troubleshooting step.
- Cross-reference the engine caveat from the troubleshooting list.
- Add `GET /api/webhooks/delivery-failures` as a step, so an operator can distinguish a delivery n8n
  rejected from one that never left the gateway.

## Verification

| Claim | Source |
|---|---|
| wwjs never emits call outcomes | `whatsapp-web-js.adapter.ts` — zero hits for `onCallOutcome` |
| Baileys does | `baileys-events.ts:522` |
| wwjs sees no call status | `whatsapp-web.js/src/Client.js:1093-1102` forwards `id`/`peerJid`/`isVideo`/`isGroup`/… with no status |
| Existing Baileys-only markers | `docs/06-api-specification.md:6130`, `docs/12-troubleshooting-faq.md:1159-1161` |

Docs-only. Prettier reports the file unchanged after the edit (table alignment preserved).