### PR TITLE
fix(engine): convert Baileys stickers to WebP before sending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - An advisory usage-statistics write no longer persists the whole API-key row. A key deleted while a request that had already loaded it was in flight was re-inserted with its original hash and authenticated again; a revocation or a narrowing of role, allowlist, IP allowlist or expiry was likewise reverted to the values that request loaded. The write is now scoped to the two usage columns and affects nothing if the row is gone.
 
+### Fixed
+
+- A sticker sent through the Baileys engine no longer reaches WhatsApp as non-WebP bytes labelled `image/webp`; the adapter converts `image/*` to a 512×512 WebP before the socket, passes genuine WebP through byte-identical, and refuses anything it cannot convert with a `400` instead of reporting success.
+
 ## [0.15.0] - 2026-08-09
 
 ### Added

--- a/docs/29-engine-capability-matrix.md
+++ b/docs/29-engine-capability-matrix.md
@@ -831,6 +831,18 @@ adapter boundary — none silently stubs.
   `msg.avParams()`, removed in a recent WA Web build (upstream wwebjs#201823, unresolved).
   Text→channel is unaffected, and Baileys has no such restriction — so these five rows are the one
   place where an engine difference does **not** show up as a per-row ❌ in 29.4.
+- **`sendStickerMessage` — what each engine converts.** Both engines guarantee the payload really is
+  WebP, but they reach it differently and they do not accept the same inputs. whatsapp-web.js passes
+  `sendMediaAsSticker: true`, and `Util.formatToWebpSticker` converts `image/*` **and** `video/*`
+  (the latter via ffmpeg), rejecting anything else with `Invalid media format`. Baileys stamps
+  `image/webp` on the payload unconditionally and transcodes nothing
+  (`prepareWAMessageMedia` → `MIMETYPE_MAP.sticker`), so the adapter converts before the socket:
+  WebP passes through byte-identical (preserving its sticker-pack EXIF), other `image/*` input is
+  re-encoded to a 512×512 WebP with animation retained, and everything else — **including
+  `video/*`** — is refused with a `400`. So an animated-video sticker works on wwjs and answers
+  `400` on Baileys. ffmpeg is deliberately not wired in on the Baileys side: the binary ships only
+  in the Docker image, so depending on it would make the same request succeed or fail depending on
+  how the gateway was installed.
 - **`deleteStatus` (baileys).** Marked ✅ (no throw), but the `sendMessage(status@broadcast,
 {delete})` revoke shape is _empirically unverified_ — only posting was live-spiked. May fall back
   to 501 if WA rejects the shape. On wwjs it calls `revokeStatusMessage(statusId)` (own status

--- a/openapi.json
+++ b/openapi.json
@@ -2503,7 +2503,7 @@
                   "summary": "Fetch the media from a URL",
                   "value": {
                     "chatId": "628123456789@c.us",
-                    "url": "https://example.com/sticker.png"
+                    "url": "https://example.com/sticker.webp"
                   }
                 }
               }

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "qrcode": "^1.5.4",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
+        "sharp": "^0.35.1",
         "socket.io": "^4.8.3",
         "socks-proxy-agent": "^8.0.5",
         "tar-stream": "^3.2.0",
@@ -649,6 +650,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1154,6 +1156,7 @@
       "resolved": "https://registry.npmjs.org/@bull-board/api/-/api-8.5.0.tgz",
       "integrity": "sha512-Wvf9JA2hrpQdS8xEQz/77ZiSmcmnAUZSJJOtdJf6two9/4Q018mZECSXSuiJBA+xilPZt62Gc1UhSoctkceLLQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "redis-info": "^3.1.0"
       },
@@ -1202,6 +1205,7 @@
       "resolved": "https://registry.npmjs.org/@bull-board/ui/-/ui-8.5.0.tgz",
       "integrity": "sha512-bTqdKd3cQY8EWFx2yLfg9+SfsxgXtCzT7AB/NyrKHtSj4Wn2+MSs5gYBpEJ9hvxJuxzjD6qfx83m7Sz6npW6eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bull-board/api": "8.5.0"
       }
@@ -1239,6 +1243,7 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -1687,7 +1692,6 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1704,7 +1708,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=20.9.0"
       },
@@ -1727,7 +1730,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=20.9.0"
       },
@@ -1747,7 +1749,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "dependencies": {
         "@img/sharp-wasm32": "0.35.1"
       },
