### PR TITLE
docs(openapi): declare the statuses routes can already answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **A hundred and twenty-five routes now document a status they could already answer** — the contract described the happy path and the timeout but almost nothing in between: ninety-one routes reach an engine whose `ensureReady()` guard answers `409` when the session has no live engine, and not one of them said so; six sends could answer `400` for a recipient WhatsApp cannot address; six group and channel writes could answer `403` on a WhatsApp-side refusal; eleven routes could answer `404` for a message, group, channel or label that does not resolve; and eleven could answer `501` on the engine that cannot serve them. A client generated from the contract had no branch for any of it, and on the four participant writes the undeclared `403` was the one status separating a refused batch from an applied one.
+
 - **Five routes now document a `503` they have been answering for releases** — the four group participant writes have spent the shared request budget since 0.14.5 and listing chats by label has answered `503` on a dead whatsapp-web.js page since 0.14.0, but all five published only their success statuses, so a client generated from the contract had no branch for a failure the gateway was already returning; the participant `503` in particular is the one status that separates "WhatsApp never answered" from the per-participant refusals a `200` reports inside `results`.
 
 ### Fixed

--- a/openapi.json
+++ b/openapi.json
@@ -758,6 +758,9 @@
           },
           "404": {
             "description": "Session not found"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           }
         },
         "summary": "Get QR code for session authentication",
@@ -806,6 +809,9 @@
           },
           "404": {
             "description": "Session not found"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           }
         },
         "summary": "Request an 8-char pairing code to link via phone number (alternative to QR)",
@@ -855,6 +861,9 @@
           },
           "404": {
             "description": "Session not found"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           },
           "503": {
             "description": "WhatsApp did not answer the group-list query. Deliberately not reported as an empty list — the engine returns the same empty value for \"you are in no groups\", and a caller cannot tell those apart from the body."
@@ -917,6 +926,9 @@
           },
           "404": {
             "description": "Session not found"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           }
         },
         "summary": "Get active chats for a session",
@@ -958,6 +970,9 @@
           },
           "404": {
             "description": "Session not found"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
@@ -1003,6 +1018,9 @@
           },
           "404": {
             "description": "Session not found"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           },
           "501": {
             "description": "The active engine cannot observe presence (whatsapp-web.js)"
@@ -1093,6 +1111,9 @@
           "404": {
             "description": "Session not found"
           },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
           }
@@ -1135,6 +1156,9 @@
           },
           "404": {
             "description": "Session not found"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
@@ -1180,6 +1204,9 @@
           "404": {
             "description": "Session not found"
           },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
           }
@@ -1224,6 +1251,9 @@
           "404": {
             "description": "Session not found"
           },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
           }
@@ -1264,6 +1294,9 @@
           },
           "404": {
             "description": "Session not found"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           }
         },
         "summary": "Send a typing/recording presence indicator to a chat (or clear it with 'paused')",
@@ -1946,6 +1979,12 @@
           },
           "404": {
             "description": "Session not found"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
+          "501": {
+            "description": "The active engine cannot serve this operation. It is part of the engine contract, but the engine currently running has no implementation for it."
           }
         },
         "summary": "Send a text message",
@@ -1994,6 +2033,9 @@
           },
           "404": {
             "description": "Session or template not found"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           }
         },
         "summary": "Render a stored text template and send it as a text message",
@@ -2049,6 +2091,12 @@
           },
           "400": {
             "description": "Session not active or invalid request"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
+          "501": {
+            "description": "Sending media to a channel (`<id>@newsletter`) is not supported by the whatsapp-web.js engine — the page method it needs was removed by a WhatsApp Web update. Text to a channel still works."
           }
         },
         "summary": "Send an image message",
@@ -2103,6 +2151,12 @@
           },
           "400": {
             "description": "Session not active or invalid request"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
+          "501": {
+            "description": "Sending media to a channel (`<id>@newsletter`) is not supported by the whatsapp-web.js engine — the page method it needs was removed by a WhatsApp Web update. Text to a channel still works."
           }
         },
         "summary": "Send a video message",
@@ -2158,6 +2212,12 @@
           },
           "400": {
             "description": "Session not active or invalid request"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
+          "501": {
+            "description": "Sending media to a channel (`<id>@newsletter`) is not supported by the whatsapp-web.js engine — the page method it needs was removed by a WhatsApp Web update. Text to a channel still works."
           }
         },
         "summary": "Send an audio/voice message",
@@ -2213,6 +2273,12 @@
           },
           "400": {
             "description": "Session not active or invalid request"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
+          "501": {
+            "description": "Sending media to a channel (`<id>@newsletter`) is not supported by the whatsapp-web.js engine — the page method it needs was removed by a WhatsApp Web update. Text to a channel still works."
           }
         },
         "summary": "Send a document/file",
@@ -2255,6 +2321,12 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "The recipient could not be addressed — WhatsApp reports no deliverable id for that `chatId`, which is how it says the number is not reachable on WhatsApp. `400` rather than `404`, because a `404` on these routes already means the session was not found."
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           }
         },
         "summary": "Send a location message",
@@ -2297,6 +2369,12 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "The recipient could not be addressed — WhatsApp reports no deliverable id for that `chatId`, which is how it says the number is not reachable on WhatsApp. `400` rather than `404`, because a `404` on these routes already means the session was not found."
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           }
         },
         "summary": "Send a contact card message",
@@ -2348,6 +2426,15 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "The recipient could not be addressed — WhatsApp reports no deliverable id for that `chatId`, which is how it says the number is not reachable on WhatsApp. `400` rather than `404`, because a `404` on these routes already means the session was not found."
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
+          "501": {
+            "description": "Sending media to a channel (`<id>@newsletter`) is not supported by the whatsapp-web.js engine — the page method it needs was removed by a WhatsApp Web update. Text to a channel still works."
           }
         },
         "summary": "Send a sticker message",
@@ -2390,6 +2477,12 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "The recipient could not be addressed — WhatsApp reports no deliverable id for that `chatId`, which is how it says the number is not reachable on WhatsApp. `400` rather than `404`, because a `404` on these routes already means the session was not found."
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           }
         },
         "summary": "Send a native WhatsApp poll",
@@ -2432,6 +2525,15 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "The recipient could not be addressed — WhatsApp reports no deliverable id for that `chatId`, which is how it says the number is not reachable on WhatsApp. `400` rather than `404`, because a `404` on these routes already means the session was not found."
+          },
+          "404": {
+            "description": "No such message — the id is outside the engine's lookup window (roughly the last hundred messages of the chat, or absent from the Baileys store) or the message was revoked."
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           }
         },
         "summary": "Reply to a message",
@@ -2474,6 +2576,15 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "The recipient could not be addressed — WhatsApp reports no deliverable id for that `chatId`, which is how it says the number is not reachable on WhatsApp. `400` rather than `404`, because a `404` on these routes already means the session was not found."
+          },
+          "404": {
+            "description": "No such message — the id is outside the engine's lookup window (roughly the last hundred messages of the chat, or absent from the Baileys store) or the message was revoked."
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           }
         },
         "summary": "Forward a message to another chat",
@@ -2512,6 +2623,12 @@
           },
           "400": {
             "description": "Session not active or message not found"
+          },
+          "404": {
+            "description": "No such message — the id is outside the engine's lookup window (roughly the last hundred messages of the chat, or absent from the Baileys store) or the message was revoked."
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           }
         },
         "summary": "Add or remove a reaction to a message",
@@ -2574,6 +2691,12 @@
         "responses": {
           "200": {
             "description": "Chat history (most recent messages)"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
+          "501": {
+            "description": "The active engine cannot serve this operation. It is part of the engine contract, but the engine currently running has no implementation for it."
           }
         },
         "summary": "Fetch chat history live from WhatsApp",
@@ -2617,6 +2740,15 @@
         "responses": {
           "200": {
             "description": "List of reactions with senders"
+          },
+          "404": {
+            "description": "No such message — the id is outside the engine's lookup window (roughly the last hundred messages of the chat, or absent from the Baileys store) or the message was revoked."
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
+          "501": {
+            "description": "The active engine cannot serve this operation. It is part of the engine contract, but the engine currently running has no implementation for it."
           }
         },
         "summary": "Get reactions for a specific message",
@@ -2710,6 +2842,12 @@
           "400": {
             "description": "Session not active or message not found"
           },
+          "404": {
+            "description": "No such message — the id is outside the engine's lookup window (roughly the last hundred messages of the chat, or absent from the Baileys store) or the message was revoked."
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
           }
@@ -2753,6 +2891,9 @@
           },
           "404": {
             "description": "Poll not found in the chat’s recent history"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           },
           "501": {
             "description": "Not supported on the Baileys engine"
@@ -2800,6 +2941,9 @@
           },
           "404": {
             "description": "Message not found in the chat"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           }
         },
         "summary": "Pin a message in its chat",
