### PR TITLE
docs(engine): make every docs/29 count agree with the matrix, and gate it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `npm run check:sdk-events` compares each typed SDK's webhook event list to the contract, so an event the gateway accepts can no longer be missing from the SDKs.
 - `npm run check:sdk-docs` compares the SDK design doc and the coverage tables to the shipped client surface, so a client method can no longer ship undocumented.
 - `POST /sessions/:sessionId/calls/link` generates a shareable WhatsApp call link on both engines, returning the finished `https://call.whatsapp.com/…` URL; a WhatsApp-side failure answers `403` rather than a success carrying an empty link.
+- `docs-29-counts.spec.ts` binds every count-shaped claim in `docs/29` to the capability matrix, so a figure restated in the intro, the architecture prose, a mermaid node or a section heading cannot drift from the source it restates.
 
 ### Fixed
 

--- a/docs/29-engine-capability-matrix.md
+++ b/docs/29-engine-capability-matrix.md
@@ -3,7 +3,7 @@
 Three-way comparison of every capability: the **Baileys library** (`@whiskeysockets/baileys`
 7.0.0-rc13), the **whatsapp-web.js library** (1.34.7), and what **OpenWA actually exposes** through
 its adapter layer and REST API — including which "supported" cells only work because OpenWA patches
-the installed library. Coverage is total: all 108 `IWhatsAppEngine` methods (29.4), **all 152
+the installed library. Coverage is total: all 109 `IWhatsAppEngine` methods (29.4), **all 152
 Baileys + 81 whatsapp-web.js library methods** (29.5), all 34 + 31 library events (29.5.4), and all
 5 install-time patches (29.3). If it exists upstream or in OpenWA, it has a row here.
 
@@ -24,7 +24,7 @@ Statuses used in the tables:
 
 Two complementary views:
 
-- **29.4 — the OpenWA contract view.** Rows are the 108 `IWhatsAppEngine` methods; use it to see
+- **29.4 — the OpenWA contract view.** Rows are the 109 `IWhatsAppEngine` methods; use it to see
   what a REST caller gets per engine. Source of truth: `src/engine/engine-capability-matrix.ts`
   (per-cell `evidence` strings cite the exact library `file:symbol` inspected).
 - **29.5 — the full engine inventory.** Rows are **every method the installed libraries expose**,
@@ -36,14 +36,14 @@ Two complementary views:
 ## 29.2 Adapter architecture
 
 OpenWA never calls a WhatsApp library directly from a controller. Every session owns one engine
