### PR TITLE
fix(baileys): bound the post-connect group-name hydration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A post-connect group-name hydration WhatsApp never answered no longer finishes without a word** — the read shared the ambiguity `GET /sessions/{id}/groups` was bounded against in 0.14.5, where an unanswered query and an account with no groups both yield an empty result, but only the REST caller got a clock: the hydration step logged neither its success line nor its failure line, so group chats stayed unnamed with nothing to explain it.
+
 ## [0.14.5] - 2026-08-08
 
 ### Added

--- a/src/engine/adapters/baileys-history.spec.ts
+++ b/src/engine/adapters/baileys-history.spec.ts
@@ -1,0 +1,105 @@
+import type { WASocket } from '@whiskeysockets/baileys';
+import { BaileysHistory, BaileysHistoryHost } from './baileys-history';
+
+/**
+ * `groupFetchAllParticipating` yields `{}` for BOTH an unanswered query and an account with no groups —
+ * the same ambiguity `getGroups` is bounded against in baileys-groups.ts. Nothing in the VALUE separates
+ * them, so only a clock we own can.
+ *
+ * That makes the stub shape load-bearing: a stub resolving `{}` immediately models the BENIGN case, and
+ * a test built on it passes with or without a deadline. The unanswered case has to be modelled as a
+ * promise that does not settle, with the clock advanced past the budget.
+ */
+
+function history(sock: Record<string, jest.Mock>) {
+  const logger = { warn: jest.fn(), debug: jest.fn(), info: jest.fn(), error: jest.fn() };
+  const upsertChats = jest.fn();
+  const host = {
+    getSocket: () => sock as unknown as WASocket,
+    logger,
+    upsertChats,
+    loadLib: () => Promise.resolve({ ALL_WA_PATCH_NAMES: [] }),
+  } as unknown as BaileysHistoryHost;
+  return { history: new BaileysHistory(host), logger, upsertChats };
+}
+
+const groupWarnCount = (logger: { warn: jest.Mock }): number =>
+  (logger.warn.mock.calls as unknown[][]).filter(call => String(call[0]).includes('Group name hydration')).length;
+
+describe('hydrateNames', () => {
+  afterEach(() => jest.useRealTimers());
+
+  it('reports a group query WhatsApp never answered instead of finishing silently', async () => {
+    jest.useFakeTimers();
+    const {
+      history: h,
+      logger,
+      upsertChats,
+    } = history({
+      groupFetchAllParticipating: jest.fn(() => new Promise<never>(() => undefined)),
+      resyncAppState: jest.fn().mockResolvedValue(undefined),
+    });
+
+    const settled = h.hydrateNames();
+    await jest.advanceTimersByTimeAsync(120_000);
+    await settled;
+
+    expect(upsertChats).not.toHaveBeenCalled();
+    expect(groupWarnCount(logger)).toBe(1);
+  });
+
+  it('stays quiet when WhatsApp answers that the account has no groups', async () => {
+    // The benign twin of the case above, and the reason the deadline must not simply warn on an empty
+    // result: this answer ARRIVED, so it is not a failure and must not be reported as one.
+    const {
+      history: h,
+      logger,
+      upsertChats,
+    } = history({
+      groupFetchAllParticipating: jest.fn().mockResolvedValue({}),
+      resyncAppState: jest.fn().mockResolvedValue(undefined),
+    });
+
+    await h.hydrateNames();
+
+    expect(upsertChats).not.toHaveBeenCalled();
+    expect(groupWarnCount(logger)).toBe(0);
+  });
+
+  it('hydrates the names an answered query returns', async () => {
+    const {
+      history: h,
+      logger,
+      upsertChats,
+    } = history({
+      groupFetchAllParticipating: jest.fn().mockResolvedValue({
+        '1@g.us': { id: '1@g.us', subject: 'Engineering' },
+        '2@g.us': { id: '2@g.us' },
+      }),
+      resyncAppState: jest.fn().mockResolvedValue(undefined),
+    });
+
+    await h.hydrateNames();
+
+    // The subject-less group is skipped: a chat row with no name is worse than no row.
+    expect(upsertChats).toHaveBeenCalledWith([{ id: '1@g.us', name: 'Engineering' }]);
+    expect(groupWarnCount(logger)).toBe(0);
+  });
+
+  it('still runs the app-state resync after an unanswered group query', async () => {
+    // The two steps are independent best-effort work. Bounding the first exists partly so the second is
+    // reached on the repo's own budget rather than the library's much longer default.
+    jest.useFakeTimers();
+    const resyncAppState = jest.fn().mockResolvedValue(undefined);
+    const { history: h } = history({
+      groupFetchAllParticipating: jest.fn(() => new Promise<never>(() => undefined)),
+      resyncAppState,
+    });
+
+    const settled = h.hydrateNames();
+    await jest.advanceTimersByTimeAsync(120_000);
+    await settled;
+
+    expect(resyncAppState).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/engine/adapters/baileys-history.ts
+++ b/src/engine/adapters/baileys-history.ts
@@ -2,6 +2,7 @@ import type * as BaileysLib from '@whiskeysockets/baileys';
 import type { Chat, Contact as BaileysContact, WAMessage, WASocket } from '@whiskeysockets/baileys';
 import { EngineEventCallbacks, IncomingMessage } from '../interfaces/whatsapp-engine.interface';
 import { buildIncomingMessageFromBaileys, extractBaileysBody } from './baileys-message-mapper';
+import { BAILEYS_QUERY_BUDGET_MS, withQueryDeadline } from './baileys-query-deadline';
 import { type createLogger } from '../../common/services/logger.service';
 
 /**
@@ -88,7 +89,15 @@ export class BaileysHistory {
    */
   async hydrateNames(): Promise<void> {
     try {
-      const groups = await this.sock().groupFetchAllParticipating();
+      // Same ambiguity getGroups is bounded against: an unanswered query and an account with no groups
+      // both yield `{}`, and query() resolves rather than throwing, so neither the catch below nor an
+      // empty result can tell them apart. Without a clock of our own this step finishes silently — no
+      // warn, because nothing threw, and no debug, because there was nothing to hydrate.
+      const groups = await withQueryDeadline(
+        this.sock().groupFetchAllParticipating(),
+        BAILEYS_QUERY_BUDGET_MS,
+        'WhatsApp did not answer the group list query in time',
+      );
       const named = Object.values(groups)
         .filter(g => g?.id && g.subject)
         .map(g => ({ id: g.id, name: g.subject }));


### PR DESCRIPTION
## What

`BaileysHistory.hydrateNames()` runs `groupFetchAllParticipating()` on every connection open to backfill the group subjects the initial sync skips. That read had no deadline. It now shares the same 30-second budget as the rest of the adapter.

## Why

`groupFetchAllParticipating` returns an empty object for **two different things**: a query WhatsApp never answered, and an account that genuinely has no groups. Baileys' `query()` resolves rather than throwing when it times out, so nothing in the value — and nothing in the control flow — separates them. Only a clock we own can.

0.14.5 bounded `GET /sessions/{id}/groups` for exactly this reason, and `baileys-groups.ts` carries a comment describing the hazard. The post-connect hydration reads the same library function and was left unbounded.

The consequence here is silence rather than a wrong answer. With an empty result the success log sits behind `if (named.length)` and never fires; nothing rejects, so the `catch` and its warning never fire either. Group chats stayed unnamed after a connect with no line anywhere to explain it, and the app-state resync that follows waited out the library's much longer default before starting.

This is diagnosability, not correctness — no caller receives a wrong value, because this path returns nothing to anybody. It is fire-and-forget and cannot fail a session either before or after this change.

## What this does not change

An answered-but-empty result still means what it always meant. An account with no groups hydrates nothing and stays quiet, which is why the deadline reports the *unanswered* case specifically rather than warning on any empty result.

## Tests

`baileys-history.ts` had no spec. It has one now, covering both arms of the ambiguity:

| Case | Expectation |
| --- | --- |
| Query never answered | reports it, and the resync still runs |
| Account genuinely has no groups | hydrates nothing, stays quiet |
| Answered with names | hydrates them; a subject-less group is skipped |

The unanswered case is modelled as a promise that does not settle, with the clock advanced past the budget. This matters: a stub that resolves empty *immediately* models the benign case, so a test built on one passes identically with and without the deadline and proves nothing. Against the unpatched file the two unanswered-query tests fail; against this change all four pass.

## Verification

`lint`, `format:check`, `build`, `openapi:check`, `tsc --noEmit -p tsconfig.json`, and the full unit suite — 299 suites, 5105 tests — all green.