### PR TITLE
fix(wwjs): survive WhatsApp Web page navigations across the engine lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- ⚠️ **Breaking (behavior). Engine operations during a WhatsApp Web page reload answer `409` instead of a raw `500`** — WhatsApp Web reloads its own page (measured ~5 minutes after a fresh pairing, among others) and whatsapp-web.js re-injects into it; for that bounded window every engine route now answers the documented retryable `409` naming the reload, where it previously surfaced raw `TypeError` 500s — and the six chat write routes (`read`/`unread`/`archive`/`unarchive`/`typing`/clear) answered `200 {success:false}`. Retry after the session re-emits `ready`. Typed 4xx also no longer count toward the send breaker, so a reload can no longer latch its 15-minute cooldown.
+
+- **`GET /sessions/{id}/chats` now documents and answers the `503` a dead page deserves** — the one read route that still surfaced a page-transport death as a raw `500`, now split exactly like its siblings.
+
 - **125 routes now document a status they could already answer** — 91 gained the `409` an unconnected session answers, plus `400` on six sends, `403` on six group and channel writes, `404` on eleven, and `501` on eleven more. A generated client had no branch for any of them.
 
 - **Five routes now document a `503` they have been answering for releases** — the four group participant writes since 0.14.5, and listing chats by label since 0.14.0. There the `503` is what separates "WhatsApp never answered" from the per-participant refusals a `200` reports inside `results`.
@@ -28,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **A bulk media send lost its attachment when the engine echo won the persist race** — the batch write collided on `UNIQUE(sessionId, waMessageId)` and was swallowed into a warning, leaving only the echo's row, which on a Baileys API send carries a media-less marker; it now merges onto that row like the single-send path already did.
+
+- **A WhatsApp Web page reload no longer kills a starting session** — a navigation landing during the first injection rejects `Client.initialize()` before whatsapp-web.js has installed its own re-inject handler, and the adapter's error channel is terminal, so one reload parked the session `FAILED` with nobody retrying (on start and on reconnect alike); the engine now retries that launch once, within the init deadline, before declaring failure.
+
+- **The liveness watchdog no longer tears down a session that is healing itself** — a post-`ready` page navigation makes `getState()` reject until WhatsApp Web reboots, which read as two failed probes and a teardown of a page whatsapp-web.js was about to re-inject; the probe now grants a bounded post-navigation grace (never for a logout navigation, and capped per episode so a reload loop cannot mask a genuinely dead page).
 
 - **Three shared status descriptions said the wrong thing on the routes that borrowed them** — `send-text`'s `501` is specifically a caller-supplied `customLinkPreview`, which only Baileys accepts, not a wholesale gap in the engine; `POST /channels/subscribe` takes an invite code and no channel id, so its `404` is an unresolvable invite; and the `400` on six send routes named the unreachable recipient as though it were the only cause, while omitting body validation and an inactive session, and cited a `404` meaning that four of those six routes do not declare.
 

--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -362,7 +362,7 @@ Get active chats for a session, most-recent first (paginated).
 
 Sorted by `timestamp` DESC (most recent first) then paginated. `timestamp` is an epoch number (seconds). `kind` is the user-facing chat discriminator — one of `individual|group|channel|status|broadcast|unknown`; `isGroup` is retained for back-compat (true only for `kind: "group"`).
 
-**Errors:** `400` session not started · `401` · `403` · `404` session not found
+**Errors:** `400` session not started · `401` · `403` · `404` session not found · `409` session not connected (also answered for a few seconds while WhatsApp Web reloads its page and the engine re-injects) · `503` page connection died mid-read
 
 #### GET /api/sessions/stats/overview
 

--- a/openapi.json
+++ b/openapi.json
@@ -760,7 +760,7 @@
             "description": "Session not found"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           }
         },
         "summary": "Get QR code for session authentication",
@@ -811,7 +811,7 @@
             "description": "Session not found"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           }
         },
         "summary": "Request an 8-char pairing code to link via phone number (alternative to QR)",
@@ -863,7 +863,7 @@
             "description": "Session not found"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer the group-list query. Deliberately not reported as an empty list — the engine returns the same empty value for \"you are in no groups\", and a caller cannot tell those apart from the body."
@@ -928,7 +928,10 @@
             "description": "Session not found"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
+          },
+          "503": {
+            "description": "The whatsapp-web.js page connection died mid-read, so nothing could be read. Deliberately not reported as an empty list — a page that went away says nothing about the chats."
           }
         },
         "summary": "Get active chats for a session",
@@ -972,7 +975,7 @@
             "description": "Session not found"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
@@ -1020,7 +1023,7 @@
             "description": "Session not found"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "501": {
             "description": "The active engine cannot observe presence (whatsapp-web.js)"
@@ -1068,7 +1071,7 @@
             "description": "Session not found"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           }
         },
         "summary": "Set the account's own global presence (appear online or offline)",
@@ -1157,7 +1160,7 @@
             "description": "Session not found"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
@@ -1203,7 +1206,7 @@
             "description": "Session not found"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
@@ -1250,7 +1253,7 @@
             "description": "Session not found"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
@@ -1297,7 +1300,7 @@
             "description": "Session not found"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
@@ -1341,7 +1344,7 @@
             "description": "Session not found"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           }
         },
         "summary": "Send a typing/recording presence indicator to a chat (or clear it with 'paused')",
@@ -2026,7 +2029,7 @@
             "description": "Session not found"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "501": {
             "description": "A caller-supplied `customLinkPreview` is not supported by the whatsapp-web.js engine — only Baileys can attach one. The send itself is supported on both; omit the field, or use `linkPreview`."
@@ -2080,7 +2083,7 @@
             "description": "Session or template not found"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           }
         },
         "summary": "Render a stored text template and send it as a text message",
@@ -2138,7 +2141,7 @@
             "description": "Session not active or invalid request"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "501": {
             "description": "Sending media to a channel (`<id>@newsletter`) is not supported by the whatsapp-web.js engine — the page method it needs was removed by a WhatsApp Web update. Text to a channel still works."
@@ -2198,7 +2201,7 @@
             "description": "Session not active or invalid request"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "501": {
             "description": "Sending media to a channel (`<id>@newsletter`) is not supported by the whatsapp-web.js engine — the page method it needs was removed by a WhatsApp Web update. Text to a channel still works."
@@ -2259,7 +2262,7 @@
             "description": "Session not active or invalid request"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "501": {
             "description": "Sending media to a channel (`<id>@newsletter`) is not supported by the whatsapp-web.js engine — the page method it needs was removed by a WhatsApp Web update. Text to a channel still works."
@@ -2320,7 +2323,7 @@
             "description": "Session not active or invalid request"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "501": {
             "description": "Sending media to a channel (`<id>@newsletter`) is not supported by the whatsapp-web.js engine — the page method it needs was removed by a WhatsApp Web update. Text to a channel still works."
@@ -2371,7 +2374,7 @@
             "description": "The request was rejected before anything was sent. Among the causes: the recipient could not be addressed — WhatsApp reports no deliverable id for that `chatId`, which is how it says the number is not on WhatsApp — as well as body validation and a session that is not active."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           }
         },
         "summary": "Send a location message",
@@ -2419,7 +2422,7 @@
             "description": "The request was rejected before anything was sent. Among the causes: the recipient could not be addressed — WhatsApp reports no deliverable id for that `chatId`, which is how it says the number is not on WhatsApp — as well as body validation and a session that is not active."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           }
         },
         "summary": "Send a contact card message",
@@ -2476,7 +2479,7 @@
             "description": "The request was rejected before anything was sent. Among the causes: the recipient could not be addressed — WhatsApp reports no deliverable id for that `chatId`, which is how it says the number is not on WhatsApp — as well as body validation and a session that is not active."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "501": {
             "description": "Sending media to a channel (`<id>@newsletter`) is not supported by the whatsapp-web.js engine — the page method it needs was removed by a WhatsApp Web update. Text to a channel still works."
@@ -2527,7 +2530,7 @@
             "description": "The request was rejected before anything was sent. Among the causes: the recipient could not be addressed — WhatsApp reports no deliverable id for that `chatId`, which is how it says the number is not on WhatsApp — as well as body validation and a session that is not active."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           }
         },
         "summary": "Send a native WhatsApp poll",
@@ -2578,7 +2581,7 @@
             "description": "No such message — the id is outside the engine's lookup window (roughly the last hundred messages of the chat, or absent from the Baileys store) or the message was revoked."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           }
         },
         "summary": "Reply to a message",
@@ -2629,7 +2632,7 @@
             "description": "No such message — the id is outside the engine's lookup window (roughly the last hundred messages of the chat, or absent from the Baileys store) or the message was revoked."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           }
         },
         "summary": "Forward a message to another chat",
@@ -2673,7 +2676,7 @@
             "description": "No such message — the id is outside the engine's lookup window (roughly the last hundred messages of the chat, or absent from the Baileys store) or the message was revoked."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           }
         },
         "summary": "Add or remove a reaction to a message",
