### PR TITLE
docs(openapi): document the 503 five more routes already answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Five routes now document a `503` they have been answering for releases** — the four group participant writes have spent the shared request budget since 0.14.5 and listing chats by label has answered `503` on a dead whatsapp-web.js page since 0.14.0, but all five published only their success statuses, so a client generated from the contract had no branch for a failure the gateway was already returning; the participant `503` in particular is the one status that separates "WhatsApp never answered" from the per-participant refusals a `200` reports inside `results`.
+
 ## [0.14.6] - 2026-08-08
 
 ### Added

--- a/openapi.json
+++ b/openapi.json
@@ -4553,6 +4553,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "description": "WhatsApp did not answer within the request budget, so no per-participant outcome was read at all. Deliberately not folded into the 200 above — a participant WhatsApp turned down is reported inside `results` and is an answer; an update that never came back is not."
           }
         },
         "summary": "Add participants to a group",
@@ -4602,6 +4605,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "description": "WhatsApp did not answer within the request budget, so no per-participant outcome was read at all. Deliberately not folded into the 200 above — a participant WhatsApp turned down is reported inside `results` and is an answer; an update that never came back is not."
           }
         },
         "summary": "Remove participants from a group",
@@ -4653,6 +4659,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "description": "WhatsApp did not answer within the request budget, so no per-participant outcome was read at all. Deliberately not folded into the 200 above — a participant WhatsApp turned down is reported inside `results` and is an answer; an update that never came back is not."
           }
         },
         "summary": "Promote participants to admin",
@@ -4704,6 +4713,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "description": "WhatsApp did not answer within the request budget, so no per-participant outcome was read at all. Deliberately not folded into the 200 above — a participant WhatsApp turned down is reported inside `results` and is an answer; an update that never came back is not."
           }
         },
         "summary": "Demote participants from admin",
@@ -5550,6 +5562,9 @@
           },
           "501": {
             "description": "The active engine cannot list chats by label (Baileys)"
+          },
+          "503": {
+            "description": "The whatsapp-web.js page connection died mid-read, so nothing could be read. Deliberately not reported as a missing label — a page that went away says nothing about whether the label exists. The other engine never answers this: Baileys has no label query at all and answers 501 above."
           }
         },
         "summary": "Get every chat carrying a label",

--- a/src/config/openapi-contract.spec.ts
+++ b/src/config/openapi-contract.spec.ts
@@ -73,6 +73,37 @@ describe('openapi.json structural invariants', () => {
     expect(untyped).toEqual([]);
   });
 
