### PR TITLE
fix(sdk): correct the group-create shape and expose session pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Two statements in the codebase that were not true** — a load-bearing comment justified skipping a lookup on the grounds that PostgreSQL would raise a 500 against a uuid column, when `sessions.id` is `varchar` on both dialects and a malformed id simply matches nothing; and the webhook event table stated all 22 events are actively dispatched by the engines without saying that four of them fire on Baileys only, which the same document states 2 200 lines later.
 - **All five SDKs now give the retryable status a type of its own** — every one classified `401`, `403`, `404`, `409`, `429` and `501` into a dedicated error and let `503` fall through to the base class, which inverted the mapping against usefulness: `501 Not Implemented` is permanent and never worth retrying, while `503` is the transport failure a caller should retry — and 0.14.5 made it the standard answer for "WhatsApp never confirmed" across 47 of the 189 operations.
+- ⚠️ **Breaking (SDK types only, no gateway change). Creating a group returns the summary shape, and the SDKs said otherwise** — `POST /groups` answers `{id, name, participantsCount, isAdmin?, linkedParentJID?}`, but the four typed SDKs declared the DETAIL type `get()` returns, so `participants`, `description`, `owner` and `createdAt` were typed as present on a response that never carries them.
+- **Four SDKs could not paginate the session list** — `GET /api/sessions` takes `limit` and `offset`, and only the Go SDK exposed them; the other four sent a bare path and pinned the caller to the server default.
 
 ### Fixed
 

--- a/sdk/go/groups.go
+++ b/sdk/go/groups.go
@@ -42,8 +42,10 @@ func (s *GroupsService) JoinInfo(ctx context.Context, sessionID, code string) (*
 }
 
 // Create creates a group.
