### PR TITLE
fix(config): stop .env.example pinning the production Swagger opt-in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -655,7 +655,12 @@ PLUGINS_DIR=./data/plugins          # Plugin directory (default: ./data/plugins)
 # =============================================================================
 # DEVELOPER SETTINGS
 # =============================================================================
-ENABLE_SWAGGER=true                 # Enable API documentation at /api/docs (set false to disable on exposed deployments)
+# ENABLE_SWAGGER=true               # Serve the API docs + Swagger UI at /api/docs. Default: ON outside
+                                    # production, OFF under NODE_ENV=production. Left commented on purpose:
+                                    # this file ships NODE_ENV=production, so an uncommented value here would
+                                    # pin the opt-in the production default exists to withhold. The mount is
+                                    # not behind the API-key guard, so serving it exposes the schema and the
+                                    # exact running version to anyone who can reach the port.
 # BODY_SIZE_LIMIT=25mb                # Max request body size (base64 media sends ride in the JSON body)
 # Aggregate cap on request-body bytes buffered across ALL connections. Once exceeded, new requests
 # get 503 + Retry-After without their body being read (protects against slow-body memory pinning).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The JavaScript, Python, Go and Java SDKs list `group.join_request`, an event the gateway has accepted and dispatched all along, so a typed client can subscribe to it without casting past its own type.
 - A webhook's `lastTriggeredAt` is published as a nullable date-time string instead of an object, so a client generated from the contract no longer rejects both of the values the field actually carries. The response itself is unchanged.
 - The group-list and status routes no longer appear twice in the OpenAPI contract under different path-parameter names, so a client generated from it gets one method per endpoint; the parameters are now `sessionId` and `id`. The URLs themselves are unchanged.
+- A bare `@SkipThrottle()` no longer leaves a route throttled: it writes one metadata key the guard never read, so `/api/metrics` and the `/api/health*` probes were rate-limited despite being documented as exempt, and a 429 on readiness reads as unhealthy to every configured probe. Those four routes are also `@Public()`, so the global IP limit was the only one reaching them and they now carry none — rate-limit them at your proxy if they are internet-facing.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - An advisory usage-statistics write no longer persists the whole API-key row. A key deleted while a request that had already loaded it was in flight was re-inserted with its original hash and authenticated again; a revocation or a narrowing of role, allowlist, IP allowlist or expiry was likewise reverted to the values that request loaded. The write is now scoped to the two usage columns and affects nothing if the row is gone.
+- `.env.example` no longer ships `ENABLE_SWAGGER=true` uncommented: the template also declares `NODE_ENV=production`, so copying it pinned the opt-in that production withholds and served the schema and running version at `/api/docs`, which sits outside the API-key guard. Bare-metal operators who already copied it should check their own `.env`; Docker and Helm are unaffected.
 
 ## [0.15.0] - 2026-08-09
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,6 +50,13 @@ the README and `docs/` — in particular `CORS_ORIGINS`, `ALLOW_DEV_API_KEY`,
 Never expose the dashboard/API to the public internet with the development API key
 enabled.
 
+If you created your `.env` by copying `.env.example` before this advisory, check it for
+`ENABLE_SWAGGER=true`. Earlier templates shipped that line uncommented alongside
+`NODE_ENV=production`, so a copied file pinned the opt-in that production otherwise
+withholds, and `/api/docs` is served outside the API-key guard. Comment the line out or
+set it to `false` to restore the production default. Docker Compose and the Helm chart
+are unaffected — neither forwards `ENABLE_SWAGGER` and the container never reads `.env`.
+
 ### Docker socket proxy — scope and residual risk
 
 The application container never mounts `/var/run/docker.sock`; it reaches the daemon

--- a/docs/08-development-guidelines.md
+++ b/docs/08-development-guidelines.md
@@ -698,7 +698,8 @@ SESSION_DATA_PATH=./data/sessions
 ENGINE_TYPE=whatsapp-web.js
 PUPPETEER_HEADLESS=true
 
