### PR TITLE
fix(security): honour a bare @SkipThrottle() in the proxy-aware guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The JavaScript, Python, Go and Java SDKs list `group.join_request`, an event the gateway has accepted and dispatched all along, so a typed client can subscribe to it without casting past its own type.
 - A webhook's `lastTriggeredAt` is published as a nullable date-time string instead of an object, so a client generated from the contract no longer rejects both of the values the field actually carries. The response itself is unchanged.
 - The group-list and status routes no longer appear twice in the OpenAPI contract under different path-parameter names, so a client generated from it gets one method per endpoint; the parameters are now `sessionId` and `id`. The URLs themselves are unchanged.
+- A bare `@SkipThrottle()` no longer leaves a route throttled: it writes one metadata key the guard never read, so `/api/metrics` and the `/api/health*` probes were rate-limited despite being documented as exempt, and a 429 on readiness reads as unhealthy to every configured probe. Those four routes are also `@Public()`, so the global IP limit was the only one reaching them and they now carry none — rate-limit them at your proxy if they are internet-facing.
 
 ### Security
 

--- a/src/common/security/proxy-aware-throttler.guard.spec.ts
+++ b/src/common/security/proxy-aware-throttler.guard.spec.ts
@@ -1,3 +1,5 @@
+import type { ExecutionContext } from '@nestjs/common';
+import type { Reflector } from '@nestjs/core';
 import { ProxyAwareThrottlerGuard } from './proxy-aware-throttler.guard';
 
 /**
@@ -45,5 +47,67 @@ describe('ProxyAwareThrottlerGuard.getTracker', () => {
     process.env.TRUSTED_PROXIES = '172.18.0.0/16';
     // peer 203.0.113.9 is NOT a trusted proxy → its XFF is ignored, key on the socket IP
     expect(await track(reqFrom('203.0.113.9', '10.0.0.1'))).toBe('203.0.113.9');
+  });
+});
+
+/**
+ * Regression lock: a bare `@SkipThrottle()` must actually exempt the route.
+ *
+ * The decorator writes ONE metadata key, `THROTTLER:SKIP` + the key of its argument object, which
+ * defaults to `{ default: true }`. The base guard reads `THROTTLER:SKIP` + the name of each
+ * CONFIGURED tier, and this application names its tiers `short`, `medium` and `long`. The two
+ * spellings never intersect, so a bare decorator writes a key nothing reads and the route stays
+ * throttled. Unlike the tier loop, `shouldSkip` runs before any tier is evaluated, so honouring the
+ * library's default key here exempts the route from every tier and from the storage round-trip each
+ * one would perform.
+ *
+ * These cases instantiate the guard properly rather than via `Object.create`: unlike `getTracker`,
+ * `shouldSkip` reads `this.reflector`.
+ */
+describe('ProxyAwareThrottlerGuard.shouldSkip', () => {
+  const LIBRARY_DEFAULT_SKIP_KEY = 'THROTTLER:SKIPdefault';
+
+  const handler = (): void => undefined;
+  class Controller {}
+  const context = {
+    getHandler: () => handler,
+    getClass: () => Controller,
+  } as unknown as ExecutionContext;
+
+  function guardReading(metadata: boolean | undefined): {
+    skip: () => Promise<boolean>;
+    reflector: { getAllAndOverride: jest.Mock };
+  } {
+    const reflector = { getAllAndOverride: jest.fn().mockReturnValue(metadata) };
+    type GuardArgs = ConstructorParameters<typeof ProxyAwareThrottlerGuard>;
+    const guard = new ProxyAwareThrottlerGuard(
+      { throttlers: [] },
+      {} as GuardArgs[1],
+      reflector as unknown as Reflector,
+    );
+    const skip = (): Promise<boolean> =>
+      (guard as unknown as { shouldSkip(c: ExecutionContext): Promise<boolean> }).shouldSkip(context);
+    return { skip, reflector };
+  }
+
+  it('exempts a route whose bare @SkipThrottle() wrote the library default key', async () => {
+    const { skip } = guardReading(true);
+    expect(await skip()).toBe(true);
+  });
+
+  it('reads the key the library actually writes, on handler then class', async () => {
+    const { skip, reflector } = guardReading(true);
+    await skip();
+    expect(reflector.getAllAndOverride).toHaveBeenCalledWith(LIBRARY_DEFAULT_SKIP_KEY, [handler, Controller]);
+  });
+
+  it('does not exempt a route carrying no skip metadata', async () => {
+    const { skip } = guardReading(undefined);
+    expect(await skip()).toBe(false);
+  });
+
+  it('does not exempt an explicit opt-out — @SkipThrottle({ default: false })', async () => {
+    const { skip } = guardReading(false);
+    expect(await skip()).toBe(false);
   });
 });