-func (s *GroupsService) Create(ctx context.Context, sessionID string, body CreateGroupRequest) (*GroupInfo, error) {
-	var out GroupInfo
+// Create makes a new group. It answers the group SUMMARY, not the detail shape Get returns — there is
+// no participant list, description, owner or creation time on a create response.
+func (s *GroupsService) Create(ctx context.Context, sessionID string, body CreateGroupRequest) (*GroupSummary, error) {
+	var out GroupSummary
 	err := s.client.do(ctx, "POST", s.base(sessionID), nil, body, &out)
 	if err != nil {
 		return nil, err

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/model/ListSessionsQuery.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/model/ListSessionsQuery.java
@@ -1,0 +1,29 @@
+package com.rmyndharis.openwa.model;
+
+/** Query parameters for listing sessions. Null fields are omitted from the query string. */
+public record ListSessionsQuery(Integer limit, Integer offset) {
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private Integer limit;
+        private Integer offset;
+
+        /** Maximum number of sessions to return. */
+        public Builder limit(Integer v) {
+            this.limit = v;
+            return this;
+        }
+
+        /** Number of sessions to skip. */
+        public Builder offset(Integer v) {
+            this.offset = v;
+            return this;
+        }
+
+        public ListSessionsQuery build() {
+            return new ListSessionsQuery(limit, offset);
+        }
+    }
+}

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/resources/GroupsResource.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/resources/GroupsResource.java
@@ -52,9 +52,13 @@ public final class GroupsResource {
     }
 
     /** Create a new group. */
-    public GroupInfo create(String sessionId, CreateGroupRequest body) {
+    /**
+     * Create a group. Answers the group SUMMARY, not the detail shape {@code get} returns — there is
+     * no participant list, description, owner or creation time on a create response.
+     */
+    public GroupSummary create(String sessionId, CreateGroupRequest body) {
         return client.request(
-            HttpMethod.POST, "/api/sessions/" + encodeSegment(sessionId) + "/groups", null, body, GroupInfo.class);
+            HttpMethod.POST, "/api/sessions/" + encodeSegment(sessionId) + "/groups", null, body, GroupSummary.class);
     }
 
     /** Add participants to a group. */

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/resources/SessionsResource.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/resources/SessionsResource.java
@@ -5,6 +5,7 @@ import static com.rmyndharis.openwa.http.Http.encodeSegment;
 import com.rmyndharis.openwa.OpenWAClient;
 import com.rmyndharis.openwa.http.HttpMethod;
 import com.rmyndharis.openwa.model.CreateSessionRequest;
+import com.rmyndharis.openwa.model.ListSessionsQuery;
 import com.rmyndharis.openwa.model.PairingCodeResponse;
 import com.rmyndharis.openwa.model.QrCodeResponse;
 import com.rmyndharis.openwa.model.RequestPairingCodeRequest;
@@ -22,7 +23,12 @@ public final class SessionsResource {
 
     /** List all sessions (scoped to the API key's allowed sessions). */
     public List<SessionResponse> list() {
-        return client.requestList(HttpMethod.GET, "/api/sessions", null, null, SessionResponse.class);
+        return list(null);
+    }
+
+    /** List sessions, applying the given pagination query. */
+    public List<SessionResponse> list(ListSessionsQuery query) {
+        return client.requestList(HttpMethod.GET, "/api/sessions", query, null, SessionResponse.class);
     }
 
     /** Get a single session by id. */

--- a/sdk/javascript/src/resources/groups.ts
+++ b/sdk/javascript/src/resources/groups.ts
@@ -47,9 +47,14 @@ export class GroupsResource {
     });
   }
 
-  /** Create a new group. */
-  create(sessionId: string, body: CreateGroupRequest): Promise<GroupInfo> {
-    return this.client.request<GroupInfo>({
+  /**
+   * Create a new group.
+   *
+   * Answers the group SUMMARY, not the detail shape `get()` returns — there is no participant list,
+   * description, owner or creation time on a create response.
+   */
+  create(sessionId: string, body: CreateGroupRequest): Promise<GroupSummary> {
+    return this.client.request<GroupSummary>({
       method: 'POST',
       path: `/api/sessions/${encodeSegment(sessionId)}/groups`,
       body,

--- a/sdk/javascript/src/resources/sessions.ts
+++ b/sdk/javascript/src/resources/sessions.ts
@@ -16,12 +16,18 @@ import type {
   SessionStatsOverview,
 } from '../types.js';
 
+/** Pagination for {@link SessionsResource.list}. The server applies its own default when omitted. */
+export interface ListSessionsQuery {
+  limit?: number;
+  offset?: number;
+}
+
 export class SessionsResource {
   constructor(private readonly client: OpenWAClient) {}
 
   /** List all sessions (scoped to the API key's `allowedSessions`). */
-  list(): Promise<SessionResponse[]> {
-    return this.client.request<SessionResponse[]>({ method: 'GET', path: '/api/sessions' });
+  list(query?: ListSessionsQuery): Promise<SessionResponse[]> {
+    return this.client.request<SessionResponse[]>({ method: 'GET', path: '/api/sessions', query });
   }
 
   /** Get a single session by id. */

--- a/sdk/php/src/Resources/SessionsResource.php
+++ b/sdk/php/src/Resources/SessionsResource.php
@@ -20,10 +20,14 @@ class SessionsResource
         $this->http = $http;
     }
 
-    /** @return array<int,array<string,mixed>> */
-    public function list(): array
+    /**
+     * @param array<string,mixed> $query Optional pagination: `limit`, `offset`.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function list(array $query = []): array
     {
-        return $this->http->request('GET', '/api/sessions') ?? [];
+        return $this->http->request('GET', '/api/sessions', $query) ?? [];
     }
 
     /** @return array<string,mixed> */

--- a/sdk/python/openwa/resources/groups.py
+++ b/sdk/python/openwa/resources/groups.py
@@ -41,7 +41,12 @@ class GroupsResource:
     def get(self, session_id: str, group_id: str) -> GroupInfo:
         return self._http.request("GET", f"/api/sessions/{quote_segment(session_id)}/groups/{quote_segment(group_id)}")
 
-    def create(self, session_id: str, body: CreateGroupRequest) -> GroupInfo:
+    def create(self, session_id: str, body: CreateGroupRequest) -> GroupSummary:
+        """Create a group.
+
+        Answers the group SUMMARY, not the detail shape ``get()`` returns -- no participant list,
+        description, owner or creation time.
+        """
         return self._http.request("POST", f"/api/sessions/{quote_segment(session_id)}/groups", body=body)
 
     def add_participants(self, session_id: str, group_id: str, participants: list[str]) -> ParticipantsResult:

--- a/sdk/python/openwa/resources/sessions.py
+++ b/sdk/python/openwa/resources/sessions.py
@@ -5,7 +5,7 @@ Backed by ``src/modules/session/session.controller.ts``.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypedDict
 
 from .._http import quote_segment
 from ..types import (
@@ -21,13 +21,20 @@ if TYPE_CHECKING:
     from .._http import HttpExecutor
 
 
+class ListSessionsQuery(TypedDict, total=False):
+    """Pagination for :meth:`SessionsResource.list`. The server applies its own default when omitted."""
+
+    limit: int
+    offset: int
+
+
 class SessionsResource:
     def __init__(self, http: "HttpExecutor") -> None:
         self._http = http
 
-    def list(self) -> list[SessionResponse]:
+    def list(self, query: ListSessionsQuery | None = None) -> list[SessionResponse]:
         """List sessions."""
-        return self._http.request("GET", "/api/sessions")
+        return self._http.request("GET", "/api/sessions", query=query)
 
     def get(self, session_id: str) -> SessionResponse:
         """Return a single session."""


### PR DESCRIPTION
## Group create returned the wrong declared shape

`POST /groups` answers the group **summary** — `{id, name, participantsCount, isAdmin?, linkedParentJID?}` — which is what the controller declares (`type: GroupSummaryDto`).

All four typed SDKs returned `GroupInfo`: the **detail** shape `get()` answers, whose own docstring says it is what `GET /groups/{id}` returns. So `participants`, `description`, `owner` and `createdAt` were typed as present on a response that never carries them. A caller reading them got `undefined` at runtime with no type error to warn them first.

The `id` — the one field anyone actually wants after creating a group — is present in both shapes and always decoded correctly. That is why this stayed hidden: the common path works.

## Four SDKs could not paginate the session list

`GET /api/sessions` accepts `limit` and `offset`. Only the **Go** SDK exposed them; JavaScript, Python, Java and PHP sent a bare path, pinning the caller to the server default.

Each now takes the same optional query its own **groups** list already took, expressed in that language's existing idiom rather than a new one:

| SDK | Shape |
| --- | --- |
| JavaScript | optional `ListSessionsQuery` object |
| Python | optional `ListSessionsQuery` TypedDict |
| Java | `list()` / `list(ListSessionsQuery)` overload with a builder, mirroring `ListGroupsQuery` |
| PHP | defaulted `array $query = []` |
| Go | already had it |

Honestly scoped: a deployment with more than the default page of sessions is not a realistic configuration for this product — each session is a Chromium instance or a full socket. This closes an API-surface gap, not a live truncation bug.

## Compatibility

Breaking for SDK callers on the group-create return type, and **narrowing** — the removed fields were never populated. No gateway change; the pagination additions are all optional parameters.

## Verification

All five SDKs build and test clean. Repo-level `lint`, `format:check`, `check:sdk-routes` and the full unit suite — 5114 tests — green.