### PR TITLE
fix(openapi): publish webhook lastTriggeredAt as a nullable date-time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `docs/29-engine-capability-matrix.md` (`docs/29`) now covers all 152 Baileys socket methods, all 81 whatsapp-web.js Client methods, all 34 + 31 library events and all five install-time patches, each mapped to the interface method that uses it or marked unexposed.
 - An onboarding modal the "What's new" probe does not recognise is now logged once with its heading and confirm-button labels (`onboarding_dialog_unrecognized`), so it can be covered via `WWEBJS_ONBOARDING_CONTINUE_LABELS` before WhatsApp unlinks the companion. Refs #1072.
 
+### Fixed
+
+- A webhook's `lastTriggeredAt` is published as a nullable date-time string instead of an object, so a client generated from the contract no longer rejects both of the values the field actually carries. The response itself is unchanged.
+
 ### Security
 
 - An advisory usage-statistics write no longer persists the whole API-key row. A key deleted while a request that had already loaded it was in flight was re-inserted with its original hash and authenticated again; a revocation or a narrowing of role, allowlist, IP allowlist or expiry was likewise reverted to the values that request loaded. The write is now scoped to the two usage columns and affects nothing if the row is gone.

--- a/openapi.json
+++ b/openapi.json
@@ -9967,7 +9967,9 @@
             "type": "number"
           },
           "lastTriggeredAt": {
-            "type": "object"
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
           },
           "createdAt": {
             "format": "date-time",

--- a/src/config/openapi-contract.spec.ts
+++ b/src/config/openapi-contract.spec.ts
@@ -115,6 +115,29 @@ describe('openapi.json structural invariants', () => {
 
     expect(silent).toEqual([]);
   });
+
+  it('never types a timestamp property as a bare object', () => {
+    const doc = snapshot();
+    // A `Date | null` member with no explicit @ApiProperty type is emitted as `type: object`, and the
+    // published schema then rejects the ISO string the gateway actually sends. Restricted to
+    // timestamp-named properties: the document's other bare objects are genuine Record maps, and the
+    // Unix-seconds fields are legitimately `type: number`.
+    const scanned: string[] = [];
+    const bare: string[] = [];
+
+    for (const [name, schema] of Object.entries(doc.components?.schemas ?? {})) {
+      const properties = (schema as { properties?: Record<string, { type?: string }> }).properties ?? {};
+      for (const [property, spec] of Object.entries(properties)) {
+        if (!/(At|Timestamp)$/.test(property)) continue;
+        scanned.push(`${name}.${property}`);
+        if (spec.type === 'object') bare.push(`${name}.${property}`);
+      }
+    }
+
+    // Guard the selector: if the naming convention changed, this would scan nothing and pass.
+    expect(scanned.length).toBeGreaterThan(20);
+    expect(bare).toEqual([]);
+  });
 });
 
 // The document is produced in TWO places: scripts/export-openapi.ts for the committed snapshot, and

--- a/src/modules/webhook/dto/webhook.dto.ts
+++ b/src/modules/webhook/dto/webhook.dto.ts
@@ -218,7 +218,9 @@ export class WebhookResponseDto {
   retryCount!: number;
 
   @Expose()
-  @ApiPropertyOptional()
+  // Spelled out because a bare @ApiPropertyOptional() on `Date | null` emits `type: object`, and the
+  // published schema then rejects both values this field actually carries.
+  @ApiPropertyOptional({ type: String, format: 'date-time', nullable: true })
   lastTriggeredAt?: Date | null;
 
   @Expose()


### PR DESCRIPTION
`lastTriggeredAt?: Date | null` carried a bare `@ApiPropertyOptional()`, which the generator turns into `type: object`. The gateway sends an ISO string or null, so the published schema rejects both values the field can hold — checked by validating the two values `WebhookResponseDto.fromEntity()` actually produces against the committed contract:

```
lastTriggeredAt  "2026-08-09T10:00:00.000Z" = REJECT (data should be object)  |  null = REJECT
createdAt        "2026-08-09T10:00:00.000Z" = accept                          |  null = REJECT
connectedAt      "2026-08-09T10:00:00.000Z" = accept                          |  null = accept
```

Nothing is wrong at runtime and nothing about the response changes. What broke is the description: a client generated from the contract types the field as an object and refuses the payload it is handed.

This gives it the shape the identical member on `SessionResponseDto` already uses. The regenerated contract differs by four lines in one hunk, all inside this property.

It also adds an invariant, because `openapi:check` only proves the snapshot matches a fresh export and both were wrong together. It is scoped to timestamp-named properties: the document's other bare objects are genuine `Record` maps, and the Unix-seconds fields are correctly typed as numbers. Reverting the decorator and re-exporting fails it.