@@ -2738,7 +2741,7 @@
             "description": "Chat history (most recent messages)"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "501": {
             "description": "The active engine cannot serve this operation. It is part of the engine contract, but the engine currently running has no implementation for it."
@@ -2790,7 +2793,7 @@
             "description": "No such message — the id is outside the engine's lookup window (roughly the last hundred messages of the chat, or absent from the Baileys store) or the message was revoked."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "501": {
             "description": "The active engine cannot serve this operation. It is part of the engine contract, but the engine currently running has no implementation for it."
@@ -2891,7 +2894,7 @@
             "description": "No such message — the id is outside the engine's lookup window (roughly the last hundred messages of the chat, or absent from the Baileys store) or the message was revoked."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
@@ -2938,7 +2941,7 @@
             "description": "Poll not found in the chat’s recent history"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "501": {
             "description": "Not supported on the Baileys engine"
@@ -2988,7 +2991,7 @@
             "description": "Message not found in the chat"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           }
         },
         "summary": "Pin a message in its chat",
@@ -3035,7 +3038,7 @@
             "description": "Message not found in the chat"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           }
         },
         "summary": "Remove a message’s pin",
@@ -3079,7 +3082,7 @@
             "description": "Message not found in the chat"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
@@ -3136,7 +3139,7 @@
             "description": "Message not found"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           }
         },
         "summary": "Edit the text of a message sent by this account",
@@ -4003,7 +4006,7 @@
             "description": "Session not found"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           }
         },
         "summary": "Get all contacts for a session",
@@ -4048,7 +4051,7 @@
             }
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           }
         },
         "summary": "Batch-resolve profile picture URLs for up to 50 contacts",
@@ -4087,7 +4090,7 @@
             }
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer the blocklist query — retry shortly"
@@ -4137,7 +4140,7 @@
             "description": "Contact not found"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           }
         },
         "summary": "Get a specific contact by ID",
@@ -4192,7 +4195,7 @@
             "description": "Session not active or invalid request"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
@@ -4240,7 +4243,7 @@
             "description": "Session not active"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
@@ -4288,7 +4291,7 @@
             }
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer the lookup. Deliberately not reported as `exists: false` — that would be a claim about the number rather than about the query, and this route exists to be trusted before a send."
@@ -4335,7 +4338,7 @@
             }
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer the lookup. Deliberately not reported as `url: null` — that is the same answer a contact with no picture gives, and a caller cannot tell them apart."
@@ -4382,7 +4385,7 @@
             }
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           }
         },
         "summary": "Resolve a contact id (e.g. an @lid) to a phone number — best-effort",
@@ -4426,7 +4429,7 @@
             }
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
@@ -4471,7 +4474,7 @@
             }
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
@@ -4525,7 +4528,7 @@
             "description": "No such invite — invalid, expired or revoked"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget. Deliberately not folded into the 404 above — a query that never came back is not the same claim as a group that does not exist."
@@ -4575,7 +4578,7 @@
             "description": "Group not found"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget. Deliberately not folded into the 404 above — a query that never came back is not the same claim as a group that does not exist."
@@ -4626,7 +4629,7 @@
             "description": "Invalid or expired invite code, or session is not started"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
@@ -4676,7 +4679,7 @@
             "description": "Group not found"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget — nothing could be read."
@@ -4740,7 +4743,7 @@
             "description": "Group not found"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "501": {
             "description": "The active engine does not support a requested setting"
@@ -4794,7 +4797,7 @@
             "description": "WhatsApp refused the operation. The request was well formed — the refusal happened WhatsApp-side, most often because the account lacks the admin rights the operation requires."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           }
         },
         "summary": "Create a new group",
@@ -4851,7 +4854,7 @@
             "description": "WhatsApp refused the operation. The request was well formed — the refusal happened WhatsApp-side, most often because the account lacks the admin rights the operation requires."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget, so no per-participant outcome was read at all. Deliberately not folded into the 200 above — a participant WhatsApp turned down is reported inside `results` and is an answer; an update that never came back is not."
@@ -4909,7 +4912,7 @@
             "description": "WhatsApp refused the operation. The request was well formed — the refusal happened WhatsApp-side, most often because the account lacks the admin rights the operation requires."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget, so no per-participant outcome was read at all. Deliberately not folded into the 200 above — a participant WhatsApp turned down is reported inside `results` and is an answer; an update that never came back is not."
@@ -4969,7 +4972,7 @@
             "description": "WhatsApp refused the operation. The request was well formed — the refusal happened WhatsApp-side, most often because the account lacks the admin rights the operation requires."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget, so no per-participant outcome was read at all. Deliberately not folded into the 200 above — a participant WhatsApp turned down is reported inside `results` and is an answer; an update that never came back is not."
@@ -5029,7 +5032,7 @@
             "description": "WhatsApp refused the operation. The request was well formed — the refusal happened WhatsApp-side, most often because the account lacks the admin rights the operation requires."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget, so no per-participant outcome was read at all. Deliberately not folded into the 200 above — a participant WhatsApp turned down is reported inside `results` and is an answer; an update that never came back is not."
@@ -5083,7 +5086,7 @@
             "description": "WhatsApp refused the operation. The request was well formed — the refusal happened WhatsApp-side, most often because the account lacks the admin rights the operation requires."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget — retry shortly"
@@ -5144,7 +5147,7 @@
             "description": "WhatsApp refused the operation. The request was well formed — the refusal happened WhatsApp-side, most often because the account lacks the admin rights the operation requires."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget, so no per-participant outcome was read at all. Deliberately not folded into the 200 above — a participant WhatsApp turned down is reported inside `results` and is an answer; an update that never came back is not."
@@ -5205,7 +5208,7 @@
             "description": "WhatsApp refused the operation. The request was well formed — the refusal happened WhatsApp-side, most often because the account lacks the admin rights the operation requires."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget, so no per-participant outcome was read at all. Deliberately not folded into the 200 above — a participant WhatsApp turned down is reported inside `results` and is an answer; an update that never came back is not."
@@ -5265,7 +5268,7 @@
             "description": "The engine refused the change — admin rights are required"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
@@ -5325,7 +5328,7 @@
             "description": "The engine refused the change — admin rights are required"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
@@ -5372,7 +5375,7 @@
             }
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
@@ -5419,7 +5422,7 @@
             }
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget — nothing could be read."
@@ -5483,7 +5486,7 @@
             "description": "No such group — the id is unknown, or it addresses a 1:1 chat rather than a group."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
@@ -5534,7 +5537,7 @@
             "description": "No such group — the id is unknown, or it addresses a 1:1 chat rather than a group."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
@@ -5584,7 +5587,7 @@
             "description": "The engine refused the request — admin rights required for this group"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer the invite-code query — retry shortly"
@@ -5634,7 +5637,7 @@
             "description": "The engine refused the request — admin rights required for this group"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer the invite-code query — retry shortly"
@@ -5688,7 +5691,7 @@
             "description": "The engine refused the name change"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
@@ -5739,7 +5742,7 @@
             "description": "Session is not started"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
