### PR TITLE
fix(sdk): list the group.join_request webhook event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Check SDK routes against the contract
         run: npm run check:sdk-routes
 
+      - name: Check SDK webhook events against the contract
+        run: npm run check:sdk-events
+
   # Deliberately its own job rather than a step inside Lint. `npm audit` reports against the
   # advisory database, not against the diff, so a newly published advisory turns red on unrelated
   # PRs. While it lived as the first step of Lint, that failure aborted the job before ESLint, the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `engine-inventory-parity.spec.ts` fails when a `docs/29` exposure or event mark no longer matches the adapters: a symbol marked as used must appear in adapter code rather than only in a comment, and an event marked consumed must have a listener behind it.
 - `docs/29-engine-capability-matrix.md` (`docs/29`) now covers all 152 Baileys socket methods, all 81 whatsapp-web.js Client methods, all 34 + 31 library events and all five install-time patches, each mapped to the interface method that uses it or marked unexposed.
 - An onboarding modal the "What's new" probe does not recognise is now logged once with its heading and confirm-button labels (`onboarding_dialog_unrecognized`), so it can be covered via `WWEBJS_ONBOARDING_CONTINUE_LABELS` before WhatsApp unlinks the companion. Refs #1072.
+- `npm run check:sdk-events` compares each typed SDK's webhook event list to the contract, so an event the gateway accepts can no longer be missing from the SDKs.
 
 ### Fixed
 
+- The JavaScript, Python, Go and Java SDKs list `group.join_request`, an event the gateway has accepted and dispatched all along, so a typed client can subscribe to it without casting past its own type.
 - A webhook's `lastTriggeredAt` is published as a nullable date-time string instead of an object, so a client generated from the contract no longer rejects both of the values the field actually carries. The response itself is unchanged.
 - The group-list and status routes no longer appear twice in the OpenAPI contract under different path-parameter names, so a client generated from it gets one method per endpoint; the parameters are now `sessionId` and `id`. The URLs themselves are unchanged.
 

--- a/docs/09-testing-strategy.md
+++ b/docs/09-testing-strategy.md
@@ -234,17 +234,17 @@ on broad integration coverage.
 
 Main CI is defined in `.github/workflows/ci.yml`.
 
