### PR TITLE
fix(openapi): correct seven examples that publish values the API cannot produce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Five routes now document a `503` they have been answering for releases** — the four group participant writes have spent the shared request budget since 0.14.5 and listing chats by label has answered `503` on a dead whatsapp-web.js page since 0.14.0, but all five published only their success statuses, so a client generated from the contract had no branch for a failure the gateway was already returning; the participant `503` in particular is the one status that separates "WhatsApp never answered" from the per-participant refusals a `200` reports inside `results`.
 
+### Fixed
+
+- **Seven published examples showed values the API cannot produce** — the session id carried a `sess_` prefix that every session route's `ParseUUIDPipe` rejects before the handler runs, two row ids were UUIDs truncated to `4f1c9b2a-...`, the logout response example omitted `engineLoaded` although its own schema marks it required, the readiness probe keyed its details on `database` where the code writes `mainDatabase` and `dataDatabase`, the engine list advertised a `send-text` capability neither engine declares, and the Baileys-only product send documented the whatsapp-web.js `true_<jid>_<id>` id form that route never returns.
+
 ## [0.14.6] - 2026-08-08
 
 ### Added

--- a/openapi.json
+++ b/openapi.json
@@ -667,7 +667,9 @@
                   "lastActive": "2026-06-25T09:01:55.000Z",
                   "createdAt": "2026-06-20T11:30:00.000Z",
                   "updatedAt": "2026-06-25T09:11:00.000Z",
-                  "lastError": null
+                  "lastError": null,
+                  "restriction": null,
+                  "engineLoaded": false
                 }
               }
             }
