### PR TITLE
docs(testing): make the CI job table match the workflow, and keep it that way

### DIFF
--- a/docs/09-testing-strategy.md
+++ b/docs/09-testing-strategy.md
@@ -234,16 +234,17 @@ on broad integration coverage.
 
 Main CI is defined in `.github/workflows/ci.yml`.
 
-| Job             | Checks                                                                                                                  |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `lint`          | backend ESLint, full-program TypeScript check, formatting, version consistency, .dockerignore context, OpenAPI snapshot |
-| `audit`         | dependency security audit                                                                                               |
-| `test`          | backend coverage run, script unit tests (node:test), e2e smoke tests, Codecov upload                                    |
-| `test-postgres` | real PostgreSQL 16 service, backend build, migration smoke, and PostgreSQL FTS provider spec                            |
-| `dashboard`     | dashboard install, lint, test type-check, unit tests, i18n parity, build                                                |
-| `scripts-smoke` | shellcheck on the backup/restore scripts plus the backup/restore smoke test                                             |
-| `build`         | backend build after lint/audit/test/dashboard/scripts-smoke jobs pass                                                   |
-| `docker`        | multi-arch Docker build on pushes and pull requests; publish only where workflow permissions allow                      |
+| Job             | Checks                                                                                                                                                    |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `lint`          | backend ESLint, full-program TypeScript check, formatting, version consistency, .dockerignore context, OpenAPI snapshot, SDK routes against the contract  |
+| `audit`         | dependency security audit                                                                                                                                 |
+| `test`          | backend coverage run, script unit tests (node:test), e2e smoke tests, Codecov upload                                                                      |
+| `test-postgres` | real PostgreSQL 16 service, backend build, migration smoke, and PostgreSQL FTS provider spec                                                              |
+| `dashboard`     | dashboard install, lint, formatting, type-check, i18n parity, build, unit tests                                                                           |
+| `scripts-smoke` | shellcheck on `docker-entrypoint.sh` and every `scripts/*.sh`, plus the backup/restore smoke test                                                         |
+| `chart`         | helm lint, helm template with default and fully-toggled values, kubeconform on both renders, actionlint on the workflows                                  |
+| `build`         | backend build after lint/audit/test/dashboard/scripts-smoke/chart jobs pass                                                                               |
+| `docker`        | multi-arch Docker build on pushes and pull requests; publishes to GHCR only on push, so fork pull requests validate both architectures without publishing |
 
 SDK CI is defined in `.github/workflows/sdk-ci.yml` and is path-filtered to SDK sources plus server
 contract surfaces that SDKs mirror (`src/**/dto/**`, `src/**/*.controller.ts`, `src/**/*.service.ts`, and

--- a/src/common/docs-ci-jobs.spec.ts
+++ b/src/common/docs-ci-jobs.spec.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * `docs/09-testing-strategy.md` §9.6 restates the jobs in `.github/workflows/ci.yml` so a contributor
+ * can read which gates must pass. Nothing bound the two, so the table rotted: three commits on a single
+ * day added a job, added a lint step and widened a shellcheck scope, and none of them touched `docs/`.
+ * The table stayed green while describing CI that no longer existed.
+ *
+ * This gate compares the two directly. A job added to the workflow without a row, a row left behind
+ * after the workflow drops the job, a reordering, or a `build` dependency list that no longer matches
+ * `needs:` all fail here.
+ */
+describe('docs/09 §9.6 matches the CI workflow', () => {
+  const read = (...parts: string[]): string => readFileSync(join(__dirname, '..', '..', ...parts), 'utf8');
+
+  const workflow = (): string => {
+    const yaml = read('.github', 'workflows', 'ci.yml');
+    return yaml.slice(yaml.indexOf('\njobs:\n'));
+  };
+
+  /** Top-level job ids, in declaration order: two-space-indented keys under `jobs:`. */
+  const declaredJobs = (): string[] => [...workflow().matchAll(/^ {2}([a-z][a-z0-9-]*):$/gm)].map(match => match[1]);
+
+  /** The `needs:` list of one job, as written. */
+  const needsOf = (job: string): string[] => {
+    const jobs = workflow();
+    const header = `\n  ${job}:\n`;
+    // Start past the job's own header line, or the search for the next job would match it at index 0.
+    const rest = jobs.slice(jobs.indexOf(header) + header.length);
+    const end = rest.search(/^ {2}[a-z][a-z0-9-]*:$/m);
+    const block = end === -1 ? rest : rest.slice(0, end);
+    const needs = block.match(/^ {4}needs: \[([^\]]+)\]$/m);
+    return needs ? needs[1].split(',').map(id => id.trim()) : [];
+  };
+
+  /** Parse the §9.6 table: `| \`job\` | prose |`, job ids backticked in the first column. */
+  const section = (): string => {
+    const doc = read('docs', '09-testing-strategy.md');
+    return doc.slice(doc.indexOf('## 9.6'), doc.indexOf('## 9.7'));
+  };
+
+  const documentedRows = (): Map<string, string> => {
+    const rows = new Map<string, string>();
+    for (const line of section().split('\n')) {
+      const cells = line.split('|').map(cell => cell.trim());
+      // A data row is `| `id` | checks |` — exactly two cells, the first a backticked id.
+      if (cells.length !== 4) continue;
+      const id = cells[1].match(/^`([a-z][a-z0-9-]*)`$/);
+      if (id) rows.set(id[1], cells[2]);
+    }
+    return rows;
+  };
+
+  it('lists every workflow job, only those, in declaration order', () => {
+    const declared = declaredJobs();
+    const documented = [...documentedRows().keys()];
+
+    // Guard both parsers: either one silently matching nothing would make this pass vacuously.
+    expect(declared.length).toBeGreaterThan(5);
+    expect(documented.length).toBeGreaterThan(5);
+    expect(documented).toEqual(declared);
+  });
+
+  it("states the build job's full dependency list", () => {
+    const row = documentedRows().get('build');
+    expect(row).toBeDefined();
+
+    // The row reads `... after a/b/c jobs pass`; compare token-for-token, so a merely
+    // overlapping list — one id short, or naming `test-postgres` where `needs` says `test` — fails.
+    const listed = row?.match(/after ([a-z0-9/-]+) jobs pass/);
+    expect(listed).not.toBeNull();
+    expect(listed?.[1].split('/')).toEqual(needsOf('build'));
+  });
+});


