### PR TITLE
refactor(session): drop three unused members from SessionService

### DIFF
--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -5545,23 +5545,7 @@ describe('SessionService', () => {
     });
   });
 
-  // ── getActiveCount / isActive ─────────────────────────────────────
-
-  describe('getActiveCount', () => {
-    it('should return 0 when no engines are running', () => {
-      expect(service.getActiveCount()).toBe(0);
-    });
-
-    it('should return correct count after starting sessions', async () => {
-      const session = createMockSession();
-      (repository.findOne as jest.Mock).mockResolvedValue(session);
-      (repository.update as jest.Mock).mockResolvedValue({ affected: 1 });
-
-      await service.start('sess-uuid-1');
-
-      expect(service.getActiveCount()).toBe(1);
-    });
-  });
+  // ── isActive ──────────────────────────────────────────────────────
 
   describe('isActive', () => {
     it('should return false for inactive session', () => {
@@ -5621,7 +5605,7 @@ describe('SessionService', () => {
       await service.onModuleDestroy();
 
       expect(mockEngine.destroy).toHaveBeenCalled();
-      expect(service.getActiveCount()).toBe(0);
+      expect(service.isActive('sess-uuid-1')).toBe(false);
     });
   });
 

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -13,10 +13,8 @@ import { InjectRepository, InjectDataSource } from '@nestjs/typeorm';
 import { Repository, In, Not, IsNull, DataSource, FindManyOptions } from 'typeorm';
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 import { Session, SessionStatus } from './entities/session.entity';
-import { Message } from '../message/entities/message.entity';
 import { CreateSessionDto, SessionConfigResponseDto, UpdateSessionConfigDto } from './dto';
 import { EngineRegistry } from '../../engine/engine-registry.service';
-import { SessionLidResolver } from './session-lid-resolver.service';
 import { SessionLivenessWatchdog } from './session-liveness-watchdog.service';
 import { SessionErrorStore } from './session-error-store.service';
 import { SessionRestrictionStore } from './session-restriction-store.service';
@@ -66,12 +64,9 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
   constructor(
     @InjectRepository(Session, 'data')
     private readonly sessionRepository: Repository<Session>,
-    @InjectRepository(Message, 'data')
-    private readonly messageRepository: Repository<Message>,
     @InjectDataSource('data')
     private readonly dataSource: DataSource,
     private readonly engineRegistry: EngineRegistry,
-    private readonly lidResolver: SessionLidResolver,
     private readonly watchdog: SessionLivenessWatchdog,
     private readonly sessionErrors: SessionErrorStore,
     private readonly sessionRestrictions: SessionRestrictionStore,
@@ -657,13 +652,6 @@ export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicat
         rss: Math.round(memory.rss / 1024 / 1024),
       },
     };
-  }
-
-  /**
-   * Get count of currently active (running) sessions
-   */
-  getActiveCount(): number {
-    return this.engines.size;
   }
 
   /**


### PR DESCRIPTION
## What

Three unused members leave `SessionService`: the `messageRepository` and `lidResolver` constructor parameters, and the `getActiveCount()` method. 30 lines out, 2 in.

They are judged **separately, not as a bundle** — the earlier audit that grouped them with `findByName` had already gone stale on `isActive`, which has a caller now.

| Symbol | Why it is unused |
| --- | --- |
| `lidResolver` | Refactor residue |
| `messageRepository` | Known dead, already documented |
| `getActiveCount` | Never called outside its own spec |

## `lidResolver` — refactor residue

`ce480d41` (30 Jul) injected `SessionLidResolver` into `SessionService` and used it. `8eb7221a` (31 Jul) extracted `MessageProjector` and moved the use there, leaving the parameter behind. Occurrences in this file went **2 → 1** across that commit and have sat at 1 since.

## `messageRepository` — already known dead

The `SessionEngineLifecycle` constructor carries this note:

> `// messageRepository is NOT injected here (it is a dead dep in SessionService too): delete()'s`
> `// cascade goes through the transaction manager (manager.delete), never the repository.`

The author declined to repeat the dead dependency in the new service and wrote down why, but left the original in place.

## `getActiveCount` — never called

`git log --all -S "getActiveCount"` returns the initial commit and the spec commit. The same shape `findByName` had.

## Removing a constructor parameter is not like removing a method

The blast radius was checked before editing:

- `SessionService` is **never** constructed manually with positional arguments — `grep "new SessionService("` across `src` and `test` returns nothing.
- No module wires it through a `useFactory`; it is a plain class provider, so NestJS resolves by token, not position.
- The `getRepositoryToken(Message, 'data')` provider that three specs supply is **still required by `MessageProjector`**. The 96 `messageRepository` references in `session.service.spec.ts` are mocks observing that projector, and are untouched and still correct.

## One test kept its assertion

`getActiveCount` was not only its own subject. `onModuleDestroy`'s *"should destroy all running engines on shutdown"* ended with `expect(service.getActiveCount()).toBe(0)` — a real assertion about shutdown, not about the getter.

That assertion is **kept**, expressed as `expect(service.isActive('sess-uuid-1')).toBe(false)`, which reads the same engine registry. Only the two tests whose *subject* was `getActiveCount` are removed, which is the whole of the 5117 → 5115 drop.

## Verification

`lint`, `format:check`, `openapi:check`, `tsc --noEmit`, `build` all exit 0. `npm test -- --coverage`, exactly as CI runs it, exits 0 with no threshold violation. `messageRepository`, `lidResolver` and `getActiveCount` all report zero references in `session.service.ts`.

The now-orphaned `Message` and `SessionLidResolver` imports go with them.