@@ -8363,7 +8365,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "example": "4f1c9b2a-..."
+            "example": "4f1c9b2a-8d3e-4c5b-9a17-2e6f0b4d8c31"
           },
           "action": {
             "type": "string",
@@ -8761,7 +8763,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "example": "sess_123e4567-e89b-12d3-a456-426614174000"
+            "example": "0a941dac-a965-45e7-b318-74ae8be134f0"
           },
           "name": {
             "type": "string",
@@ -10326,7 +10328,10 @@
             "type": "object",
             "description": "Per-dependency outcome, keyed by dependency name. Present on both the 200 and the 503.",
             "example": {
-              "database": {
+              "mainDatabase": {
+                "status": "up"
+              },
+              "dataDatabase": {
                 "status": "up"
               }
             },
@@ -10704,7 +10709,9 @@
           "features": {
             "description": "Capabilities the engine declares.",
             "example": [
-              "send-text"
+              "text-messages",
+              "media-messages",
+              "group-management"
             ],
             "type": "array",
             "items": {
@@ -13469,8 +13476,8 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The message id, assigned when the gateway accepts the message for sending. Note the field name: the send routes served by MessageService answer `messageId` for the same value. A 2xx here means the message was handed to the WhatsApp client, not that it was delivered.",
-            "example": "true_628123456789@c.us_3EB0123456789"
+            "description": "The message id, assigned when the gateway accepts the message for sending. Note the field name: the send routes served by MessageService answer `messageId` for the same value. A 2xx here means the message was handed to the WhatsApp client, not that it was delivered.\n\nThis route is Baileys-only, so the id is the bare key id Baileys assigns — not the `true_<jid>_<id>` serialized form the whatsapp-web.js send routes report.",
+            "example": "3EB0C767D26B8A3F6E"
           },
           "timestamp": {
             "type": "number",
@@ -13805,7 +13812,7 @@
           "messageId": {
             "type": "string",
             "description": "Gateway message row id.",
-            "example": "4f1c9b2a-..."
+            "example": "7c2e5a91-3b8d-4f6a-a05c-9d1e4b7f2306"
           },
           "waMessageId": {
             "type": "string",

--- a/src/modules/audit/dto/audit-response.dto.ts
+++ b/src/modules/audit/dto/audit-response.dto.ts
@@ -7,7 +7,7 @@ import { ApiProperty } from '@nestjs/swagger';
  */
 
 export class AuditLogDto {
-  @ApiProperty({ example: '4f1c9b2a-...' }) id!: string;
+  @ApiProperty({ example: '4f1c9b2a-8d3e-4c5b-9a17-2e6f0b4d8c31' }) id!: string;
 
   @ApiProperty({ description: 'What happened.', example: 'session.create' })
   action!: string;

--- a/src/modules/catalog/dto/catalog-response.dto.ts
+++ b/src/modules/catalog/dto/catalog-response.dto.ts
@@ -102,8 +102,10 @@ export class ProductMessageResponseDto {
     description:
       'The message id, assigned when the gateway accepts the message for sending. Note the field ' +
       'name: the send routes served by MessageService answer `messageId` for the same value. A 2xx ' +
-      'here means the message was handed to the WhatsApp client, not that it was delivered.',
-    example: 'true_628123456789@c.us_3EB0123456789',
+      'here means the message was handed to the WhatsApp client, not that it was delivered.\n\n' +
+      'This route is Baileys-only, so the id is the bare key id Baileys assigns — not the ' +
+      '`true_<jid>_<id>` serialized form the whatsapp-web.js send routes report.',
+    example: '3EB0C767D26B8A3F6E',
   })
   id!: string;
 

--- a/src/modules/health/dto/health-response.dto.ts
+++ b/src/modules/health/dto/health-response.dto.ts
@@ -31,7 +31,7 @@ export class ReadinessResponseDto {
 
   @ApiProperty({
     description: 'Per-dependency outcome, keyed by dependency name. Present on both the 200 and the 503.',
-    example: { database: { status: 'up' } },
+    example: { mainDatabase: { status: 'up' }, dataDatabase: { status: 'up' } },
     additionalProperties: { type: 'object' },
   })
   details!: { [dependency: string]: object };

--- a/src/modules/infra/dto/infra-response.dto.ts
+++ b/src/modules/infra/dto/infra-response.dto.ts
@@ -174,7 +174,11 @@ export class AvailableEngineDto {
   @ApiProperty({ description: 'Whether the plugin is enabled. Disabled engines are still listed.', example: true })
   enabled!: boolean;
 
-  @ApiProperty({ type: [String], description: 'Capabilities the engine declares.', example: ['send-text'] })
+  @ApiProperty({
+    type: [String],
+    description: 'Capabilities the engine declares.',
+    example: ['text-messages', 'media-messages', 'group-management'],
+  })
   features!: string[];
 
   @ApiPropertyOptional({

--- a/src/modules/search/dto/search-response.dto.ts
+++ b/src/modules/search/dto/search-response.dto.ts
@@ -7,7 +7,7 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
  */
 
 export class SearchHitDto {
-  @ApiProperty({ description: 'Gateway message row id.', example: '4f1c9b2a-...' })
+  @ApiProperty({ description: 'Gateway message row id.', example: '7c2e5a91-3b8d-4f6a-a05c-9d1e4b7f2306' })
   messageId!: string;
 
   @ApiProperty({ description: "WhatsApp's own message id.", example: 'true_628123456789@c.us_3EB0123' })

--- a/src/modules/session/dto/session-response.dto.ts
+++ b/src/modules/session/dto/session-response.dto.ts
@@ -35,7 +35,7 @@ export class AccountRestrictionDto {
 }
 
 export class SessionResponseDto {
-  @ApiProperty({ example: 'sess_123e4567-e89b-12d3-a456-426614174000' })
+  @ApiProperty({ example: '0a941dac-a965-45e7-b318-74ae8be134f0' })
   id!: string;
 
   @ApiProperty({ example: 'my-bot' })

--- a/src/modules/session/session.controller.ts
+++ b/src/modules/session/session.controller.ts
@@ -276,6 +276,9 @@ export class SessionController {
           createdAt: '2026-06-20T11:30:00.000Z',
           updatedAt: '2026-06-25T09:11:00.000Z',
           lastError: null,
+          restriction: null,
+          // The engine is torn out of the map before the status write, so a logout always reports false.
+          engineLoaded: false,
         },
       },
     },


### PR DESCRIPTION
## What

Seven published examples show values the gateway cannot produce. An example is the part of a contract people copy first, so each of these teaches a shape that fails on use. No runtime behaviour changes.

| Location | Was | Now | Why it was impossible |
| --- | --- | --- | --- |
| `session-response.dto.ts:38` | `sess_123e4567-…` | `0a941dac-…` | prefixed ids are rejected by `ParseUUIDPipe` |
| `audit-response.dto.ts:10` | `4f1c9b2a-...` | full UUID v4 | column is a full UUID |
| `search-response.dto.ts:10` | `4f1c9b2a-...` | full UUID v4 | column is a full UUID |
| `session.controller.ts:268` | `engineLoaded` absent | `engineLoaded: false`, `restriction: null` | violates its own schema's `required` |
| `health-response.dto.ts:34` | `{ database: … }` | `{ mainDatabase, dataDatabase }` | handler builds those two keys |
| `infra-response.dto.ts:177` | `['send-text']` | real capability vocabulary | no engine declares it |
| `catalog-response.dto.ts:106` | `true_<jid>_<id>` | bare Baileys key id | route is Baileys-only |

## The session id, in detail

Session ids are bare UUIDs — `@PrimaryGeneratedColumn('uuid')` — and all 21 session routes bind `@Param('id', ParseUUIDPipe)`, so `sess_…` is rejected before the handler runs. The example was wrong twice over: the UUID inside the prefix is a v1, where TypeORM generates v4. The replacement is the literal this repo already uses for a session id in the search and stats DTOs.

`sess_` in `webhook/utils/idempotency.util.ts` is a different thing entirely — it builds an idempotency key — and is untouched.

## The logout example

It is bound to `schema: { $ref: '#/components/schemas/SessionResponseDto' }` but omitted `engineLoaded`, which that schema lists in `required`. `SessionResponseDto.fromEntity` takes `engineLoaded` as a mandatory parameter precisely so it can never default away, so no handler can emit that body — the example was invalid against its own `$ref`, and a schema-validating consumer rejects it. `false` is the value this route actually produces: `session-engine-controls.ts:341` deletes the engine from the map before `:342` writes `DISCONNECTED`. `restriction`, also always written, was missing too.

## One literal, two verdicts

`true_628123456789@c.us_3EB0123456789` appears on both the message send route and the product send route. It is correct on the first — that route is served by whatsapp-web.js, which emits exactly that serialized form — and impossible on the second, which is Baileys-only: whatsapp-web.js answers `501` there and Baileys returns a bare key id. Only the catalog one is changed.

## Checked and deliberately left alone

- `qr_ready` and `reachout_timelock` are legal values of `SessionStatus` and of the `kind` union declared directly above them.
- The `owa_k1_` API key prefix is exactly what `auth.service.ts:37` generates.
- Ellipses on base64 payloads and on the API key secret stay: there, eliding is a documentation convention, not a claim about form. Only fixed-length identifiers were completed.
- `allowedSessions: ['session-uuid-1', 'session-uuid-2']` is useless rather than impossible — the entries can never match a session id, but nothing validates them, so this is a judgement call left open rather than changed.
- `channel-response.dto.ts:22` `inviteCode: '0029Va...'` — invite codes are variable-length and no fixed form could be proven.

## No test added, deliberately

The one class here that a structural invariant could catch — an inline example violating its own schema's `required` — has a population of exactly one in the whole document (measured against `openapi.json`), now at zero violations. A test guarding a population of one is not worth the file it lives in. Say the word if you want it anyway.

## Verification

`openapi:check`, `lint`, `format:check`, `tsc --noEmit`, `build`, dashboard `build` all exit 0; `npm test` passes 5119 tests across 300 suites. `openapi.json` was regenerated with `npm run openapi:export` after rebasing onto the current main, and the export matched the rebase's textual merge exactly.

## Follow-up, not in this repo

The docs site generates its API Reference from this `openapi.json`, and `docs/getting-started/quick-start.md` mirrors the `sess_` prefix at lines 124, 135, 192, 256 and 259. That prose was deliberately not changed first, since changing it alone would have put the site at odds with its own reference pages. With this snapshot clean, docs can follow.
