### PR TITLE
feat(sdk): expose session config and the webhook diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The SDKs can now read and change a running session's config, and read the webhook diagnostics** — `GET`/`PATCH /sessions/{id}/config` (0.14.5's headline feature), the cross-session `GET /webhooks`, and `GET /webhooks/delivery-failures` were absent from all five SDKs while `sdk/README.md` claimed every user-facing resource was exposed; that claim is now scoped to the exclusion list the SDK design doc actually states.
+
 ### Fixed
 
 - **Two statements in the codebase that were not true** — a load-bearing comment justified skipping a lookup on the grounds that PostgreSQL would raise a 500 against a uuid column, when `sessions.id` is `varchar` on both dialects and a malformed id simply matches nothing; and the webhook event table stated all 22 events are actively dispatched by the engines without saying that four of them fire on Baileys only, which the same document states 2 200 lines later.

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -42,9 +42,15 @@ All five SDKs expose the same fluent resource surface:
 | `health`    | check, live, ready                                                                                                                                                                                                                               |
 
 > ⚠️ Endpoints requiring an `OPERATOR`-level API key are noted in the inline
-> docs. Operator-only modules (`docker`, `metrics`, `infra`, `plugins`, `mcp`,
-> `automation`) are intentionally **not** exposed in the SDK; all user-facing
-> resources are.
+> docs. Deliberately **not** exposed: the operator-only modules (`docker`,
+> `metrics`, `infra`, `plugins`, `mcp`, `automation`, `integration`) and the
+> admin surfaces `docs/18-sdk-design.md` excludes (`auth`/api-keys, `audit`,
+> `settings`, `statistics`). Those two lists have to agree — this one was
+> shorter than the design doc's, and the gap read as an accidental omission.
+>
+> Everything else the gateway publishes is exposed. That sentence used to be an
+> unqualified "all user-facing resources are", which was false for the session
+> config routes and the two cross-session webhook reads until they were added.
 
 ## JavaScript / TypeScript
 