@@ -5793,7 +5796,7 @@
             "description": "The engine refused the picture change"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "413": {
             "description": "Decoded base64 image exceeds the configured media cap"
@@ -5849,7 +5852,7 @@
             "description": "Call not found or no longer ringing"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
@@ -5896,7 +5899,7 @@
             "description": "Session not found"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "501": {
             "description": "The active engine cannot serve this operation. It is part of the engine contract, but the engine currently running has no implementation for it."
@@ -5946,7 +5949,7 @@
             "description": "Label not found"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "501": {
             "description": "The active engine cannot serve this operation. It is part of the engine contract, but the engine currently running has no implementation for it."
@@ -6005,7 +6008,7 @@
             "description": "Session not started, or validation failed"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "501": {
             "description": "The active engine cannot edit labels (whatsapp-web.js)"
@@ -6057,7 +6060,7 @@
             "description": "Session not started"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "501": {
             "description": "The active engine cannot edit labels (whatsapp-web.js)"
@@ -6117,7 +6120,7 @@
             "description": "No such label — it was never created, or the account is not a WhatsApp Business one and holds no labels at all. Both are the same answer to the caller."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "501": {
             "description": "The active engine cannot list chats by label (Baileys)"
@@ -6170,7 +6173,7 @@
             }
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "501": {
             "description": "The active engine cannot serve this operation. It is part of the engine contract, but the engine currently running has no implementation for it."
@@ -6234,7 +6237,7 @@
             }
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "422": {
             "description": "Labels require a WhatsApp Business account, or the chat type has no labels"
@@ -6293,7 +6296,7 @@
             }
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "422": {
             "description": "Labels require a WhatsApp Business account, or the chat type has no labels"
@@ -6340,7 +6343,7 @@
             "description": "Session not ready"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "501": {
             "description": "Not supported by the active engine: the Baileys adapter cannot list subscribed channels."
@@ -6393,7 +6396,7 @@
             "description": "The engine refused — channel creation may be disabled for this account"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           }
         },
         "summary": "Create a channel",
@@ -6440,7 +6443,7 @@
             "description": "Channel not found"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget — the operation may or may not have applied."
@@ -6488,7 +6491,7 @@
             "description": "WhatsApp refused the operation. The request was well formed — the refusal happened WhatsApp-side, most often because the account lacks the admin rights the operation requires."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget — the operation may or may not have applied."
@@ -6550,7 +6553,7 @@
             "description": "No such channel — the id is not among the session's subscribed channels, either because it is wrong or because the channel has not synced into the local collection yet."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "501": {
             "description": "Not supported by the active engine: the Baileys adapter cannot read channel messages."
@@ -6604,7 +6607,7 @@
             "description": "The engine refused — not found, or this account does not own it"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget — the operation may or may not have applied."
@@ -6671,7 +6674,7 @@
             "description": "No such channel — the id is not among the session's subscribed channels, either because it is wrong or because the channel has not synced into the local collection yet."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "503": {
             "description": "WhatsApp did not answer within the request budget — the operation may or may not have applied."
@@ -6732,7 +6735,7 @@
             "description": "The invite code does not resolve to a channel — it is wrong, expired, or revoked. This route takes an invite code rather than a channel id."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "501": {
             "description": "Not supported by the active engine: whatsapp-web.js cannot subscribe by invite code."
@@ -7025,7 +7028,7 @@
             "description": "No session is running under that id — it was never started, was stopped, or does not exist. These routes report an unstarted session as `404`, where the message and group routes report it as `400`."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           }
         },
         "summary": "Post a text status",
@@ -7075,7 +7078,7 @@
             "description": "No session is running under that id — it was never started, was stopped, or does not exist. These routes report an unstarted session as `404`, where the message and group routes report it as `400`."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "413": {
             "description": "Base64 media exceeds MEDIA_DOWNLOAD_MAX_BYTES."
@@ -7128,7 +7131,7 @@
             "description": "No session is running under that id — it was never started, was stopped, or does not exist. These routes report an unstarted session as `404`, where the message and group routes report it as `400`."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "413": {
             "description": "Base64 media exceeds MEDIA_DOWNLOAD_MAX_BYTES."
@@ -7181,7 +7184,7 @@
             "description": "No session is running under that id — it was never started, was stopped, or does not exist. These routes report an unstarted session as `404`, where the message and group routes report it as `400`."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "413": {
             "description": "Base64 media exceeds MEDIA_DOWNLOAD_MAX_BYTES."
@@ -7229,7 +7232,7 @@
             "description": "No session is running under that id — it was never started, was stopped, or does not exist. These routes report an unstarted session as `404`, where the message and group routes report it as `400`."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           }
         },
         "summary": "Delete own status",
@@ -7400,7 +7403,7 @@
             "description": "No session is running under that id — it was never started, was stopped, or does not exist. These routes report an unstarted session as `404`, where the message and group routes report it as `400`."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "501": {
             "description": "Not supported by the active engine: whatsapp-web.js has no catalog API."
@@ -7465,7 +7468,7 @@
             "description": "No session is running under that id — it was never started, was stopped, or does not exist. These routes report an unstarted session as `404`, where the message and group routes report it as `400`."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "501": {
             "description": "Not supported by the active engine: whatsapp-web.js has no catalog API."
@@ -7516,7 +7519,7 @@
             "description": "No session is running under that id — it was never started, was stopped, or does not exist. These routes report an unstarted session as `404`, where the message and group routes report it as `400`."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "501": {
             "description": "Not supported by the active engine: whatsapp-web.js has no catalog API."
@@ -7572,7 +7575,7 @@
             "description": "Product id not found in the session catalog."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "501": {
             "description": "Not supported by the active engine: whatsapp-web.js cannot send product messages."
@@ -7615,7 +7618,7 @@
             "description": "No session is running under that id — it was never started, was stopped, or does not exist. These routes report an unstarted session as `404`, where the message and group routes report it as `400`."
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this."
+            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
           "501": {
             "description": "Not supported by the active engine: no engine can send catalog links."

--- a/src/common/openapi/engine-status-responses.ts
+++ b/src/common/openapi/engine-status-responses.ts
@@ -18,7 +18,9 @@ export const ENGINE_NOT_READY_409 =
   'The session is not connected — an engine exists for it but is not `ready`: disconnected, ' +
   'reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and ' +
   'retry. A session that was never started answers `400` instead, and the session lifecycle routes ' +
-  'answer `409` for a conflicting state rather than this.';
+  'answer `409` for a conflicting state rather than this. One window answers this while the session ' +
+  'still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects ' +
+  'into it — for those few seconds the answer is a `409` naming the reload; retry shortly.';
 
 /**
  * The catalog and status services pass a `NotFoundException` factory to `EngineRegistry.require()`

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -14,6 +14,8 @@ import {
   extractWwebjsCall,
   READY_RECONCILE_TIMEOUT_MS,
   READY_RECONCILE_BRIDGE_RELOAD_GRACE_MS,
+  NAVIGATION_REINJECT_GRACE_MS,
+  NAVIGATION_EPISODE_CAP_MS,
 } from './whatsapp-web-js.adapter';
 import { getEffectiveWebVersionInfo, resolveWebVersionPin, __resetWebVersionCache } from '../wa-web-version';
 import * as fs from 'fs';
@@ -186,6 +188,208 @@ describe('WhatsAppWebJsAdapter initialize() failure reason (#1081)', () => {
     const raw = 'Failed to launch the browser process:  Code: null';
 
     expect(await reasonFor(raw)).toBe(raw);
+  });
+});
+
+// A WhatsApp Web page navigation during the FIRST inject rejects Client.initialize() before the
+// library's own framenavigated re-inject handler exists (Client.js:502 vs :504), so nothing upstream
+// retries it — and the adapter's onError channel is terminal. One in-adapter retry converts that
+// one-navigation death into a normal slow start (#1081).
+describe('WhatsAppWebJsAdapter initialize() retry on a navigation-killed first inject (#1081)', () => {
+  const newAdapter = (): WhatsAppWebJsAdapter =>
+    new WhatsAppWebJsAdapter({ sessionId: 'sess-nav-retry', sessionDataPath: './data/sessions', puppeteer: {} });
+
+  const EXEC_CTX = 'Protocol error (Runtime.callFunctionOn): Execution context was destroyed.';
+
+  let rmSpy: jest.SpyInstance;
+  let clientInitSpy: jest.SpyInstance;
+  let clientDestroySpy: jest.SpyInstance;
+  let savedWebVersion: string | undefined;
+  let savedAuthTimeout: string | undefined;
+
+  beforeEach(() => {
+    savedWebVersion = process.env.WWEBJS_WEB_VERSION;
+    process.env.WWEBJS_WEB_VERSION = 'off';
+    // The budget tests assume the 60s outer-deadline floor; an ambient WWEBJS_AUTH_TIMEOUT_MS
+    // (a documented operator knob, #353) would widen it and flip their expectations.
+    savedAuthTimeout = process.env.WWEBJS_AUTH_TIMEOUT_MS;
+    delete process.env.WWEBJS_AUTH_TIMEOUT_MS;
+    rmSpy = jest.spyOn(fs.promises, 'rm').mockResolvedValue(undefined);
+    clientInitSpy = jest.spyOn(Client.prototype as unknown as { initialize: () => Promise<void> }, 'initialize');
+    // The inter-attempt cleanup destroys the failed client; the real destroy() would throw on a
+    // browserless Client, which is best-effort-tolerated but noisy — keep it deterministic.
+    clientDestroySpy = jest
+      .spyOn(Client.prototype as unknown as { destroy: () => Promise<void> }, 'destroy')
+      .mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    rmSpy.mockRestore();
+    clientInitSpy.mockRestore();
+    clientDestroySpy.mockRestore();
+    jest.useRealTimers();
+    if (savedWebVersion === undefined) {
+      delete process.env.WWEBJS_WEB_VERSION;
+    } else {
+      process.env.WWEBJS_WEB_VERSION = savedWebVersion;
+    }
+    if (savedAuthTimeout !== undefined) {
+      process.env.WWEBJS_AUTH_TIMEOUT_MS = savedAuthTimeout;
+    }
+  });
+
+  it('retries once when the first inject dies to a navigation, without surfacing an error', async () => {
+    clientInitSpy.mockRejectedValueOnce(new Error(EXEC_CTX)).mockResolvedValueOnce(undefined);
+    const onError = jest.fn();
+
+    await expect(newAdapter().initialize({ onError })).resolves.toBeUndefined();
+
+    expect(clientInitSpy).toHaveBeenCalledTimes(2);
+    expect(onError).not.toHaveBeenCalled();
+    // The inter-attempt reset destroys attempt 1's client, and BOTH attempts run the pre-launch
+    // Singleton sweep (3 rm's each) — the docblocks present both as load-bearing.
+    expect(clientDestroySpy).toHaveBeenCalledTimes(1);
+    expect(rmSpy).toHaveBeenCalledTimes(6);
+  });
+
+  it('still retries with exactly the minimum outer budget remaining', async () => {
+    jest.useFakeTimers();
+    clientInitSpy
+      .mockImplementationOnce(() => {
+        jest.setSystemTime(Date.now() + 40_000); // 60s floor − 40s = exactly the 20s floor
+        throw new Error(EXEC_CTX);
+      })
+      .mockResolvedValueOnce(undefined);
+    const onError = jest.fn();
+
+    await expect(newAdapter().initialize({ onError })).resolves.toBeUndefined();
+
+    expect(clientInitSpy).toHaveBeenCalledTimes(2);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("abandons the retry when attempt 1's browser will not die — never two Chromiums on one profile", async () => {
+    // Real timers: the destroy bound is 5s of wall clock. Fake timers cannot drive this path —
+    // the pre-launch sweep's real IO and the race's timer interleave in ways an advance loop
+    // starves — so this one test simply waits the bound out.
+    clientInitSpy.mockRejectedValueOnce(new Error(EXEC_CTX)).mockResolvedValueOnce(undefined);
+    clientDestroySpy.mockImplementation(() => new Promise<never>(() => {}));
+    const onError = jest.fn();
+
+    await expect(newAdapter().initialize({ onError })).rejects.toThrow(EXEC_CTX);
+
+    expect(clientInitSpy).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+  }, 10_000);
+
+  it("silences attempt 1's client: a late event from its persisted bindings cannot corrupt the retry", async () => {
+    jest.useFakeTimers();
+    clientInitSpy.mockRejectedValueOnce(new Error(EXEC_CTX)).mockResolvedValueOnce(undefined);
+    const adapter = newAdapter();
+
+    await expect(adapter.initialize({ onError: jest.fn() })).resolves.toBeUndefined();
+    // 'authenticated' has no source-client identity fence: without the removeAllListeners in
+    // resetForInitRetry, this late emit would flip the retry to AUTHENTICATING and arm a
+    // reconcile deadline that belongs to no live attempt. mock.contexts[0] is attempt 1's client.
+    (clientInitSpy.mock.contexts[0] as Client).emit('authenticated');
+
+    expect(adapter.getStatus()).toBe(EngineStatus.INITIALIZING);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it("retries the 'window.require is not a function' navigation variant too", async () => {
+    clientInitSpy
+      .mockRejectedValueOnce(new Error('Evaluation failed: TypeError: window.require is not a function'))
+      .mockResolvedValueOnce(undefined);
+    const onError = jest.fn();
+
+    await expect(newAdapter().initialize({ onError })).resolves.toBeUndefined();
+
+    expect(clientInitSpy).toHaveBeenCalledTimes(2);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('fails terminally after the single retry: onError exactly once, raw error rethrown', async () => {
+    clientInitSpy.mockRejectedValue(new Error(EXEC_CTX));
+    const onError = jest.fn();
+
+    await expect(newAdapter().initialize({ onError })).rejects.toThrow(EXEC_CTX);
+
+    expect(clientInitSpy).toHaveBeenCalledTimes(2);
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    'Failed to launch the browser process:  Code: null',
+    'Protocol error (Runtime.callFunctionOn): Target closed',
+  ])('does not retry a non-navigation failure: %s', async raw => {
+    clientInitSpy.mockRejectedValue(new Error(raw));
+    const onError = jest.fn();
+
+    await expect(newAdapter().initialize({ onError })).rejects.toThrow(raw);
+
+    expect(clientInitSpy).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry upstream's bare 'auth timeout' string (its 504 mapping matches by exact message)", async () => {
+    clientInitSpy.mockRejectedValue('auth timeout');
+    const onError = jest.fn();
+
+    await expect(newAdapter().initialize({ onError })).rejects.toEqual('auth timeout');
+
+    expect(clientInitSpy).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the retry when the outer init budget is nearly spent (the lifecycle race must win instead)', async () => {
+    jest.useFakeTimers();
+    clientInitSpy.mockImplementationOnce(() => {
+      jest.setSystemTime(Date.now() + 55_000);
+      throw new Error(EXEC_CTX);
+    });
+    const onError = jest.fn();
+
+    await expect(newAdapter().initialize({ onError })).rejects.toThrow(EXEC_CTX);
+
+    expect(clientInitSpy).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry once a teardown has begun', async () => {
+    const adapter = newAdapter();
+    clientInitSpy.mockImplementationOnce(async () => {
+      // A destroy() lands while attempt 1 is in flight: tearingDown latches before the catch runs.
+      await adapter.destroy();
+      throw new Error(EXEC_CTX);
+    });
+    const onError = jest.fn();
+
+    await expect(adapter.initialize({ onError })).rejects.toThrow(EXEC_CTX);
+
+    expect(clientInitSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the abandoned reconcile deadline from a first attempt that authenticated before dying', async () => {
+    jest.useFakeTimers();
+    clientInitSpy
+      .mockImplementationOnce(function (this: Client) {
+        // The patched hasSynced level-check can fire AUTHENTICATED before the killed evaluate
+        // rejects initialize() — attempt 1 then leaves a live 90s reconcile deadline behind, whose
+        // non-bridge branch DELETES credentials (recoverFromStuckAuth). The retry must clear it.
+        this.emit('authenticated');
+        throw new Error(EXEC_CTX);
+      })
+      .mockResolvedValueOnce(undefined);
+    const onError = jest.fn();
+    const adapter = newAdapter();
+
+    await expect(adapter.initialize({ onError })).resolves.toBeUndefined();
+
+    expect(jest.getTimerCount()).toBe(0);
+    expect(onError).not.toHaveBeenCalled();
+    // Attempt 2 starts from a clean INITIALIZING, not attempt 1's leftover AUTHENTICATING.
+    expect(adapter.getStatus()).toBe(EngineStatus.INITIALIZING);
   });
 });
 
@@ -4683,6 +4887,215 @@ describe('WhatsAppWebJsAdapter.probeLiveness (session watchdog probe)', () => {
   });
 });
 
+// A post-READY WhatsApp Web page navigation is a designed-survivable event: whatsapp-web.js
+// re-injects on framenavigated. But getState() rejects until WA Web reboots, so without a grace the
+// watchdog (2 failed probes) tears down a session that was about to heal, and every delegate call
+// answers a raw 500 while the status still says READY (#1081).
+describe('WhatsAppWebJsAdapter navigation re-inject grace (#1081)', () => {
+  type NavFakeClient = EventEmitter & {
+    getState: jest.Mock;
+    getChats?: jest.Mock;
+    lastLoggedOut?: boolean;
+    pupBrowser: EventEmitter;
+    pupPage: EventEmitter & { mainFrame?: () => unknown };
+  };
+
+  const wireAdapter = (
+    clientOverrides: Partial<NavFakeClient> = {},
+  ): { adapter: WhatsAppWebJsAdapter; client: NavFakeClient } => {
+    const adapter = new WhatsAppWebJsAdapter({
+      sessionId: 'sess-nav',
+      sessionDataPath: './data/sessions',
+      puppeteer: {},
+    });
+    const client = Object.assign(new EventEmitter(), {
+      getState: jest
+        .fn()
+        .mockRejectedValue(new Error('Execution context was destroyed, most likely because of a navigation.')),
+      pupBrowser: new EventEmitter(),
+      pupPage: new EventEmitter(),
+      ...clientOverrides,
+    }) as NavFakeClient;
+    (adapter as unknown as { client: unknown }).client = client;
+    (adapter as unknown as { callbacks: unknown }).callbacks = {};
+    (adapter as unknown as { status: EngineStatus }).status = EngineStatus.READY;
+    // Mirror the real init order: event handlers first, puppeteer listeners after initialize().
+    (adapter as unknown as { setupEventHandlers: () => void }).setupEventHandlers();
+    (adapter as unknown as { attachPuppeteerLifecycleListeners: () => void }).attachPuppeteerLifecycleListeners();
+    return { adapter, client };
+  };
+
+  const navFrame = (url = 'https://web.whatsapp.com/'): { url: () => string } => ({ url: () => url });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('keeps answering the liveness probe while a fresh main-frame navigation is re-injecting', async () => {
+    const { adapter, client } = wireAdapter();
+
+    client.pupPage.emit('framenavigated', navFrame());
+
+    await expect(adapter.probeLiveness()).resolves.toBe(true);
+  });
+
+  it('stops gracing once the per-navigation window has expired', async () => {
+    jest.useFakeTimers();
+    const { adapter, client } = wireAdapter();
+
+    client.pupPage.emit('framenavigated', navFrame());
+    jest.setSystemTime(Date.now() + NAVIGATION_REINJECT_GRACE_MS);
+
+    await expect(adapter.probeLiveness()).resolves.toBe(false);
+  });
+
+  it('a navigation loop cannot suppress the watchdog forever: the episode cap denies further grace', async () => {
+    jest.useFakeTimers();
+    const { adapter, client } = wireAdapter();
+
+    // Re-navigate every 30s: each nav lands inside the previous grace, so the rolling window alone
+    // would never expire — only the episode cap ends it.
+    client.pupPage.emit('framenavigated', navFrame());
+    for (let elapsed = 0; elapsed < NAVIGATION_EPISODE_CAP_MS; elapsed += 30_000) {
+      jest.setSystemTime(Date.now() + 30_000);
+      client.pupPage.emit('framenavigated', navFrame());
+    }
+
+    await expect(adapter.probeLiveness()).resolves.toBe(false);
+  });
+
+  it("a completed re-inject (the library's re-emitted 'ready') closes the window", async () => {
+    const { adapter, client } = wireAdapter();
+
+    client.pupPage.emit('framenavigated', navFrame());
+    client.emit('ready');
+
+    await expect(adapter.probeLiveness()).resolves.toBe(false);
+  });
+
+  it('does not stamp a post_logout navigation — the credential teardown path must win', async () => {
+    const { adapter, client } = wireAdapter();
+
+    client.pupPage.emit('framenavigated', navFrame('https://web.whatsapp.com/?post_logout=1&logout_reason=0'));
+
+    await expect(adapter.probeLiveness()).resolves.toBe(false);
+  });
+
+  it('does not stamp when upstream has latched a logout (lastLoggedOut)', async () => {
+    const { adapter, client } = wireAdapter({ lastLoggedOut: true });
+
+    client.pupPage.emit('framenavigated', navFrame());
+
+    await expect(adapter.probeLiveness()).resolves.toBe(false);
+  });
+
+  it('does not stamp a subframe navigation', async () => {
+    const { adapter, client } = wireAdapter();
+    const mainFrame = navFrame();
+    client.pupPage.mainFrame = () => mainFrame;
+
+    client.pupPage.emit('framenavigated', navFrame());
+
+    await expect(adapter.probeLiveness()).resolves.toBe(false);
+  });
+
+  it('never graces past the status gate: a non-READY adapter stays dead to the probe', async () => {
+    const { adapter, client } = wireAdapter();
+
+    client.pupPage.emit('framenavigated', navFrame());
+    (adapter as unknown as { status: EngineStatus }).status = EngineStatus.ACTION_REQUIRED;
+
+    await expect(adapter.probeLiveness()).resolves.toBe(false);
+    expect(client.getState).not.toHaveBeenCalled();
+  });
+
+  it('also graces a probe that RESOLVES non-CONNECTED during the window (WA Web mid-boot)', async () => {
+    const { adapter, client } = wireAdapter();
+    client.getState.mockResolvedValue(WAState.OPENING);
+
+    client.pupPage.emit('framenavigated', navFrame());
+
+    await expect(adapter.probeLiveness()).resolves.toBe(true);
+  });
+
+  it('stamps a REAL main frame — the page shape production always has', async () => {
+    const { adapter, client } = wireAdapter();
+    const mainFrame = navFrame();
+    client.pupPage.mainFrame = () => mainFrame;
+
+    client.pupPage.emit('framenavigated', mainFrame);
+
+    await expect(adapter.probeLiveness()).resolves.toBe(true);
+  });
+
+  it('a CONNECTED probe closes the episode, so a much later navigation gets a fresh grace', async () => {
+    jest.useFakeTimers();
+    const { adapter, client } = wireAdapter();
+    client.getState.mockResolvedValueOnce(WAState.CONNECTED);
+
+    // Episode 1: the re-inject dies silently (no 'ready'), but WA Web's socket comes back —
+    // the watchdog's CONNECTED probe is the observed recovery that must close the episode.
+    client.pupPage.emit('framenavigated', navFrame());
+    await expect(adapter.probeLiveness()).resolves.toBe(true);
+
+    // Hours later, the next routine reload must still be graced — a stale episode anchor would
+    // trip the episode cap and hand the healing page straight back to the watchdog.
+    jest.setSystemTime(Date.now() + 4 * 60 * 60 * 1000);
+    client.pupPage.emit('framenavigated', navFrame());
+    await expect(adapter.probeLiveness()).resolves.toBe(true);
+  });
+
+  it('does not report a transport-matching error as death inside the window (in-flight race)', () => {
+    const { adapter, client } = wireAdapter();
+    const report = (adapter as unknown as { reportIfPageTransportError: (e: unknown, c: string) => void })
+      .reportIfPageTransportError;
+
+    client.pupPage.emit('framenavigated', navFrame());
+    report.call(
+      adapter,
+      new Error('Protocol error (Runtime.callFunctionOn): Execution context was destroyed.'),
+      'getChats',
+    );
+
+    expect(adapter.getStatus()).toBe(EngineStatus.READY);
+  });
+
+  it('reports a transport-matching error as death again once the window expired', () => {
+    jest.useFakeTimers();
+    const { adapter, client } = wireAdapter();
+    const report = (adapter as unknown as { reportIfPageTransportError: (e: unknown, c: string) => void })
+      .reportIfPageTransportError;
+
+    client.pupPage.emit('framenavigated', navFrame());
+    jest.setSystemTime(Date.now() + NAVIGATION_REINJECT_GRACE_MS);
+    report.call(adapter, new Error('Protocol error: Target closed'), 'getChats');
+
+    expect(adapter.getStatus()).toBe(EngineStatus.DISCONNECTED);
+  });
+
+  it('answers engine operations with a retryable 409 while the page is re-injecting', async () => {
+    const getChats = jest.fn();
+    const { adapter, client } = wireAdapter({ getChats });
+
+    client.pupPage.emit('framenavigated', navFrame());
+
+    await expect(adapter.getChats()).rejects.toBeInstanceOf(EngineNotReadyError);
+    await expect(adapter.getChats()).rejects.toThrow(/reload/i);
+    expect(getChats).not.toHaveBeenCalled();
+  });
+
+  it('lets engine operations through again once the window has expired', async () => {
+    jest.useFakeTimers();
+    const getChats = jest.fn().mockResolvedValue([]);
+    const { adapter, client } = wireAdapter({ getChats });
+
+    client.pupPage.emit('framenavigated', navFrame());
+    jest.setSystemTime(Date.now() + NAVIGATION_REINJECT_GRACE_MS);
+
+    await expect(adapter.getChats()).resolves.toEqual([]);
+  });
+});
+
 describe('WhatsAppWebJsAdapter stale Singleton cleanup (pre-launch)', () => {
   const SESSION_ID = 'sess-singleton';
   const newAdapter = (): WhatsAppWebJsAdapter =>
@@ -6372,6 +6785,24 @@ describe('WhatsAppWebJsAdapter transport death is not a not-found', () => {
       getChatsByLabelId: jest.fn().mockRejectedValue(new TypeError('Cannot read properties of undefined')),
     });
     await expect(unknown.getChatsByLabel('7')).rejects.toBeInstanceOf(LabelNotFoundError);
+  });
+
+  // getChats was the one read delegate without this split: a dead page propagated raw as a 500
+  // while the status still said READY, and the early-death signal never fired (#1081).
+  it('getChats answers 503 for a dead page and feeds the death signal', async () => {
+    const adapter = readyAdapter({
+      getChats: jest.fn().mockRejectedValue(new Error('Protocol error (Runtime.callFunctionOn): Target closed')),
+    });
+
+    await expect(adapter.getChats()).rejects.toBeInstanceOf(EngineTransportError);
+    expect(adapter.getStatus()).toBe(EngineStatus.DISCONNECTED);
+  });
+
+  it('getChats rethrows a non-transport failure untouched', async () => {
+    const boom = new TypeError("Cannot read properties of undefined (reading 'getChats')");
+    const adapter = readyAdapter({ getChats: jest.fn().mockRejectedValue(boom) });
+
+    await expect(adapter.getChats()).rejects.toBe(boom);
   });
 });
 

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -49,7 +49,7 @@ import {
 } from '../interfaces/whatsapp-engine.interface';
 import { EngineNotSupportedError } from '../../common/errors/engine-not-supported.error';
 import { resolveWebVersionPin } from '../wa-web-version';
-import { resolveAuthTimeoutMs } from '../engine-init-timeout';
+import { resolveAuthTimeoutMs, resolveEngineInitTimeoutMs } from '../engine-init-timeout';
 import { killOrphanedChromiumProcesses, removeStaleSingletonFiles } from './chromium-profile-hygiene';
 import { isChannelJid } from '../identity/wa-id';
 import { LidMappingStore } from '../identity/lid-mapping-store.service';
@@ -99,6 +99,20 @@ export function isExecutionContextDestroyedError(reason: string): boolean {
   return /execution context was destroyed/i.test(reason);
 }
 
+/**
+ * A first-inject rejection that reads as "the page navigated out from under the in-flight evaluate":
+ * the exec-context class above plus the 'window.require is not a function' variant (an evaluate
+ * landing on a document whose WA bundle has not booted yet). Deliberately SEPARATE from the
+ * stale-profile advisory classifier: the advisory names a remedy (delete the profile) that is wrong
+ * for the window.require shape (see src/config/process-error-monitor.ts) — this predicate only
+ * decides whether one in-place retry is worth it, both shapes being transient when a reload caused
+ * them. whatsapp-web.js registers its own re-inject handler only AFTER the first inject succeeds
+ * (Client.js:502 vs :504), so a navigation landing during it is caught by nothing upstream (#1081).
+ */
+function isNavigationShapedInitRejection(reason: string): boolean {
+  return isExecutionContextDestroyedError(reason) || /window\.require is not a function/i.test(reason);
+}
+
 export interface WhatsAppWebJsConfig {
   sessionId: string;
   sessionDataPath: string;
@@ -130,6 +144,30 @@ export const READY_RECONCILE_TIMEOUT_MS = 90_000;
 // for the rest of the pipeline, and stay well under READY_RECONCILE_TIMEOUT_MS so a reload that IS
 // warranted still has time to reinject before the deadline.
 export const READY_RECONCILE_BRIDGE_RELOAD_GRACE_MS = 45_000;
+
+// A post-READY page navigation (WhatsApp Web's ~5-minute first reload on a fresh pairing, a
+// service-worker update, …) destroys the page's JS world; whatsapp-web.js re-injects on its own
+// framenavigated handler (Client.js:504-513), but until WA Web has booted again getState() REJECTS,
+// so the liveness probe reads a healing page as dead and every delegate evaluate dies as a raw
+// TypeError under a status that still says READY (#1081). Sizing — floor: the pre-boot phase alone
+// (page load + WA Web bundle boot, the stretch where getState() rejects) takes tens of seconds on a
+// slow host, and upstream's re-inject then polls up to 30s for window.WWebJS (Client.js:332-343);
+// ceiling: one watchdog interval (60s), so a page that navigates and then wedges loses at most one
+// probe to the grace and still dies within one extra interval. NOT a sibling of
+// READY_RECONCILE_BRIDGE_RELOAD_GRACE_MS above: that one is capped by the 90s reconcile deadline,
+// this one by keeping the watchdog's safety net alive — do not "harmonize" them.
+export const NAVIGATION_REINJECT_GRACE_MS = 60_000;
+
+// Hard bound per recovery episode (first navigation → the next completed re-inject): a page stuck in
+// a navigation loop re-stamps the rolling grace faster than it expires, which would suppress the
+// watchdog forever and leave a zombie session READY that only ever answers 409. Past this cap the
+// probe reports the truth again and the watchdog takes over.
+export const NAVIGATION_EPISODE_CAP_MS = 3 * NAVIGATION_REINJECT_GRACE_MS;
+
+// The single in-adapter retry of a navigation-killed first inject only runs while at least this much
+// of the lifecycle's outer init deadline remains — a retry the outer race SIGKILLs mid-launch would
+// surface as a bare 504 with no reason. Below it, fail with today's exact terminal shape instead.
+const INIT_RETRY_MIN_REMAINING_MS = 20_000;
 
 // WhatsApp Web states that mean WhatsApp has judged the account or its egress, mapped to the neutral
 // restriction kinds. This is the ONLY channel the library offers: there is no dedicated event, error
@@ -201,6 +239,11 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
   // decision (a CONNECTED session must never have its credentials wiped).
   private lastProbeStateConnected = false;
   private readyReconcileReloadAttempted = false;
+  // Navigation re-inject window (#1081): stamped by our framenavigated listener, closed by the
+  // library's re-emitted 'ready' and by teardown. Timestamps, never timers — several suites pin
+  // exact jest timer counts, and a timer would also outlive the single-use adapter.
+  private lastMainFrameNavigationAt = 0;
+  private navigationEpisodeStartedAt = 0;
   // Onboarding-modal watcher handle (#982). Self-rescheduling setTimeout so a hung probe can't stall
   // the loop; cleared on teardown exactly like readyReconcileTimer.
   private onboardingWatcherTimer: ReturnType<typeof setTimeout> | null = null;
@@ -373,6 +416,7 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
   async initialize(callbacks: EngineEventCallbacks): Promise<void> {
     this.callbacks = callbacks;
     this.setStatus(EngineStatus.INITIALIZING);
+    const initStartedAt = Date.now();
 
     // An install that skipped the message-id backport fails later with errors that name no cause
     // (#889) — say so here instead, while the operator is still looking at the startup logs.
@@ -441,51 +485,44 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
         this.logger.log(`Using auth timeout ${authTimeoutMs}ms`);
       }
 
-      this.client = new Client({
-        authStrategy: new LocalAuth({
-          clientId: this.config.sessionId,
-          dataPath: path.resolve(this.config.sessionDataPath),
-        }),
-        puppeteer: {
-          headless: this.config.puppeteer?.headless ?? true,
-          args: puppeteerArgs,
-          // Do NOT let Puppeteer install its own process signal handlers. By default it handles
-          // SIGINT (→ synchronous process.exit(130), which would skip the graceful drain entirely)
-          // and SIGTERM/SIGHUP (→ kills Chromium at signal time, defeating the drain window). We own
-          // signal handling in main.ts. Puppeteer's unconditional `exit` hook still SIGKILLs this
-          // browser when the process actually exits, so nothing is orphaned.
-          handleSIGINT: false,
-          handleSIGTERM: false,
-          handleSIGHUP: false,
-          // Only override the executable when explicitly configured; otherwise let
-          // whatsapp-web.js fall back to Puppeteer's bundled Chromium.
-          ...(this.config.puppeteer?.executablePath ? { executablePath: this.config.puppeteer.executablePath } : {}),
-        },
-        ...(authTimeoutMs !== undefined ? { authTimeoutMs } : {}),
-        ...(proxyAuthentication ? { proxyAuthentication } : {}),
-        ...(versionPin ?? {}),
-      });
-
-      this.setupEventHandlers();
-      if (this.tearingDown) {
-        this.client = null;
-        this.setStatus(EngineStatus.DISCONNECTED);
-        return;
+      // One retry for a navigation-killed first inject (#1081): a WhatsApp Web reload landing
+      // mid-inject rejects initialize() with nothing upstream ever retrying (see
+      // isNavigationShapedInitRejection), and the onError channel below is terminal end to end.
+      // Structurally a single second try — skipped when the lifecycle's outer init race is nearly
+      // spent (a retry the race SIGKILLs mid-launch would surface as a bare 504 with no reason), and
+      // abandoned when attempt 1's browser cannot be destroyed (see resetForInitRetry).
+      try {
+        await this.runInitAttempt(puppeteerArgs, authTimeoutMs, proxyAuthentication, versionPin);
+      } catch (attemptError) {
+        const attemptReason = attemptError instanceof Error ? attemptError.message : String(attemptError);
+        const budgetLeftMs = resolveEngineInitTimeoutMs() - (Date.now() - initStartedAt);
+        if (
+          this.tearingDown ||
+          !isNavigationShapedInitRejection(attemptReason) ||
+          budgetLeftMs < INIT_RETRY_MIN_REMAINING_MS
+        ) {
+          throw attemptError;
+        }
+        this.logger.warn(
+          `"${attemptReason}" killed the first inject — a page navigation landed before ` +
+            `whatsapp-web.js installed its re-inject handler. Retrying the launch once (#1081).`,
+          { sessionId: this.config.sessionId, action: 'init_navigation_retry' },
+        );
+        const cleaned = await this.resetForInitRetry();
+        if (this.tearingDown) {
+          this.setStatus(EngineStatus.DISCONNECTED);
+          return;
+        }
+        if (!cleaned) {
+          this.logger.warn(
+            "Attempt 1's browser did not die within the destroy bound — abandoning the retry rather " +
+              'than launching a second Chromium into the same profile',
+            { sessionId: this.config.sessionId, action: 'init_navigation_retry_abandoned' },
+          );
+          throw attemptError;
+        }
+        await this.runInitAttempt(puppeteerArgs, authTimeoutMs, proxyAuthentication, versionPin);
       }
-      // Kill any Chromium that survived a hard kill of a previous OpenWA process lifetime (its
-      // Puppeteer exit hook never ran, leaving an orphaned browser holding the profile). Safe here
-      // for the same reason as the Singleton cleanup below: this runs only at engine (re)start,
-      // before this lifetime's browser exists, so it cannot kill a live browser.
-      await killOrphanedChromiumProcesses(this.config.sessionId, this.logger);
-      // Clear stale Chromium Singleton* files left by a hard kill before launching — see
-      // removeStaleSingletonFiles. This runs only at engine (re)start, never while
-      // the browser is alive, so it cannot pull the files out from under a running Chromium.
-      await removeStaleSingletonFiles(this.config.sessionId, this.config.sessionDataPath, this.logger);
-      await this.client.initialize();
-      // whatsapp-web.js 1.34.x never observes the Chromium process/page it drives, so a crashed
-      // browser leaves the client looking READY forever ("silent death"). Attach death listeners
-      // to the puppeteer handles so a dead browser surfaces as a normal disconnect → reconnect.
-      this.attachPuppeteerLifecycleListeners();
     } catch (error) {
       this.setStatus(EngineStatus.FAILED);
       const reason = error instanceof Error ? error.message : String(error);
@@ -520,6 +557,116 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
       }
       this.callbacks.onError?.(surfacedReason);
       throw error;
+    }
+  }
+
+  /**
+   * One construction+launch attempt: everything from `new Client(...)` through the puppeteer death
+   * listeners. Extracted so the navigation retry (#1081) repeats the FULL sequence — a second
+   * attempt without setupEventHandlers() would have no qr/authenticated/ready handlers at all, and
+   * without the pre-launch sweeps it would trip over attempt 1's stale Singleton files. A LIVE
+   * attempt-1 browser never reaches attempt 2: resetForInitRetry() abandons the retry instead.
+   */
+  private async runInitAttempt(
+    puppeteerArgs: string[],
+    authTimeoutMs: number | undefined,
+    proxyAuthentication: { username: string; password: string } | undefined,
+    versionPin: Awaited<ReturnType<typeof resolveWebVersionPin>>,
+  ): Promise<void> {
+    const client = new Client({
+      authStrategy: new LocalAuth({
+        clientId: this.config.sessionId,
+        dataPath: path.resolve(this.config.sessionDataPath),
+      }),
+      puppeteer: {
+        headless: this.config.puppeteer?.headless ?? true,
+        args: puppeteerArgs,
+        // Do NOT let Puppeteer install its own process signal handlers. By default it handles
+        // SIGINT (→ synchronous process.exit(130), which would skip the graceful drain entirely)
+        // and SIGTERM/SIGHUP (→ kills Chromium at signal time, defeating the drain window). We own
+        // signal handling in main.ts. Puppeteer's unconditional `exit` hook still SIGKILLs this
+        // browser when the process actually exits, so nothing is orphaned.
+        handleSIGINT: false,
+        handleSIGTERM: false,
+        handleSIGHUP: false,
+        // Only override the executable when explicitly configured; otherwise let
+        // whatsapp-web.js fall back to Puppeteer's bundled Chromium.
+        ...(this.config.puppeteer?.executablePath ? { executablePath: this.config.puppeteer.executablePath } : {}),
+      },
+      ...(authTimeoutMs !== undefined ? { authTimeoutMs } : {}),
+      ...(proxyAuthentication ? { proxyAuthentication } : {}),
+      ...(versionPin ?? {}),
+    });
+    this.client = client;
+
+    this.setupEventHandlers();
+    if (this.tearingDown) {
+      this.client = null;
+      this.setStatus(EngineStatus.DISCONNECTED);
+      return;
+    }
+    // Kill any Chromium that survived a hard kill of a previous OpenWA process lifetime (its
+    // Puppeteer exit hook never ran, leaving an orphaned browser holding the profile). Safe here:
+    // this runs before this attempt's browser exists, so the only thing it can kill is an orphan —
+    // including attempt 1's browser when the bounded inter-attempt destroy did not finish it.
+    await killOrphanedChromiumProcesses(this.config.sessionId, this.logger);
+    // Clear stale Chromium Singleton* files left by a hard kill before launching — see
+    // removeStaleSingletonFiles. This runs after the orphan kill above and before this attempt's
+    // browser exists, so it cannot pull the files out from under a running Chromium.
+    await removeStaleSingletonFiles(this.config.sessionId, this.config.sessionDataPath, this.logger);
+    await client.initialize();
+    // whatsapp-web.js 1.34.x never observes the Chromium process/page it drives, so a crashed
+    // browser leaves the client looking READY forever ("silent death"). Attach death listeners
+    // to the puppeteer handles so a dead browser surfaces as a normal disconnect → reconnect.
+    this.attachPuppeteerLifecycleListeners();
+  }
+
+  /**
+   * Reset between a failed first init attempt and its single retry (#1081). Deliberately NOT
+   * beginClientTeardown(): that would latch tearingDown (the adapter is single-use after teardown)
+   * and write DISCONNECTED, whose disconnectReported latch permanently drops the retry's
+   * qr/authenticated events. The reconcile clear matters most: the patched hasSynced level-check can
+   * fire AUTHENTICATED before the navigation-killed evaluate rejects initialize(), leaving attempt
+   * 1's 90s deadline live — its non-bridge branch deletes credentials (recoverFromStuckAuth), which
+   * must never run underneath a retry that is about to succeed.
+   *
+   * Returns false when attempt 1's browser could not be destroyed within the bound — the caller
+   * must then abandon the retry: launching a second Chromium into the same LocalAuth profile risks
+   * corrupting the only credential copy (an irreversible re-pair), and the marker-based orphan
+   * sweep is explicitly best-effort, so it cannot be trusted as the escalation for a LIVE browser.
+   */
+  private async resetForInitRetry(): Promise<boolean> {
+    const failed = this.client;
+    this.client = null;
+    this.clearReadyReconcile();
+    this.qrCode = null;
+    this.setStatus(EngineStatus.INITIALIZING);
+    if (!failed) return true;
+    // The old client may still emit late events from persisted page bindings; 'authenticated' and
+    // 'ready' have no source-client identity fence, so silence it before the new attempt starts.
+    failed.removeAllListeners();
+    // Bounded DIRECT destroy — never this.destroy()/forceDestroy(), both of which latch the
+    // teardown flags above.
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        failed.destroy(),
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(() => reject(new Error('init-retry destroy timed out')), 5_000);
+          timeout.unref?.();
+        }),
+      ]);
+      return true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn('Destroying the failed first init attempt did not complete cleanly', {
+        error: message,
+      });
+      // A FAST rejection means the browser was already gone (destroy found nothing live to close) —
+      // safe to relaunch. A TIMEOUT means a live, wedged Chromium still holds the profile.
+      return message !== 'init-retry destroy timed out';
+    } finally {
+      if (timeout) clearTimeout(timeout);
     }
   }
 
@@ -588,6 +735,11 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     });
 
     this.client.on('ready', () => {
+      // The library re-emits 'ready' at the end of EVERY completed (re)inject pipeline — for a
+      // post-navigation re-inject this is the completion edge, and the only one it offers. Close the
+      // navigation window HERE, before the guards below: markReadyFromClientInfo early-returns while
+      // already READY, so a clear behind it would never run for the re-inject case (#1081).
+      this.clearNavigationReinjectWindow();
       // whatsapp-web.js can emit `ready` BEFORE its message listeners are attached: its post-auth
       // callback runs once per hasSynced trigger, and any run that finds `window.WWebJS` already
       // defined skips the attach and bare-emits `ready` — including while the first run's attach is
@@ -865,11 +1017,41 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     if (!this.client) return;
     const { pupBrowser, pupPage } = this.client as unknown as {
       pupBrowser?: { on: (event: 'disconnected', cb: () => void) => void };
-      pupPage?: { on: (event: 'error' | 'close', cb: () => void) => void };
+      pupPage?: {
+        on: (event: 'error' | 'close' | 'framenavigated', cb: (frame?: { url?: () => string }) => void) => void;
+        mainFrame?: () => unknown;
+      };
     };
     pupBrowser?.on('disconnected', () => this.handlePuppeteerDeath('Browser process closed or crashed'));
     pupPage?.on('error', () => this.handlePuppeteerDeath('Page crashed'));
     pupPage?.on('close', () => this.handlePuppeteerDeath('Page closed'));
+    // A page NAVIGATION fires none of the above: the page is healing, not dead — whatsapp-web.js
+    // re-injects on its own framenavigated handler and re-emits 'ready' when done. Stamp the window
+    // so probeLiveness and ensureReady treat it as alive-but-recovering (#1081). Never stamp the
+    // LOGOUT navigation shapes (post_logout URL, or upstream's latched lastLoggedOut): there the
+    // credential teardown driven by the DISCONNECTED('LOGOUT') event is the path that must win.
+    pupPage?.on('framenavigated', frame => {
+      try {
+        // mainFrame is feature-detected: the spec harnesses' EventEmitter pages have no frames.
+        if (typeof pupPage.mainFrame === 'function' && frame !== pupPage.mainFrame()) return;
+        if (typeof frame?.url === 'function' && frame.url().includes('post_logout=1')) return;
+      } catch {
+        return; // the frame detached before this handler ran — nothing worth stamping
+      }
+      // lastLoggedOut is a runtime field the wwjs typings do not declare (same loose-cast pattern as
+      // the pupBrowser/pupPage handles above).
+      if ((this.client as unknown as { lastLoggedOut?: boolean } | null)?.lastLoggedOut) return;
+      const now = Date.now();
+      if (this.navigationEpisodeStartedAt === 0) this.navigationEpisodeStartedAt = now;
+      this.lastMainFrameNavigationAt = now;
+      // `graced: false` here means the episode cap already expired — the stamp is recorded but the
+      // probe/ensureReady grace is NOT being granted, so the log must not claim it is.
+      this.logger.warn('Page navigated; whatsapp-web.js is re-injecting', {
+        sessionId: this.config.sessionId,
+        action: 'page_navigation_reinject_window',
+        graced: this.isInNavigationReinjectWindow(),
+      });
+    });
   }
 
   /**
@@ -911,6 +1093,20 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
    */
   private reportIfPageTransportError(error: unknown, context: string): void {
     if (!this.isPageTransportError(error)) {
+      return;
+    }
+    // Inside the navigation re-inject window the same signatures ride a HEALING page: an in-flight
+    // evaluate killed by the navigation keeps its 'Protocol error' prefix (puppeteer only rewrites
+    // the shapes that END with a context-gone suffix), and a navigating page transiently detaches
+    // frames. Reporting that as death would tear down the session whatsapp-web.js is about to
+    // re-inject — faster than the watchdog the grace protects against (#1081). Log the match so the
+    // theory stays falsifiable from field logs; the error still propagates to the caller, and a
+    // REAL browser death still reports through the pupBrowser/pupPage death listeners untouched.
+    if (this.isInNavigationReinjectWindow()) {
+      this.logger.warn(`Page transport error during ${context} inside the navigation re-inject window — not a death`, {
+        error: error instanceof Error ? error.message : String(error),
+        action: 'page_transport_error_graced',
+      });
       return;
     }
     this.logger.warn(`Page transport error during ${context} — treating the session as dead`, {
@@ -1296,6 +1492,9 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     // Any cached call handle is dead once the client goes away — drop them all so a later
     // rejectCall() reports not-found instead of acting on a destroyed page.
     this.liveCalls.clear();
+    // Before the clientless early-return: a teardown must always close the navigation window, or a
+    // stale stamp could grace the next generation's probe (single-use contract notwithstanding).
+    this.clearNavigationReinjectWindow();
     const client = this.client;
     if (!client) return null;
 
@@ -1314,6 +1513,7 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     }
     this.clearReadyReconcile();
     this.clearOnboardingWatcher();
+    this.clearNavigationReinjectWindow();
   }
 
   async disconnect(): Promise<void> {
@@ -1418,10 +1618,32 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
   }
 
   /**
+   * Whether a recent main-frame navigation is still inside its bounded re-inject window. Two bounds:
+   * the rolling per-navigation grace, and the per-episode cap that stops a navigation LOOP from
+   * re-stamping its way past the watchdog forever. Consulted only AFTER the READY-status gates in
+   * probeLiveness()/ensureReady() — a teardown or LOGOUT drops the status first, and the grace must
+   * never outrank that (#1081).
+   */
+  private isInNavigationReinjectWindow(): boolean {
+    if (this.lastMainFrameNavigationAt === 0) return false;
+    const now = Date.now();
+    return (
+      now - this.lastMainFrameNavigationAt < NAVIGATION_REINJECT_GRACE_MS &&
+      now - this.navigationEpisodeStartedAt < NAVIGATION_EPISODE_CAP_MS
+    );
+  }
+
+  private clearNavigationReinjectWindow(): void {
+    this.lastMainFrameNavigationAt = 0;
+    this.navigationEpisodeStartedAt = 0;
+  }
+
+  /**
    * Active liveness probe for the session watchdog: race a real getState() round-trip against a 10s
    * timeout. Probe failure or timeout means dead — a wedged page can keep reporting CONNECTED
    * (whatsapp-web.js #5728), so turning consecutive probe failures into a reconnect decision stays
-   * the calling watchdog's job.
+   * the calling watchdog's job. One exception: inside the bounded navigation re-inject window a
+   * failing probe answers alive, since the page is healing, not dead (#1081).
    */
   async probeLiveness(): Promise<boolean> {
     if (this.status !== EngineStatus.READY || !this.client) return false;
@@ -1435,9 +1657,20 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
           timeout.unref?.();
         }),
       ]);
-      return state === WAState.CONNECTED;
+      if (state === WAState.CONNECTED) {
+        // Observed recovery closes the navigation episode. Without this, an episode whose re-inject
+        // died silently (no 'ready' re-emit, but WA Web's socket back up) would keep a stale episode
+        // anchor forever, denying the grace to every LATER navigation via the episode cap.
+        this.clearNavigationReinjectWindow();
+        return true;
+      }
+      return this.isInNavigationReinjectWindow();
     } catch {
-      return false;
+      // Inside the navigation window the evaluate rejecting (context destroyed, window.require not
+      // yet a function) means the page is healing, not dead — answer alive so the watchdog does not
+      // tear down a session whatsapp-web.js is about to re-inject (#1081). The window is bounded, so
+      // a page that navigated and then wedged still dies within one extra watchdog interval.
+      return this.isInNavigationReinjectWindow();
     } finally {
       // Never leave the timeout dangling when getState() settles first (Jest open-handle hygiene).
       if (timeout) clearTimeout(timeout);
@@ -1863,6 +2096,15 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
       // instead of a 500 when an engine op is attempted while the session is
       // disconnected / reconnecting / still initializing (#100).
       throw new EngineNotReadyError();
+    }
+    // Post-READY navigation window: window.WWebJS is gone until the re-inject completes, so every
+    // delegate evaluate would die as a raw TypeError 500 (and five raw send failures latch the send
+    // breaker for its 15-minute cooldown). Answer the same retryable 409 the pre-READY states get,
+    // naming the reload so the operator can tell this state from a plain disconnect (#1081).
+    if (this.isInNavigationReinjectWindow()) {
+      throw new EngineNotReadyError(
+        'WhatsApp Web is reloading its page and the session is re-injecting. Retry in a few seconds.',
+      );
     }
   }
 

--- a/src/engine/adapters/wwebjs-chats.ts
+++ b/src/engine/adapters/wwebjs-chats.ts
@@ -1,5 +1,6 @@
 import { MessageTypes, type Client } from 'whatsapp-web.js';
 import { ChatSummary, ChatState } from '../interfaces/whatsapp-engine.interface';
+import { EngineTransportError } from '../../common/errors/engine-transport.error';
 import { chatKind, isChannelJid } from '../identity/wa-id';
 import { WwebjsMessaging } from './wwebjs-messaging';
 import { type WwebjsEngineHost } from './wwebjs-host';
@@ -23,7 +24,18 @@ export class WwebjsChats {
 
   async getChats(): Promise<ChatSummary[]> {
     this.host.ensureReady();
-    const chats = await this.client().getChats();
+    let chats: Awaited<ReturnType<Client['getChats']>>;
+    try {
+      chats = await this.client().getChats();
+    } catch (error) {
+      // Same split every sibling read makes (see getChatsByLabel): a dead page is a 503 and an
+      // early death signal, not an opaque 500 under a status that still says READY (#1081).
+      if (this.host.isPageTransportError(error)) {
+        this.host.reportIfPageTransportError(error, 'getChats');
+        throw new EngineTransportError('Transport died while listing chats');
+      }
+      throw error;
+    }
     const summaries: ChatSummary[] = [];
     let skipped = 0;
 

--- a/src/modules/session/session.controller.ts
+++ b/src/modules/session/session.controller.ts
@@ -406,6 +406,12 @@ export class SessionController {
   @ApiResponse({ status: 400, description: 'Session not ready' })
   @ApiResponse({ status: 404, description: 'Session not found' })
   @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
+  @ApiResponse({
+    status: 503,
+    description:
+      'The whatsapp-web.js page connection died mid-read, so nothing could be read. Deliberately not ' +
+      'reported as an empty list — a page that went away says nothing about the chats.',
+  })
   @ApiQuery({ name: 'limit', required: false, description: 'Max chats to return (1–1000, default 1000)' })
   @ApiQuery({ name: 'offset', required: false, description: 'Number of chats to skip (for paging)' })
   async getChats(


### PR DESCRIPTION
## Summary

WhatsApp Web reloads its own page at times the gateway does not control — a first reload lands roughly five minutes after a fresh pairing (documented in `docs/12-troubleshooting-faq.md`), and service-worker updates or Web build moves navigate it again later. whatsapp-web.js is designed to survive a post-`ready` navigation (its `framenavigated` handler re-injects), but it installs that handler only **after** the first injection succeeds — and several gateway layers assumed a navigation could not happen inside their window. Every failure reported in #1081 traces back to that mismatch:

- a navigation during the **first injection** rejected `Client.initialize()`, and the error channel it lands on is terminal on both start and reconnect — one reload parked the session `FAILED` with nothing retrying;
- a navigation **after `ready`** made `getState()` reject until WhatsApp Web rebooted, which the liveness watchdog read as two failed probes — it tore down the very page whatsapp-web.js was about to re-inject, then spent ~80 seconds rebuilding it;
- during that same window every engine route surfaced raw `TypeError` 500s (or misclassified `200 {success:false}`) while the session status still said `ready`, and five raw send failures were enough to latch the send breaker's 15-minute cooldown.

## Changes

All in the whatsapp-web.js adapter; no engine-interface, lifecycle, or watchdog changes.

1. **Single bounded retry of a navigation-killed first injection.** A rejection whose shape says "the page navigated out from under the inject" (`Execution context was destroyed`, `window.require is not a function`) is retried once — full sequence: fresh `Client`, event handlers, pre-launch sweeps — before the existing terminal path runs. The retry is skipped when the outer init deadline is nearly spent, and **abandoned** when attempt 1's browser cannot be destroyed within a 5s bound: a second Chromium is never launched into a profile a live one may still hold.
2. **Navigation re-inject window.** The adapter now listens to `framenavigated` (main frame only, never for logout navigations) and stamps a bounded window: the liveness probe answers alive-but-recovering inside it, and it closes on the library's re-emitted `ready`, on an observed `CONNECTED` probe, or at a hard per-episode cap — a reload loop cannot suppress the watchdog indefinitely.
3. **Clean `409` during the window.** `ensureReady()` answers the documented retryable `409` (naming the reload) instead of letting delegates die mid-evaluate as raw 500s. Typed 4xx are already excluded from the send breaker, so a reload no longer latches its cooldown.
4. **Transport-death reports are graced inside the window.** An in-flight evaluate killed by the navigation can keep its `Protocol error` prefix and match the dead-transport signatures; reporting that as a death tore the healing session down even faster than the watchdog. Real browser deaths still report immediately through the browser/page death listeners, which are untouched.
5. **`getChats` transport parity.** The one read delegate without the dead-page split now answers `503` for a transport death and feeds the early-death signal, exactly like its siblings.

Contract artifacts move with the code: the shared `409` description and `GET /sessions/{id}/chats` `503` in `openapi.json` + `docs/06`, and a ⚠️ behavior callout in the CHANGELOG (same category as the 0.14.5 transport-status callout; PATCH by the contract test — no removals).

## Behavior deltas worth knowing

- Navigation-shaped init deaths become **one-retry-then-terminal**; every other init failure class (`auth timeout`, launch failures, transport deaths, `auth_failure`, stuck-auth budget denial, bridge-dead) is untouched and still terminal.
- An outer init timeout that fires mid-retry lands `DISCONNECTED` (reconnect-eligible) rather than `FAILED` — a strictly more recoverable outcome. On the default 60s deadline the retry only fits when the first attempt died early; `WWEBJS_AUTH_TIMEOUT_MS` widens both.
- Detection of a page that navigates and then genuinely wedges shifts by up to one watchdog interval (bounded by the episode cap).

## Verification

- 20 new adapter specs (retry, window lifecycle, episode cap, logout skips, transport grace, `getChats` split), each mutation-tested: every guard was individually broken and its test observed to fail.
- Full backend gate: lint, format, `tsc --noEmit`, build, 5224 unit tests, 148 e2e tests, `openapi:check`, script checks; dashboard lint/typecheck/i18n/unit/build.

## Known residuals (tracked as follow-ups, out of scope here)

- A request already past `ensureReady` when the navigation lands still surfaces one pre-gate error (bounded to in-flight calls; `rejectCall` bypasses the guard by design).
- A re-inject that dies silently *after* WhatsApp Web boots leaves a `ready` session whose WWebJS-backed calls fail until the next navigation — pre-existing, and invisible to both the probe (`getState()` answers `CONNECTED`) and the transport signatures.
- A navigation storm during the authenticating window can still reach the one-shot stuck-auth recovery; the session-owned budget bounds it, and the new navigation stamp makes a targeted guard there a small follow-up.
- The reporter's separate observation about large chat/contact fetches being slower than earlier versions is a distinct report and is not addressed by this change.

Fixes #1081
