### PR TITLE
ci(release): validate the Helm chart on the tag path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,10 +245,45 @@ jobs:
       - name: Run backup/restore smoke test
         run: ./scripts/smoke-test-backup-restore.sh
 
+  # Mirrors ci.yml's chart job. The chart is published from the tag, so without this the only path
+  # that renders and validates it is the branch path — a chart that breaks between the last branch
+  # build and the tag ships unvalidated.
+  chart:
+    name: Helm chart and workflows
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: helm lint
+        run: docker run --rm -v "$PWD/charts:/charts:ro" alpine/helm:4.2.3 lint /charts/openwa
+
+      # Two value sets: the defaults an operator gets, and every optional resource switched on, so a
+      # template that only breaks under a toggle cannot pass unnoticed.
+      - name: helm template
+        run: |
+          mkdir -p rendered
+          docker run --rm -v "$PWD/charts:/charts:ro" alpine/helm:4.2.3 \
+            template ci /charts/openwa > rendered/default.yaml
+          docker run --rm -v "$PWD/charts:/charts:ro" alpine/helm:4.2.3 \
+            template ci /charts/openwa \
+            --set ingress.enabled=true \
+            --set podDisruptionBudget.enabled=true \
+            --set serviceMonitor.enabled=true > rendered/toggled.yaml
+
+      # -ignore-missing-schemas so the ServiceMonitor CRD is skipped rather than failing the run;
+      # without it the toggled render exits 1 on a resource whose schema is not in the catalogue.
+      - name: Validate rendered manifests
+        run: |
+          docker run --rm -v "$PWD/rendered:/w:ro" ghcr.io/yannh/kubeconform:v0.8.0 \
+            -strict -ignore-missing-schemas -summary /w/default.yaml /w/toggled.yaml
+
+      - name: actionlint
+        run: docker run --rm -v "$PWD:/repo:ro" -w /repo rhysd/actionlint:1.7.12 -color
+
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint, test, dashboard, scripts-smoke]
+    needs: [lint, test, dashboard, scripts-smoke, chart]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 


### PR DESCRIPTION
`ci.yml` gained a `chart` job — helm lint, two helm template renders, kubeconform over both, and actionlint — and `release.yml` never got a counterpart. The chart is published from the tag, so the only path that rendered and validated it was the branch path. A chart that breaks between the last branch build and the tag is published unvalidated, and the manifests an operator installs are the ones nothing checked.

This mirrors the job and adds it to `build`'s `needs`, which is the same wiring the shell-scripts job received. That one edge is enough: the skip propagates through `build` to `docker`, `boot-smoke`, `image-scan`, `promote` and `release`, so a broken chart stops the publish rather than riding along with it.

Verified structurally rather than by eye: every command a CI gate job runs is now also run on the tag path by a job that is an ancestor of both publish terminals. Removing the `chart` edge while keeping the job reports the chart commands as ungated, which is the failure this is meant to prevent. `actionlint` passes on the result and fails on a deliberately broken variant, so that is measured rather than assumed.