### PR TITLE
fix(engine): stop the parity check skipping optional interface members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A plugin whose code went missing is recoverable through the API again: reinstalling now writes over its surviving `ctx.storage` directory instead of answering `409`, and uninstalling a known-but-unloaded id no longer answers `404`.
 - A sticker sent through the Baileys engine no longer reaches WhatsApp as non-WebP bytes labelled `image/webp`; the adapter converts `image/*` to a 512×512 WebP before the socket, passes genuine WebP through byte-identical, and refuses anything it cannot convert with a `400` instead of reporting success.
 - `docs/18-sdk-design.md` and the SDK READMEs now list every method the five clients ship: the whole `media` resource plus 26 methods across nine others were missing, so server-side media conversion, presence subscription, session config and webhook delivery diagnostics read as unavailable.
+- The engine parity check no longer skips optional interface members. `probeLiveness?()` did not match its member pattern, so the capability matrix could omit any optional method while the check reported green; it now has a row recording that wwjs probes with a real round trip and Baileys with a local check.
 
 ### Security
 

--- a/docs/29-engine-capability-matrix.md
+++ b/docs/29-engine-capability-matrix.md
@@ -176,6 +176,14 @@ session runs; ⚠️ depends on the session engine; ❌ 501 on both.
 | `getQRCode`          | ✅                  | ✅                 | ✅          |
 | `requestPairingCode` | ✅                  | ✅                 | ✅          |
 | `getStatus`          | ✅                  | ✅                 | ✅          |
+| `probeLiveness`      | ✅ local            | ✅ round trip      | ⚙️ internal |
+
+`probeLiveness` is the one optional member of `IWhatsAppEngine`, and the two adapters answer it to
+different depths — which is what the optional marker exists to allow. wwjs races a real
+`Client.getState()` round trip against a 10s timeout, because a wedged page keeps reporting
+CONNECTED. Baileys returns a local check (`status === READY && sock != null`), because its keepalive
+already emits a close event within ~35s. So a wedged wwjs page is caught here; a wedged Baileys
+socket is caught by the transport instead. No REST route: the session watchdog polls it.
 
 ### 29.4.2 Sending messages
 
@@ -868,13 +876,13 @@ adapter boundary — none silently stubs.
 Recomputed from `engine-capability-matrix.ts`, `upstream-surface.snapshot.json`, and a scan of the
 adapter sources — re-derive the same way when anything changes:
 