@@ -2844,6 +2988,9 @@
           },
           "404": {
             "description": "Message not found in the chat"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           }
         },
         "summary": "Remove a message’s pin",
@@ -2885,6 +3032,9 @@
           },
           "404": {
             "description": "Message not found in the chat"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
@@ -2939,6 +3089,9 @@
           },
           "404": {
             "description": "Message not found"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           }
         },
         "summary": "Edit the text of a message sent by this account",
@@ -2984,6 +3137,9 @@
           },
           "400": {
             "description": "Session not active or invalid request"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           }
         },
         "summary": "Send messages to multiple recipients (async batch processing)",
@@ -3803,6 +3959,9 @@
           },
           "404": {
             "description": "Session not found"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           }
         },
         "summary": "Get all contacts for a session",
@@ -3845,6 +4004,9 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           }
         },
         "summary": "Batch-resolve profile picture URLs for up to 50 contacts",
@@ -3889,6 +4051,9 @@
           },
           "404": {
             "description": "Contact not found"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           }
         },
         "summary": "Get a specific contact by ID",
@@ -3942,6 +4107,9 @@
           "400": {
             "description": "Session not active or invalid request"
           },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
           }
@@ -3986,6 +4154,9 @@
           },
           "400": {
             "description": "Session not active"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
@@ -4032,6 +4203,9 @@
               }
             }
           },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "503": {
             "description": "WhatsApp did not answer the lookup. Deliberately not reported as `exists: false` — that would be a claim about the number rather than about the query, and this route exists to be trusted before a send."
           }
@@ -4076,6 +4250,9 @@
               }
             }
           },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "503": {
             "description": "WhatsApp did not answer the lookup. Deliberately not reported as `url: null` — that is the same answer a contact with no picture gives, and a caller cannot tell them apart."
           }
@@ -4119,6 +4296,9 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           }
         },
         "summary": "Resolve a contact id (e.g. an @lid) to a phone number — best-effort",
@@ -4161,6 +4341,9 @@
               }
             }
           },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
           }
@@ -4202,6 +4385,9 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
@@ -4254,6 +4440,9 @@
           "404": {
             "description": "No such invite — invalid, expired or revoked"
           },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "503": {
             "description": "WhatsApp did not answer within the request budget. Deliberately not folded into the 404 above — a query that never came back is not the same claim as a group that does not exist."
           }
@@ -4300,6 +4489,9 @@
           },
           "404": {
             "description": "Group not found"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget. Deliberately not folded into the 404 above — a query that never came back is not the same claim as a group that does not exist."
@@ -4349,6 +4541,9 @@
           "400": {
             "description": "Invalid or expired invite code, or session is not started"
           },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
           }
@@ -4395,6 +4590,9 @@
           },
           "404": {
             "description": "Group not found"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget — nothing could be read."
@@ -4457,6 +4655,9 @@
           "404": {
             "description": "Group not found"
           },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "501": {
             "description": "The active engine does not support a requested setting"
           },
@@ -4504,6 +4705,12 @@
                 }
               }
             }
+          },
+          "403": {
+            "description": "WhatsApp refused the operation. The request was well formed — the refusal happened WhatsApp-side, most often because the account lacks the admin rights the operation requires."
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           }
         },
         "summary": "Create a new group",
@@ -4556,6 +4763,12 @@
               }
             }
           },
+          "403": {
+            "description": "WhatsApp refused the operation. The request was well formed — the refusal happened WhatsApp-side, most often because the account lacks the admin rights the operation requires."
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "503": {
             "description": "WhatsApp did not answer within the request budget, so no per-participant outcome was read at all. Deliberately not folded into the 200 above — a participant WhatsApp turned down is reported inside `results` and is an answer; an update that never came back is not."
           }
@@ -4607,6 +4820,12 @@
                 }
               }
             }
+          },
+          "403": {
+            "description": "WhatsApp refused the operation. The request was well formed — the refusal happened WhatsApp-side, most often because the account lacks the admin rights the operation requires."
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget, so no per-participant outcome was read at all. Deliberately not folded into the 200 above — a participant WhatsApp turned down is reported inside `results` and is an answer; an update that never came back is not."
@@ -4662,6 +4881,12 @@
               }
             }
           },
+          "403": {
+            "description": "WhatsApp refused the operation. The request was well formed — the refusal happened WhatsApp-side, most often because the account lacks the admin rights the operation requires."
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "503": {
             "description": "WhatsApp did not answer within the request budget, so no per-participant outcome was read at all. Deliberately not folded into the 200 above — a participant WhatsApp turned down is reported inside `results` and is an answer; an update that never came back is not."
           }
@@ -4715,6 +4940,12 @@
                 }
               }
             }
+          },
+          "403": {
+            "description": "WhatsApp refused the operation. The request was well formed — the refusal happened WhatsApp-side, most often because the account lacks the admin rights the operation requires."
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget, so no per-participant outcome was read at all. Deliberately not folded into the 200 above — a participant WhatsApp turned down is reported inside `results` and is an answer; an update that never came back is not."
@@ -4773,6 +5004,9 @@
           "403": {
             "description": "The engine refused the change — admin rights are required"
           },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
           }
@@ -4830,6 +5064,9 @@
           "403": {
             "description": "The engine refused the change — admin rights are required"
           },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
           }
@@ -4874,6 +5111,9 @@
               }
             }
           },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
           }
@@ -4917,6 +5157,9 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget — nothing could be read."
@@ -4976,6 +5219,12 @@
           "403": {
             "description": "The engine refused the change — admin rights required"
           },
+          "404": {
+            "description": "No such group — the id is unknown, or it addresses a 1:1 chat rather than a group."
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
           }
@@ -5020,6 +5269,12 @@
           },
           "403": {
             "description": "The engine refused the change — admin rights required"
+          },
+          "404": {
+            "description": "No such group — the id is unknown, or it addresses a 1:1 chat rather than a group."
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
@@ -5068,6 +5323,9 @@
           "403": {
             "description": "The engine refused the request — admin rights required for this group"
           },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "503": {
             "description": "WhatsApp did not answer the invite-code query — retry shortly"
           }
@@ -5114,6 +5372,9 @@
           },
           "403": {
             "description": "The engine refused the request — admin rights required for this group"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           },
           "503": {
             "description": "WhatsApp did not answer the invite-code query — retry shortly"
@@ -5166,6 +5427,9 @@
           "403": {
             "description": "The engine refused the name change"
           },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
           }
@@ -5213,6 +5477,9 @@
           },
           "400": {
             "description": "Session is not started"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
@@ -5264,6 +5531,9 @@
           },
           "403": {
             "description": "The engine refused the picture change"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           },
           "413": {
             "description": "Decoded base64 image exceeds the configured media cap"
@@ -5318,6 +5588,9 @@
           "404": {
             "description": "Call not found or no longer ringing"
           },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
           }
@@ -5361,6 +5634,12 @@
           },
           "404": {
             "description": "Session not found"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
+          "501": {
+            "description": "The active engine cannot serve this operation. It is part of the engine contract, but the engine currently running has no implementation for it."
           }
         },
         "summary": "Get all labels (WhatsApp Business only)",
@@ -5405,6 +5684,12 @@
           },
           "404": {
             "description": "Label not found"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
+          "501": {
+            "description": "The active engine cannot serve this operation. It is part of the engine contract, but the engine currently running has no implementation for it."
           }
         },
         "summary": "Get a specific label by ID",
@@ -5459,6 +5744,9 @@
           "400": {
             "description": "Session not started, or validation failed"
           },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "501": {
             "description": "The active engine cannot edit labels (whatsapp-web.js)"
           },
@@ -5507,6 +5795,9 @@
           },
           "400": {
             "description": "Session not started"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           },
           "501": {
             "description": "The active engine cannot edit labels (whatsapp-web.js)"
@@ -5562,6 +5853,12 @@
           "400": {
             "description": "Session not started"
           },
+          "404": {
+            "description": "No such label — it was never created, or the account is not a WhatsApp Business one and holds no labels at all. Both are the same answer to the caller."
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "501": {
             "description": "The active engine cannot list chats by label (Baileys)"
           },
@@ -5611,6 +5908,12 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
+          "501": {
+            "description": "The active engine cannot serve this operation. It is part of the engine contract, but the engine currently running has no implementation for it."
           }
         },
         "summary": "Get labels for a specific chat",
@@ -5670,6 +5973,9 @@
               }
             }
           },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "422": {
             "description": "Labels require a WhatsApp Business account, or the chat type has no labels"
           },
@@ -5726,6 +6032,9 @@
               }
             }
           },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "422": {
             "description": "Labels require a WhatsApp Business account, or the chat type has no labels"
           },
@@ -5769,6 +6078,9 @@
           },
           "400": {
             "description": "Session not ready"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           },
           "501": {
             "description": "Not supported by the active engine: the Baileys adapter cannot list subscribed channels."
@@ -5819,6 +6131,9 @@
           },
           "403": {
             "description": "The engine refused — channel creation may be disabled for this account"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           }
         },
         "summary": "Create a channel",