-instance behind the neutral `IWhatsAppEngine` interface (108 methods +
+instance behind the neutral `IWhatsAppEngine` interface (109 methods +
 `EngineEventCallbacks`), and all modules go through it:
 
 ```mermaid
 flowchart LR
     subgraph OpenWA["OpenWA"]
         API["REST API controllers"] --> SVC["Modules / services"]
-        SVC --> IF["IWhatsAppEngine - 108 methods"]
+        SVC --> IF["IWhatsAppEngine - 109 methods"]
         IF --> WA["WwebjsAdapter"]
         IF --> BA["BaileysAdapter"]
         SVC --> STORE["OpenWA-side stores"]
@@ -156,7 +156,7 @@ Rows that are ✅ on **both** engines where one side is patch-dependent: `initia
 rests on the column-wide 🔧¹ (wwjs) and 🔧⁵ (baileys) — no row runs on stock library code on both
 sides.
 
-## 29.4 Full capability matrix — the OpenWA contract view (108 methods)
+## 29.4 Full capability matrix — the OpenWA contract view (109 methods)
 
 Legend recap: **✅** supported · **✅🔧ⁿ** supported via OpenWA patch `🔧ⁿ` (29.3) ·
 **❌ gap** adapter-gap · **❌ lib** library-limitation. Column headers carry the engine-wide
@@ -345,8 +345,8 @@ answers 501.
 | `rejectCall`          | ✅                  | ✅                 | ✅              |
 | `createCallLink`      | ✅                  | ✅                 | ✅              |
 
-**Totals:** 108 methods → 216 adapter cells: **194 ✅, 22 ❌** (2 adapter-gaps, 20
-library-limitations, 0 uncertain) across 21 methods. From the REST caller's side: **89** methods
+**Totals:** 109 methods → 218 adapter cells: **196 ✅, 22 ❌** (2 adapter-gaps, 20
+library-limitations, 0 uncertain) across 21 methods. From the REST caller's side: **90** methods
 work on any engine (87 fully supported + 2 store-backed status reads), **9** are Baileys-only,
 **9** are wwjs-only (the 2 store-backed rows excluded), **1** (`sendCatalog`) is 501 on both.
 

--- a/src/engine/docs-29-counts.spec.ts
+++ b/src/engine/docs-29-counts.spec.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * `docs/29` states the same three figures in ten places — the intro, the architecture prose, a
+ * mermaid node, two section headings, the §29.4 totals and the §29.8 summary. All ten are
+ * hand-written restatements of what `engine-capability-matrix.ts` contains.
+ *
+ * Adding one interface method updated the matrix and §29.8 and left the other six behind, and
+ * nothing noticed: the parity gates compare the matrix to the interface, and no check reads the
+ * prose. This binds every count-shaped claim in the file to the source it restates.
+ */
+describe('docs/29 counts match the capability matrix', () => {
+  const read = (...parts: string[]): string => readFileSync(join(__dirname, '..', '..', ...parts), 'utf8');
+
+  /** Recount from the matrix source. Line-oriented on purpose — see the note on the fixture below. */
+  const recount = () => {
+    const lines = read('src', 'engine', 'engine-capability-matrix.ts').split('\n');
+    const rows: { wwjs: string | null; baileys: string | null }[] = [];
+    let current: { wwjs: string | null; baileys: string | null } | null = null;
+    for (const line of lines) {
+      if (/^ {2}[A-Za-z][A-Za-z0-9_]*: \{/.test(line)) {
+        current = { wwjs: null, baileys: null };
+        rows.push(current);
+      }
+      if (!current) continue;
+      const wwjs = line.match(/wwjs: \{ ?status: '([a-z-]+)'/);
+      if (wwjs && current.wwjs === null) current.wwjs = wwjs[1];
+      const baileys = line.match(/baileys: \{ ?status: '([a-z-]+)'/);
+      if (baileys && current.baileys === null) current.baileys = baileys[1];
+    }
+    const complete = rows.filter(r => r.wwjs && r.baileys);
+    // A parse that dropped rows would understate every figure and make the whole file "agree".
+    expect(complete.length).toBe(rows.length);
+    expect(rows.length).toBeGreaterThan(80);
+
+    const ok = (s: string | null): boolean => s === 'supported';
+    const supported = rows.filter(r => ok(r.wwjs)).length + rows.filter(r => ok(r.baileys)).length;
+    // The REST caller's view counts the two store-backed status reads as neutral rather than
+    // wwjs-only; docs/29 states that adjustment explicitly where it uses the figure.
+    const neutralRaw = rows.filter(r => ok(r.wwjs) && ok(r.baileys)).length;
+    return { methods: rows.length, cells: rows.length * 2, supported, neutral: neutralRaw + 2 };
+  };
+
+  /** Every phrasing in the file that restates one of those figures. */
+  const CLAIMS: { label: string; re: RegExp; of: 'methods' | 'cells' | 'supported' | 'neutral' }[] = [
+    { label: 'intro coverage', re: /Coverage is total: all (\d+) `IWhatsAppEngine` methods/, of: 'methods' },
+    { label: 'section guide', re: /Rows are the (\d+) `IWhatsAppEngine` methods/, of: 'methods' },
+    { label: 'architecture prose', re: /`IWhatsAppEngine` interface \((\d+) methods/, of: 'methods' },
+    { label: 'mermaid node', re: /IWhatsAppEngine - (\d+) methods/, of: 'methods' },
+    { label: '29.4 heading', re: /contract view \((\d+) methods\)/, of: 'methods' },
+    { label: '29.4 totals methods', re: /\*\*Totals:\*\* (\d+) methods/, of: 'methods' },
+    { label: '29.4 totals cells', re: /\*\*Totals:\*\* \d+ methods → (\d+) adapter cells/, of: 'cells' },
+    { label: '29.4 totals supported', re: /adapter cells: \*\*(\d+) ✅/, of: 'supported' },
+    { label: '29.4 REST view', re: /From the REST caller's side: \*\*(\d+)\*\* methods/, of: 'neutral' },
+    { label: '29.8 methods', re: /- \*\*(\d+)\*\* interface methods/, of: 'methods' },
+    { label: '29.8 cells', re: /interface methods → \*\*(\d+)\*\* adapter cells/, of: 'cells' },
+    { label: '29.8 supported', re: /adapter cells: \*\*(\d+) ✅\*\*/, of: 'supported' },
+    { label: '29.8 restated supported', re: /Of the (\d+) ✅ cells/, of: 'supported' },
+    { label: '29.8 REST view', re: /REST caller's view: \*\*(\d+)\*\* engine-neutral/, of: 'neutral' },
+  ];
+
+  it('states the same figures everywhere it states them', () => {
+    const expected = recount();
+    const doc = read('docs', '29-engine-capability-matrix.md');
+
+    const wrong: string[] = [];
+    for (const claim of CLAIMS) {
+      const found = doc.match(claim.re);
+      // A phrasing that stopped matching is drift too — the claim did not disappear, the check did.
+      if (!found) {
+        wrong.push(`${claim.label}: phrasing no longer found in the document`);
+        continue;
+      }
+      const actual = Number(found[1]);
+      if (actual !== expected[claim.of]) {
+        wrong.push(`${claim.label}: says ${actual}, matrix has ${expected[claim.of]}`);
+      }
+    }
+
+    expect(wrong).toEqual([]);
+  });
+});


### PR DESCRIPTION
Adding `probeLiveness` in #1213 updated the capability matrix and §29.8 and **left six other statements of the same figures behind**. `docs/29` said 108 methods in six places and 109 in one:

```
line   6  intro          "all 108 IWhatsAppEngine methods"
line  27  section guide  "Rows are the 108 IWhatsAppEngine methods"
line  39  architecture   "(108 methods + …"
line  46  mermaid node   "IWhatsAppEngine - 108 methods"
line 159  §29.4 heading  "contract view (108 methods)"
line 348  §29.4 totals   "108 methods → 216 adapter cells: 194 ✅ … REST caller's side: 89"
line 879  §29.8          "109 interface methods → 218 adapter cells: 196 ✅ … 90"
```

Nothing caught it. The parity gates compare the matrix to the interface and never read the prose, so a file disagreeing with itself passed every check — including the one added in that same PR.

This corrects the six and binds all fourteen count-shaped claims to the source they restate. The figures come from a recount of `engine-capability-matrix.ts`, not from the document.

**Two properties the check needs, and the second is the one that usually gets skipped:**

- It fails on a figure that disagrees. Against the unfixed document it names all nine, with both values: `intro coverage: says 108, matrix has 109` … `29.4 totals cells: says 216, matrix has 218`.
- It fails on a **phrasing it can no longer find**. A claim that stops matching is drift too — someone rewording the mermaid node would otherwise silently remove it from coverage while the check stayed green. Verified by rewording that node: `mermaid node: phrasing no longer found in the document`.

The recount also asserts every matrix row yielded both statuses before it is believed, because a parse that dropped rows would understate every figure and make the whole document agree with itself.