-| Job             | Checks                                                                                                                                                    |
-| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `lint`          | backend ESLint, full-program TypeScript check, formatting, version consistency, .dockerignore context, OpenAPI snapshot, SDK routes against the contract  |
-| `audit`         | dependency security audit                                                                                                                                 |
-| `test`          | backend coverage run, script unit tests (node:test), e2e smoke tests, Codecov upload                                                                      |
-| `test-postgres` | real PostgreSQL 16 service, backend build, migration smoke, and PostgreSQL FTS provider spec                                                              |
-| `dashboard`     | dashboard install, lint, formatting, type-check, i18n parity, build, unit tests                                                                           |
-| `scripts-smoke` | shellcheck on `docker-entrypoint.sh` and every `scripts/*.sh`, plus the backup/restore smoke test                                                         |
-| `chart`         | helm lint, helm template with default and fully-toggled values, kubeconform on both renders, actionlint on the workflows                                  |
-| `build`         | backend build after lint/audit/test/dashboard/scripts-smoke/chart jobs pass                                                                               |
-| `docker`        | multi-arch Docker build on pushes and pull requests; publishes to GHCR only on push, so fork pull requests validate both architectures without publishing |
+| Job             | Checks                                                                                                                                                                      |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `lint`          | backend ESLint, full-program TypeScript check, formatting, version consistency, .dockerignore context, OpenAPI snapshot, SDK routes and webhook events against the contract |
+| `audit`         | dependency security audit                                                                                                                                                   |
+| `test`          | backend coverage run, script unit tests (node:test), e2e smoke tests, Codecov upload                                                                                        |
+| `test-postgres` | real PostgreSQL 16 service, backend build, migration smoke, and PostgreSQL FTS provider spec                                                                                |
+| `dashboard`     | dashboard install, lint, formatting, type-check, i18n parity, build, unit tests                                                                                             |
+| `scripts-smoke` | shellcheck on `docker-entrypoint.sh` and every `scripts/*.sh`, plus the backup/restore smoke test                                                                           |
+| `chart`         | helm lint, helm template with default and fully-toggled values, kubeconform on both renders, actionlint on the workflows                                                    |
+| `build`         | backend build after lint/audit/test/dashboard/scripts-smoke/chart jobs pass                                                                                                 |
+| `docker`        | multi-arch Docker build on pushes and pull requests; publishes to GHCR only on push, so fork pull requests validate both architectures without publishing                   |
 
 SDK CI is defined in `.github/workflows/sdk-ci.yml` and is path-filtered to SDK sources plus server
 contract surfaces that SDKs mirror (`src/**/dto/**`, `src/**/*.controller.ts`, `src/**/*.service.ts`, and

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "check:versions": "node scripts/check-doc-versions.mjs",
     "check:dockerignore": "node scripts/check-dockerignore.mjs",
     "check:sdk-routes": "node scripts/check-sdk-routes.mjs",
+    "check:sdk-events": "node scripts/check-sdk-events.mjs",
     "openapi:export": "ts-node scripts/export-openapi.ts openapi.json",
     "openapi:check": "ts-node scripts/export-openapi.ts /tmp/openapi.generated.json && diff -u openapi.json /tmp/openapi.generated.json",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\"",

--- a/scripts/check-sdk-events.mjs
+++ b/scripts/check-sdk-events.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * SDK webhook-event guard.
+ *
+ * Each typed SDK restates the webhook event list as a union, a Literal, a constant block or an enum.
+ * Nothing compared any of them to the gateway, so an event added to `WEBHOOK_EVENTS` shipped with
+ * four SDKs that could not name it: the subscription is valid, the server dispatches it, and a typed
+ * client rejects the string at compile time. That is how `group.join_request` sat unlisted in all
+ * four while `openapi.json` published it.
+ *
+ * SCOPE, stated so the guarantee is not read wider than it is:
+ *   - Covers JavaScript, Python, Go and Java, which all enumerate the events somewhere.
+ *   - Does NOT cover PHP, which takes the event as a plain string and enumerates nothing.
+ *   - Compares the SET of event names, not their order or their identifier spellings.
+ *
+ * Lives in ci.yml's lint job rather than sdk-ci.yml for the same reason as the route guard:
+ * sdk-ci is path-filtered and does not list openapi.json, so changing the contract alone runs none
+ * of it, and it never runs on a release tag.
+ *
+ * Run locally: `npm run check:sdk-events`.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const root = new URL('../', import.meta.url).pathname;
+const read = (...parts) => readFileSync(join(root, ...parts), 'utf8');
+
+const contract = JSON.parse(read('openapi.json'));
+const expected = new Set(contract.components.schemas.CreateWebhookDto.properties.events.items.enum);
+
+/** Harvest by the shape each SDK actually writes, rather than by a shared convention they lack. */
+const SDKS = [
+  {
+    name: 'javascript',
+    file: 'sdk/javascript/src/types.ts',
+    // `export type WebhookEvent =` followed by `| 'name'` members.
+    harvest: text => {
+      const union = text.slice(text.indexOf('export type WebhookEvent ='));
+      return [...union.slice(0, union.indexOf(';')).matchAll(/'([^']+)'/g)].map(m => m[1]);
+    },
+  },
+  {
+    name: 'python',
+    file: 'sdk/python/openwa/types.py',
+    harvest: text => {
+      const literal = text.slice(text.indexOf('WebhookEvent = Literal['));
+      return [...literal.slice(0, literal.indexOf(']')).matchAll(/"([^"]+)"/g)].map(m => m[1]);
+    },
+  },
+  {
+    name: 'go',
+    file: 'sdk/go/types_webhook.go',
+    harvest: text => [...text.matchAll(/^\s*Event\w+\s+WebhookEvent = "([^"]+)"$/gm)].map(m => m[1]),
+  },
+  {
+    name: 'java',
+    file: 'sdk/java/src/main/java/com/rmyndharis/openwa/model/WebhookEvent.java',
+    harvest: text => [...text.matchAll(/@SerializedName\("([^"]+)"\)/g)].map(m => m[1]),
+  },
+];
+
+const errors = [];
+for (const sdk of SDKS) {
+  const found = new Set(sdk.harvest(read(sdk.file)));
+
+  // A pattern that silently stopped matching would make this gate vacuous, so an empty or
+  // implausibly small harvest is a failure rather than a pass.
+  if (found.size < expected.size - 5) {
+    errors.push(`${sdk.name}: harvested only ${found.size} events from ${sdk.file} — the scan pattern has drifted.`);
+    continue;
+  }
+
+  for (const event of [...expected].sort()) {
+    if (!found.has(event)) errors.push(`${sdk.name}: does not list "${event}", which the gateway accepts and dispatches.`);
+  }
+  for (const event of [...found].sort()) {
+    if (!expected.has(event)) errors.push(`${sdk.name}: lists "${event}", which is not in the contract.`);
+  }
+}
+
+if (errors.length) {
+  console.error('\n✖ SDK webhook events drifted from the committed contract:');
+  for (const e of errors) console.error(`  - ${e}`);
+  console.error('\nAdd the event to the SDK, or regenerate the contract (`npm run openapi:export`).\n');
+  process.exit(1);
+}
+console.log(`✓ SDK webhook events OK (${expected.size} contract events across ${SDKS.length} SDKs).`);

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -1016,6 +1016,7 @@ func TestWebhookEventWireValues(t *testing.T) {
 		EventGroupJoin:            "group.join",
 		EventGroupLeave:           "group.leave",
 		EventGroupUpdate:          "group.update",
+		EventGroupJoinRequest:     "group.join_request",
 		EventCallReceived:         "call.received",
 		EventStatusReceived:       "status.received",
 		EventAll:                  "*",

--- a/sdk/go/types_webhook.go
+++ b/sdk/go/types_webhook.go
@@ -29,6 +29,7 @@ const (
 	EventGroupJoin            WebhookEvent = "group.join"
 	EventGroupLeave           WebhookEvent = "group.leave"
 	EventGroupUpdate          WebhookEvent = "group.update"
+	EventGroupJoinRequest     WebhookEvent = "group.join_request"
 	EventCallReceived         WebhookEvent = "call.received"
 	EventStatusReceived       WebhookEvent = "status.received"
 	EventAll                  WebhookEvent = "*"

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/model/WebhookEvent.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/model/WebhookEvent.java
@@ -48,6 +48,8 @@ public enum WebhookEvent {
     GROUP_LEAVE,
     @SerializedName("group.update")
     GROUP_UPDATE,
+    @SerializedName("group.join_request")
+    GROUP_JOIN_REQUEST,
     @SerializedName("call.received")
     CALL_RECEIVED,
     @SerializedName("status.received")

--- a/sdk/javascript/src/types.ts
+++ b/sdk/javascript/src/types.ts
@@ -728,6 +728,7 @@ export type WebhookEvent =
   | 'group.join'
   | 'group.leave'
   | 'group.update'
+  | 'group.join_request'
   | 'call.received'
   | 'status.received'
   | '*';

--- a/sdk/python/openwa/types.py
+++ b/sdk/python/openwa/types.py
@@ -31,7 +31,8 @@ WebhookEvent = Literal[
     "message.received", "message.sent", "message.ack", "message.failed", "message.revoked",
     "message.reaction", "message.edited", "session.status", "session.qr", "session.authenticated",
     "session.disconnected", "session.reconnect_loop", "session.restriction", "presence.update",
-    "group.join", "group.leave", "group.update", "call.received", "status.received",
+    "group.join", "group.leave", "group.update", "group.join_request",
+    "call.received", "status.received",
     "call.accepted", "call.rejected", "call.missed",
     "*",
 ]


### PR DESCRIPTION
The gateway validates subscriptions against `WEBHOOK_EVENTS`, publishes 24 events in the contract, and dispatches `group.join_request` at runtime. Four SDKs enumerate 23 and omit it, so a typed client cannot name an event the server will happily send: the subscription is legal, the delivery happens, and the union, Literal, constant block and enum all reject the string.

This adds it to JavaScript, Python, Go and Java. PHP takes the event as a plain string and enumerates nothing, so it was never affected.

The Go constant also goes into the test's `want` map, because that test iterates the map rather than the constant set — a constant added without an entry there is green and unchecked.

It also adds a derived check, because every one of these SDK lists is a hand-maintained restatement of the contract with nothing comparing the two, which is how one event went missing from four of them at once. It sits in the `lint` job rather than the SDK workflow: that workflow is path-filtered and does not list `openapi.json`, so changing the contract alone would not run it, and it never runs on a release tag. Verified against the unfixed SDKs, where it names all four, and against a deliberately broken scan pattern, where an empty harvest fails rather than passes.

Since it adds a step to the `lint` job, the §9.6 table row that enumerates that job's checks is updated in the same change.