### PR TITLE
docs(scripts): document postinstall's sixth step, and test for it

### DIFF
--- a/scripts/dockerfile-patchers.spec.js
+++ b/scripts/dockerfile-patchers.spec.js
@@ -3,6 +3,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 /**
@@ -40,7 +41,17 @@ test('every patcher is RUN fatally after npm ci', () => {
 });
 
 test('every patcher is also wired into postinstall', () => {
-  const postinstall = fs.readFileSync(path.join(__dirname, 'postinstall.js'), 'utf8');
-  const missing = patchers.filter(p => !postinstall.includes(p));
+  // Ask postinstall what it would run, rather than searching its text for the name. A substring
+  // search is satisfied by the patcher appearing in a comment, so a patcher could be described in
+  // the docblock, wired nowhere, and still pass here.
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'openwa-patchers-'));
+  fs.mkdirSync(path.join(root, 'scripts'));
+  for (const p of patchers) fs.writeFileSync(path.join(root, 'scripts', p), '// stub\n');
+
+  const planned = require('./postinstall.js')
+    .planSteps(root, {})
+    .flatMap(step => step.args || [])
+    .map(arg => path.basename(arg));
+  const missing = patchers.filter(p => !planned.includes(p));
   assert.deepEqual(missing, [], `not wired into postinstall: ${missing.join(', ')}`);
 });

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,7 +1,7 @@
 /**
  * Post-install hook (npm `postinstall`).
  *
- * Five conditional steps, each skipped when its target is absent so the hook is a no-op where the
+ * Six conditional steps, each skipped when its target is absent so the hook is a no-op where the
  * piece is missing (the Docker builder stage copies package*.json long before any source):
  *
  *   1. `npm ci` inside dashboard/ when dashboard/ exists — the dashboard carries its own lockfile and
@@ -21,6 +21,9 @@
  *      repairs, gated the same way as step 3.
  *   5. `node scripts/patch-wwebjs-ready-sync.js --best-effort` when present — the readiness
  *      marker + hasSynced level-check, gated the same way.
+ *   6. `node scripts/patch-baileys-appstate.js --best-effort` when present — the app-state resync
+ *      bound, gated the same way. This is the one step that is not a whatsapp-web.js patch, so a
+ *      Baileys-only install runs it and skips 2-5.
  *
  * Structured like scripts/patch-wwebjs-201832.js: pure planning + injectable spawn, so the spec
  * (scripts/postinstall.spec.js, node:test) exercises every branch without a real npm run.

--- a/scripts/postinstall.spec.js
+++ b/scripts/postinstall.spec.js
@@ -24,10 +24,11 @@ function makeRoot({
   previewPatcher = false,
   statusPatcher = false,
   readySyncPatcher = false,
+  baileysPatcher = false,
 } = {}) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'openwa-postinstall-'));
   if (dashboard) fs.mkdirSync(path.join(root, 'dashboard'));
-  if (patcher || previewPatcher || statusPatcher || readySyncPatcher) {
+  if (patcher || previewPatcher || statusPatcher || readySyncPatcher || baileysPatcher) {
     fs.mkdirSync(path.join(root, 'scripts'));
   }
   if (patcher) {
@@ -41,6 +42,9 @@ function makeRoot({
   }
   if (readySyncPatcher) {
     fs.writeFileSync(path.join(root, 'scripts', 'patch-wwebjs-ready-sync.js'), '// stub\n');
+  }
+  if (baileysPatcher) {
+    fs.writeFileSync(path.join(root, 'scripts', 'patch-baileys-appstate.js'), '// stub\n');
   }
   return root;
 }
@@ -111,14 +115,22 @@ test('planSteps: ready-sync patcher plans its own best-effort repair', () => {
 
 test('planSteps: dashboard and all patchers run in stable order', () => {
   const steps = planSteps(
-    makeRoot({ dashboard: true, patcher: true, previewPatcher: true, statusPatcher: true, readySyncPatcher: true }),
+    makeRoot({
+      dashboard: true,
+      patcher: true,
+      previewPatcher: true,
+      statusPatcher: true,
+      readySyncPatcher: true,
+      baileysPatcher: true,
+    }),
   );
-  assert.equal(steps.length, 5);
+  assert.equal(steps.length, 6);
   assert.equal(steps[0].command, 'npm ci');
   assert.match(steps[1].args[0], /patch-wwebjs-201832\.js$/);
   assert.match(steps[2].args[0], /patch-wwebjs-newsletter-preview\.js$/);
   assert.match(steps[3].args[0], /patch-wwebjs-status\.js$/);
   assert.match(steps[4].args[0], /patch-wwebjs-ready-sync\.js$/);
+  assert.match(steps[5].args[0], /patch-baileys-appstate\.js$/);
 });
 
 test('run: nothing to do exits 0 and never spawns', () => {
@@ -187,10 +199,17 @@ test('planSteps: strips npm_config_allow_scripts from step options.env to avoid 
     NPM_CONFIG_ALLOW_SCRIPTS: 'true',
   };
   const steps = planSteps(
-    makeRoot({ dashboard: true, patcher: true, previewPatcher: true, statusPatcher: true, readySyncPatcher: true }),
+    makeRoot({
+      dashboard: true,
+      patcher: true,
+      previewPatcher: true,
+      statusPatcher: true,
+      readySyncPatcher: true,
+      baileysPatcher: true,
+    }),
     env,
   );
-  assert.equal(steps.length, 5);
+  assert.equal(steps.length, 6);
   for (const step of steps) {
     assert.equal('npm_config_allow_scripts' in step.options.env, false);
     assert.equal('NPM_CONFIG_ALLOW_SCRIPTS' in step.options.env, false);


### PR DESCRIPTION
`patch-baileys-appstate.js` was added to `planSteps()` without touching the docblock above it, which still announces five conditional steps and enumerates five. The hook has run six ever since.

The spec did not catch it: both all-patcher fixtures seed only the four whatsapp-web.js patchers and assert a length of 5, so the sixth step is planned and never looked at.

Neither did the patcher guard — and fixing the docblock alone would have made that permanent. It asserted `postinstall.includes(name)`, a substring search over the whole file, which the docblock's own mention of the patcher satisfies. Naming the step in a comment would have been enough to keep that test green with the wiring deleted. It now asks `planSteps()` what it would run, on a temp root seeded with the patchers actually on disk.

Verified by removing the Baileys wiring while leaving the docblock claiming it: the derived guard fails with `not wired into postinstall: patch-baileys-appstate.js`, where the substring form passed.

`npm run test:scripts` passes 3/3 consecutive runs; `format:check` clean.