### PR DESCRIPTION
The §9.6 table in `docs/09-testing-strategy.md` is a hand-restated copy of the `jobs:` mapping in `ci.yml`, and nothing bound the two. Three commits on a single day drifted it apart: one added the `chart` job and its edge in `build.needs`, one added the SDK-routes contract check to `lint`, and one widened shellcheck from the backup/restore scripts to `docker-entrypoint.sh` and every `scripts/*.sh`. None of them touched `docs/`, and none of them could have failed.

The result: the only gate covering `charts/openwa` and the workflow files was invisible in the document a contributor reads to learn which gates must pass, and the `build` row understated its blocking set by one job.

This corrects the table against the workflow and adds a derived check so it cannot drift again. The check compares the Job column to the `jobs:` keys as an ordered list, and the `build` row's dependency list to `needs:` token-for-token — a containment check passes when the row names `test-postgres` where `needs` says `test`, so it has to be equality. Both parsers assert they matched something, because a check that silently matches nothing reports success forever.

Also corrected while the row was open: `dashboard` omitted its formatting step, and `docker` attributed publication to workflow permissions when it is gated on the event being a push.

The guard was checked against five controls — a new job injected into `ci.yml`, the table stripped entirely, the rows reordered, the `chart` edge removed from `build.needs`, and a substring trap naming `test-postgres` where `needs` says `test`. All five fail it.