### PR TITLE
fix(openapi): show session ids that can actually match in the key allow-list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **An API key's session allow-list showed ids that can never match** — `allowedSessions` is compared by exact equality against the session id in the request path, but the published example was `['session-uuid-1', 'session-uuid-2']`, so a reader copying its shape would scope a key to nothing and see every request denied; the field now shows real UUIDs and states that names are not accepted, which the MCP tool schema has said all along.
+
 - **Seven published examples showed values the API cannot produce** — the session id carried a `sess_` prefix that every session route's `ParseUUIDPipe` rejects before the handler runs, two row ids were UUIDs truncated to `4f1c9b2a-...`, the logout response example omitted `engineLoaded` although its own schema marks it required, the readiness probe keyed its details on `database` where the code writes `mainDatabase` and `dataDatabase`, the engine list advertised a `send-text` capability neither engine declares, and the Baileys-only product send documented the whatsapp-web.js `true_<jid>_<id>` id form that route never returns.
 
 ## [0.14.6] - 2026-08-08

--- a/openapi.json
+++ b/openapi.json
@@ -8882,10 +8882,10 @@
             }
           },
           "allowedSessions": {
-            "description": "Allowed session IDs this key can access",
+            "description": "Session **ids** this key may act on — the server-generated UUIDs, not session names. Matched by exact equality against the id in the request path, so a name never matches and would silently scope the key to nothing. Omit or leave empty to let the key reach every session.",
             "example": [
-              "session-uuid-1",
-              "session-uuid-2"
+              "0a941dac-a965-45e7-b318-74ae8be134f0",
+              "8f3c2b1a-9d4e-4c7a-8b2f-1e6d5a4c3b2a"
             ],
             "type": "array",
             "items": {

--- a/src/modules/auth/dto/api-key.dto.ts
+++ b/src/modules/auth/dto/api-key.dto.ts
@@ -33,8 +33,11 @@ export class CreateApiKeyDto {
   allowedIps?: string[];
 
   @ApiPropertyOptional({
-    description: 'Allowed session IDs this key can access',
-    example: ['session-uuid-1', 'session-uuid-2'],
+    description:
+      'Session **ids** this key may act on — the server-generated UUIDs, not session names. Matched by ' +
+      'exact equality against the id in the request path, so a name never matches and would silently ' +
+      'scope the key to nothing. Omit or leave empty to let the key reach every session.',
+    example: ['0a941dac-a965-45e7-b318-74ae8be134f0', '8f3c2b1a-9d4e-4c7a-8b2f-1e6d5a4c3b2a'],
   })
   @IsOptional()
   @IsArray()


### PR DESCRIPTION
## What

`allowedSessions` restricts an API key to named sessions. The guard compares it by **exact equality** against the session id taken from the request path (`auth.service.ts:453`, fed by `api-key.guard.ts:72`), but the published example was:

```json
["session-uuid-1", "session-uuid-2"]
```

Those are placeholders shaped like a name, not a UUID. A reader copying that shape scopes the key to nothing and every request it makes is denied, with nothing in the response explaining why.

Nothing validates the field — `@IsString({ each: true })` and no more — which is why this survived the earlier example sweep in #1166: the values are perfectly storable, they simply never match anything. It was reported there as doubtful rather than fixed, and this resolves it.

## Change

The example now uses the two UUIDs this repo already uses for a session id, and the description states outright that names are not accepted and that an empty list means unrestricted.

Worth noting: the MCP tool schema has described the same dimension as `'Session UUID (the session id, not the name)'` since it was written. The REST contract now agrees with it.

## Verification

`openapi:check`, `lint`, `format:check`, `tsc --noEmit`, `build` all exit 0; `npm test` passes 5119 tests across 300 suites. `openapi.json` regenerated with `npm run openapi:export`.