@@ -1770,7 +1771,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1787,7 +1787,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1804,7 +1803,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1821,7 +1819,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1838,7 +1835,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1855,7 +1851,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1872,7 +1867,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1889,7 +1883,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1906,7 +1899,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1923,7 +1915,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1940,7 +1931,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=20.9.0"
       },
@@ -1963,7 +1953,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=20.9.0"
       },
@@ -1986,7 +1975,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=20.9.0"
       },
@@ -2009,7 +1997,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=20.9.0"
       },
@@ -2032,7 +2019,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=20.9.0"
       },
@@ -2055,7 +2041,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=20.9.0"
       },
@@ -2078,7 +2063,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=20.9.0"
       },
@@ -2101,7 +2085,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=20.9.0"
       },
@@ -2118,7 +2101,6 @@
       "integrity": "sha512-PCQUoQdZyE8tp3HpbevuihfUmgSP4qWI0FGEPWoeXqaS+cUrFfemabHQiebUmUmlUhCuNnQMxGrQ+CPqK4hnxg==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/runtime": "^1.11.0"
       },
@@ -2138,7 +2120,6 @@
       ],
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@img/sharp-wasm32": "0.35.1"
       },
@@ -2161,7 +2142,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=20.9.0"
       },
@@ -2181,7 +2161,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.9.0"
       },
@@ -2201,7 +2180,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=20.9.0"
       },
@@ -3424,6 +3402,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/bull-shared/-/bull-shared-11.0.4.tgz",
       "integrity": "sha512-VBJcDHSAzxQnpcDfA0kt9MTGUD1XZzfByV70su0W0eDCQ9aqIEBlzWRW21tv9FG9dIut22ysgDidshdjlnczLw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "2.8.1"
       },
@@ -3592,6 +3571,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.28.tgz",
       "integrity": "sha512-bRImsxibie+AM7xjdwcrm/gr5YeacI65kSBNzTufa1Ib5iwziaY/lqMtRh9THq6pbV4e1HP9aI2ZxGUumnmaoQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "21.3.4",
         "iterare": "1.2.1",
@@ -3638,6 +3618,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.28.tgz",
       "integrity": "sha512-06m63xIRj8+l8uOeh/8LnYupGubkyu4f+bPKIadaSui6vK9KpXgoz7HveT1yOVLcEt0M0oCOEW5EuEXZkEmBBQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-safe-stringify": "2.1.1",
         "iterare": "1.2.1",
@@ -3697,6 +3678,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.28.tgz",
       "integrity": "sha512-hU+9Sz4m+onHrR5AmelI59QKmY/Re546bPnygnpqqeQdHDiJpBgjWbL4t6Jr73CBpS60cpyng7WzjgphNB9iwA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -3718,6 +3700,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-11.1.28.tgz",
       "integrity": "sha512-vY+GmU2jBcymvgm5rEnftUx4qNxK8cDJmXjl1/1NcpITTNJo0vg07xYR43MwXHcMqe7b0jwqt5+UCTzxqQFIqA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "socket.io": "4.8.3",
         "tslib": "2.8.1"
@@ -3872,6 +3855,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-11.1.28.tgz",
       "integrity": "sha512-jeyclAURCJTN8S8lctDhfLdiJeDKjZmYWWLav653Fb9hl9c+zx5jPhavI8Xk5++R8u+lX9qzaRxtsjEoxTtjyw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "iterare": "1.2.1",
         "object-hash": "3.0.0",
@@ -3923,6 +3907,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -4434,6 +4419,7 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -4563,6 +4549,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
       "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -4777,6 +4764,7 @@
       "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.65.0",
         "@typescript-eslint/types": "8.65.0",
@@ -5560,6 +5548,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5627,6 +5616,7 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5997,6 +5987,7 @@
       "integrity": "sha512-Z0lHvMayR/Pad9+O9ddzaBJE0DrhZkQlStrC1RwcAHF3AhQAsdwKHeLGK8fYKyp2DDU6xHxzGb4CLMui12yVrg==",
       "deprecated": "Renamed to @audio/decode — same API; this name remains a thin alias. npm i @audio/decode",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@wasm-audio-decoders/flac": "^0.2.4",
         "@wasm-audio-decoders/ogg-vorbis": "^0.1.15",
