### PR TITLE
refactor(session): drop the unused findByName lookup

### DIFF
--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -687,7 +687,7 @@ describe('SessionService', () => {
     });
   });
 
-  // ── findAll / findOne / findByName ────────────────────────────────
+  // ── findAll / findOne ─────────────────────────────────────────────
 
   describe('findAll', () => {
     it('should return all sessions ordered by createdAt DESC', async () => {
@@ -887,22 +887,6 @@ describe('SessionService', () => {
 
       internals.engines.clear();
       internals.initializingSessions.clear();
-    });
-  });
-
-  describe('findByName', () => {
-    it('should return session by name', async () => {
-      const session = createMockSession();
-      (repository.findOne as jest.Mock).mockResolvedValue(session);
-
-      const result = await service.findByName('test-session');
-      expect(result.name).toBe('test-session');
-    });
-
-    it('should throw NotFoundException if name not found', async () => {
-      (repository.findOne as jest.Mock).mockResolvedValue(null);
-
-      await expect(service.findByName('nonexistent')).rejects.toThrow(NotFoundException);
     });
   });
 

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -267,14 +267,6 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
     return this.sessionRestrictions.attachTo(this.sessionErrors.attachTo(session));
   }
 
-  async findByName(name: string): Promise<Session> {
-    const session = await this.sessionRepository.findOne({ where: { name } });
-    if (!session) {
-      throw new NotFoundException(`Session with name '${name}' not found`);
-    }
-    return session;
-  }
-
   /**
    * Project the opaque `config` column onto the three keys the engine actually reads, resolved
    * through the same clamp the engine uses — so a legacy row holding an out-of-range value reports


### PR DESCRIPTION
## What

`SessionService.findByName` and its spec are removed. 25 lines out, 1 in (a comment label that named it).

## It never had a caller

`git log --all --reflog -S "findByName"` across **140 refs** returns three commits: the initial commit that defined it, the commit twelve days later that gave it a spec, and a docs refresh that deleted the only sketch of an intended caller. No call site was ever added and later removed. It was born unreached and stayed that way through six months and 127 commits to this file.

## It is not a duplicate that lost its callers

The two other name-predicated queries both **invert its contract**:

| Site | Contract |
| --- | --- |
| `session.service.ts` create's duplicate check | absence is success — presence throws `409` |
| `session-engine-lifecycle.ts` purge guard | must **not** throw; a found row means skip the purge |
| `findByName` | throws `NotFoundException` on a miss |

Neither could have called a helper that raises on a miss without treating the exception as the happy path. And `create()` shipped its inline check in the *same commit* that defined `findByName`, so nothing "forgot the helper".

## The one hint of intent does not survive reading

The initial commit's `docs/09-testing-strategy.md` sketched a duplicate-name check backed by a by-name lookup — but it named `SessionRepository.findByName`, on a class that never existed, consumed by a `createSession` that never existed. That sketch was deleted wholesale in `264ca6c6`. It evidences early thinking, not a planned consumer.

## Removing it also removes a latent defect

`findByName` returned the raw row; its sibling `findOne` returns `attachRuntimeState(session)`. The two were byte-for-byte twins at birth, and only `findOne` was enriched — twice, in commits whose diffs show the `findByName` signature as untouched trailing context.

That matters because `SessionResponseDto` coerces the unattached fields with `?? null`, and documents `null` as the affirmative claim *"there is none"*. A `FAILED`, account-restricted session fetched by name would have serialised **identically to a healthy one** — failure reason dropped, restriction denied. Nothing in the suite pinned that, so wiring the method up later would have shipped a silent false negative rather than an obvious gap.

For the record, the lookup itself was correct: `sessions.name` is `UNIQUE` in the entity and in both the SQLite and PostgreSQL baseline DDL, there is no soft-delete, and `name` is write-once. It was dead, not broken.

## Left alone deliberately

- `messageRepository` and `lidResolver` are injected into `SessionService` and never read. Pre-existing, unrelated to this change, and not orphaned by it — `tsc` exits 0 both before and after.
- A prior audit bundles `findByName` with `isActive` and `getActiveCount` as dead public methods. **That bundle is stale** — `isActive` has a caller now. Do not delete the siblings on the strength of this PR; each needs its own census.

## Verification

`lint`, `format:check`, `openapi:check`, `tsc --noEmit`, `build` all exit 0. `npm test -- --coverage` — exactly as CI runs it — exits 0 with no threshold violation; the suite drops from 5119 to 5117, the two removed `findByName` tests and nothing else. Zero references remain in `src`, `test`, `dashboard`, or any of the five SDKs.
