### PR TITLE
feat(chat-media): archive media this account sent, behind CHAT_MEDIA_ARCHIVE_OUTBOUND

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -459,6 +459,10 @@ WEBHOOK_SSRF_PROTECT=true
 # require archiving. The inline copy is KEPT, so archiving roughly doubles storage for media under
 # the cap — hence off by default.
 # CHAT_MEDIA_ARCHIVE_ENABLED=false    # default false
+# Extend archiving to media this account SENT (needs CHAT_MEDIA_ARCHIVE_ENABLED=true; the retention
+# purge and orphan sweep only run while that is on). Doubles storage again for the outbound half,
+# and buys nothing for a URL-based send, whose row stores the URL rather than any bytes.
+# CHAT_MEDIA_ARCHIVE_OUTBOUND=false   # default false
 # Per-file cap on archived chat media. Media above it is simply not archived; the message row and
 # its inline copy are unaffected. A non-positive/garbage value falls back.
 # CHAT_MEDIA_ARCHIVE_MAX_BYTES=26214400   # default 25 MiB

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`CHAT_MEDIA_ARCHIVE_OUTBOUND` archives media this account sent** — a sub-flag of `CHAT_MEDIA_ARCHIVE_ENABLED` (off by default), so a sent attachment gets the same durable file copy, S3 portability and TTL retention inbound media already had. Refs #1165.
+
 - **Group membership requests: list, approve, reject, and a `group.join_request` event** — the join-approval queue wwebjs/Baileys both expose is now surfaced: `GET/POST .../groups/:groupId/membership-requests[/approve|/reject]` on both engines, plus a webhook/socket event when someone asks to join an administered group. Refs #1164 (discussion).
 
 - **Own global presence: `PUT /sessions/:id/presence`** — appear online or offline on both engines; an always-online headless bot suppresses the phone's own notifications, and `available: false` hands them back. Connection-scoped (re-issue after a reconnect). Refs #871.
@@ -30,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Five routes now document a `503` they have been answering for releases** — the four group participant writes since 0.14.5, and listing chats by label since 0.14.0. There the `503` is what separates "WhatsApp never answered" from the per-participant refusals a `200` reports inside `results`.
 
 ### Fixed
+
+- **A URL-based send no longer discards bytes the gateway already downloaded** — merging its metadata onto the engine's own-send echo replaced that echo's real payload with the URL string, so a whatsapp-web.js URL send rendered as a bare marker after a reload.
 
 - **A bulk media send lost its attachment when the engine echo won the persist race** — the batch write collided on `UNIQUE(sessionId, waMessageId)` and was swallowed into a warning, leaving only the echo's row, which on a Baileys API send carries a media-less marker; it now merges onto that row like the single-send path already did.
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -119,6 +119,7 @@ services:
       # file has no env_file, so a variable absent from this list never reaches the container and
       # the feature it gates stays off however the operator's .env is written.
       - CHAT_MEDIA_ARCHIVE_ENABLED=${CHAT_MEDIA_ARCHIVE_ENABLED:-}