@@ -6147,6 +6138,7 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -6299,6 +6291,7 @@
       "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -6423,6 +6416,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6513,6 +6507,7 @@
       "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-5.81.2.tgz",
       "integrity": "sha512-Hi9GaVCC6HE9bQP65j/FNv1aL1fcEukTF99ezS5pl1Ud+joCFpNWiPCV45mWdkEmpuacS0XJdMMFGKPIHCwoPg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cron-parser": "4.9.0",
         "ioredis": "5.11.1",
@@ -6687,6 +6682,7 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -6756,13 +6752,15 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/class-validator": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
       "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -7552,7 +7550,8 @@
       "version": "0.0.1581282",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
       "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -8022,6 +8021,7 @@
       "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -8081,6 +8081,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -8412,6 +8413,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -9209,6 +9211,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
       "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9623,6 +9626,7 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -11619,6 +11623,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
       "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.14.0",
         "pg-pool": "^3.14.0",
@@ -11947,6 +11952,7 @@
       "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -12593,7 +12599,8 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -12693,6 +12700,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -13082,6 +13090,7 @@
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.8.tgz",
       "integrity": "sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "~4.4.1",
         "ws": "~8.21.0"
@@ -13670,6 +13679,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -14008,6 +14018,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -14182,6 +14193,7 @@
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-1.1.0.tgz",
       "integrity": "sha512-iX/kvsV42/htCNAQUyElGW87E4Z12neZc6YUFBTEu0BnLiREYDNT5Wfw3wRqZw9vyOEC36zUBAY6Qvywoig06Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.3.1",
@@ -14404,6 +14416,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14720,6 +14733,7 @@
       "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -14788,6 +14802,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -15277,6 +15292,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "qrcode": "^1.5.4",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
+    "sharp": "^0.35.1",
     "socket.io": "^4.8.3",
     "socks-proxy-agent": "^8.0.5",
     "tar-stream": "^3.2.0",

--- a/src/engine/adapters/baileys-messaging.ts
+++ b/src/engine/adapters/baileys-messaging.ts
@@ -1,3 +1,4 @@
+import sharp from 'sharp';
 import type * as BaileysLib from '@whiskeysockets/baileys';
 import type { AnyMessageContent, MiscMessageGenerationOptions, WAMessage, WASocket } from '@whiskeysockets/baileys';
 import { generateSafeLinkPreview } from './safe-link-preview';
@@ -56,6 +57,57 @@ export interface BaileysMessagingHost {
     contentType: string | undefined,
     opts?: { skipMediaDownload?: boolean },
   ): Promise<IncomingMessage>;