-- **108** interface methods → **216** adapter cells: **194 ✅** / **22 ❌** (2 adapter-gaps, 20
+- **109** interface methods → **218** adapter cells: **196 ✅** / **22 ❌** (2 adapter-gaps, 20
   library-limitations, 0 uncertain), spanning **21** methods.
-- Of the 194 ✅ cells, **6 wwjs cells carry an explicit patch dependency** (4 × 🔧² status send,
+- Of the 196 ✅ cells, **6 wwjs cells carry an explicit patch dependency** (4 × 🔧² status send,
   1 × 🔧³ channel link preview, 1 × 🔧⁴ ready-sync) and the whole wwjs column additionally
   depends on 🔧¹, the whole Baileys column on 🔧⁵ — so every row rests on a patch on each side,
   even though no row carries a row-level mark on both.
-- REST caller's view: **89** engine-neutral (87 + 2 store-backed status reads), **9** Baileys-only,
+- REST caller's view: **90** engine-neutral (88 + 2 store-backed status reads), **9** Baileys-only,
   **9** wwjs-only, **1** unavailable on both (`sendCatalog`).
 - Full engine inventory (29.5), split by the exposure legend rather than lumped: Baileys **152**
   socket methods — 47 wired into interface methods, 5 internal wiring, 29 plumbing, **71 ❌ not

--- a/src/engine/engine-capability-matrix.ts
+++ b/src/engine/engine-capability-matrix.ts
@@ -262,6 +262,12 @@ export const ENGINE_CAPABILITY_MATRIX: Record<string, MethodCapability> = {
   },
   postImageStatus: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   postTextStatus: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
+  probeLiveness: {
+    wwjs: { status: 'supported' },
+    baileys: { status: 'supported' },
+    evidence:
+      'Both implement it, but not to the same depth, which is what the optional marker on the interface allows: wwjs races a real Client.getState() round trip against a 10s timeout (whatsapp-web-js.adapter.ts:1710) and answers alive inside the bounded navigation re-inject window; baileys returns a local check, status === READY && sock != null (baileys-lifecycle.ts:738), because its keepalive already emits a close event within ~35s. So a wedged wwjs page is caught by the probe, while a wedged baileys socket is caught by the transport rather than here',
+  },
   postVideoStatus: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   postVoiceStatus: { wwjs: { status: 'supported' }, baileys: { status: 'supported' } },
   promoteParticipants: {

--- a/src/engine/engine-parity.spec.ts
+++ b/src/engine/engine-parity.spec.ts
@@ -23,15 +23,31 @@ import { ENGINE_CAPABILITY_MATRIX } from './engine-capability-matrix';
  */
 const UNSUPPORTED_RE = /this\.unsupported\(|EngineNotSupportedError|ChannelMediaNotSupportedError/;
 
+/** A member declaration, optional or not. `\??` is load-bearing — see the test below. */
+const MEMBER_RE = /^\s{2}([a-zA-Z][a-zA-Z0-9]*)\??\s*\(/;
+
 function readInterfaceMethods(): string[] {
   const src = readFileSync(join(__dirname, 'interfaces', 'whatsapp-engine.interface.ts'), 'utf8');
   const names = new Set<string>();
   for (const line of src.split('\n')) {
-    const match = line.match(/^\s{2}([a-zA-Z][a-zA-Z0-9]*)\s*\(/);
+    const match = line.match(MEMBER_RE);
     if (match) names.add(match[1]);
   }
   return [...names].sort();
 }
+
+describe('the interface reader sees every member', () => {
+  // An optional member is still a member. Before `\??` was added, `probeLiveness?()` did not match
+  // here, so the matrix could omit it and this whole file reported green while doing so — every
+  // optional method added to IWhatsAppEngine would have had a permanent free pass.
+  it('matches an optional declaration as well as a required one', () => {
+    expect('  probeLiveness?(): Promise<boolean>;'.match(MEMBER_RE)?.[1]).toBe('probeLiveness');
+    expect('  getStatus(): SessionStatus;'.match(MEMBER_RE)?.[1]).toBe('getStatus');
+    // And still rejects what it should: a nested member, and a property that is not a call.
+    expect('    nested(): void;'.match(MEMBER_RE)).toBeNull();
+    expect('  someProperty: string;'.match(MEMBER_RE)).toBeNull();
+  });
+});
 
 type AdapterCtor = { prototype: Record<string, unknown> };
 type AdapterKey = 'wwjs' | 'baileys';


### PR DESCRIPTION
`readInterfaceMethods()` builds its list with `/^\s{2}([a-zA-Z][a-zA-Z0-9]*)\s*\(/` — identifier, optional whitespace, `(`. For an **optional** member the next character is `?`, so `probeLiveness?()` never matched.

The consequence is not one missing row. The check saw 108 members where the interface declares 109, the matrix had 108 keys, the two sets agreed, and it passed. **Every optional method added to `IWhatsAppEngine` would have had a permanent free pass, with the gate reporting green while granting it.**

Measured, with controls:

```
NO MATCH                       <- probeLiveness?(): Promise<boolean>;
MATCHES  getStatus             <- required member (control)
MATCHES  muteChat              <- required member (control)
MATCHES  probeLiveness         <- same line, pattern widened with \??
```

`probeLiveness` gets a row rather than an exclusion, because it says something. Both adapters implement it and they answer to different depths — which is exactly what the optional marker on the interface allows and what §29.4 exists to record:

- **wwjs** races a real `Client.getState()` round trip against a 10s timeout, because a wedged page keeps reporting CONNECTED.
- **Baileys** returns a local check (`status === READY && sock != null`), because its keepalive already emits a close event within ~35s.

So a wedged wwjs page is caught by the probe; a wedged Baileys socket is caught by the transport instead.

**The pattern change is pinned twice, deliberately.** A dedicated test asserts it matches an optional declaration as well as a required one, and still rejects a nested member and a non-call property. Independently, narrowing it again leaves the matrix holding a key the reader can no longer see, which fails the no-missing-no-stale invariant. Each mutation was run: reverting the pattern fails two tests, removing the matrix row fails one, and the unmutated tree is green.

§29.8 was recomputed from the matrix source rather than adjusted by hand — 109 methods, 218 cells, 196 supported, and the REST caller's view moves 89 → 90 through the same documented store-backed adjustment.
