### PR TITLE
test(engine): fail when a not-available cell stops throwing

### DIFF
--- a/src/engine/engine-parity.spec.ts
+++ b/src/engine/engine-parity.spec.ts
@@ -5,18 +5,18 @@ import { WhatsAppWebJsAdapter } from './adapters/whatsapp-web-js.adapter';
 import { ENGINE_CAPABILITY_MATRIX } from './engine-capability-matrix';
 
 /**
- * Drift invariants for the engine capability matrix. The matrix's `status` (supported /
- * not-available) is hand-curated and richer than a throw-scan: it also marks "phantom support"
- * methods (adapter stubs that return null/[] without throwing — see docs/29-engine-capability-matrix.md).
- * So the gate asserts the invariants a throw-scan CAN verify, not full equality:
+ * Drift invariants for the engine capability matrix. Status and throw behaviour must agree exactly:
+ * a cell is `not-available` if and only if the adapter method throws
+ * EngineNotSupportedError/ChannelMediaNotSupportedError.
  *
- *   1. A method whose adapter body throws EngineNotSupportedError/ChannelMediaNotSupportedError
- *      MUST be `not-available` in the matrix (throws always mean unavailable).
- *   2. A method the matrix marks `supported` MUST NOT throw.
+ * The reverse direction — `not-available` implies throws — is the one that catches a "phantom
+ * support" stub: an adapter method that returns null/[] for a capability it cannot deliver, so a
+ * caller reads an empty result as an answer instead of the 501 it should get. Those stubs are what
+ * docs/29-engine-capability-matrix.md's "0 phantom-support rows" asserts, and until this direction
+ * was checked, that claim was true only by inspection — a cell could be marked `not-available`,
+ * quietly stop throwing, and nothing would go red.
  *
- * The allowed gap (not deliberate drift): a method that is `not-available` but does not throw today
- * — a phantom stub. Those are hand-tracked in the matrix; a throw-scan cannot see them. If an adapter
- * method starts or stops throwing, one of the invariants trips and forces a deliberate matrix update.
+ * Both directions now trip on any change, forcing a deliberate matrix update.
  *
  * No engine is instantiated and no Chromium/socket is opened: it reads method bodies via
  * `Class.prototype.method.toString()`, a fast hermetic structural check.
@@ -98,17 +98,14 @@ describe('engine capability matrix — drift invariants', () => {
     expect({ missing, stale }).toEqual({ missing: [], stale: [] });
   });
 
-  it.each(methods)('%s: throws ⇒ not-available, supported ⇒ not-throws', method => {
+  it.each(methods)('%s: throws ⇔ not-available', method => {
     const entry = ENGINE_CAPABILITY_MATRIX[method];
     for (const [adapter, ctor] of ADAPTERS) {
       const throws = liveThrows(ctor, method, adapter);
       const status = entry[adapter].status;
-      if (throws) {
-        expect({ method, adapter, status }).toEqual({ method, adapter, status: 'not-available' });
-      }
-      if (status === 'supported') {
-        expect({ method, adapter, throws }).toEqual({ method, adapter, throws: false });
-      }
+      // A `not-available` cell that does not throw is a phantom stub: the caller gets an empty
+      // answer where the contract promises a 501.
+      expect({ method, adapter, throws }).toEqual({ method, adapter, throws: status === 'not-available' });
     }
   });
 });


### PR DESCRIPTION
## The gap

`engine-parity.spec.ts` asserted two of the three directions:

- throws ⇒ `not-available`
- `supported` ⇒ not-throws

The third was left open, and its own header comment said so: a cell marked `not-available` whose adapter method does **not** throw. That is a phantom-support stub — the caller receives an empty result where the contract promises a `501` — and it is precisely what `docs/29`'s **"0 phantom-support rows"** asserts does not exist.

So the claim was true by inspection only. Demonstrated before the change: marking `getChats` as `not-available` on Baileys, whose adapter does not throw, left the suite **green**.

## The change

The two conditionals collapse into the biconditional they were approximating:

```ts
expect({ method, adapter, throws }).toEqual({ method, adapter, throws: status === 'not-available' });
```

All 22 `not-available` cells already satisfy it (10 wwjs, 12 Baileys — each one's throw site names its own method, so the delegate registry finds them), so **no matrix change is required**. This closes the gap rather than recording new drift.

## Verification

Mutation-tested with jest exit codes, each mutation confirmed applied to the file first:

| | before | after |
| --- | --- | --- |
| baseline | green | green |
| `not-available` cell that does not throw | **green** | **red** |
| matrix key renamed (key-match invariant) | red | red |
| restored | green | green, file byte-identical |

107 tests pass; `eslint`, `prettier --check` and `tsc --noEmit` clean.

## Not touched

No `CHANGELOG` entry: this changes no user-visible behaviour, and the guarantee it enforces is one the documentation already claimed. `docs/29` is likewise unchanged — "0 phantom-support rows" was accurate before and is now machine-checked, so the sentence needs no edit. Both files are being modified by other open PRs, and this one deliberately stays clear of them.