--- a/src/common/security/proxy-aware-throttler.guard.ts
+++ b/src/common/security/proxy-aware-throttler.guard.ts
@@ -1,6 +1,16 @@
-import { Injectable } from '@nestjs/common';
+import { ExecutionContext, Injectable } from '@nestjs/common';
 import { ThrottlerGuard } from '@nestjs/throttler';
 import { resolveClientIp, RequestLike } from '../utils/ip';
+
+/**
+ * The single metadata key a bare `@SkipThrottle()` writes.
+ *
+ * The decorator defaults its argument to `{ default: true }` and writes `THROTTLER:SKIP` + each key
+ * of that object, so the bare form produces exactly this one. The base guard instead reads
+ * `THROTTLER:SKIP` + the name of each CONFIGURED tier, and this application names its tiers `short`,
+ * `medium` and `long` — so the two spellings never intersect and a bare decorator is inert.
+ */
+const LIBRARY_DEFAULT_SKIP_KEY = 'THROTTLER:SKIPdefault';
 
 /**
  * Rate-limit bucket keyed on the resolved client IP.
@@ -21,5 +31,24 @@ export class ProxyAwareThrottlerGuard extends ThrottlerGuard {
       .map(proxy => proxy.trim())
       .filter(Boolean);
     return Promise.resolve(resolveClientIp(req as unknown as RequestLike, trustedProxies));
+  }
+
+  /**
+   * Honour a bare `@SkipThrottle()` as "skip every tier this guard evaluates".
+   *
+   * `canActivate` calls this before the tier loop, so a route exempted here costs no storage
+   * round-trip for any tier and emits no rate-limit headers — which is what a scrape or a liveness
+   * probe should cost. Reading the library's own default key here also covers every future bare
+   * `@SkipThrottle()` rather than requiring each call site to re-list the configured tier names.
+   *
+   * An explicit `@SkipThrottle({ default: false })` writes `false` and is not an exemption, so the
+   * strict comparison matters: only `true` skips.
+   */
+  protected shouldSkip(context: ExecutionContext): Promise<boolean> {
+    const skip = this.reflector.getAllAndOverride<boolean | undefined>(LIBRARY_DEFAULT_SKIP_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    return Promise.resolve(skip === true);
   }
 }


### PR DESCRIPTION
`@nestjs/throttler` 6.5.0 writes a bare `@SkipThrottle()` as the metadata key `THROTTLER:SKIPdefault`, while the guard looked up `THROTTLER:SKIP` plus each configured limiter name. No configured tier is called `default`, so the decorator matched nothing and was inert wherever it appeared.

Both call sites use the bare form, so `/api/metrics` and the `/api/health*` probes have been rate-limited the whole time despite the documentation saying they are exempt.

**What this changes, stated plainly because the entry should not bury it:** four routes lose their last rate limit. All four are `@Public()`, and the global per-IP limit was the only one reaching them. Measured end to end against the app's real tiers — 15 requests from one IP, bare-skip route: `{throttled: 5, increments: 35, headers: 95}` before, `{0, 0, 0}` after. That is the documented intent, but an operator upgrading should know it happens, so the changelog entry says so and points at putting a limit in front.

The regression lock reads the key the library actually writes. Each of its assertions was mutation-checked individually: flipping the comparison to `!== false` fails only the no-metadata case, to `!== undefined` fails only the explicit opt-out, and pointing at `THROTTLER:SKIPshort` fails only the key test — so no assertion is carrying another's weight.