+}
+
+/** RIFF….WEBP magic. Sniffed from the bytes, because the declared label may be the DTO's placeholder. */
+function isWebpBuffer(data: Buffer): boolean {
+  return (
+    data.length > 12 &&
+    data.subarray(0, 4).toString('ascii') === 'RIFF' &&
+    data.subarray(8, 12).toString('ascii') === 'WEBP'
+  );
+}
+
+/**
+ * Sticker payloads must BE WebP, not merely be called WebP.
+ *
+ * Baileys stamps the label unconditionally — `prepareWAMessageMedia` applies
+ * `if (!uploadData.mimetype) uploadData.mimetype = MIMETYPE_MAP[mediaType]` with
+ * `MIMETYPE_MAP.sticker = 'image/webp'` (Utils/messages.js:18, 86-88) — and transcodes nothing. So
+ * a PNG handed over here is published as a stickerMessage whose declared type contradicts its bytes,
+ * and the send still reports success. whatsapp-web.js has no such gap: `sendMediaAsSticker: true`
+ * routes through `Util.formatToWebpSticker`, which converts `image/*` and throws for anything else.
+ *
+ * An input that is already WebP is passed through BYTE-IDENTICAL: re-encoding an existing sticker
+ * would strip the WebP EXIF sticker-pack metadata and change its size.
+ *
+ * `{ animated: true }` is not optional — without it sharp silently keeps only the first frame, which
+ * would reintroduce the same quiet-corruption this function exists to remove.
+ */
+async function toWebpSticker(data: Buffer, mimetype: string): Promise<Buffer> {
+  if (isWebpBuffer(data)) {
+    return data;
+  }
+  if (!mimetype.startsWith('image/')) {
+    // Deliberately a 400 rather than EngineNotSupportedError: the capability IS supported, this
+    // particular payload cannot become a sticker. A 501 would report the wrong thing and would also
+    // make the row look unavailable to the parity gate's throw-scan.
+    throw new BadRequestException(
+      `A sticker must be a WebP image, or an image this gateway can convert to one. Received '${mimetype}'.`,
+    );
+  }
+  try {
+    return await sharp(data, { animated: true })
+      .resize(512, 512, { fit: 'contain', background: { r: 0, g: 0, b: 0, alpha: 0 } })
+      .webp()
+      .toBuffer();
+  } catch (error) {
+    // Bytes that do not decode as the image they claim to be. Refuse before the socket rather than
+    // ship them mislabelled — that is the whole point.
+    throw new BadRequestException(
+      `The sticker image could not be converted to WebP: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
 }
 
 /** Resolve a MediaInput's data (Buffer | base64 string | http(s) URL) to bytes + mimetype. */
@@ -277,8 +329,8 @@ export class BaileysMessaging {
 
   async sendStickerMessage(chatId: string, media: MediaInput): Promise<MessageResult> {
     this.host.ensureReady();
-    const { data } = await resolveMediaBuffer(media);
-    return this.sendContent(chatId, { sticker: data });
+    const { data, mimetype } = await resolveMediaBuffer(media);
+    return this.sendContent(chatId, { sticker: await toWebpSticker(data, mimetype) });
   }
 
   async sendLocationMessage(chatId: string, location: LocationInput): Promise<MessageResult> {

--- a/src/engine/adapters/baileys-sticker-webp.spec.ts
+++ b/src/engine/adapters/baileys-sticker-webp.spec.ts
@@ -1,0 +1,139 @@
+import type { WASocket } from '@whiskeysockets/baileys';
+import { BadRequestException } from '@nestjs/common';
+import sharp from 'sharp';
+import { BaileysMessaging, type BaileysMessagingHost } from './baileys-messaging';
+import { createLogger } from '../../common/services/logger.service';
+
+/**
+ * Baileys stamps the sticker mimetype unconditionally: `prepareWAMessageMedia` applies
+ * `if (!uploadData.mimetype) uploadData.mimetype = MIMETYPE_MAP[mediaType]` with
+ * `MIMETYPE_MAP.sticker = 'image/webp'` (Utils/messages.js:18, 86-88), and nothing on that path
+ * transcodes. So whatever bytes the adapter hands over are published AS WebP whether they are WebP
+ * or not — a PNG goes out labelled `image/webp` with PNG bytes, and the send reports success.
+ *
+ * whatsapp-web.js does not have this problem: `sendMediaAsSticker: true` routes through
+ * `Util.formatToWebpSticker` (Client.js:1532, Util.js:152-159), which converts `image/*` and
+ * throws `Invalid media format` for anything else.
+ *
+ * These assertions are about what reaches the socket, because that is where the two engines
+ * diverged. The label is not ours to check — Baileys writes it — so the only thing that can keep
+ * label and payload honest is the payload.
+ */
+
+const logger = createLogger('baileys-sticker-webp.spec');
+
+// 1x1 PNG and the same pixel encoded as a real WebP. Fixtures rather than a sharp call at test
+// time, so a failure means the adapter changed rather than the encoder did.
+const PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64',
+);
+const WEBP = Buffer.from(
+  'UklGRlgAAABXRUJQVlA4WAoAAAAQAAAAAAAAAAAAQUxQSAIAAAAAf1ZQOCAwAAAA0AEAnQEqAQABAAFAJiWgAnS6AfgAA7AA/vLrf/zYFc1z7/f/0uD9Lg/S4P/SkAAA',
+  'base64',
+);
+// A hand-built 2-frame GIF89a (red, then blue), used to prove animation survives the conversion.
+const ANIMATED_GIF = Buffer.from(
+  'R0lGODlhAQABAIAAAP8AAAAA/yH/C05FVFNDQVBFMi4wAwEAAAAh+QQACgAAACwAAAAAAQABAAACAkQBACH5BAAKAAAALAAAAAABAAEAAAICTAEAOw==',
+  'base64',
+);
+
+const isWebp = (b: unknown): boolean =>
+  Buffer.isBuffer(b) &&
+  b.length > 12 &&
+  b.subarray(0, 4).toString('ascii') === 'RIFF' &&
+  b.subarray(8, 12).toString('ascii') === 'WEBP';
+
+function makeMessaging(): { messaging: BaileysMessaging; sock: { sendMessage: jest.Mock } } {
+  const sock = { sendMessage: jest.fn().mockResolvedValue({ key: { id: 'M1' }, messageTimestamp: 1 }) };
+  const host = {
+    ensureReady: jest.fn(),
+    getSocket: () => sock as unknown as WASocket,
+    logger,
+    toNeutralJid: (j: string) => j,
+    toEngineJid: (j: string) => j,
+    normalizedSelfJid: () => '628177@s.whatsapp.net',
+    getEphemeralExpiration: () => undefined,
+    toUnixSeconds: () => 1,
+    loadLib: () => Promise.resolve({} as never),
+    getStoredMessage: () => Promise.resolve(undefined),
+    putStoredMessage: () => undefined,
+    recordLidMapping: () => undefined,
+    getOnMessageCreate: () => undefined,
+    mapMessage: () => Promise.resolve({} as never),
+  } as unknown as BaileysMessagingHost;
+  return { messaging: new BaileysMessaging(host), sock };
+}
+
+const contentOf = (sock: { sendMessage: jest.Mock }): { sticker?: unknown } => {
+  const [, content] = sock.sendMessage.mock.calls[0] as unknown[];
+  return content as { sticker?: unknown };
+};
+
+describe('BaileysMessaging.sendStickerMessage — what reaches the socket must really be WebP', () => {
+  it('a PNG sticker never puts non-WebP bytes on the wire', async () => {
+    const { messaging, sock } = makeMessaging();
+
+    await messaging.sendStickerMessage('628111@s.whatsapp.net', { data: PNG, mimetype: 'image/png' });
+
+    expect(sock.sendMessage).toHaveBeenCalledTimes(1);
+    expect(isWebp(contentOf(sock).sticker)).toBe(true);
+  });
+
+  // Known-negative control. Without it a converter that mangled every input would still pass the
+  // assertion above, and the oracle would be measuring nothing.
+  it('a genuine WebP sticker still goes out byte-identical', async () => {
+    const { messaging, sock } = makeMessaging();
+
+    await messaging.sendStickerMessage('628111@s.whatsapp.net', { data: WEBP, mimetype: 'image/webp' });
+
+    const sent = contentOf(sock).sticker as Buffer;
+    expect(isWebp(sent)).toBe(true);
+    // Re-encoding an existing sticker would strip the WebP EXIF sticker-pack metadata and change
+    // its size, so passthrough is a requirement rather than an optimisation.
+    expect(sent.equals(WEBP)).toBe(true);
+  });
+
+  // The placeholder the DTO applies when a caller supplies no mimetype. A converter that trusted
+  // the label would treat this as "not an image" and refuse a perfectly good sticker.
+  it('a genuine WebP labelled application/octet-stream is recognised by its bytes', async () => {
+    const { messaging, sock } = makeMessaging();
+
+    await messaging.sendStickerMessage('628111@s.whatsapp.net', {
+      data: WEBP,
+      mimetype: 'application/octet-stream',
+    });
+
+    expect((contentOf(sock).sticker as Buffer).equals(WEBP)).toBe(true);
+  });
+
+  // A converter that drops `{ animated: true }` keeps only the first frame and still emits valid
+  // WebP, so every other assertion here would stay green while animated stickers silently became
+  // stills — the same shape of quiet corruption this whole change is about.
+  it('an animated source keeps its frames', async () => {
+    const { messaging, sock } = makeMessaging();
+
+    await messaging.sendStickerMessage('628111@s.whatsapp.net', { data: ANIMATED_GIF, mimetype: 'image/gif' });
+
+    const sent = contentOf(sock).sticker as Buffer;
+    expect(isWebp(sent)).toBe(true);
+    expect((await sharp(sent, { animated: true }).metadata()).pages).toBe(2);
+  });
+
+  it('input that cannot become a sticker is refused BEFORE the socket, as a 400', async () => {
+    const { messaging, sock } = makeMessaging();
+
+    const send = messaging.sendStickerMessage('628111@s.whatsapp.net', {
+      data: Buffer.from('%PDF-1.4 this is not an image'),
+      mimetype: 'application/pdf',
+    });
+
+    await expect(send).rejects.toBeInstanceOf(BadRequestException);
+    // Rejected on the DECLARED type, before the bytes reach the image decoder — the message names
+    // what was received. Without that check a PDF still ends in a 400, but only after libvips has
+    // been handed arbitrary bytes to parse, and this assertion is what keeps the two apart.
+    await expect(send).rejects.toThrow(/Received 'application\/pdf'/);
+    // Shipping it mislabelled is the defect; refusing after the send would not fix it.
+    expect(sock.sendMessage).not.toHaveBeenCalled();
+  });
+});

--- a/src/engine/adapters/baileys.adapter.spec.ts
+++ b/src/engine/adapters/baileys.adapter.spec.ts
@@ -2497,8 +2497,16 @@ describe('BaileysAdapter media sends', () => {
 
   it('sendStickerMessage sends the sticker buffer', async () => {
     const adapter = await ready();
-    await adapter.sendStickerMessage('628111@s.whatsapp.net', { mimetype: 'image/webp', data: Buffer.from([7]) });
-    expect(fakeSock.sendMessage).toHaveBeenCalledWith('628111@s.whatsapp.net', { sticker: Buffer.from([7]) });
+    // A REAL WebP (RIFF….WEBP), not an arbitrary byte: Baileys labels every sticker `image/webp`
+    // without transcoding, so the adapter guarantees the payload actually is one. A placeholder
+    // buffer here would pin the shape this guarantee exists to prevent. Non-WebP conversion and
+    // refusal are covered in baileys-sticker-webp.spec.ts.
+    const webp = Buffer.from(
+      'UklGRlgAAABXRUJQVlA4WAoAAAAQAAAAAAAAAAAAQUxQSAIAAAAAf1ZQOCAwAAAA0AEAnQEqAQABAAFAJiWgAnS6AfgAA7AA/vLrf/zYFc1z7/f/0uD9Lg/S4P/SkAAA',
+      'base64',
+    );
+    await adapter.sendStickerMessage('628111@s.whatsapp.net', { mimetype: 'image/webp', data: webp });
+    expect(fakeSock.sendMessage).toHaveBeenCalledWith('628111@s.whatsapp.net', { sticker: webp });
   });
 
   it('uses the caller-declared mimetype over the fetched content-type for a URL', async () => {

--- a/src/modules/message/dto/send-message.dto.ts
+++ b/src/modules/message/dto/send-message.dto.ts
@@ -227,7 +227,7 @@ export const SEND_AUDIO_BODY_EXAMPLES = mediaBodyExample('https://example.com/au
 export const SEND_DOCUMENT_BODY_EXAMPLES = mediaBodyExample('https://example.com/report.pdf', {
   filename: 'report.pdf',
 });
-export const SEND_STICKER_BODY_EXAMPLES = mediaBodyExample('https://example.com/sticker.png');
+export const SEND_STICKER_BODY_EXAMPLES = mediaBodyExample('https://example.com/sticker.webp');
 
 export class SendAudioMessageDto extends SendMediaMessageDto {
   @ApiPropertyOptional({


### PR DESCRIPTION
`sendSticker` on the Baileys adapter passed the caller's bytes straight through as `{ sticker: data }`. Baileys stamps `image/webp` on the media regardless of what the bytes actually are, so a PNG went out labelled as a sticker and did not render. whatsapp-web.js has converted for this all along — `sendMediaAsSticker` routes through `Util.formatToWebpSticker` — so the two engines disagreed on the same request.

**Verified against a live account rather than argued from the library source**, which matters here: the same class of source-traced reasoning produced a wrong unit elsewhere in this work, and only a handset caught it.

- Old build, 512×512 PNG sent as a sticker: `201`, and the message does **not** render on the handset.
- New build, the *same* PNG: `201`, and it renders — with the broken message still sitting above it as its own control.

A third leg turned up while proving it: the old build accepts a **PDF** as a sticker and answers `201`. Not merely wrong-format image bytes — arbitrary non-image bytes, accepted and reported as sent. The fix refuses on the declared type before any bytes reach the decoder, and the refusal names what it received.

Animated input survives: `{ animated: true }` is passed through, checked with a hand-built two-frame GIF, because a converter that silently flattens animation still emits valid WebP and every other assertion would have stayed green.

`sharp` moves from a transitive lockfile entry to a declared dependency. Measured: 1129 packages before and after, zero added, zero removed, zero version changes — the only diff is the edge itself and `peer: true` dropping off the platform packages.