+  // Every participant write goes through runParticipantsUpdate, which spends the shared request
+  // budget (baileys-groups.ts), so each can answer 503 — and each ALSO reports per-participant
+  // refusals inside its 200, which is the neighbouring claim it is easiest to mistake the 503 for.
+  // Keyed off the response schema rather than a list of paths: these four were missed when the rest
+  // of the module gained its 503s, and a hand-written list would miss a fifth route the same way.
+  it('every participant write documents the 503 its request budget can produce', () => {
+    const doc = snapshot();
+    const participantWrites: string[] = [];
+    const undocumented: string[] = [];
+
+    for (const [route, item] of Object.entries(doc.paths)) {
+      for (const [method, operation] of Object.entries(item)) {
+        if (!OPERATION_KEYS.has(method)) continue;
+        const responses =
+          (operation as { responses?: Record<string, { content?: Record<string, { schema?: { $ref?: string } }> }> })
+            .responses ?? {};
+        const ref = responses['200']?.content?.['application/json']?.schema?.$ref;
+        if (!ref?.endsWith('/ParticipantsOperationResponseDto')) continue;
+
+        const id = `${method.toUpperCase()} ${route}`;
+        participantWrites.push(id);
+        if (!responses['503']) undocumented.push(id);
+      }
+    }
+
+    // A renamed DTO would match nothing and leave the assertion below vacuously true — an empty
+    // result from a selector that can no longer match is not evidence of compliance.
+    expect(participantWrites.length).toBeGreaterThan(0);
+    expect(undocumented).toEqual([]);
+  });
+
   it('every operation declares at least one response', () => {
     const doc = snapshot();
     const silent = Object.entries(doc.paths).flatMap(([route, item]) =>

--- a/src/modules/group/group.controller.ts
+++ b/src/modules/group/group.controller.ts
@@ -30,6 +30,13 @@ import {
 const INVITE_CODE_403 = 'The engine refused the request — admin rights required for this group';
 const INVITE_CODE_503 = 'WhatsApp did not answer the invite-code query — retry shortly';
 
+// Shared by the four participant writes, whose 200 reports per-participant refusals inside `results` —
+// so this 503 has to say, on all four, that it is not one of those.
+const PARTICIPANTS_503 =
+  'WhatsApp did not answer within the request budget, so no per-participant outcome was read at all. ' +
+  'Deliberately not folded into the 200 above — a participant WhatsApp turned down is reported inside ' +
+  '`results` and is an answer; an update that never came back is not.';
+
 // NOTE: the session→groups LIST lives on the SessionController at GET /sessions/:id/groups (it
 // registered first and owns the canonical narrow projection). A bare @Get() here would collide on
 // the same path pattern (/sessions/{x}/groups) and be shadowed, so this controller owns only the
@@ -163,6 +170,7 @@ export class GroupController {
       'Participants processed — `results` carries the per-participant outcome (a partial refusal does not fail the batch; a total refusal is an error)',
     type: ParticipantsOperationResponseDto,
   })
+  @ApiResponse({ status: 503, description: PARTICIPANTS_503 })
   @HttpCode(HttpStatus.OK)
   async addParticipants(
     @Param('sessionId') sessionId: string,
@@ -185,6 +193,7 @@ export class GroupController {
       'Participants processed — `results` carries the per-participant outcome (a partial refusal does not fail the batch; a total refusal is an error)',
     type: ParticipantsOperationResponseDto,
   })
+  @ApiResponse({ status: 503, description: PARTICIPANTS_503 })
   async removeParticipants(
     @Param('sessionId') sessionId: string,
     @Param('groupId') groupId: string,
@@ -206,6 +215,7 @@ export class GroupController {
       'Participants processed — `results` carries the per-participant outcome (a partial refusal does not fail the batch; a total refusal is an error)',
     type: ParticipantsOperationResponseDto,
   })
+  @ApiResponse({ status: 503, description: PARTICIPANTS_503 })
   @HttpCode(HttpStatus.OK)
   async promoteParticipants(
     @Param('sessionId') sessionId: string,
@@ -228,6 +238,7 @@ export class GroupController {
       'Participants processed — `results` carries the per-participant outcome (a partial refusal does not fail the batch; a total refusal is an error)',
     type: ParticipantsOperationResponseDto,
   })
+  @ApiResponse({ status: 503, description: PARTICIPANTS_503 })
   @HttpCode(HttpStatus.OK)
   async demoteParticipants(
     @Param('sessionId') sessionId: string,

--- a/src/modules/label/label.controller.ts
+++ b/src/modules/label/label.controller.ts
@@ -43,6 +43,13 @@ export class LabelController {
   @ApiResponse({ status: 200, description: 'Chats carrying the label', type: [LabelChatDto] })
   @ApiResponse({ status: 400, description: 'Session not started' })
   @ApiResponse({ status: 501, description: 'The active engine cannot list chats by label (Baileys)' })
+  @ApiResponse({
+    status: 503,
+    description:
+      'The whatsapp-web.js page connection died mid-read, so nothing could be read. Deliberately not ' +
+      'reported as a missing label — a page that went away says nothing about whether the label exists. ' +
+      'The other engine never answers this: Baileys has no label query at all and answers 501 above.',
+  })
   async getChatsByLabel(@Param('sessionId') sessionId: string, @Param('labelId') labelId: string) {
     return this.labelService.getChatsByLabel(sessionId, labelId);
   }


### PR DESCRIPTION
## What

Five routes answer `503` today and published only their success statuses. This adds the missing `@ApiResponse` declarations and regenerates the snapshot. No runtime behaviour changes — every `503` here was already reachable.

| Route | Declared before | Answers 503 since |
| --- | --- | --- |
| `POST /sessions/{id}/groups/{groupId}/participants` | `200` | 0.14.5 |
| `DELETE /sessions/{id}/groups/{groupId}/participants` | `200` | 0.14.5 |
| `POST /sessions/{id}/groups/{groupId}/participants/promote` | `200` | 0.14.5 |
| `POST /sessions/{id}/groups/{groupId}/participants/demote` | `200` | 0.14.5 |
| `GET /sessions/{id}/labels/{labelId}/chats` | `200,400,501` | 0.14.0 |

`CHANGELOG [0.14.5]` already states the participant writes "now answer `503`", so the changelog was right and the contract was the part left behind.

## Why the previous pass missed them

#1149 derived its set from delegate methods containing a bounded call. These five fail that derivation in two different ways, which is worth recording so the next sweep does not repeat it:

**The participant writes hide the bounded call one level down.** `addParticipants`, `removeParticipants`, `promoteParticipants` and `demoteParticipants` each contain a single forwarding call and nothing else; the deadline lives inside the private `runParticipantsUpdate` they all delegate to. A derivation matching "method containing a bounded call" sees four methods containing none.

**The label read has no request budget at all.** Its `503` comes from an `EngineTransportError` thrown directly on the whatsapp-web.js side when the page connection dies mid-read. A sweep anchored on the deadline helper cannot see it by construction. It has been undocumented for five releases, with `whatsapp-web-js.adapter.spec.ts` asserting the behaviour that whole time.

## Why the two descriptions differ

The participant `503` is the one status that separates "WhatsApp never answered" from the per-participant refusals a `200` already reports inside `results` — an unanswered query yields `[]`, which the empty-results guard would otherwise turn into a `403`, selling a dead transport as a permissions problem. All four share one constant so the four cannot drift apart.

The label route has no deadline, so reusing the request-budget sentence there would have documented a mechanism that route does not have. It gets wording about the page connection instead.

## Test

The structural invariant in `openapi-contract.spec.ts` is keyed off the response schema rather than a list of paths, so a fifth participant route inherits it rather than slipping past the way these four did. It was checked in both directions: dropping the `503` from one route fails it, and renaming the schema fails the non-empty guard rather than passing vacuously.

## Deliberately unchanged

Creating a group, creating a channel and the media send path stay unbounded and undeclared, for the reason `CHANGELOG [0.14.5]` gives — they are non-idempotent and the Go SDK retries `POST` on `503`, so declaring it there would break the interlock.

## Out of scope, noted for follow-up

- The four participant routes can also answer `403` (`EngineRefusedError`, on a total refusal or an empty result) and do not declare it.
- `GET /labels/{labelId}/chats` can answer `404` (`LabelNotFoundError`, unknown label) and does not declare it.
- The MCP tool surface reaches the same service methods over HTTP but carries no `@ApiResponse` surface at all.
- `openapi.json` is copied into the docs repository; that snapshot needs refreshing, and the API-conventions and troubleshooting pages can now claim the `503` for these routes.

## Verification

`openapi:check`, `lint`, `format:check`, `tsc --noEmit`, `build`, dashboard `build` all exit 0; `npm test` passes 5119 tests across 300 suites. `openapi.json` was regenerated with `npm run openapi:export`, never edited by hand.

Refs #1149