-# Swagger is enabled by default. Set false to disable.
+# Swagger defaults ON outside production and OFF under NODE_ENV=production.
+# Set it explicitly to force either way.
 ENABLE_SWAGGER=true
 ```
 

--- a/src/common/security/proxy-aware-throttler.guard.spec.ts
+++ b/src/common/security/proxy-aware-throttler.guard.spec.ts
@@ -1,3 +1,5 @@
+import type { ExecutionContext } from '@nestjs/common';
+import type { Reflector } from '@nestjs/core';
 import { ProxyAwareThrottlerGuard } from './proxy-aware-throttler.guard';
 
 /**
@@ -45,5 +47,67 @@ describe('ProxyAwareThrottlerGuard.getTracker', () => {
     process.env.TRUSTED_PROXIES = '172.18.0.0/16';
     // peer 203.0.113.9 is NOT a trusted proxy → its XFF is ignored, key on the socket IP
     expect(await track(reqFrom('203.0.113.9', '10.0.0.1'))).toBe('203.0.113.9');
+  });
+});
+
+/**
+ * Regression lock: a bare `@SkipThrottle()` must actually exempt the route.
+ *
+ * The decorator writes ONE metadata key, `THROTTLER:SKIP` + the key of its argument object, which
+ * defaults to `{ default: true }`. The base guard reads `THROTTLER:SKIP` + the name of each
+ * CONFIGURED tier, and this application names its tiers `short`, `medium` and `long`. The two
+ * spellings never intersect, so a bare decorator writes a key nothing reads and the route stays
+ * throttled. Unlike the tier loop, `shouldSkip` runs before any tier is evaluated, so honouring the
+ * library's default key here exempts the route from every tier and from the storage round-trip each
+ * one would perform.
+ *
+ * These cases instantiate the guard properly rather than via `Object.create`: unlike `getTracker`,
+ * `shouldSkip` reads `this.reflector`.
+ */
+describe('ProxyAwareThrottlerGuard.shouldSkip', () => {
+  const LIBRARY_DEFAULT_SKIP_KEY = 'THROTTLER:SKIPdefault';
+
+  const handler = (): void => undefined;
+  class Controller {}
+  const context = {
+    getHandler: () => handler,
+    getClass: () => Controller,
+  } as unknown as ExecutionContext;
+
+  function guardReading(metadata: boolean | undefined): {
+    skip: () => Promise<boolean>;
+    reflector: { getAllAndOverride: jest.Mock };
+  } {
+    const reflector = { getAllAndOverride: jest.fn().mockReturnValue(metadata) };
+    type GuardArgs = ConstructorParameters<typeof ProxyAwareThrottlerGuard>;
+    const guard = new ProxyAwareThrottlerGuard(
+      { throttlers: [] },
+      {} as GuardArgs[1],
+      reflector as unknown as Reflector,
+    );
+    const skip = (): Promise<boolean> =>
+      (guard as unknown as { shouldSkip(c: ExecutionContext): Promise<boolean> }).shouldSkip(context);
+    return { skip, reflector };
+  }
+
+  it('exempts a route whose bare @SkipThrottle() wrote the library default key', async () => {
+    const { skip } = guardReading(true);
+    expect(await skip()).toBe(true);
+  });
+
+  it('reads the key the library actually writes, on handler then class', async () => {
+    const { skip, reflector } = guardReading(true);
+    await skip();
+    expect(reflector.getAllAndOverride).toHaveBeenCalledWith(LIBRARY_DEFAULT_SKIP_KEY, [handler, Controller]);
+  });
+
+  it('does not exempt a route carrying no skip metadata', async () => {
+    const { skip } = guardReading(undefined);
+    expect(await skip()).toBe(false);
+  });
+
+  it('does not exempt an explicit opt-out — @SkipThrottle({ default: false })', async () => {
+    const { skip } = guardReading(false);
+    expect(await skip()).toBe(false);
   });
 });

--- a/src/common/security/proxy-aware-throttler.guard.ts
+++ b/src/common/security/proxy-aware-throttler.guard.ts
@@ -1,6 +1,16 @@
-import { Injectable } from '@nestjs/common';
+import { ExecutionContext, Injectable } from '@nestjs/common';
 import { ThrottlerGuard } from '@nestjs/throttler';
 import { resolveClientIp, RequestLike } from '../utils/ip';
+
+/**
+ * The single metadata key a bare `@SkipThrottle()` writes.
+ *
+ * The decorator defaults its argument to `{ default: true }` and writes `THROTTLER:SKIP` + each key
+ * of that object, so the bare form produces exactly this one. The base guard instead reads
+ * `THROTTLER:SKIP` + the name of each CONFIGURED tier, and this application names its tiers `short`,
+ * `medium` and `long` — so the two spellings never intersect and a bare decorator is inert.
+ */
+const LIBRARY_DEFAULT_SKIP_KEY = 'THROTTLER:SKIPdefault';
 
 /**
  * Rate-limit bucket keyed on the resolved client IP.
@@ -21,5 +31,24 @@ export class ProxyAwareThrottlerGuard extends ThrottlerGuard {
       .map(proxy => proxy.trim())
       .filter(Boolean);
     return Promise.resolve(resolveClientIp(req as unknown as RequestLike, trustedProxies));
+  }
+
+  /**
+   * Honour a bare `@SkipThrottle()` as "skip every tier this guard evaluates".
+   *
+   * `canActivate` calls this before the tier loop, so a route exempted here costs no storage
+   * round-trip for any tier and emits no rate-limit headers — which is what a scrape or a liveness
+   * probe should cost. Reading the library's own default key here also covers every future bare
+   * `@SkipThrottle()` rather than requiring each call site to re-list the configured tier names.
+   *
+   * An explicit `@SkipThrottle({ default: false })` writes `false` and is not an exemption, so the
+   * strict comparison matters: only `true` skips.
+   */
+  protected shouldSkip(context: ExecutionContext): Promise<boolean> {
+    const skip = this.reflector.getAllAndOverride<boolean | undefined>(LIBRARY_DEFAULT_SKIP_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    return Promise.resolve(skip === true);
   }
 }

--- a/src/config/production-template-optin.spec.ts
+++ b/src/config/production-template-optin.spec.ts
@@ -1,0 +1,75 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as dotenv from 'dotenv';
+import { isSwaggerEnabled, isValidationErrorDetailEnabled } from './bootstrap-security';
+
+/**
+ * `.env.example` is both the "copy me" template and a self-described production config — it ships
+ * `NODE_ENV=production` uncommented. Anything else shipped uncommented becomes a PIN the moment an
+ * operator copies the file, so a setting that defaults OFF under production must not be pre-selected
+ * ON in the template: copying it would silently opt a production host into the very thing the
+ * default exists to withhold.
+ *
+ * This is deliberately BEHAVIOURAL rather than lexical. A lexical "KEY must not appear uncommented"
+ * rule mis-fires on settings shipped uncommented in the SAFE direction, and it cannot tell the two
+ * apart. Here the template is parsed and the REAL resolvers are run over it, so a key only counts
+ * when the template's own value resolves ON while the unset default would resolve OFF.
+ */
+
+/** Resolvers that default OFF under production and are forced ON by an explicit `true`. */
+const PRODUCTION_OFF_OPT_INS: ReadonlyArray<{
+  key: string;
+  resolve: (value: string | undefined, nodeEnv: string | undefined) => boolean;
+}> = [
+  { key: 'ENABLE_SWAGGER', resolve: isSwaggerEnabled },
+  { key: 'VALIDATION_ERROR_DETAIL', resolve: isValidationErrorDetailEnabled },
+];
+
+/**
+ * The production-off opt-ins a copied template would pre-select. Empty for a template that does not
+ * declare production — the rule is about what `cp .env.example .env` pins on a production host.
+ */
+function preSelectedOptIns(templateText: string): string[] {
+  const env = dotenv.parse(templateText);
+  if (env.NODE_ENV !== 'production') return [];
+  return PRODUCTION_OFF_OPT_INS.filter(
+    optIn => optIn.resolve(env[optIn.key], env.NODE_ENV) && !optIn.resolve(undefined, env.NODE_ENV),
+  ).map(optIn => optIn.key);
+}
+
+describe('.env.example does not pre-select a production-off opt-in', () => {
+  const templatePath = path.join(__dirname, '..', '..', '.env.example');
+  const template = fs.readFileSync(templatePath, 'utf8');
+
+  it('pre-selects nothing that production defaults off', () => {
+    expect(preSelectedOptIns(template)).toEqual([]);
+  });
+
+  it('still gives a developer the documented defaults when they set NODE_ENV=development', () => {
+    // The reason a bare removal is not the fix: shipping `ENABLE_SWAGGER=false` would also satisfy
+    // the assertion above while breaking the contributor workflow that copies this same file.
+    const env = dotenv.parse(template);
+    expect(isSwaggerEnabled(env.ENABLE_SWAGGER, 'development')).toBe(true);
+    expect(isValidationErrorDetailEnabled(env.VALIDATION_ERROR_DETAIL, 'development')).toBe(true);
+  });
+
+  it('leaves the documented production opt-in working when an operator sets it themselves', () => {
+    expect(isSwaggerEnabled('true', 'production')).toBe(true);
+    expect(isValidationErrorDetailEnabled('true', 'production')).toBe(true);
+  });
+
+  // Self-mutation controls: the check must be capable of firing, and must not fire on the safe cases.
+  it('fires when a production-off opt-in is shipped uncommented', () => {
+    expect(preSelectedOptIns(`${template}\nVALIDATION_ERROR_DETAIL=true\n`)).toEqual(['VALIDATION_ERROR_DETAIL']);
+    expect(preSelectedOptIns(`${template}\nENABLE_SWAGGER=true\n`)).toEqual(['ENABLE_SWAGGER']);
+  });
+
+  it('does not fire on a template that declares a non-production environment', () => {
+    const asDevelopment = `${template}\nNODE_ENV=development\nENABLE_SWAGGER=true\n`;
+    expect(preSelectedOptIns(asDevelopment)).toEqual([]);
+  });
+
+  it('does not fire on a setting shipped uncommented in the safe direction', () => {
+    expect(preSelectedOptIns(`${template}\nVALIDATION_ERROR_DETAIL=false\n`)).toEqual([]);
+  });
+});


### PR DESCRIPTION
`.env.example` assigned `ENABLE_SWAGGER=true`. Copying it to `.env` — which is what the file is for — overrides the production default and serves the API documentation on a deployment that was meant to have it off.

The assignment is commented out, so the key stays documented and the real default applies. `SECURITY.md` gains the advisory, and a spec pins the property: a template key whose value would flip a production-safe default must not be assigned.

Note the guard is one-directional by construction — it compares the resolved template value against the resolved default, so it catches a pin that *weakens* a default and not one that merely restates it. That is the direction that matters here, and it is stated rather than implied.

Filed under Security rather than Fixed: it ships an advisory and tells operators to go and check their own `.env`, which is the same shape as the API-key entry above it.