@@ -5864,6 +6179,9 @@
           "404": {
             "description": "Channel not found"
           },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "503": {
             "description": "WhatsApp did not answer within the request budget — the operation may or may not have applied."
           }
@@ -5905,6 +6223,12 @@
                 }
               }
             }
+          },
+          "403": {
+            "description": "WhatsApp refused the operation. The request was well formed — the refusal happened WhatsApp-side, most often because the account lacks the admin rights the operation requires."
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget — the operation may or may not have applied."
@@ -5962,6 +6286,12 @@
               }
             }
           },
+          "404": {
+            "description": "No such channel — the id is not among the session's subscribed channels, either because it is wrong or because the channel has not synced into the local collection yet."
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "501": {
             "description": "Not supported by the active engine: the Baileys adapter cannot read channel messages."
           }
@@ -6012,6 +6342,9 @@
           },
           "403": {
             "description": "The engine refused — not found, or this account does not own it"
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget — the operation may or may not have applied."
@@ -6074,6 +6407,12 @@
           "403": {
             "description": "The engine refused"
           },
+          "404": {
+            "description": "No such channel — the id is not among the session's subscribed channels, either because it is wrong or because the channel has not synced into the local collection yet."
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "503": {
             "description": "WhatsApp did not answer within the request budget — the operation may or may not have applied."
           }
@@ -6128,6 +6467,12 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "No such channel — the id is not among the session's subscribed channels, either because it is wrong or because the channel has not synced into the local collection yet."
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           },
           "501": {
             "description": "Not supported by the active engine: whatsapp-web.js cannot subscribe by invite code."
@@ -6415,6 +6760,9 @@
           },
           "400": {
             "description": "Invalid request, or the post was blocked by a plugin."
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           }
         },
         "summary": "Post a text status",
@@ -6459,6 +6807,9 @@
           },
           "400": {
             "description": "Neither url nor base64 provided, or the post was blocked by a plugin."
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           },
           "413": {
             "description": "Base64 media exceeds MEDIA_DOWNLOAD_MAX_BYTES."
@@ -6507,6 +6858,9 @@
           "400": {
             "description": "Neither url nor base64 provided, or the post was blocked by a plugin."
           },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "413": {
             "description": "Base64 media exceeds MEDIA_DOWNLOAD_MAX_BYTES."
           }
@@ -6554,6 +6908,9 @@
           "400": {
             "description": "Neither url nor base64 provided, or the post was blocked by a plugin."
           },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "413": {
             "description": "Base64 media exceeds MEDIA_DOWNLOAD_MAX_BYTES."
           }
@@ -6595,6 +6952,9 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           }
         },
         "summary": "Delete own status",
@@ -6761,6 +7121,9 @@
               }
             }
           },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "501": {
             "description": "Not supported by the active engine: whatsapp-web.js has no catalog API."
           },
@@ -6820,6 +7183,9 @@
               }
             }
           },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "501": {
             "description": "Not supported by the active engine: whatsapp-web.js has no catalog API."
           },