+      - CHAT_MEDIA_ARCHIVE_OUTBOUND=${CHAT_MEDIA_ARCHIVE_OUTBOUND:-}
       - CHAT_MEDIA_ARCHIVE_MAX_BYTES=${CHAT_MEDIA_ARCHIVE_MAX_BYTES:-}
       - CHAT_MEDIA_ARCHIVE_TTL_DAYS=${CHAT_MEDIA_ARCHIVE_TTL_DAYS:-}
       - CHAT_MEDIA_ORPHAN_SWEEP_INTERVAL_MS=${CHAT_MEDIA_ORPHAN_SWEEP_INTERVAL_MS:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -190,6 +190,7 @@ services:
       # variable absent from this list simply never reaches the container and the feature stays off
       # no matter what the operator's .env says.
       - CHAT_MEDIA_ARCHIVE_ENABLED=${CHAT_MEDIA_ARCHIVE_ENABLED:-}
+      - CHAT_MEDIA_ARCHIVE_OUTBOUND=${CHAT_MEDIA_ARCHIVE_OUTBOUND:-}
       - CHAT_MEDIA_ARCHIVE_MAX_BYTES=${CHAT_MEDIA_ARCHIVE_MAX_BYTES:-}
       - CHAT_MEDIA_ARCHIVE_TTL_DAYS=${CHAT_MEDIA_ARCHIVE_TTL_DAYS:-}
       - CHAT_MEDIA_ORPHAN_SWEEP_INTERVAL_MS=${CHAT_MEDIA_ORPHAN_SWEEP_INTERVAL_MS:-}

--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -1200,12 +1200,19 @@ Download a message's **stored** media bytes.
 The route serves the chat-media **archive** first, and falls back to the **inline base64 copy** on
 the message row when no archived file is servable. Archiving is **opt-in and off by default**
 (`CHAT_MEDIA_ARCHIVE_ENABLED`); when enabled, each inbound message's media is written to whatever
-backs `StorageService` (local disk or S3) in addition to the inline copy. The inline fallback is
-what makes media **sent by this account** downloadable here — outbound messages are never archived,
-but their payload is stored inline (base64 API sends persist it on the send path; media composed on
-a linked phone is downloaded by the engine for the own-send echo). It also keeps an inbound
-message's media downloadable after `CHAT_MEDIA_ARCHIVE_TTL_DAYS` retention purges the archived
-file, since retention leaves the inline copy in place.
+backs `StorageService` (local disk or S3) in addition to the inline copy. Media **sent by this
+account** is archived too when `CHAT_MEDIA_ARCHIVE_OUTBOUND=true` is set alongside it — off by
+default, since it doubles storage again for the outbound half.
+
+Media sent by this account is downloadable here regardless of that flag, because its payload is
+stored inline: base64 API sends persist it on the send path, and media composed on a linked phone is
+downloaded by the engine for the own-send echo. The flag buys a durable copy with its own lifecycle
+(S3 portability, TTL retention), not retrievability. A **URL-based send is the exception**: the
+gateway fetches those bytes at send time and stores none, so there is nothing to serve or archive.
+
+The inline fallback also keeps an inbound message's media downloadable after
+`CHAT_MEDIA_ARCHIVE_TTL_DAYS` retention purges the archived file, since retention leaves the inline
+copy in place.
 
 **Auth:** API key
 

--- a/docs/07-api-collection.md
+++ b/docs/07-api-collection.md
@@ -314,9 +314,9 @@ curl -X POST "$BASE/api/sessions/$SESSION_ID/messages/unpin" \
 
 #### GET /api/sessions/:sessionId/messages/:chatId/:messageId/media
 
-Download a message's stored media: the archived file when one exists
-(`CHAT_MEDIA_ARCHIVE_ENABLED=true` when the message arrived), else the inline copy on the message
-row — which covers media sent by this account; `404` when neither holds bytes.
+Download a message's stored media: the archived file when one exists (`CHAT_MEDIA_ARCHIVE_ENABLED`,
+plus `CHAT_MEDIA_ARCHIVE_OUTBOUND` for media this account sent), else the inline copy on the message
+row — which covers media sent by this account either way; `404` when neither holds bytes.
 
 ```bash
 curl "$BASE/api/sessions/$SESSION_ID/messages/628123456789@c.us/true_628123456789@c.us_3EB0ABCD/media" \

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -374,6 +374,11 @@ export default () => ({
   chatMedia: {
     // Off by default: archiving doubles storage for media under the cap, since the inline copy stays.
     archiveEnabled: process.env.CHAT_MEDIA_ARCHIVE_ENABLED === 'true',
+    // Extend archiving to media this account SENT. A sub-flag rather than a mode of its own, so the
+    // retention purge and orphan sweep — which only run while archiving is enabled — are guaranteed
+    // to be maintaining whatever it writes. Off by default because it doubles storage again for the
+    // outbound half, and because a URL-based send stores no bytes to archive in the first place.
+    archiveOutbound: process.env.CHAT_MEDIA_ARCHIVE_OUTBOUND === 'true',
     // Per-file cap on archived chat media (default 25 MiB). Media above it is simply not archived —
     // the message row and its inline copy are unaffected.
     maxBytes: (() => {

--- a/src/config/env-precedence.ts
+++ b/src/config/env-precedence.ts
@@ -47,6 +47,7 @@ export const BLANK_SHADOWED_ENV_KEYS: string[] = [
   // Chat-media archiving. Blank-forwarded by compose like the storage keys above, so an operator
   // who sets nothing must not have an empty string pin the feature off against data/.env.generated.
   'CHAT_MEDIA_ARCHIVE_ENABLED',
+  'CHAT_MEDIA_ARCHIVE_OUTBOUND',
   'CHAT_MEDIA_ARCHIVE_MAX_BYTES',
   'CHAT_MEDIA_ARCHIVE_TTL_DAYS',
   'CHAT_MEDIA_ORPHAN_SWEEP_INTERVAL_MS',

--- a/src/config/env.validation.spec.ts
+++ b/src/config/env.validation.spec.ts
@@ -197,7 +197,7 @@ describe('validateEnv', () => {
     expect(() => validateEnv({})).not.toThrow();
   });
 
-  it.each(['MEDIA_CONVERSION_ENABLED', 'CHAT_MEDIA_ARCHIVE_ENABLED'])(
+  it.each(['MEDIA_CONVERSION_ENABLED', 'CHAT_MEDIA_ARCHIVE_ENABLED', 'CHAT_MEDIA_ARCHIVE_OUTBOUND'])(
     'rejects a %s typo instead of silently leaving the feature off',
     key => {
       // Both are read at boot with `=== 'true'`, so a typo silently disables the feature and the

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -300,6 +300,7 @@ export function validateEnv(config: EnvConfig): EnvConfig {
     // conversion/archive endpoints answer as if nothing was configured. Same class as the above.
     'MEDIA_CONVERSION_ENABLED',
     'CHAT_MEDIA_ARCHIVE_ENABLED',
+    'CHAT_MEDIA_ARCHIVE_OUTBOUND',
     // Read with `=== 'true'` in BOTH configuration.ts and data-source.ts, and this is the one whose
     // typo fails OPEN: `DATABASE_SSL=require` is the natural Postgres spelling and reads as OFF, so
     // credentials and message bodies cross the wire in plaintext to a server the operator believed

--- a/src/modules/chat-media/chat-media-archive.service.spec.ts
+++ b/src/modules/chat-media/chat-media-archive.service.spec.ts
@@ -117,6 +117,37 @@ describe('ChatMediaArchiveService', () => {
       expect((await repository.findOneByOrFail({ id: row.id })).mediaPath).toBeNull();
     });
 
+    it.each([['https://example.com/cat.png'], ['HTTPS://example.com/cat.png'], ['http://example.com/cat.png']])(
+      'skips the URL pointer %s rather than decoding it as base64',
+      async url => {
+        // A URL-based send stores the URL STRING as `data`. Buffer.from(url, 'base64') does not
+        // throw — it yields ~18 bytes of noise — and the archive is consulted BEFORE the inline
+        // fallback, so an archived garbage file would be served in place of the correct 404.
+        const row = await saveRow({ mimetype: 'image/png', data: url });
+
+        expect(await enabled().archive(row)).toBeNull();
+
+        expect((await repository.findOneByOrFail({ id: row.id })).mediaPath).toBeNull();
+        const files = [];
+        for await (const f of storageService.iterateFiles('')) files.push(f);
+        expect(files).toEqual([]);
+      },
+    );
+
+    it('does not re-archive a row that already points at a file', async () => {
+      // Outbound rows have two possible writers (the REST/bulk persist and the engine echo), so the
+      // same row can reach archive() twice; a second write would orphan the first file.
+      const row = await saveRow({ mimetype: 'image/png', data: PNG.toString('base64') });
+      const first = await enabled().archive(row);
+
+      const reloaded = await repository.findOneByOrFail({ id: row.id });
+      expect(await enabled().archive(reloaded)).toBeNull();
+
+      const files = [];
+      for await (const f of storageService.iterateFiles('')) files.push(f);
+      expect(files).toEqual([first]);
+    });
+
     it('skips media above the archive cap without touching the row', async () => {
       const row = await saveRow({ mimetype: 'image/png', data: PNG.toString('base64') });
 
@@ -156,7 +187,7 @@ describe('ChatMediaArchiveService', () => {
       const row = await saveRow({ mimetype: 'image/png', data: PNG.toString('base64') });
       const key = await enabled().archive(row);
 
-      expect(await enabled().getMedia('sess-1', row.chatId, row.waMessageId)).toEqual({
+      expect(await enabled().getMedia('sess-1', [row.chatId], row.waMessageId)).toEqual({
         path: key,
         mimetype: 'image/png',
       });
@@ -164,14 +195,30 @@ describe('ChatMediaArchiveService', () => {
 
     it('returns null for a message with nothing archived', async () => {
       const row = await saveRow({ mimetype: 'image/png', data: PNG.toString('base64') });
-      expect(await enabled().getMedia('sess-1', row.chatId, row.waMessageId)).toBeNull();
+      expect(await enabled().getMedia('sess-1', [row.chatId], row.waMessageId)).toBeNull();
     });
 
     it('does not leak another session’s archived media', async () => {
       const row = await saveRow({ mimetype: 'image/png', data: PNG.toString('base64') });
       await enabled().archive(row);
 
-      expect(await enabled().getMedia('other-sess', row.chatId, row.waMessageId)).toBeNull();
+      expect(await enabled().getMedia('other-sess', [row.chatId], row.waMessageId)).toBeNull();
+    });
+
+    it('matches any of the caller’s chatId dialects', async () => {
+      // An outbound row stores the caller's literal chatId or the engine-neutral form depending on
+      // which writer won the persist race, so the archive lookup must accept both — the same
+      // duality MessageService already resolves for the inline fallback.
+      const row = await saveRow(
+        { mimetype: 'image/png', data: PNG.toString('base64') },
+        { chatId: '628111@s.whatsapp.net', direction: MessageDirection.OUTGOING },
+      );
+      const key = await enabled().archive(row);
+
+      expect(await enabled().getMedia('sess-1', ['628111@c.us', '628111@s.whatsapp.net'], row.waMessageId)).toEqual({
+        path: key,
+        mimetype: 'image/png',
+      });
     });
   });
 

--- a/src/modules/chat-media/chat-media-archive.service.ts
+++ b/src/modules/chat-media/chat-media-archive.service.ts
@@ -37,6 +37,9 @@ function extFromMimetype(mimetype: string): string {
   return MIME_SUBTYPE_EXT_OVERRIDES[subtype] ?? subtype;
 }
 
+/** `metadata.media.data` holding a remote URL (a URL-based send) rather than base64 bytes. */
+const MEDIA_URL_POINTER = /^https?:\/\//i;
+
 /** The inline media shape carried on a persisted row's `metadata.media`. */
 interface InlineMedia {
   mimetype?: string;
@@ -121,11 +124,20 @@ export class ChatMediaArchiveService implements OnModuleInit, OnModuleDestroy {
    * Never throws: archiving is a side benefit of receiving a message, and a storage hiccup must not
    * surface on the receive path. Returns the storage key when a file was written.
    */
-  async archive(row: Pick<Message, 'id' | 'sessionId' | 'metadata'>): Promise<string | null> {
+  async archive(row: Pick<Message, 'id' | 'sessionId' | 'metadata' | 'mediaPath'>): Promise<string | null> {
     if (!this.enabled) return null;
+    // Outbound rows have two possible writers (the REST/bulk persist and the engine echo), so the
+    // same row can reach here twice. A second write would leave the first file referenced by
+    // nothing but still inside the grace window — work and storage for no gain.
+    if (row.mediaPath) return null;
 
     const media = (row.metadata as { media?: InlineMedia } | null | undefined)?.media;
     if (!media?.data || media.omitted || !media.mimetype) return null;
+    // A URL-based send stores the URL STRING as `data`, not bytes. `Buffer.from(url, 'base64')`
+    // does not throw — it yields ~18 bytes of noise — and the read endpoint consults the archive
+    // BEFORE the inline copy, so archiving one would serve garbage in place of the correct 404.
+    // Same discriminator the send path and the export controller already apply to this value.
+    if (MEDIA_URL_POINTER.test(media.data)) return null;
 
     const maxBytes = this.configService.get<number>('chatMedia.maxBytes', DEFAULT_ARCHIVE_MAX_BYTES);
     const sizeBytes = media.sizeBytes ?? Buffer.byteLength(media.data, 'base64');
@@ -165,10 +177,13 @@ export class ChatMediaArchiveService implements OnModuleInit, OnModuleDestroy {
    */
   async getMedia(
     sessionId: string,
-    chatId: string,
+    chatIds: string[],
     waMessageId: string,
   ): Promise<{ path: string; mimetype: string } | null> {
-    const row = await this.repository.findOne({ where: { sessionId, chatId, waMessageId } });
+    // Candidates rather than one id: an outbound row stores the caller's literal chatId or the
+    // engine-neutral form depending on which writer won the persist race. The caller owns the
+    // dialect resolution (it holds the lid table), so this only has to match any of them.
+    const row = await this.repository.findOne({ where: { sessionId, chatId: In(chatIds), waMessageId } });
     if (!row?.mediaPath || !row.mediaMimetype) return null;
     return { path: row.mediaPath, mimetype: row.mediaMimetype };
   }

--- a/src/modules/message/message.service.spec.ts
+++ b/src/modules/message/message.service.spec.ts
@@ -1512,6 +1512,23 @@ describe('MessageService', () => {
       expect(saved).toEqual(expect.objectContaining({ id: 'echo-row' }));
     });
 
+    it('does not overwrite the echo row’s downloaded bytes with a URL pointer', async () => {
+      // A wwjs echo carries the media it downloaded; a URL-based send carries only the URL string.
+      // Merging ours over theirs would discard bytes the gateway already holds — and leave a row
+      // the archive cannot use.
+      (repository.save as jest.Mock).mockRejectedValueOnce(uniqueViolation);
+      (repository.findOne as jest.Mock).mockResolvedValueOnce({ id: 'echo-row' });
+
+      await service.saveOutgoingMessage('sess-1', {
+        ...bulkRow,
+        metadata: { media: { mimetype: 'image/png', data: 'https://example.com/cat.png' } },
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const patch = (repository.update as jest.Mock).mock.calls[0]?.[1] as Record<string, unknown>;
+      expect(patch).not.toHaveProperty('metadata');
+    });
+
     it('leaves the echo row metadata alone when this write carries none', async () => {
       (repository.save as jest.Mock).mockRejectedValueOnce(uniqueViolation);
       (repository.findOne as jest.Mock).mockResolvedValueOnce({ id: 'echo-row' });
@@ -1571,6 +1588,18 @@ describe('MessageService', () => {
       const patch = (repository.update as jest.Mock).mock.calls[0]?.[1] as Record<string, unknown> | undefined;
       expect((patch?.metadata as { media?: { data?: string } } | undefined)?.media?.data).toBe('QUJD');
       expect(repository.delete).toHaveBeenCalledWith({ id: 'msg-uuid-1' });
+    });
+
+    it('keeps the echo row’s downloaded bytes rather than merging a URL pointer over them', async () => {
+      (repository.save as jest.Mock)
+        .mockImplementationOnce(msg => Promise.resolve(msg))
+        .mockRejectedValueOnce(new Error('UNIQUE constraint failed: messages.sessionId, messages.waMessageId'));
+
+      await service.sendImage('sess-1', { chatId: '621@c.us', url: 'https://example.com/cat.png' });
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const patch = (repository.update as jest.Mock).mock.calls[0]?.[1] as Record<string, unknown> | undefined;
+      expect(patch).not.toHaveProperty('metadata');
     });
 
     it('does NOT delete anything on a transient (non-unique) persist error', async () => {
@@ -1685,6 +1714,71 @@ describe('MessageService', () => {
     ])('404s when the row outlived its file (%s)', async (_label, err) => {
       const svc = build(archived('image/png'), { getFile: jest.fn().mockRejectedValue(err) });
       await expect(svc.getChatMedia('sess-1', 'c@c.us', 'wa-1')).rejects.toThrow(NotFoundException);
+    });
+
+    // ── outbound archiving (CHAT_MEDIA_ARCHIVE_OUTBOUND) ─────────────
+
+    describe('archiving media this account sent', () => {
+      const withFlag = (archiveOutbound: boolean, archive: { archive: jest.Mock }): MessageService =>
+        new MessageService(
+          repository as Repository<Message>,
+          sessionService as unknown as SessionService,
+          engines,
+          messageProjector as unknown as MessageProjector,
+          hookManager as HookManager,
+          templateService as unknown as TemplateService,
+          lidMappingStore as unknown as LidMappingStoreService,
+          inertPacing(),
+          {
+            get: (key: string, fallback?: unknown) =>
+              key === 'chatMedia.archiveOutbound' ? archiveOutbound : fallback,
+          } as never,
+          archive as never,
+          undefined,
+        );
+
+      it('archives a SENT outbound row when the flag is on', async () => {
+        const archive = { archive: jest.fn().mockResolvedValue('chat-media/k') };
+        const svc = withFlag(true, archive);
+
+        await svc.saveOutgoingMessage('sess-1', {
+          waMessageId: 'wa-1',
+          chatId: '621@c.us',
+          type: 'image',
+          status: MessageStatus.SENT,
+          metadata: { media: { mimetype: 'image/png', data: 'QUJD' } },
+        });
+
+        expect(archive.archive).toHaveBeenCalledWith(expect.objectContaining({ waMessageId: 'wa-1' }));
+      });
+
+      it('archives nothing while the flag is off', async () => {
+        const archive = { archive: jest.fn() };
+        const svc = withFlag(false, archive);
+
+        await svc.saveOutgoingMessage('sess-1', {
+          waMessageId: 'wa-1',
+          chatId: '621@c.us',
+          type: 'image',
+          status: MessageStatus.SENT,
+          metadata: { media: { mimetype: 'image/png', data: 'QUJD' } },
+        });
+
+        expect(archive.archive).not.toHaveBeenCalled();
+      });
+
+      it('never archives a PENDING row — the merge may delete it and the reaper may rewrite it', async () => {
+        const archive = { archive: jest.fn() };
+        const svc = withFlag(true, archive);
+
+        await svc.saveOutgoingMessage('sess-1', {
+          chatId: '621@c.us',
+          type: 'image',
+          metadata: { media: { mimetype: 'image/png', data: 'QUJD' } },
+        });
+
+        expect(archive.archive).not.toHaveBeenCalled();
+      });
     });
 
     it('does not swallow a genuine storage fault as a 404', async () => {

--- a/src/modules/message/message.service.ts
+++ b/src/modules/message/message.service.ts
@@ -52,6 +52,17 @@ function inertMimetype(mimetype: string): string {
 }
 
 /**
+ * True when this write's media is only a remote-URL pointer (a URL-based send, whose bytes the
+ * engine fetches and discards). Merging such metadata onto an echo row would REPLACE bytes the
+ * gateway already downloaded — wwjs enriches its own-send echo with the real payload — leaving a
+ * row that renders as a bare marker and that the archive cannot use.
+ */
+function isUrlPointerMetadata(metadata: Record<string, unknown> | undefined): boolean {
+  const data = (metadata as { media?: { data?: unknown } } | undefined)?.media?.data;
+  return typeof data === 'string' && /^https?:\/\//i.test(data);
+}
+
+/**
  * Outbound sends are executed directly against the WhatsApp engine, not via a BullMQ queue.
  *
  * The engine is single-threaded per session (a Puppeteer page for the whatsapp-web.js adapter, a
@@ -661,8 +672,9 @@ export class MessageService {
         status: message.status,
         timestamp: message.timestamp,
       };
-      // Only when this write actually carries metadata: a text item must not blank the echo's.
-      if (message.metadata) {
+      // Only when this write actually carries metadata worth merging: a text item must not blank
+      // the echo's, and a URL pointer must not replace bytes the engine already downloaded.
+      if (message.metadata && !isUrlPointerMetadata(message.metadata)) {
         patch.metadata = message.metadata as QueryDeepPartialEntity<Record<string, unknown>>;
       }
       await this.messageRepository.update({ sessionId, waMessageId }, patch);
@@ -680,10 +692,23 @@ export class MessageService {
   // transition (SENT / FAILED / merge) — so a provider's copy never stays stuck at PENDING (#906).
   // The payload is a shallow snapshot: the same entity instance is mutated as the send progresses
   // (PENDING → SENT/FAILED), and fire-and-forget execution must still see the state at emission time.
+  //
+  // Outbound archiving rides the same chokepoint rather than a call at each of the four persist
+  // sites: every terminal state of an outbound row passes here. Gated on SENT because a PENDING row
+  // may still be deleted by the dedup merge or rewritten by the pending reaper, and a FAILED one has
+  // had its payload stripped — archiving either would strand a file the row never points at.
   private emitPersisted(sessionId: string, message: Message): void {
     void this.hookManager
       .execute('message:persisted', { sessionId, message: { ...message } }, { sessionId, source: 'MessageService' })
       .catch(() => undefined);
+    if (message.status === MessageStatus.SENT && this.archiveOutboundEnabled) {
+      void this.chatMediaArchive?.archive(message).catch(() => undefined);
+    }
+  }
+
+  /** Whether media this account sent is archived too — a sub-flag of the archive itself. */
+  private get archiveOutboundEnabled(): boolean {
+    return this.configService?.get<boolean>('chatMedia.archiveOutbound', false) === true;
   }
 
   /**
@@ -737,7 +762,7 @@ export class MessageService {
           },
         );
         const patch: QueryDeepPartialEntity<Message> = { status: MessageStatus.SENT, timestamp: result.timestamp };
-        if (message.metadata) {
+        if (message.metadata && !isUrlPointerMetadata(message.metadata)) {
           patch.metadata = message.metadata as QueryDeepPartialEntity<Record<string, unknown>>;
         }
         await this.messageRepository
@@ -801,7 +826,8 @@ export class MessageService {
     chatId: string,
     messageId: string,
   ): Promise<{ buffer: Buffer; mimetype: string }> {
-    const media = await this.chatMediaArchive?.getMedia(sessionId, chatId, messageId);
+    const chatIds = this.resolveJidCandidates(chatId);
+    const media = await this.chatMediaArchive?.getMedia(sessionId, chatIds, messageId);
     if (media && this.storageService) {
       try {
         return { buffer: await this.storageService.getFile(media.path), mimetype: inertMimetype(media.mimetype) };
@@ -818,7 +844,7 @@ export class MessageService {
     // chatId (REST persist) or the engine-neutral form (own-send echo) depending on which writer
     // won the persist race, so a literal match would 404 on half the rows this fallback exists for.
     const row = await this.messageRepository.findOne({
-      where: { sessionId, chatId: In(this.resolveJidCandidates(chatId)), waMessageId: messageId },
+      where: { sessionId, chatId: In(chatIds), waMessageId: messageId },
     });
     const inline = (row?.metadata as { media?: { data?: unknown; mimetype?: unknown; omitted?: unknown } })?.media;
     if (

--- a/src/modules/session/message-projector.service.ts
+++ b/src/modules/session/message-projector.service.ts
@@ -435,6 +435,14 @@ export class MessageProjector {
                 { sessionId: id, source: 'SessionService' },
               )
               .catch(() => undefined);
+
+            // Archive this send's media, mirroring onMessage. This is the ONLY path a phone-composed
+            // send takes, so the REST-side chokepoint would never see it. Opt-in twice over
+            // (CHAT_MEDIA_ARCHIVE_ENABLED + _OUTBOUND) and a no-op otherwise; archive() itself
+            // refuses a row that is already archived, so the REST writer racing us costs nothing.
+            if (this.configService?.get<boolean>('chatMedia.archiveOutbound', false) === true) {
+              void this.chatMediaArchive?.archive(dbMessage).catch(() => undefined);
+            }
           }
         }
 


### PR DESCRIPTION
## Summary

The chat-media archive only ever wrote **inbound** media — `archive()` had a single call site, on the inbound persist path — so a sent attachment had no durable copy, no S3 portability and no TTL retention. #1172 made sent media *retrievable* from the inline row copy; this makes it *archivable*.

Archiving now runs for outbound rows when `CHAT_MEDIA_ARCHIVE_OUTBOUND=true` is set alongside `CHAT_MEDIA_ARCHIVE_ENABLED`. It is a sub-flag rather than a mode of its own, so the retention purge and orphan sweep — which only run while archiving is enabled — are guaranteed to be maintaining whatever it writes. Off by default: it doubles storage again for the outbound half.

Refs #1165.

## The guards this needed first

Pointing the existing `archive()` at outbound rows would have been actively harmful, so three guards land with it, all **inside** `archive()` so every current and future caller inherits them:

- **URL pointers are refused.** A URL-based send stores the URL *string*, not bytes. `Buffer.from('https://example.com/cat.png','base64')` does not throw — it yields 18 bytes of noise — and the read endpoint consults the archive **before** the inline copy. Archiving one would have replaced the correct `404` with a `200` carrying garbage labelled `image/png`, in a file the orphan sweep treats as referenced and therefore never reaps. This is the third copy of a discriminator the send path and the export controller already apply to this value.
- **Idempotence.** An outbound row has two possible writers (the REST/bulk persist and the engine echo), so the same row can reach `archive()` twice; a row already pointing at a file is left alone rather than orphaning the first one.
- **`getMedia` matches chatId dialects.** An outbound row stores the caller's literal chatId or the engine-neutral form depending on which writer won the persist race — the same duality the inline fallback already resolves. Without this, archived outbound media would be unreadable exactly when the inline copy cannot stand in for it.

## Also fixed

Merging a URL-pointer payload onto the engine's own-send echo replaced bytes the gateway had **already downloaded** (whatsapp-web.js enriches its echo with the real payload), leaving a row that rendered as a bare marker after a reload. Both merge sites now keep the richer copy. This is opportunistic — whatsapp-web.js only, and only when the echo wins the race — not a general fix for URL sends.

## Deliberately not included

Pre-fetching a URL send's bytes in `MessageService` so they could be stored. It is not a localised change: it moves the fetch outside the `failSend` funnel, so an SSRF block would surface as a raw `500` — potentially leaking the resolved internal address the current path explicitly redacts — instead of the sanitised `400`; it bypasses the whatsapp-web.js sticker `trustDeclaredType:false` anti-forgery branch; it drops the URL-basename filename default; it inflates every URL-send row from ~40 bytes to the full base64 payload, which `GET /messages` returns verbatim and the export budget charges for; and it would make ~18 unmocked unit tests hit the network. That deserves its own decision, not a footnote in this one.

## Surfaces

`configuration.ts`, `env.validation.ts` (strict boolean — a typo silently leaves outbound rows unarchived), `env-precedence.ts`, both compose files, `.env.example`, `env.validation.spec.ts`, `docs/06` (the "outbound messages are never archived" sentence was rewritten, not patched), `docs/07`, and the changelog. The controller's OpenAPI descriptions and the five SDK docstrings describe the serving order rather than the configuration, and already name the URL-send case, so they stay accurate and `openapi.json` is unchanged.

## Verification

Nine new tests: three URL-pointer spellings including `HTTPS://`, idempotence, the dialect-matched lookup, both merge sites keeping downloaded bytes, and the flag/SENT gating on the archive call. Each guard was mutation-checked — removing the flag check, the SENT gate, the compose forward and the `checkBool` entry each make their own test fail.

Full gate on the rebased tree: lint, `format:check`, build, `tsc --noEmit`, 5206 unit tests (run twice), `test:scripts` (55), and 148 e2e tests.