### PR TITLE
fix(openapi): correct three shared descriptions that misdescribed borrowing routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Three shared status descriptions said the wrong thing on the routes that borrowed them** — `send-text`'s `501` is specifically a caller-supplied `customLinkPreview`, which only Baileys accepts, not a wholesale gap in the engine; `POST /channels/subscribe` takes an invite code and no channel id, so its `404` is an unresolvable invite; and the `400` on six send routes named the unreachable recipient as though it were the only cause, while omitting body validation and an inactive session, and cited a `404` meaning that four of those six routes do not declare.
+
 - **Four contract corrections from a review of this cycle's own work** — the `409` description said the session had no engine when the guard actually fires on an engine that exists but is not `ready` (an unstarted session answers `400`); `send-bulk` declared a `409` it cannot produce, since the batch drains after the handler has answered `202`; the nine catalog and status routes declared that `409` but not the `404` their own service throws for an unstarted session; and the logout example showed a null `pushName` and `connectedAt` beside a populated `lastActive`, though logout clears only `phone`.
 
 - **An API key's session allow-list showed ids that can never match** — `allowedSessions` is matched by exact equality against the session id, but the example was `['session-uuid-1', 'session-uuid-2']`, which would scope a key to nothing and deny every request. It now shows real UUIDs.

--- a/openapi.json
+++ b/openapi.json
@@ -1984,7 +1984,7 @@
             "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
           },
           "501": {
-            "description": "The active engine cannot serve this operation. It is part of the engine contract, but the engine currently running has no implementation for it."
+            "description": "A caller-supplied `customLinkPreview` is not supported by the whatsapp-web.js engine — only Baileys can attach one. The send itself is supported on both; omit the field, or use `linkPreview`."
           }
         },
         "summary": "Send a text message",