@@ -6864,6 +7230,9 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
           },
           "501": {
             "description": "Not supported by the active engine: whatsapp-web.js has no catalog API."
@@ -6918,6 +7287,9 @@
           "404": {
             "description": "Product id not found in the session catalog."
           },
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "501": {
             "description": "Not supported by the active engine: whatsapp-web.js cannot send product messages."
           },
@@ -6955,6 +7327,9 @@
           }
         },
         "responses": {
+          "409": {
+            "description": "The session is not connected — it exists, but no engine is running for it, so the request never reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle routes answer, which reports a conflicting state rather than a missing engine."
+          },
           "501": {
             "description": "Not supported by the active engine: no engine can send catalog links."
           }

--- a/src/common/openapi/engine-status-responses.ts
+++ b/src/common/openapi/engine-status-responses.ts
@@ -1,0 +1,61 @@
+/**
+ * Response descriptions shared by every route that reaches a WhatsApp engine.
+ *
+ * Kept in one place rather than repeated per controller: the text describes the engine's own
+ * behaviour, not any one route's, so eleven copies would drift apart the moment one of them was
+ * reworded — which is how the contract fell behind the code in the first place.
+ */
+
+/**
+ * `EngineNotReadyError` (409) — thrown by every adapter's `ensureReady()` guard, which each engine
+ * method calls before touching the socket or the page. Distinct from the 409 the session, auth and
+ * plugin routes already declare: those report a semantic conflict (a name already taken, a plugin
+ * already installed, a session already running), whereas this one says the session exists but has
+ * no live engine behind it yet.
+ */
+export const ENGINE_NOT_READY_409 =
+  'The session is not connected — it exists, but no engine is running for it, so the request never ' +
+  'reached WhatsApp. Start the session and retry. Distinct from the `409` the session lifecycle ' +
+  'routes answer, which reports a conflicting state rather than a missing engine.';
+
+/**
+ * `RecipientUnreachableError` (400) — whatsapp-web.js could not resolve the recipient to an
+ * addressable id, so the send never left the gateway.
+ */
+export const RECIPIENT_UNREACHABLE_400 =
+  'The recipient could not be addressed — WhatsApp reports no deliverable id for that `chatId`, ' +
+  'which is how it says the number is not reachable on WhatsApp. `400` rather than `404`, because a ' +
+  '`404` on these routes already means the session was not found.';
+
+/** `EngineRefusedError` (403) — the request was well formed; WhatsApp itself refused it. */
+export const ENGINE_REFUSED_403 =
+  'WhatsApp refused the operation. The request was well formed — the refusal happened WhatsApp-side, ' +
+  'most often because the account lacks the admin rights the operation requires.';
+
+/** `MessageNotFoundError` (404) — outside the adapter's lookup window, or revoked. */
+export const MESSAGE_NOT_FOUND_404 =
+  "No such message — the id is outside the engine's lookup window (roughly the last hundred messages " +
+  'of the chat, or absent from the Baileys store) or the message was revoked.';
+
+/** `ChannelNotFoundError` (404). */
+export const CHANNEL_NOT_FOUND_404 =
+  "No such channel — the id is not among the session's subscribed channels, either because it is " +
+  'wrong or because the channel has not synced into the local collection yet.';
+
+/** `GroupNotFoundError` (404) — unknown id, or an id that addresses a 1:1 chat. */
+export const GROUP_NOT_FOUND_404 = 'No such group — the id is unknown, or it addresses a 1:1 chat rather than a group.';
+
+/** `LabelNotFoundError` (404) — never created, or the account is not a Business one. */
+export const LABEL_NOT_FOUND_404 =
+  'No such label — it was never created, or the account is not a WhatsApp Business one and holds no ' +
+  'labels at all. Both are the same answer to the caller.';
+
+/** `EngineNotSupportedError` (501) — in the engine contract, but not implementable on this engine. */
+export const ENGINE_NOT_SUPPORTED_501 =
+  'The active engine cannot serve this operation. It is part of the engine contract, but the engine ' +
+  'currently running has no implementation for it.';
+
+/** `ChannelMediaNotSupportedError` (501) — media to an `@newsletter` recipient on whatsapp-web.js. */
+export const CHANNEL_MEDIA_501 =
+  'Sending media to a channel (`<id>@newsletter`) is not supported by the whatsapp-web.js engine — ' +
+  'the page method it needs was removed by a WhatsApp Web update. Text to a channel still works.';

--- a/src/modules/call/call.controller.ts
+++ b/src/modules/call/call.controller.ts
@@ -4,6 +4,7 @@ import { CallAckResponseDto } from './dto/call-response.dto';
 import { CallService } from './call.service';
 import { RequireRole } from '../auth/decorators/auth.decorators';
 import { ApiKeyRole } from '../auth/entities/api-key.entity';
+import { ENGINE_NOT_READY_409 } from '../../common/openapi/engine-status-responses';
 
 @ApiTags('calls')
 @Controller('sessions/:sessionId/calls')
@@ -25,6 +26,7 @@ export class CallController {
       'WhatsApp did not answer within the request budget. The change may or may not have been applied — ' +
       'the gateway stopped waiting for a confirmation that never came.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async reject(@Param('sessionId') sessionId: string, @Param('callId') callId: string) {
     await this.callService.rejectCall(sessionId, callId);
     return { success: true };

--- a/src/modules/catalog/catalog.controller.ts
+++ b/src/modules/catalog/catalog.controller.ts
@@ -5,6 +5,7 @@ import { SendProductDto, SendCatalogDto, ProductQueryDto } from './dto/send-prod
 import { RequireRole } from '../auth/decorators/auth.decorators';
 import { ApiKeyRole } from '../auth/entities/api-key.entity';
 import { CatalogDto, PaginatedProductsDto, ProductDto, ProductMessageResponseDto } from './dto/catalog-response.dto';
+import { ENGINE_NOT_READY_409 } from '../../common/openapi/engine-status-responses';
 
 /**
  * Every catalog read walks WhatsApp's business-catalog IQ, which the server simply leaves
@@ -30,6 +31,7 @@ export class CatalogController {
     description: 'Not supported by the active engine: whatsapp-web.js has no catalog API.',
   })
   @ApiResponse({ status: 503, description: CATALOG_TIMEOUT_503 })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async getCatalog(@Param('sessionId') sessionId: string) {
     return this.catalogService.getCatalog(sessionId);
   }
@@ -42,6 +44,7 @@ export class CatalogController {
     description: 'Not supported by the active engine: whatsapp-web.js has no catalog API.',
   })
   @ApiResponse({ status: 503, description: CATALOG_TIMEOUT_503 })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async getProducts(@Param('sessionId') sessionId: string, @Query() query: ProductQueryDto) {
     return this.catalogService.getProducts(sessionId, query.page, query.limit);
   }
@@ -58,6 +61,7 @@ export class CatalogController {
     description: 'Not supported by the active engine: whatsapp-web.js has no catalog API.',
   })
   @ApiResponse({ status: 503, description: CATALOG_TIMEOUT_503 })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async getProduct(@Param('sessionId') sessionId: string, @Param('productId') productId: string) {
     return this.catalogService.getProduct(sessionId, productId);
   }
@@ -73,6 +77,7 @@ export class CatalogController {
     description: 'Not supported by the active engine: whatsapp-web.js cannot send product messages.',
   })
   @ApiResponse({ status: 503, description: CATALOG_TIMEOUT_503 })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async sendProduct(@Param('sessionId') sessionId: string, @Body() dto: SendProductDto) {
     return this.catalogService.sendProduct(sessionId, dto.chatId, dto.productId, dto.body);
   }
@@ -81,6 +86,7 @@ export class CatalogController {
   @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Send catalog link (not supported by any engine)' })
   @ApiResponse({ status: 501, description: 'Not supported by the active engine: no engine can send catalog links.' })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async sendCatalog(@Param('sessionId') sessionId: string, @Body() dto: SendCatalogDto) {
     return this.catalogService.sendCatalog(sessionId, dto.chatId, dto.body);
   }

--- a/src/modules/channel/channel.controller.ts
+++ b/src/modules/channel/channel.controller.ts
@@ -7,6 +7,11 @@ import { CreateChannelDto } from './dto/create-channel.dto';
 import { MuteChannelDto } from './dto/mute-channel.dto';
 import { RequireRole } from '../auth/decorators/auth.decorators';
 import { ApiKeyRole } from '../auth/entities/api-key.entity';
+import {
+  CHANNEL_NOT_FOUND_404,
+  ENGINE_NOT_READY_409,
+  ENGINE_REFUSED_403,
+} from '../../common/openapi/engine-status-responses';
 
 @ApiTags('channels')
 @Controller('sessions/:sessionId/channels')
@@ -22,6 +27,7 @@ export class ChannelController {
     status: 501,
     description: 'Not supported by the active engine: the Baileys adapter cannot list subscribed channels.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async findAll(@Param('sessionId') sessionId: string) {
     return this.channelService.getSubscribedChannels(sessionId);
   }
@@ -36,6 +42,7 @@ export class ChannelController {
     description: 'WhatsApp did not answer within the request budget — the operation may or may not have applied.',
   })
   @ApiResponse({ status: 404, description: 'Channel not found' })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async findOne(@Param('sessionId') sessionId: string, @Param('channelId') channelId: string) {
     return this.channelService.getChannelById(sessionId, channelId);
   }
@@ -55,6 +62,8 @@ export class ChannelController {
     status: 501,
     description: 'Not supported by the active engine: the Baileys adapter cannot read channel messages.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
+  @ApiResponse({ status: 404, description: CHANNEL_NOT_FOUND_404 })
   async getMessages(
     @Param('sessionId') sessionId: string,
     @Param('channelId') channelId: string,
@@ -80,6 +89,7 @@ export class ChannelController {
   @ApiResponse({ status: 201, description: 'The created channel', type: ChannelDto })
   @ApiResponse({ status: 400, description: 'Session not started, or validation failed' })
   @ApiResponse({ status: 403, description: 'The engine refused — channel creation may be disabled for this account' })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async create(@Param('sessionId') sessionId: string, @Body() dto: CreateChannelDto) {
     return this.channelService.createChannel(sessionId, dto.name, dto.description);
   }
@@ -103,6 +113,7 @@ export class ChannelController {
   })
   @ApiResponse({ status: 400, description: 'Session not started' })
   @ApiResponse({ status: 403, description: 'The engine refused — not found, or this account does not own it' })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async remove(
     @Param('sessionId') sessionId: string,
     @Param('channelId') channelId: string,
@@ -128,6 +139,8 @@ export class ChannelController {
   })
   @ApiResponse({ status: 400, description: 'Session not started, or validation failed' })
   @ApiResponse({ status: 403, description: 'The engine refused' })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
+  @ApiResponse({ status: 404, description: CHANNEL_NOT_FOUND_404 })
   async mute(
     @Param('sessionId') sessionId: string,
     @Param('channelId') channelId: string,
@@ -163,6 +176,8 @@ export class ChannelController {
     status: 501,
     description: 'Not supported by the active engine: whatsapp-web.js cannot subscribe by invite code.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
+  @ApiResponse({ status: 404, description: CHANNEL_NOT_FOUND_404 })
   async subscribe(@Param('sessionId') sessionId: string, @Body() body: SubscribeChannelDto) {
     return this.channelService.subscribeToChannel(sessionId, body.inviteCode);
   }
@@ -177,6 +192,8 @@ export class ChannelController {
     status: 503,
     description: 'WhatsApp did not answer within the request budget — the operation may or may not have applied.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
+  @ApiResponse({ status: 403, description: ENGINE_REFUSED_403 })
   async unsubscribe(@Param('sessionId') sessionId: string, @Param('channelId') channelId: string) {
     await this.channelService.unsubscribeFromChannel(sessionId, channelId);
     return { success: true };

--- a/src/modules/contact/contact.controller.ts
+++ b/src/modules/contact/contact.controller.ts
@@ -12,6 +12,7 @@ import {
   ProfilePicturesResponseDto,
   ResolvedPhoneResponseDto,
 } from './dto/contact-response.dto';
+import { ENGINE_NOT_READY_409 } from '../../common/openapi/engine-status-responses';
 
 @ApiTags('contacts')
 @Controller('sessions/:sessionId/contacts')
@@ -28,6 +29,7 @@ export class ContactController {
   })
   @ApiResponse({ status: 400, description: 'Session not ready' })
   @ApiResponse({ status: 404, description: 'Session not found' })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   @ApiQuery({ name: 'limit', required: false, description: 'Max contacts to return (1–1000, default 1000)' })
   @ApiQuery({ name: 'offset', required: false, description: 'Number of contacts to skip (for paging)' })
   async findAll(
@@ -51,6 +53,7 @@ export class ContactController {
   @ApiParam({ name: 'sessionId', description: 'Session ID' })
   @ApiQuery({ name: 'ids', required: true, description: 'Comma-separated contact ids (max 50 used)' })
   @ApiResponse({ status: 200, description: 'Picture URL per requested id', type: ProfilePicturesResponseDto })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   // NOTE: declared BEFORE @Get(':contactId') so the literal segment wins over the param route.
   async getProfilePictures(@Param('sessionId') sessionId: string, @Query('ids') ids?: string) {
     const list = (ids ?? '')
@@ -71,6 +74,7 @@ export class ContactController {
     type: ContactDto,
   })
   @ApiResponse({ status: 404, description: 'Contact not found' })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async findOne(@Param('sessionId') sessionId: string, @Param('contactId') contactId: string) {
     return this.contactService.getContactById(sessionId, contactId);
   }
@@ -98,6 +102,7 @@ export class ContactController {
       'would be a claim about the number rather than about the query, and this route exists to be ' +
       'trusted before a send.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async checkNumber(@Param('sessionId') sessionId: string, @Param('number') number: string) {
     // The engine returns the canonical chat id in its native format; we don't build the JID here
     // (decoupled from the whatsapp-web.js `@c.us` scheme).
@@ -126,6 +131,7 @@ export class ContactController {
       'WhatsApp did not answer the lookup. Deliberately not reported as `url: null` — that is the ' +
       'same answer a contact with no picture gives, and a caller cannot tell them apart.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async getProfilePicture(@Param('sessionId') sessionId: string, @Param('contactId') contactId: string) {
     const url = await this.contactService.getProfilePicture(sessionId, contactId);
     return { url };
@@ -140,6 +146,7 @@ export class ContactController {
     description: 'Resolved phone number (MSISDN digits), or null when the engine cannot map it',
     type: ResolvedPhoneResponseDto,
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async resolvePhone(@Param('sessionId') sessionId: string, @Param('contactId') contactId: string) {
     const phone = await this.contactService.resolveContactPhone(sessionId, contactId);
     return { contactId, phone };
@@ -159,6 +166,7 @@ export class ContactController {
       'WhatsApp did not answer within the request budget. The change may or may not have been applied — ' +
       'the gateway stopped waiting for a confirmation that never came.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async upsertContact(
     @Param('sessionId') sessionId: string,
     @Param('contactId') contactId: string,
@@ -183,6 +191,7 @@ export class ContactController {
       'WhatsApp did not answer within the request budget. The change may or may not have been applied — ' +
       'the gateway stopped waiting for a confirmation that never came.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async deleteContact(@Param('sessionId') sessionId: string, @Param('contactId') contactId: string) {
     await this.contactService.deleteContact(sessionId, contactId);
     return { success: true, message: 'Contact deleted' };
@@ -205,6 +214,7 @@ export class ContactController {
       'WhatsApp did not answer within the request budget. The change may or may not have been applied — ' +
       'the gateway stopped waiting for a confirmation that never came.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async blockContact(@Param('sessionId') sessionId: string, @Param('contactId') contactId: string) {
     await this.contactService.blockContact(sessionId, contactId);
     return { success: true, message: 'Contact blocked' };
@@ -226,6 +236,7 @@ export class ContactController {
       'WhatsApp did not answer within the request budget. The change may or may not have been applied — ' +
       'the gateway stopped waiting for a confirmation that never came.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async unblockContact(@Param('sessionId') sessionId: string, @Param('contactId') contactId: string) {
     await this.contactService.unblockContact(sessionId, contactId);
     return { success: true, message: 'Contact unblocked' };

--- a/src/modules/group/group.controller.ts
+++ b/src/modules/group/group.controller.ts
@@ -24,6 +24,11 @@ import {
   GroupSummaryDto,
   ParticipantsOperationResponseDto,
 } from './dto/group-response.dto';
+import {
+  ENGINE_NOT_READY_409,
+  ENGINE_REFUSED_403,
+  GROUP_NOT_FOUND_404,
+} from '../../common/openapi/engine-status-responses';
 
 // Reading an invite code is admin-only, but the groups list returns every group the account
 // belongs to whatever its role — so these two statuses apply to ids the caller was just given.
@@ -69,6 +74,7 @@ export class GroupController {
   })
   @ApiResponse({ status: 400, description: 'Session not started, or no code supplied' })
   @ApiResponse({ status: 404, description: 'No such invite — invalid, expired or revoked' })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async joinInfo(@Param('sessionId') sessionId: string, @Query('code') code: string) {
     return this.groupService.getGroupJoinInfo(sessionId, code);
   }
@@ -85,6 +91,7 @@ export class GroupController {
       'a query that never came back is not the same claim as a group that does not exist.',
   })
   @ApiResponse({ status: 404, description: 'Group not found' })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async findOne(@Param('sessionId') sessionId: string, @Param('groupId') groupId: string) {
     return this.groupService.getGroupInfo(sessionId, groupId);
   }
@@ -103,6 +110,7 @@ export class GroupController {
       'WhatsApp did not answer within the request budget. The change may or may not have been applied — ' +
       'the gateway stopped waiting for a confirmation that never came.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async join(@Param('sessionId') sessionId: string, @Body() dto: JoinGroupDto) {
     const groupId = await this.groupService.joinGroupViaInviteCode(sessionId, dto.inviteCode);
     return { success: true, groupId };
@@ -118,6 +126,7 @@ export class GroupController {
     status: 503,
     description: 'WhatsApp did not answer within the request budget — nothing could be read.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async getSettings(@Param('sessionId') sessionId: string, @Param('groupId') groupId: string) {
     return this.groupService.getGroupSettings(sessionId, groupId);
   }
@@ -139,6 +148,7 @@ export class GroupController {
       'WhatsApp did not answer within the request budget. The change may or may not have been applied — ' +
       'the gateway stopped waiting for a confirmation that never came.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async updateSettings(
     @Param('sessionId') sessionId: string,
     @Param('groupId') groupId: string,
@@ -154,6 +164,8 @@ export class GroupController {
   @ApiParam({ name: 'sessionId', description: 'Session ID' })
   @ApiBody({ type: CreateGroupDto })
   @ApiResponse({ status: 201, description: 'Group created', type: GroupSummaryDto })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
+  @ApiResponse({ status: 403, description: ENGINE_REFUSED_403 })
   async create(@Param('sessionId') sessionId: string, @Body() dto: CreateGroupDto) {
     return this.groupService.createGroup(sessionId, dto.name, dto.participants);
   }
@@ -171,6 +183,8 @@ export class GroupController {
     type: ParticipantsOperationResponseDto,
   })
   @ApiResponse({ status: 503, description: PARTICIPANTS_503 })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
+  @ApiResponse({ status: 403, description: ENGINE_REFUSED_403 })
   @HttpCode(HttpStatus.OK)
   async addParticipants(
     @Param('sessionId') sessionId: string,
@@ -194,6 +208,8 @@ export class GroupController {
     type: ParticipantsOperationResponseDto,
   })
   @ApiResponse({ status: 503, description: PARTICIPANTS_503 })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
+  @ApiResponse({ status: 403, description: ENGINE_REFUSED_403 })
   async removeParticipants(
     @Param('sessionId') sessionId: string,
     @Param('groupId') groupId: string,
@@ -216,6 +232,8 @@ export class GroupController {
     type: ParticipantsOperationResponseDto,
   })
   @ApiResponse({ status: 503, description: PARTICIPANTS_503 })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
+  @ApiResponse({ status: 403, description: ENGINE_REFUSED_403 })
   @HttpCode(HttpStatus.OK)
   async promoteParticipants(
     @Param('sessionId') sessionId: string,
@@ -239,6 +257,8 @@ export class GroupController {
     type: ParticipantsOperationResponseDto,
   })
   @ApiResponse({ status: 503, description: PARTICIPANTS_503 })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
+  @ApiResponse({ status: 403, description: ENGINE_REFUSED_403 })
   @HttpCode(HttpStatus.OK)
   async demoteParticipants(
     @Param('sessionId') sessionId: string,
@@ -263,6 +283,7 @@ export class GroupController {
       'WhatsApp did not answer within the request budget. The change may or may not have been applied — ' +
       'the gateway stopped waiting for a confirmation that never came.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async setSubject(
     @Param('sessionId') sessionId: string,
     @Param('groupId') groupId: string,
@@ -286,6 +307,7 @@ export class GroupController {
       'WhatsApp did not answer within the request budget. The change may or may not have been applied — ' +
       'the gateway stopped waiting for a confirmation that never came.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async setDescription(
     @Param('sessionId') sessionId: string,
     @Param('groupId') groupId: string,
@@ -308,6 +330,7 @@ export class GroupController {
       'WhatsApp did not answer within the request budget. The change may or may not have been applied — ' +
       'the gateway stopped waiting for a confirmation that never came.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async leave(@Param('sessionId') sessionId: string, @Param('groupId') groupId: string) {
     await this.groupService.leaveGroup(sessionId, groupId);
     return { success: true, message: 'Left the group' };
@@ -328,6 +351,7 @@ export class GroupController {
     status: 503,
     description: 'WhatsApp did not answer within the request budget — nothing could be read.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async getPicture(@Param('sessionId') sessionId: string, @Param('groupId') groupId: string) {
     return { url: await this.groupService.getGroupPicture(sessionId, groupId) };
   }
@@ -347,6 +371,8 @@ export class GroupController {
       'WhatsApp did not answer within the request budget. The change may or may not have been applied — ' +
       'the gateway stopped waiting for a confirmation that never came.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
+  @ApiResponse({ status: 404, description: GROUP_NOT_FOUND_404 })
   async setPicture(
     @Param('sessionId') sessionId: string,
     @Param('groupId') groupId: string,
@@ -370,6 +396,8 @@ export class GroupController {
       'WhatsApp did not answer within the request budget. The change may or may not have been applied — ' +
       'the gateway stopped waiting for a confirmation that never came.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
+  @ApiResponse({ status: 404, description: GROUP_NOT_FOUND_404 })
   async deletePicture(@Param('sessionId') sessionId: string, @Param('groupId') groupId: string) {
     await this.groupService.deleteGroupPicture(sessionId, groupId);
     return { success: true, message: 'Group picture removed' };
@@ -382,6 +410,7 @@ export class GroupController {
   @ApiResponse({ status: 200, description: 'Group invite code', type: GroupInviteCodeResponseDto })
   @ApiResponse({ status: 403, description: INVITE_CODE_403 })
   @ApiResponse({ status: 503, description: INVITE_CODE_503 })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async getInviteCode(@Param('sessionId') sessionId: string, @Param('groupId') groupId: string) {
     const inviteCode = await this.groupService.getGroupInviteCode(sessionId, groupId);
     return {
@@ -399,6 +428,7 @@ export class GroupController {
   @ApiResponse({ status: 200, description: 'New invite code generated', type: GroupInviteCodeRevokedResponseDto })
   @ApiResponse({ status: 403, description: INVITE_CODE_403 })
   @ApiResponse({ status: 503, description: INVITE_CODE_503 })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async revokeInviteCode(@Param('sessionId') sessionId: string, @Param('groupId') groupId: string) {
     const newCode = await this.groupService.revokeGroupInviteCode(sessionId, groupId);
     return {

--- a/src/modules/label/label.controller.ts
+++ b/src/modules/label/label.controller.ts
@@ -6,6 +6,11 @@ import { AddLabelDto } from './dto/add-label.dto';
 import { UpsertLabelDto } from './dto/upsert-label.dto';
 import { RequireRole } from '../auth/decorators/auth.decorators';
 import { ApiKeyRole } from '../auth/entities/api-key.entity';
+import {
+  ENGINE_NOT_READY_409,
+  ENGINE_NOT_SUPPORTED_501,
+  LABEL_NOT_FOUND_404,
+} from '../../common/openapi/engine-status-responses';
 
 @ApiTags('labels')
 @Controller('sessions/:sessionId/labels')
@@ -18,6 +23,8 @@ export class LabelController {
   @ApiResponse({ status: 200, description: 'List of labels', type: [LabelDto] })
   @ApiResponse({ status: 400, description: 'Session not ready or not a business account' })
   @ApiResponse({ status: 404, description: 'Session not found' })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
+  @ApiResponse({ status: 501, description: ENGINE_NOT_SUPPORTED_501 })
   async findAll(@Param('sessionId') sessionId: string) {
     return this.labelService.getLabels(sessionId);
   }
@@ -28,6 +35,8 @@ export class LabelController {
   @ApiParam({ name: 'labelId', description: 'Label ID' })
   @ApiResponse({ status: 200, description: 'Label details', type: LabelDto })
   @ApiResponse({ status: 404, description: 'Label not found' })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
+  @ApiResponse({ status: 501, description: ENGINE_NOT_SUPPORTED_501 })
   async findOne(@Param('sessionId') sessionId: string, @Param('labelId') labelId: string) {
     return this.labelService.getLabelById(sessionId, labelId);
   }
@@ -50,6 +59,8 @@ export class LabelController {
       'reported as a missing label — a page that went away says nothing about whether the label exists. ' +
       'The other engine never answers this: Baileys has no label query at all and answers 501 above.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
+  @ApiResponse({ status: 404, description: LABEL_NOT_FOUND_404 })
   async getChatsByLabel(@Param('sessionId') sessionId: string, @Param('labelId') labelId: string) {
     return this.labelService.getChatsByLabel(sessionId, labelId);
   }
@@ -79,6 +90,7 @@ export class LabelController {
       'WhatsApp did not answer within the request budget. The change may or may not have been applied — ' +
       'the gateway stopped waiting for a confirmation that never came.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async upsertLabel(
     @Param('sessionId') sessionId: string,
     @Param('labelId') labelId: string,
@@ -108,6 +120,7 @@ export class LabelController {
       'WhatsApp did not answer within the request budget. The change may or may not have been applied — ' +
       'the gateway stopped waiting for a confirmation that never came.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async deleteLabel(
     @Param('sessionId') sessionId: string,
     @Param('labelId') labelId: string,
@@ -121,6 +134,8 @@ export class LabelController {
   @ApiParam({ name: 'sessionId', description: 'Session ID' })
   @ApiParam({ name: 'chatId', description: 'Chat ID' })
   @ApiResponse({ status: 200, description: 'List of labels for the chat', type: [LabelDto] })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
+  @ApiResponse({ status: 501, description: ENGINE_NOT_SUPPORTED_501 })
   async getChatLabels(@Param('sessionId') sessionId: string, @Param('chatId') chatId: string) {
     return this.labelService.getChatLabels(sessionId, chatId);
   }
@@ -151,6 +166,7 @@ export class LabelController {
       'WhatsApp did not answer within the request budget. The change may or may not have been applied — ' +
       'the gateway stopped waiting for a confirmation that never came.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async addLabelToChat(
     @Param('sessionId') sessionId: string,
     @Param('chatId') chatId: string,
@@ -177,6 +193,7 @@ export class LabelController {
       'WhatsApp did not answer within the request budget. The change may or may not have been applied — ' +
       'the gateway stopped waiting for a confirmation that never came.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async removeLabelFromChat(
     @Param('sessionId') sessionId: string,
     @Param('chatId') chatId: string,

--- a/src/modules/message/message.controller.ts
+++ b/src/modules/message/message.controller.ts
@@ -33,6 +33,13 @@ import {
 } from './dto/message-actions.dto';
 import { RequireRole } from '../auth/decorators/auth.decorators';
 import { ApiKeyRole } from '../auth/entities/api-key.entity';
+import {
+  CHANNEL_MEDIA_501,
+  ENGINE_NOT_READY_409,
+  ENGINE_NOT_SUPPORTED_501,
+  MESSAGE_NOT_FOUND_404,
+  RECIPIENT_UNREACHABLE_400,
+} from '../../common/openapi/engine-status-responses';
 
 @ApiTags('messages')
 @Controller('sessions/:sessionId/messages')
@@ -90,6 +97,8 @@ export class MessageController {
     description: 'Session not active or invalid request',
   })
   @ApiResponse({ status: 404, description: 'Session not found' })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
+  @ApiResponse({ status: 501, description: ENGINE_NOT_SUPPORTED_501 })
   async sendText(@Param('sessionId') sessionId: string, @Body() dto: SendTextMessageDto): Promise<MessageResponseDto> {
     return this.messageService.sendText(sessionId, dto);
   }
@@ -108,6 +117,7 @@ export class MessageController {
     description: 'Session not active or invalid request',
   })
   @ApiResponse({ status: 404, description: 'Session or template not found' })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async sendTemplate(
     @Param('sessionId') sessionId: string,
     @Body() dto: SendTemplateMessageDto,
@@ -131,6 +141,8 @@ export class MessageController {
     status: 400,
     description: 'Session not active or invalid request',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
+  @ApiResponse({ status: 501, description: CHANNEL_MEDIA_501 })
   async sendImage(
     @Param('sessionId') sessionId: string,
     @Body() dto: SendMediaMessageDto,
@@ -152,6 +164,8 @@ export class MessageController {
     status: 400,
     description: 'Session not active or invalid request',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
+  @ApiResponse({ status: 501, description: CHANNEL_MEDIA_501 })
   async sendVideo(
     @Param('sessionId') sessionId: string,
     @Body() dto: SendMediaMessageDto,
@@ -173,6 +187,8 @@ export class MessageController {
     status: 400,
     description: 'Session not active or invalid request',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
+  @ApiResponse({ status: 501, description: CHANNEL_MEDIA_501 })
   async sendAudio(
     @Param('sessionId') sessionId: string,
     @Body() dto: SendAudioMessageDto,
@@ -194,6 +210,8 @@ export class MessageController {
     status: 400,
     description: 'Session not active or invalid request',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
+  @ApiResponse({ status: 501, description: CHANNEL_MEDIA_501 })
   async sendDocument(
     @Param('sessionId') sessionId: string,
     @Body() dto: SendMediaMessageDto,
@@ -212,6 +230,8 @@ export class MessageController {
     description: 'Location sent',
     type: MessageResponseDto,
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
+  @ApiResponse({ status: 400, description: RECIPIENT_UNREACHABLE_400 })
   async sendLocation(@Param('sessionId') sessionId: string, @Body() dto: SendLocationDto): Promise<MessageResponseDto> {
     return this.messageService.sendLocation(sessionId, dto);
   }
@@ -225,6 +245,8 @@ export class MessageController {
     description: 'Contact sent',
     type: MessageResponseDto,
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
+  @ApiResponse({ status: 400, description: RECIPIENT_UNREACHABLE_400 })
   async sendContact(@Param('sessionId') sessionId: string, @Body() dto: SendContactDto): Promise<MessageResponseDto> {
     return this.messageService.sendContact(sessionId, dto);
   }
@@ -239,6 +261,9 @@ export class MessageController {
     description: 'Sticker sent',
     type: MessageResponseDto,
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
+  @ApiResponse({ status: 400, description: RECIPIENT_UNREACHABLE_400 })
+  @ApiResponse({ status: 501, description: CHANNEL_MEDIA_501 })
   async sendSticker(
     @Param('sessionId') sessionId: string,
     @Body() dto: SendMediaMessageDto,
@@ -255,6 +280,8 @@ export class MessageController {
     description: 'Poll sent',
     type: MessageResponseDto,
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
+  @ApiResponse({ status: 400, description: RECIPIENT_UNREACHABLE_400 })
   async sendPoll(@Param('sessionId') sessionId: string, @Body() dto: SendPollDto): Promise<MessageResponseDto> {
     return this.messageService.sendPoll(sessionId, dto);
   }
@@ -268,6 +295,9 @@ export class MessageController {
     description: 'Reply sent',
     type: MessageResponseDto,
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
+  @ApiResponse({ status: 400, description: RECIPIENT_UNREACHABLE_400 })
+  @ApiResponse({ status: 404, description: MESSAGE_NOT_FOUND_404 })
   async reply(@Param('sessionId') sessionId: string, @Body() dto: ReplyMessageDto): Promise<MessageResponseDto> {
     return this.messageService.reply(sessionId, dto);
   }
@@ -281,6 +311,9 @@ export class MessageController {
     description: 'Message forwarded',
     type: MessageResponseDto,
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
+  @ApiResponse({ status: 400, description: RECIPIENT_UNREACHABLE_400 })
+  @ApiResponse({ status: 404, description: MESSAGE_NOT_FOUND_404 })
   async forward(@Param('sessionId') sessionId: string, @Body() dto: ForwardMessageDto): Promise<MessageResponseDto> {
     return this.messageService.forward(sessionId, dto);
   }
@@ -300,6 +333,8 @@ export class MessageController {
     status: 400,
     description: 'Session not active or message not found',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
+  @ApiResponse({ status: 404, description: MESSAGE_NOT_FOUND_404 })
   async react(@Param('sessionId') sessionId: string, @Body() dto: ReactMessageDto): Promise<{ success: boolean }> {
     await this.messageService.reactToMessage(sessionId, dto);
     return { success: true };
@@ -331,6 +366,8 @@ export class MessageController {
       'is ignored). Large/slow requests may increase WhatsApp rate-limiting risk; default false.',
   })
   @ApiResponse({ status: 200, description: 'Chat history (most recent messages)' })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
+  @ApiResponse({ status: 501, description: ENGINE_NOT_SUPPORTED_501 })
   async getChatHistory(
     @Param('sessionId') sessionId: string,
     @Param('chatId') chatId: string,
@@ -366,6 +403,9 @@ export class MessageController {
     status: 200,
     description: 'List of reactions with senders',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
+  @ApiResponse({ status: 404, description: MESSAGE_NOT_FOUND_404 })
+  @ApiResponse({ status: 501, description: ENGINE_NOT_SUPPORTED_501 })
   async getReactions(
     @Param('sessionId') sessionId: string,
     @Param('chatId') chatId: string,
@@ -432,6 +472,8 @@ export class MessageController {
       'WhatsApp did not answer within the request budget. The change may or may not have been applied — ' +
       'the gateway stopped waiting for a confirmation that never came.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
+  @ApiResponse({ status: 404, description: MESSAGE_NOT_FOUND_404 })
   async deleteMessage(
     @Param('sessionId') sessionId: string,
     @Body() dto: DeleteMessageDto,
@@ -449,6 +491,7 @@ export class MessageController {
   @ApiResponse({ status: 400, description: 'Session not active, or the target message is not a poll' })
   @ApiResponse({ status: 404, description: 'Poll not found in the chat’s recent history' })
   @ApiResponse({ status: 501, description: 'Not supported on the Baileys engine' })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async votePoll(@Param('sessionId') sessionId: string, @Body() dto: VotePollDto): Promise<{ success: boolean }> {
     return this.messageService.votePoll(sessionId, dto);
   }
@@ -467,6 +510,7 @@ export class MessageController {
   })
   @ApiResponse({ status: 403, description: 'The engine refused the pin — in a group only admins may pin' })
   @ApiResponse({ status: 404, description: 'Message not found in the chat' })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async pinMessage(@Param('sessionId') sessionId: string, @Body() dto: PinMessageDto): Promise<{ success: boolean }> {
     return this.messageService.pinMessage(sessionId, dto);
   }
@@ -480,6 +524,7 @@ export class MessageController {
   @ApiResponse({ status: 400, description: 'Session not active' })
   @ApiResponse({ status: 403, description: 'The engine refused the unpin — in a group only admins may unpin' })
   @ApiResponse({ status: 404, description: 'Message not found in the chat' })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async unpinMessage(
     @Param('sessionId') sessionId: string,
     @Body() dto: UnpinMessageDto,
@@ -506,6 +551,7 @@ export class MessageController {
       'WhatsApp did not answer within the request budget. The change may or may not have been applied — ' +
       'the gateway stopped waiting for a confirmation that never came.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async starMessage(@Param('sessionId') sessionId: string, @Body() dto: StarMessageDto): Promise<{ success: boolean }> {
     return this.messageService.starMessage(sessionId, dto);
   }
@@ -531,6 +577,7 @@ export class MessageController {
     description: 'The message was not sent by this account, or the engine refused the edit',
   })
   @ApiResponse({ status: 404, description: 'Message not found' })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async edit(@Param('sessionId') sessionId: string, @Body() dto: EditMessageDto): Promise<MessageResponseDto> {
     return this.messageService.editMessage(sessionId, dto);
   }
@@ -551,6 +598,7 @@ export class MessageController {
     status: 400,
     description: 'Session not active or invalid request',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async sendBulk(
     @Param('sessionId') sessionId: string,
     @Body() dto: SendBulkMessageDto,

--- a/src/modules/profile/profile.controller.ts
+++ b/src/modules/profile/profile.controller.ts
@@ -5,6 +5,7 @@ import { ProfileService } from './profile.service';
 import { SetProfileNameDto, SetProfileStatusDto, SetProfilePictureDto } from './dto/profile.dto';
 import { RequireRole } from '../auth/decorators/auth.decorators';
 import { ApiKeyRole } from '../auth/entities/api-key.entity';
+import { ENGINE_NOT_READY_409 } from '../../common/openapi/engine-status-responses';
 
 @ApiTags('profile')
 @Controller('sessions/:sessionId/profile')
@@ -25,6 +26,7 @@ export class ProfileController {
       'WhatsApp did not answer within the request budget. The change may or may not have been applied — ' +
       'the gateway stopped waiting for a confirmation that never came.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async setName(@Param('sessionId') sessionId: string, @Body() dto: SetProfileNameDto) {
     await this.profileService.setProfileName(sessionId, dto.name);
     return { success: true, message: 'Profile name updated' };
@@ -43,6 +45,7 @@ export class ProfileController {
       'WhatsApp did not answer within the request budget. The change may or may not have been applied — ' +
       'the gateway stopped waiting for a confirmation that never came.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async setStatus(@Param('sessionId') sessionId: string, @Body() dto: SetProfileStatusDto) {
     await this.profileService.setProfileStatus(sessionId, dto.status);
     return { success: true, message: 'Profile status updated' };
@@ -66,6 +69,7 @@ export class ProfileController {
       'WhatsApp did not answer within the request budget. The change may or may not have been applied — ' +
       'the gateway stopped waiting for a confirmation that never came.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async setPicture(@Param('sessionId') sessionId: string, @Body() dto: SetProfilePictureDto) {
     await this.profileService.setProfilePicture(sessionId, dto);
     return { success: true, message: 'Profile picture updated' };

--- a/src/modules/session/session.controller.ts
+++ b/src/modules/session/session.controller.ts
@@ -35,6 +35,7 @@ import { AuditService } from '../audit/audit.service';
 import { AuditAction } from '../audit/entities/audit-log.entity';
 import { RequireRole, CurrentApiKey, SessionScoped, RequireUnscopedKey } from '../auth/decorators/auth.decorators';
 import { ApiKey, ApiKeyRole } from '../auth/entities/api-key.entity';
+import { ENGINE_NOT_READY_409 } from '../../common/openapi/engine-status-responses';
 
 @ApiTags('sessions')
 @Controller('sessions')
@@ -340,6 +341,7 @@ export class SessionController {
     description: 'QR code not ready or session already authenticated',
   })
   @ApiResponse({ status: 404, description: 'Session not found' })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async getQRCode(@Param('id', ParseUUIDPipe) id: string): Promise<QRCodeResponseDto> {
     const qrCode = await this.sessionService.getQRCode(id);
     await this.auditService.logInfo(AuditAction.SESSION_QR_GENERATED, {
@@ -355,6 +357,7 @@ export class SessionController {
   @ApiResponse({ status: 201, description: 'Pairing code generated', type: PairingCodeResponseDto })
   @ApiResponse({ status: 400, description: 'Session not started or already authenticated' })
   @ApiResponse({ status: 404, description: 'Session not found' })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async requestPairingCode(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: RequestPairingCodeDto,
@@ -378,6 +381,7 @@ export class SessionController {
       'the engine returns the same empty value for "you are in no groups", and a caller cannot tell ' +
       'those apart from the body.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   @ApiQuery({ name: 'limit', required: false, description: 'Max groups to return (1–1000, default 1000)' })
   @ApiQuery({ name: 'offset', required: false, description: 'Number of groups to skip (for paging)' })
   async getGroups(
@@ -397,6 +401,7 @@ export class SessionController {
   @ApiResponse({ status: 200, description: 'List of active chats (most recent first)', type: [ChatSummaryDto] })
   @ApiResponse({ status: 400, description: 'Session not ready' })
   @ApiResponse({ status: 404, description: 'Session not found' })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   @ApiQuery({ name: 'limit', required: false, description: 'Max chats to return (1–1000, default 1000)' })
   @ApiQuery({ name: 'offset', required: false, description: 'Number of chats to skip (for paging)' })
   async getChats(
@@ -424,6 +429,7 @@ export class SessionController {
       'WhatsApp did not answer within the request budget. The change may or may not have been applied — ' +
       'the gateway stopped waiting for a confirmation that never came.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async markChatRead(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: MarkChatReadDto,
@@ -452,6 +458,7 @@ export class SessionController {
   @ApiResponse({ status: 400, description: 'Session not started' })
   @ApiResponse({ status: 404, description: 'Session not found' })
   @ApiResponse({ status: 501, description: 'The active engine cannot observe presence (whatsapp-web.js)' })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async subscribeToPresence(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: SubscribePresenceDto,
@@ -498,6 +505,7 @@ export class SessionController {
       'WhatsApp did not answer within the request budget. The change may or may not have been applied — ' +
       'the gateway stopped waiting for a confirmation that never came.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async markChatUnread(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: MarkChatReadDto,
@@ -526,6 +534,7 @@ export class SessionController {
       'WhatsApp did not answer within the request budget. The change may or may not have been applied — ' +
       'the gateway stopped waiting for a confirmation that never came.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async clearChatMessages(
     @Param('id', ParseUUIDPipe) id: string,
     @Param('chatId') chatId: string,
@@ -553,6 +562,7 @@ export class SessionController {
       'WhatsApp did not answer within the request budget. The change may or may not have been applied — ' +
       'the gateway stopped waiting for a confirmation that never came.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async archiveChat(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: ArchiveChatDto,
@@ -575,6 +585,7 @@ export class SessionController {
       'WhatsApp did not answer within the request budget. The change may or may not have been applied — ' +
       'the gateway stopped waiting for a confirmation that never came.',
   })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async deleteChat(@Param('id', ParseUUIDPipe) id: string, @Body() dto: DeleteChatDto): Promise<{ success: boolean }> {
     const success = await this.sessionService.deleteChat(id, dto.chatId);
     return { success };
@@ -587,6 +598,7 @@ export class SessionController {
   @ApiParam({ name: 'id', description: 'Session ID' })
   @ApiResponse({ status: 200, description: 'Presence sent' })
   @ApiResponse({ status: 404, description: 'Session not found' })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async sendChatState(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: SendChatStateDto,

--- a/src/modules/status/status.controller.ts
+++ b/src/modules/status/status.controller.ts
@@ -7,6 +7,7 @@ import { SendTextStatusDto } from './dto/send-text-status.dto';
 import { SendImageStatusDto, SendVideoStatusDto, SendVoiceStatusDto } from './dto/send-media-status.dto';
 import { RequireRole } from '../auth/decorators/auth.decorators';
 import { ApiKeyRole } from '../auth/entities/api-key.entity';
+import { ENGINE_NOT_READY_409 } from '../../common/openapi/engine-status-responses';
 
 @ApiTags('status')
 @Controller('sessions/:sessionId/status')
@@ -62,6 +63,7 @@ export class StatusController {
     type: StatusResultDto,
   })
   @ApiResponse({ status: 400, description: 'Invalid request, or the post was blocked by a plugin.' })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async sendTextStatus(@Param('sessionId') sessionId: string, @Body() dto: SendTextStatusDto) {
     return this.statusService.postTextStatus(sessionId, dto.text, {
       recipients: dto.recipients,
@@ -85,6 +87,7 @@ export class StatusController {
     description: 'Neither url nor base64 provided, or the post was blocked by a plugin.',
   })
   @ApiResponse({ status: 413, description: 'Base64 media exceeds MEDIA_DOWNLOAD_MAX_BYTES.' })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async sendImageStatus(@Param('sessionId') sessionId: string, @Body() dto: SendImageStatusDto) {
     return this.statusService.postImageStatus(sessionId, dto.image, {
       recipients: dto.recipients,
@@ -107,6 +110,7 @@ export class StatusController {
     description: 'Neither url nor base64 provided, or the post was blocked by a plugin.',
   })
   @ApiResponse({ status: 413, description: 'Base64 media exceeds MEDIA_DOWNLOAD_MAX_BYTES.' })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async sendVideoStatus(@Param('sessionId') sessionId: string, @Body() dto: SendVideoStatusDto) {
     return this.statusService.postVideoStatus(sessionId, dto.video, {
       recipients: dto.recipients,
@@ -130,6 +134,7 @@ export class StatusController {
     description: 'Neither url nor base64 provided, or the post was blocked by a plugin.',
   })
   @ApiResponse({ status: 413, description: 'Base64 media exceeds MEDIA_DOWNLOAD_MAX_BYTES.' })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async sendVoiceStatus(@Param('sessionId') sessionId: string, @Body() dto: SendVoiceStatusDto) {
     return this.statusService.postVoiceStatus(sessionId, dto.audio, {
       recipients: dto.recipients,
@@ -141,6 +146,7 @@ export class StatusController {
   @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Delete own status' })
   @ApiResponse({ status: 200, description: 'Status deleted.', type: StatusDeletedResponseDto })
+  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async deleteStatus(@Param('sessionId') sessionId: string, @Param('statusId') statusId: string) {
     await this.statusService.deleteStatus(sessionId, statusId);
     return { message: 'Status deleted successfully' };


### PR DESCRIPTION
## What

The contract described the happy path and the timeout but almost nothing in between. This adds **125 declarations across eleven controllers**. No runtime behaviour changes — every status added was already reachable before this PR.

| Status | Routes | Error class |
| --- | --- | --- |
| `409` | 91 | `EngineNotReadyError` |
| `501` | 11 | `EngineNotSupportedError`, `ChannelMediaNotSupportedError` |
| `404` | 11 | `Message` / `Group` / `Channel` / `LabelNotFoundError` |
| `400` | 6 | `RecipientUnreachableError` |
| `403` | 6 | `EngineRefusedError` |

Follows #1163, which did the same for `503` alone. The generalisation is that thirteen error classes in `src/common/errors` map to a status through their NestJS base, not one.

## The 409, which is most of it

Every adapter method calls `ensureReady()` before touching the socket or the page — **168 call sites** — and that guard throws `EngineNotReadyError`. So any route that reaches an engine answers `409` when the session exists but has no live engine behind it. None of the 91 said so.

Ten routes already declared a `409`, for an unrelated reason: a name already taken, a plugin already installed, a session already running. Those are semantic conflicts rather than a missing engine, and the two sets do not overlap, so the new declaration carries its own description distinguishing them.

## How the route set was derived

Handler → service → both adapters, per route. Two things are worth stating because they changed the answer:

**Reachability is type-resolved, not name-matched.** An earlier pass keyed on the method name alone and wrongly flagged `GET /plugins/catalog`: `PluginsService.getCatalog` shares a name with `CatalogService.getCatalog`, and only the latter touches an engine. Resolving `this.<prop>.<method>()` through the controller's constructor types drops it, and re-running the corrected predicate reports zero remaining mismatches.

**The predicate was checked against a known answer.** Of the 52 routes declaring `503`, it flags 49 as engine-reaching and excludes exactly the three whose `503` comes from elsewhere — the readiness probe and the two media-conversion routes. That is the expected split, which is what makes the 91 trustworthy.

"Session-scoped" was deliberately *not* used as the criterion, though it was how the scale was first measured: `GET /sessions/{id}/config` sits under that prefix and never reaches an engine, so keying on the path shape would have published a status that cannot occur.

## Two structural choices

**Descriptions live in one shared module** (`src/common/openapi/engine-status-responses.ts`) rather than per controller. The text describes engine behaviour, not any one route's, so eleven copies would drift the moment one was reworded — which is how the contract fell behind in the first place.

**They are applied per handler, not at class level.** Seven of the eleven controllers are 100% engine-touching, so a class-level `@ApiResponse` would have cut the diff from 92 lines to 7. It was rejected: a future route added to one of those controllers would silently inherit a `409` whether or not it touches an engine, which is the same rot as a hand-maintained list, only harder to notice.

## The one that mattered most

On the four group participant writes, the undeclared `403` is the status separating a batch WhatsApp refused outright from one that was applied with some members rejected — the latter is reported inside `results` on a `200`. Those four now declare `200, 403, 409, 503`.

## Verification

`openapi:check`, `lint`, `format:check`, `tsc --noEmit`, `build` all exit 0; `npm test` passes 5119 tests across 300 suites. `openapi.json` regenerated with `npm run openapi:export`, never hand-edited. Status totals moved exactly as intended: `400` 64→70, `403` 21→27, `404` 64→75, `409` 10→101, `501` 16→27, with `503` unchanged at 52.