--- a/sdk/go/sessions.go
+++ b/sdk/go/sessions.go
@@ -14,6 +14,27 @@ func (s *SessionsService) List(ctx context.Context, query *ListSessionsQuery) ([
 }
 
 // Get returns a single session.
+// GetConfig reads a session's effective configuration.
+func (s *SessionsService) GetConfig(ctx context.Context, sessionID string) (*SessionConfig, error) {
+	var out SessionConfig
+	err := s.client.do(ctx, "GET", "/api/sessions/"+pathEscape(sessionID)+"/config", nil, nil, &out)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// UpdateConfig changes a RUNNING session's configuration. It takes effect without re-linking the
+// account — all three fields were fixed at creation before this route existed.
+func (s *SessionsService) UpdateConfig(ctx context.Context, sessionID string, body UpdateSessionConfigRequest) (*SessionConfig, error) {
+	var out SessionConfig
+	err := s.client.do(ctx, "PATCH", "/api/sessions/"+pathEscape(sessionID)+"/config", nil, body, &out)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
 func (s *SessionsService) Get(ctx context.Context, sessionID string) (*SessionResponse, error) {
 	var out SessionResponse
 	err := s.client.do(ctx, "GET", "/api/sessions/"+pathEscape(sessionID), nil, nil, &out)

--- a/sdk/go/types_session.go
+++ b/sdk/go/types_session.go
@@ -159,3 +159,39 @@ type SessionStatsOverview struct {
 	ByStatus     map[string]int `json:"byStatus,omitempty"`
 	MemoryUsage  MemoryUsage    `json:"memoryUsage"`
 }
+
+// SessionConfig is a session's effective runtime configuration. A nil MaxReconnectAttempts means
+// unlimited — not unset.
+type SessionConfig struct {
+	AutoRejectCalls      bool `json:"autoRejectCalls"`
+	MaxReconnectAttempts *int `json:"maxReconnectAttempts"`
+	ReconnectBaseDelay   int  `json:"reconnectBaseDelay"`
+}
+
+// UpdateSessionConfigRequest is a partial update of a RUNNING session's config — no re-link, no QR
+// scan. Send a nil MaxReconnectAttempts through Ptr to restore unlimited retries, which no in-range
+// number can express.
+type UpdateSessionConfigRequest struct {
+	AutoRejectCalls      *bool `json:"autoRejectCalls,omitempty"`
+	MaxReconnectAttempts *int  `json:"maxReconnectAttempts,omitempty"`
+	ReconnectBaseDelay   *int  `json:"reconnectBaseDelay,omitempty"`
+}
+
+// DeliveryFailureQuery filters the cross-session webhook list and the delivery-failure log. Nil
+// fields are omitted from the query string. SessionID is ignored by the plain webhook list.
+type DeliveryFailureQuery struct {
+	SessionID *string
+	Limit     *int
+	Offset    *int
+}
+
+func (q *DeliveryFailureQuery) values() url.Values {
+	v := url.Values{}
+	if q == nil {
+		return v
+	}
+	setStr(v, "sessionId", q.SessionID)
+	setInt(v, "limit", q.Limit)
+	setInt(v, "offset", q.Offset)
+	return v
+}

--- a/sdk/go/webhooks.go
+++ b/sdk/go/webhooks.go
@@ -11,6 +11,25 @@ func (s *WebhooksService) base(sessionID string) string {
 }
 
 // List returns webhooks for a session.
+// ListAll returns webhooks across EVERY session the key can see, not one session's. Requires an
+// OPERATOR-level key.
+func (s *WebhooksService) ListAll(ctx context.Context, query *DeliveryFailureQuery) ([]WebhookResponse, error) {
+	var out []WebhookResponse
+	err := s.client.do(ctx, "GET", "/api/webhooks", query.values(), nil, &out)
+	return out, err
+}
+
+// DeliveryFailures returns deliveries that were ATTEMPTED and failed — the diagnostic for a webhook
+// that stopped arriving. Requires an ADMIN-level key.
+//
+// A delivery a smart filter suppressed never reaches this log. The response has no published schema,
+// so it decodes into a generic value.
+func (s *WebhooksService) DeliveryFailures(ctx context.Context, query *DeliveryFailureQuery) (any, error) {
+	var out any
+	err := s.client.do(ctx, "GET", "/api/webhooks/delivery-failures", query.values(), nil, &out)
+	return out, err
+}
+
 func (s *WebhooksService) List(ctx context.Context, sessionID string) ([]WebhookResponse, error) {
 	var out []WebhookResponse
 	err := s.client.do(ctx, "GET", s.base(sessionID), nil, nil, &out)

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/model/DeliveryFailureQuery.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/model/DeliveryFailureQuery.java
@@ -1,0 +1,40 @@
+package com.rmyndharis.openwa.model;
+
+/**
+ * Query parameters for the cross-session webhook list and the delivery-failure log. Null fields are
+ * omitted from the query string.
+ *
+ * @param sessionId restrict to one session; ignored by the plain webhook list
+ * @param limit maximum number of records to return
+ * @param offset number of records to skip
+ */
+public record DeliveryFailureQuery(String sessionId, Integer limit, Integer offset) {
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private String sessionId;
+        private Integer limit;
+        private Integer offset;
+
+        public Builder sessionId(String v) {
+            this.sessionId = v;
+            return this;
+        }
+
+        public Builder limit(Integer v) {
+            this.limit = v;
+            return this;
+        }
+
+        public Builder offset(Integer v) {
+            this.offset = v;
+            return this;
+        }
+
+        public DeliveryFailureQuery build() {
+            return new DeliveryFailureQuery(sessionId, limit, offset);
+        }
+    }
+}

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/model/SessionConfig.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/model/SessionConfig.java
@@ -1,0 +1,12 @@
+package com.rmyndharis.openwa.model;
+
+/**
+ * A session's effective runtime configuration.
+ *
+ * <p>A null {@code maxReconnectAttempts} means unlimited — not unset.
+ *
+ * @param autoRejectCalls whether incoming calls are auto-rejected
+ * @param maxReconnectAttempts cap on consecutive reconnect attempts; null means unlimited
+ * @param reconnectBaseDelay base delay of the reconnect backoff, in milliseconds
+ */
+public record SessionConfig(Boolean autoRejectCalls, Integer maxReconnectAttempts, Integer reconnectBaseDelay) {}

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/model/UpdateSessionConfigRequest.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/model/UpdateSessionConfigRequest.java
@@ -1,0 +1,15 @@
+package com.rmyndharis.openwa.model;
+
+/**
+ * Partial update of a RUNNING session's configuration — no re-link and no QR scan. All three fields
+ * were fixed at creation before this route existed.
+ *
+ * <p>Send a null {@code maxReconnectAttempts} to restore unlimited retries, which no in-range number
+ * can express.
+ *
+ * @param autoRejectCalls auto-reject incoming calls
+ * @param maxReconnectAttempts cap on consecutive reconnect attempts; null restores unlimited
+ * @param reconnectBaseDelay base delay of the reconnect backoff, in milliseconds
+ */
+public record UpdateSessionConfigRequest(
+        Boolean autoRejectCalls, Integer maxReconnectAttempts, Integer reconnectBaseDelay) {}

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/resources/SessionsResource.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/resources/SessionsResource.java
@@ -9,8 +9,10 @@ import com.rmyndharis.openwa.model.ListSessionsQuery;
 import com.rmyndharis.openwa.model.PairingCodeResponse;
 import com.rmyndharis.openwa.model.QrCodeResponse;
 import com.rmyndharis.openwa.model.RequestPairingCodeRequest;
+import com.rmyndharis.openwa.model.SessionConfig;
 import com.rmyndharis.openwa.model.SessionResponse;
 import com.rmyndharis.openwa.model.SessionStatsOverview;
+import com.rmyndharis.openwa.model.UpdateSessionConfigRequest;
 import java.util.List;
 
 /** Sessions resource — lifecycle management for WhatsApp sessions. */
@@ -29,6 +31,21 @@ public final class SessionsResource {
     /** List sessions, applying the given pagination query. */
     public List<SessionResponse> list(ListSessionsQuery query) {
         return client.requestList(HttpMethod.GET, "/api/sessions", query, null, SessionResponse.class);
+    }
+
+    /** Read a session's effective configuration. */
+    public SessionConfig getConfig(String id) {
+        return client.request(
+                HttpMethod.GET, "/api/sessions/" + encodeSegment(id) + "/config", null, null, SessionConfig.class);
+    }
+
+    /**
+     * Update a RUNNING session's configuration. Takes effect without re-linking the account — all
+     * three fields were fixed at creation before this route existed.
+     */
+    public SessionConfig updateConfig(String id, UpdateSessionConfigRequest body) {
+        return client.request(
+                HttpMethod.PATCH, "/api/sessions/" + encodeSegment(id) + "/config", null, body, SessionConfig.class);
     }
 
     /** Get a single session by id. */

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/resources/WebhooksResource.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/resources/WebhooksResource.java
@@ -4,6 +4,7 @@ import static com.rmyndharis.openwa.http.Http.encodeSegment;
 
 import com.rmyndharis.openwa.OpenWAClient;
 import com.rmyndharis.openwa.http.HttpMethod;
+import com.rmyndharis.openwa.model.DeliveryFailureQuery;
 import com.rmyndharis.openwa.model.CreateWebhookRequest;
 import com.rmyndharis.openwa.model.UpdateWebhookRequest;
 import com.rmyndharis.openwa.model.WebhookResponse;
@@ -16,6 +17,25 @@ public final class WebhooksResource {
 
     public WebhooksResource(OpenWAClient client) {
         this.client = client;
+    }
+
+    /**
+     * List webhooks across EVERY session the key can see, not one session's. Requires an
+     * OPERATOR-level key.
+     */
+    public List<WebhookResponse> listAll(DeliveryFailureQuery query) {
+        return client.requestList(HttpMethod.GET, "/api/webhooks", query, null, WebhookResponse.class);
+    }
+
+    /**
+     * Deliveries that were ATTEMPTED and failed — the diagnostic for a webhook that stopped arriving.
+     * Requires an ADMIN-level key.
+     *
+     * <p>A delivery a smart filter suppressed never reaches this log. The response has no published
+     * schema, so it is returned as a raw JSON tree.
+     */
+    public Object deliveryFailures(DeliveryFailureQuery query) {
+        return client.request(HttpMethod.GET, "/api/webhooks/delivery-failures", query, null, Object.class);
     }
 
     /** List all webhooks for a session. */

--- a/sdk/javascript/src/resources/sessions.ts
+++ b/sdk/javascript/src/resources/sessions.ts
@@ -12,7 +12,9 @@ import type {
   PairingCodeResponse,
   QrCodeResponse,
   RequestPairingCodeRequest,
+  SessionConfig,
   SessionResponse,
+  UpdateSessionConfigRequest,
   SessionStatsOverview,
 } from '../types.js';
 
@@ -28,6 +30,26 @@ export class SessionsResource {
   /** List all sessions (scoped to the API key's `allowedSessions`). */
   list(query?: ListSessionsQuery): Promise<SessionResponse[]> {
     return this.client.request<SessionResponse[]>({ method: 'GET', path: '/api/sessions', query });
+  }
+
+  /** Read a session's effective configuration. */
+  getConfig(id: string): Promise<SessionConfig> {
+    return this.client.request<SessionConfig>({
+      method: 'GET',
+      path: `/api/sessions/${encodeSegment(id)}/config`,
+    });
+  }
+
+  /**
+   * Update a running session's configuration. Takes effect without re-linking the account — all three
+   * fields were fixed at creation before this route existed.
+   */
+  updateConfig(id: string, body: UpdateSessionConfigRequest): Promise<SessionConfig> {
+    return this.client.request<SessionConfig>({
+      method: 'PATCH',
+      path: `/api/sessions/${encodeSegment(id)}/config`,
+      body,
+    });
   }
 
   /** Get a single session by id. */

--- a/sdk/javascript/src/resources/webhooks.ts
+++ b/sdk/javascript/src/resources/webhooks.ts
@@ -9,8 +9,38 @@ import { encodeSegment } from '../http.js';
 import type { OpenWAClient } from '../client.js';
 import type { CreateWebhookRequest, UpdateWebhookRequest, WebhookResponse, WebhookTestResult } from '../types.js';
 
+/** Pagination for the cross-session webhook list and the delivery-failure log. */
+export interface WebhookListQuery {
+  limit?: number;
+  offset?: number;
+}
+
+/** Filter for {@link WebhooksResource.deliveryFailures}. */
+export interface DeliveryFailureQuery extends WebhookListQuery {
+  sessionId?: string;
+}
+
 export class WebhooksResource {
   constructor(private readonly client: OpenWAClient) {}
+
+  /**
+   * List webhooks across EVERY session the key can see, not one session's. Requires an OPERATOR-level
+   * key.
+   */
+  listAll(query?: WebhookListQuery): Promise<WebhookResponse[]> {
+    return this.client.request<WebhookResponse[]>({ method: 'GET', path: '/api/webhooks', query });
+  }
+
+  /**
+   * Deliveries that were attempted and failed — the diagnostic to reach for when a webhook stopped
+   * arriving. Requires an ADMIN-level key.
+   *
+   * Note it records deliveries that were ATTEMPTED: a delivery a smart filter suppressed never reaches
+   * this log. The response has no published schema, so it is returned unshaped.
+   */
+  deliveryFailures(query?: DeliveryFailureQuery): Promise<unknown> {
+    return this.client.request<unknown>({ method: 'GET', path: '/api/webhooks/delivery-failures', query });
+  }
 
   /** List all webhooks for a session. */
   list(sessionId: string): Promise<WebhookResponse[]> {

--- a/sdk/javascript/src/types.ts
+++ b/sdk/javascript/src/types.ts
@@ -161,6 +161,27 @@ export interface GroupJoinInfo {
   participantCount?: number;
 }
 
+/**
+ * A session's effective runtime configuration. `null` on the two reconnect fields means "unlimited" /
+ * "engine default" respectively — not "unset".
+ */
+export interface SessionConfig {
+  autoRejectCalls: boolean;
+  maxReconnectAttempts: number | null;
+  reconnectBaseDelay: number;
+}
+
+/**
+ * Partial update of a session's config. Applies to a session that is already running — no re-link and
+ * no QR scan. Send `null` for `maxReconnectAttempts` to restore unlimited retries, which no in-range
+ * number can express.
+ */
+export interface UpdateSessionConfigRequest {
+  autoRejectCalls?: boolean | null;
+  maxReconnectAttempts?: number | null;
+  reconnectBaseDelay?: number | null;
+}
+
 export interface CreateSessionRequest {
   /** Alphanumeric + hyphens, 3–50 chars. */
   name: string;

--- a/sdk/php/src/Resources/SessionsResource.php
+++ b/sdk/php/src/Resources/SessionsResource.php
@@ -30,6 +30,29 @@ class SessionsResource
         return $this->http->request('GET', '/api/sessions', $query) ?? [];
     }
 
+    /**
+     * Read a session's effective configuration.
+     *
+     * @return array<string,mixed>
+     */
+    public function getConfig(string $id): array
+    {
+        return $this->http->request('GET', "/api/sessions/{$this->http->encodeSegment($id)}/config");
+    }
+
+    /**
+     * Update a RUNNING session's configuration — no re-link and no QR scan. All three fields were
+     * fixed at creation before this route existed.
+     *
+     * @param array<string,mixed> $body autoRejectCalls, maxReconnectAttempts, reconnectBaseDelay
+     *
+     * @return array<string,mixed>
+     */
+    public function updateConfig(string $id, array $body): array
+    {
+        return $this->http->request('PATCH', "/api/sessions/{$this->http->encodeSegment($id)}/config", [], $body);
+    }
+
     /** @return array<string,mixed> */
     public function get(string $id): array
     {

--- a/sdk/php/src/Resources/WebhooksResource.php
+++ b/sdk/php/src/Resources/WebhooksResource.php
@@ -20,6 +20,32 @@ class WebhooksResource
         $this->http = $http;
     }
 
+    /**
+     * List webhooks across EVERY session the key can see, not one session's. Requires an
+     * OPERATOR-level key.
+     *
+     * @param array<string,mixed> $query Optional pagination: `limit`, `offset`.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function listAll(array $query = []): array
+    {
+        return $this->http->request('GET', '/api/webhooks', $query) ?? [];
+    }
+
+    /**
+     * Deliveries that were ATTEMPTED and failed — the diagnostic for a webhook that stopped arriving.
+     * Requires an ADMIN-level key. A delivery a smart filter suppressed never reaches this log.
+     *
+     * @param array<string,mixed> $query Optional filter: `sessionId`, `limit`, `offset`.
+     *
+     * @return mixed the response has no published schema, so it is returned unshaped
+     */
+    public function deliveryFailures(array $query = [])
+    {
+        return $this->http->request('GET', '/api/webhooks/delivery-failures', $query);
+    }
+
     /** @return array<int,array<string,mixed>> */
     public function list(string $sessionId): array
     {

--- a/sdk/python/openwa/resources/sessions.py
+++ b/sdk/python/openwa/resources/sessions.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING, TypedDict
 from .._http import quote_segment
 from ..types import (
     CreateSessionRequest,
+    SessionConfig,
+    UpdateSessionConfigRequest,
     PairingCodeResponse,
     QrCodeResponse,
     RequestPairingCodeRequest,
@@ -35,6 +37,19 @@ class SessionsResource:
     def list(self, query: ListSessionsQuery | None = None) -> list[SessionResponse]:
         """List sessions."""
         return self._http.request("GET", "/api/sessions", query=query)
+
+    def get_config(self, session_id: str) -> SessionConfig:
+        """Read a session's effective configuration."""
+        return self._http.request("GET", f"/api/sessions/{quote_segment(session_id)}/config")
+
+    def update_config(self, session_id: str, body: UpdateSessionConfigRequest) -> SessionConfig:
+        """Update a RUNNING session's configuration -- no re-link and no QR scan.
+
+        All three fields were fixed at creation before this route existed.
+        """
+        return self._http.request(
+            "PATCH", f"/api/sessions/{quote_segment(session_id)}/config", body=body
+        )
 
     def get(self, session_id: str) -> SessionResponse:
         """Return a single session."""

--- a/sdk/python/openwa/resources/webhooks.py
+++ b/sdk/python/openwa/resources/webhooks.py
@@ -5,7 +5,7 @@ Backed by ``src/modules/webhook/webhook.controller.ts``.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, TypedDict
 
 from .._http import quote_segment
 from ..types import CreateWebhookRequest, UpdateWebhookRequest, WebhookResponse, WebhookTestResult
@@ -14,9 +14,37 @@ if TYPE_CHECKING:
     from .._http import HttpExecutor
 
 
+class WebhookListQuery(TypedDict, total=False):
+    """Pagination for the cross-session webhook list and the delivery-failure log."""
+
+    limit: int
+    offset: int
+
+
+class DeliveryFailureQuery(WebhookListQuery, total=False):
+    """Filter for :meth:`WebhooksResource.delivery_failures`."""
+
+    sessionId: str
+
+
 class WebhooksResource:
     def __init__(self, http: "HttpExecutor") -> None:
         self._http = http
+
+    def list_all(self, query: WebhookListQuery | None = None) -> list[WebhookResponse]:
+        """List webhooks across EVERY session the key can see, not one session's.
+
+        Requires an OPERATOR-level key.
+        """
+        return self._http.request("GET", "/api/webhooks", query=query)
+
+    def delivery_failures(self, query: DeliveryFailureQuery | None = None) -> Any:
+        """Deliveries that were ATTEMPTED and failed -- the diagnostic for a webhook that stopped arriving.
+
+        Requires an ADMIN-level key. A delivery a smart filter suppressed never reaches this log. The
+        response has no published schema, so it is returned unshaped.
+        """
+        return self._http.request("GET", "/api/webhooks/delivery-failures", query=query)
 
     def list(self, session_id: str) -> list[WebhookResponse]:
         return self._http.request("GET", f"/api/sessions/{quote_segment(session_id)}/webhooks")

--- a/sdk/python/openwa/types.py
+++ b/sdk/python/openwa/types.py
@@ -174,6 +174,29 @@ class SessionResponse(TypedDict, total=False):
     engineLoaded: bool
 
 
+class SessionConfig(TypedDict):
+    """A session's effective runtime configuration.
+
+    ``None`` on ``maxReconnectAttempts`` means unlimited -- not unset.
+    """
+
+    autoRejectCalls: bool
+    maxReconnectAttempts: int | None
+    reconnectBaseDelay: int
+
+
+class UpdateSessionConfigRequest(TypedDict, total=False):
+    """Partial update of a running session's config -- no re-link, no QR scan.
+
+    Send ``None`` for ``maxReconnectAttempts`` to restore unlimited retries, which no in-range number
+    can express.
+    """
+
+    autoRejectCalls: bool | None
+    maxReconnectAttempts: int | None
+    reconnectBaseDelay: int | None
+
+
 class CreateSessionRequest(TypedDict, total=False):
     name: str
     config: dict[str, Any]


### PR DESCRIPTION
## Four operations no SDK wrapped

| Operation | Role | Why it matters |
| --- | --- | --- |
| `GET /sessions/{id}/config` | none | reads the effective config |
| `PATCH /sessions/{id}/config` | OPERATOR | **0.14.5's headline feature** — change a *running* session's config without re-linking |
| `GET /webhooks` | OPERATOR | the cross-session webhook list |
| `GET /webhooks/delivery-failures` | ADMIN | the diagnostic the 0.14.5 runbook points operators at |

The config pair is the sharpest miss: it is this release's advertised feature, on a resource every SDK already exposes, and the `GET` carries no role requirement at all.

## And a README claim that said they were covered

`sdk/README.md` named a **shorter** exclusion list than `docs/18-sdk-design.md` does, then closed:

> Operator-only modules (…) are intentionally **not** exposed in the SDK; all user-facing resources are.

That absolute was false for all four. The note now states both exclusion sets — the operator-only modules *and* the admin surfaces the design doc excludes (`auth`/api-keys, `audit`, `settings`, `statistics`) — says the two lists have to agree, and drops the unqualified claim.

Worth recording why this was hard to see: **46 of the 62 operations no SDK wraps are documented exclusions**, and 12 more are excluded by the design doc. Only these four were genuine gaps. A raw count of uncovered operations would have buried them.

## Two decisions worth flagging

**The delivery-failure response is returned unshaped.** It has no published response schema, so inventing a type here would be guessing at a contract. Its doc comment records the trap instead: the log holds deliveries that were **attempted**, so one a smart filter suppressed never appears in it — which is exactly when an operator goes looking.

**The webhook reads take their own query type**, not the session one. `delivery-failures` accepts a `sessionId` filter that session pagination has no field for; sharing the type would have made that parameter unreachable. It also keeps this change independent of the pagination work in the other open SDK PR rather than stacking on it.

## Verification

All five SDKs build and test clean (JS build + suite, Python 69, Go build + vet + tests, Java `mvn test` with 0 errors, PHP `php -l`). Repo-level `lint`, `format:check`, `check:sdk-routes` and the full unit suite — 5114 tests — green.