### PR TITLE
ci(release): run the SDK route gate on the tag path too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,12 @@ jobs:
       - name: Check OpenAPI snapshot is up to date
         run: npm run openapi:check
 
+      # The same gate ci.yml runs. Its comment there notes this workflow never ran it, which is the
+      # gap: a tag pushed with `--follow-tags` starts both workflows, and only the branch one could
+      # see an SDK left behind by a contract change. The release path has to stand on its own.
+      - name: Check SDK routes against the contract
+        run: npm run check:sdk-routes
+
   test:
     name: Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
Found by the pre-release review of the release path itself.

`release.yml` ran **five of the six** contract gates `ci.yml` runs. `check:sdk-routes` was missing.

The comment that introduced it in `ci.yml` names this exact gap and then does not close it:

> *Lives here, not in sdk-ci.yml: that workflow is path-filtered and does not list openapi.json, so a contract change alone runs none of it — **and it never runs on a release tag at all**.*

## Why it has not bitten yet

`git push --follow-tags` starts both workflows, so a contract change that leaves an SDK behind goes red on the branch run while the tag run stays green. The release still gets built and published — the failure is on a different workflow, on a different page.

It stops being merely untidy the moment a tag is pushed on its own, or a branch run is skipped. The release path should stand on its own, and now does.

## Verification

Gate parity derived rather than eyeballed — the set of `npm run <gate>` steps in `ci.yml` minus those in `release.yml` is now empty. `npm run check:sdk-routes` passes on the current contract.