@@ -2323,7 +2323,7 @@
             }
           },
           "400": {
-            "description": "The recipient could not be addressed — WhatsApp reports no deliverable id for that `chatId`, which is how it says the number is not reachable on WhatsApp. `400` rather than `404`, because a `404` on these routes already means the session was not found."
+            "description": "The request was rejected before anything was sent. Among the causes: the recipient could not be addressed — WhatsApp reports no deliverable id for that `chatId`, which is how it says the number is not on WhatsApp — as well as body validation and a session that is not active."
           },
           "409": {
             "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
@@ -2371,7 +2371,7 @@
             }
           },
           "400": {
-            "description": "The recipient could not be addressed — WhatsApp reports no deliverable id for that `chatId`, which is how it says the number is not reachable on WhatsApp. `400` rather than `404`, because a `404` on these routes already means the session was not found."
+            "description": "The request was rejected before anything was sent. Among the causes: the recipient could not be addressed — WhatsApp reports no deliverable id for that `chatId`, which is how it says the number is not on WhatsApp — as well as body validation and a session that is not active."
           },
           "409": {
             "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
@@ -2428,7 +2428,7 @@
             }
           },
           "400": {
-            "description": "The recipient could not be addressed — WhatsApp reports no deliverable id for that `chatId`, which is how it says the number is not reachable on WhatsApp. `400` rather than `404`, because a `404` on these routes already means the session was not found."
+            "description": "The request was rejected before anything was sent. Among the causes: the recipient could not be addressed — WhatsApp reports no deliverable id for that `chatId`, which is how it says the number is not on WhatsApp — as well as body validation and a session that is not active."
           },
           "409": {
             "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
@@ -2479,7 +2479,7 @@
             }
           },
           "400": {
-            "description": "The recipient could not be addressed — WhatsApp reports no deliverable id for that `chatId`, which is how it says the number is not reachable on WhatsApp. `400` rather than `404`, because a `404` on these routes already means the session was not found."
+            "description": "The request was rejected before anything was sent. Among the causes: the recipient could not be addressed — WhatsApp reports no deliverable id for that `chatId`, which is how it says the number is not on WhatsApp — as well as body validation and a session that is not active."
           },
           "409": {
             "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
@@ -2527,7 +2527,7 @@
             }
           },
           "400": {
-            "description": "The recipient could not be addressed — WhatsApp reports no deliverable id for that `chatId`, which is how it says the number is not reachable on WhatsApp. `400` rather than `404`, because a `404` on these routes already means the session was not found."
+            "description": "The request was rejected before anything was sent. Among the causes: the recipient could not be addressed — WhatsApp reports no deliverable id for that `chatId`, which is how it says the number is not on WhatsApp — as well as body validation and a session that is not active."
           },
           "404": {
             "description": "No such message — the id is outside the engine's lookup window (roughly the last hundred messages of the chat, or absent from the Baileys store) or the message was revoked."
@@ -2578,7 +2578,7 @@
             }
           },
           "400": {
-            "description": "The recipient could not be addressed — WhatsApp reports no deliverable id for that `chatId`, which is how it says the number is not reachable on WhatsApp. `400` rather than `404`, because a `404` on these routes already means the session was not found."
+            "description": "The request was rejected before anything was sent. Among the causes: the recipient could not be addressed — WhatsApp reports no deliverable id for that `chatId`, which is how it says the number is not on WhatsApp — as well as body validation and a session that is not active."
           },
           "404": {
             "description": "No such message — the id is outside the engine's lookup window (roughly the last hundred messages of the chat, or absent from the Baileys store) or the message was revoked."
@@ -6466,7 +6466,7 @@
             }
           },
           "404": {
-            "description": "No such channel — the id is not among the session's subscribed channels, either because it is wrong or because the channel has not synced into the local collection yet."
+            "description": "The invite code does not resolve to a channel — it is wrong, expired, or revoked. This route takes an invite code rather than a channel id."
           },
           "409": {
             "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."

--- a/src/common/openapi/engine-status-responses.ts
+++ b/src/common/openapi/engine-status-responses.ts
@@ -32,12 +32,14 @@ export const SESSION_NOT_STARTED_404 =
 
 /**
  * `RecipientUnreachableError` (400) — whatsapp-web.js could not resolve the recipient to an
- * addressable id, so the send never left the gateway.
+ * addressable id, so the send never left the gateway. The wording stays non-exclusive: 400 is also
+ * what body validation and an inactive session answer on these routes, and the earlier text claimed
+ * a 404 meaning that four of the six routes carrying this constant do not even declare.
  */
 export const RECIPIENT_UNREACHABLE_400 =
-  'The recipient could not be addressed — WhatsApp reports no deliverable id for that `chatId`, ' +
-  'which is how it says the number is not reachable on WhatsApp. `400` rather than `404`, because a ' +
-  '`404` on these routes already means the session was not found.';
+  'The request was rejected before anything was sent. Among the causes: the recipient could not be ' +
+  'addressed — WhatsApp reports no deliverable id for that `chatId`, which is how it says the number ' +
+  'is not on WhatsApp — as well as body validation and a session that is not active.';
 
 /** `EngineRefusedError` (403) — the request was well formed; WhatsApp itself refused it. */
 export const ENGINE_REFUSED_403 =
@@ -49,10 +51,26 @@ export const MESSAGE_NOT_FOUND_404 =
   "No such message — the id is outside the engine's lookup window (roughly the last hundred messages " +
   'of the chat, or absent from the Baileys store) or the message was revoked.';
 
-/** `ChannelNotFoundError` (404). */
+/** `ChannelNotFoundError` (404), on routes addressed by channel id. */
 export const CHANNEL_NOT_FOUND_404 =
   "No such channel — the id is not among the session's subscribed channels, either because it is " +
   'wrong or because the channel has not synced into the local collection yet.';
+
+/**
+ * `ChannelNotFoundError` (404) on `POST /channels/subscribe`, which takes an invite code and no
+ * channel id at all — so the id-based wording above would describe the wrong thing.
+ */
+export const CHANNEL_INVITE_NOT_FOUND_404 =
+  'The invite code does not resolve to a channel — it is wrong, expired, or revoked. This route takes ' +
+  'an invite code rather than a channel id.';
+
+/**
+ * `EngineNotSupportedError` (501) on `POST /messages/send-text`, which is supported by both engines;
+ * only the caller-supplied link preview is not. The generic engine-wide wording would overstate it.
+ */
+export const CUSTOM_LINK_PREVIEW_501 =
+  'A caller-supplied `customLinkPreview` is not supported by the whatsapp-web.js engine — only ' +
+  'Baileys can attach one. The send itself is supported on both; omit the field, or use `linkPreview`.';
 
 /** `GroupNotFoundError` (404) — unknown id, or an id that addresses a 1:1 chat. */
 export const GROUP_NOT_FOUND_404 = 'No such group — the id is unknown, or it addresses a 1:1 chat rather than a group.';

--- a/src/modules/channel/channel.controller.ts
+++ b/src/modules/channel/channel.controller.ts
@@ -8,6 +8,7 @@ import { MuteChannelDto } from './dto/mute-channel.dto';
 import { RequireRole } from '../auth/decorators/auth.decorators';
 import { ApiKeyRole } from '../auth/entities/api-key.entity';
 import {
+  CHANNEL_INVITE_NOT_FOUND_404,
   CHANNEL_NOT_FOUND_404,
   ENGINE_NOT_READY_409,
   ENGINE_REFUSED_403,
@@ -177,7 +178,7 @@ export class ChannelController {
     description: 'Not supported by the active engine: whatsapp-web.js cannot subscribe by invite code.',
   })
   @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
-  @ApiResponse({ status: 404, description: CHANNEL_NOT_FOUND_404 })
+  @ApiResponse({ status: 404, description: CHANNEL_INVITE_NOT_FOUND_404 })
   async subscribe(@Param('sessionId') sessionId: string, @Body() body: SubscribeChannelDto) {
     return this.channelService.subscribeToChannel(sessionId, body.inviteCode);
   }

--- a/src/modules/message/message.controller.ts
+++ b/src/modules/message/message.controller.ts
@@ -35,6 +35,7 @@ import { RequireRole } from '../auth/decorators/auth.decorators';
 import { ApiKeyRole } from '../auth/entities/api-key.entity';
 import {
   CHANNEL_MEDIA_501,
+  CUSTOM_LINK_PREVIEW_501,
   ENGINE_NOT_READY_409,
   ENGINE_NOT_SUPPORTED_501,
   MESSAGE_NOT_FOUND_404,
@@ -98,7 +99,7 @@ export class MessageController {
   })
   @ApiResponse({ status: 404, description: 'Session not found' })
   @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
-  @ApiResponse({ status: 501, description: ENGINE_NOT_SUPPORTED_501 })
+  @ApiResponse({ status: 501, description: CUSTOM_LINK_PREVIEW_501 })
   async sendText(@Param('sessionId') sessionId: string, @Body() dto: SendTextMessageDto): Promise<MessageResponseDto> {
     return this.messageService.sendText(sessionId, dto);
   }


### PR DESCRIPTION
## What

A shared description is only as good as its least-similar consumer. Three had drifted past that line — all three introduced when #1167 pointed one constant at several routes.

| Route | Said | Actually |
| --- | --- | --- |
| `POST /messages/send-text` 501 | the engine has no implementation | only a caller-supplied `customLinkPreview` is unsupported, and only on whatsapp-web.js |
| `POST /channels/subscribe` 404 | the id is not among subscribed channels | the route takes **no channel id** — its 404 is an unresolvable invite code |
| six send routes 400 | the recipient could not be addressed | that is one cause; body validation and an inactive session also 400 |

## Detail

**send-text.** Both engines send text. The only unsupported thing is `customLinkPreview`, rejected at `wwebjs-messaging.ts:304` with `EngineNotSupportedError('sendTextMessage(customPreview)')`. The generic wording told callers the route was unavailable on one engine, which would send them to the wrong workaround.

**subscribe.** `SubscribeChannelDto` declares `inviteCode` and nothing else, so the id-based wording described a parameter that does not exist. The 404 comes from an invite lookup resolving nothing (`baileys-channels.ts:74`).

**The six 400s.** The old text also justified itself with *"a 404 on these routes already means the session was not found"* — but only `reply` and `forward` declare a 404; `send-sticker`, `send-location`, `send-contact` and `send-poll` do not. That rationale came from the error class's doc comment, where it was true of the routes it was written for. It belongs there, not in the published contract.

## Verification

`openapi:check`, `lint`, `format:check`, `tsc --noEmit`, `build` all exit 0; `npm test -- --coverage` exits 0. **Status counts are unchanged** — 400:70, 403:27, 404:84, 409:100, 501:27, 503:52 — only wording moved.