### PR TITLE
fix(docs): stop naming a withdrawn WhatsApp Web build, and gate against it

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -149,7 +149,7 @@ OPENWA_PIDS_LIMIT=2048
 # HTML URL template (use {version} as the placeholder) to fetch from an operator-controlled copy
 # instead. The active build + its source (pinned/auto/native) is shown on the dashboard's
 # Infrastructure page.
-# WWEBJS_WEB_VERSION=2.3000.1040641150-alpha
+# WWEBJS_WEB_VERSION=<a build from that registry's html/ folder>
 # WWEBJS_WEB_VERSION=off
 
 # Extend the initial boot/inject wait (milliseconds) before QR generation. On slow first boots

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A sticker sent through the Baileys engine no longer reaches WhatsApp as non-WebP bytes labelled `image/webp`; the adapter converts `image/*` to a 512×512 WebP before the socket, passes genuine WebP through byte-identical, and refuses anything it cannot convert with a `400` instead of reporting success.
 - `docs/18-sdk-design.md` and the SDK READMEs now list every method the five clients ship: the whole `media` resource plus 26 methods across nine others were missing, so server-side media conversion, presence subscription, session config and webhook delivery diagnostics read as unavailable.
 - The engine parity check no longer skips optional interface members. `probeLiveness?()` did not match its member pattern, so the capability matrix could omit any optional method while the check reported green; it now has a row recording that wwjs probes with a real round trip and Baileys with a local check.
+- `.env.example` and the troubleshooting FAQ no longer name a specific WhatsApp Web build to pin with `WWEBJS_WEB_VERSION`. The build they named has since been withdrawn from the registry, and a build the registry no longer serves is fetched, missed and silently ignored — so an operator following the FAQ's own workaround got the default behaviour while the log claimed the pin had been applied. Both now point at the registry's `html/` folder for a build that is currently served.
 
 ### Security
 

--- a/docs/12-troubleshooting-faq.md
+++ b/docs/12-troubleshooting-faq.md
@@ -294,12 +294,14 @@ environment still hits a WA-Web compatibility hang, pin a known-good WA-Web vers
 `WWEBJS_WEB_VERSION`:
 
 ```bash
-# Optional workaround:
-WWEBJS_WEB_VERSION=2.3000.1040641150-alpha
+# Optional workaround — substitute a build that the registry currently serves:
+WWEBJS_WEB_VERSION=<a build from that registry's html/ folder>
 ```
 
-Restart the container after changing it. Browse newer versions at
-[wppconnect-team/wa-version](https://github.com/wppconnect-team/wa-version) (the `html/` folder). With
+Restart the container after changing it. Pick the build from
+[wppconnect-team/wa-version](https://github.com/wppconnect-team/wa-version) (the `html/` folder) — a
+build the registry no longer serves is fetched, missed, and silently ignored, leaving you on the
+default behaviour rather than the pin you asked for. With
 `WWEBJS_WEB_VERSION` unset, `latest`, or `auto` (the default), OpenWA auto-resolves a settled build
 from that registry and pins its HTML — note this HTML is fetched from a third-party repository and
 executed inside the `web.whatsapp.com` origin without an integrity check. Set

--- a/src/config/wa-web-version-example-pin.spec.ts
+++ b/src/config/wa-web-version-example-pin.spec.ts
@@ -1,0 +1,78 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Operator-facing guidance must not hand out a literal WhatsApp Web build to copy into
+ * `WWEBJS_WEB_VERSION`.
+ *
+ * The wa-version registry withdraws old builds, and whatsapp-web.js's remote cache is non-strict:
+ * a pin whose HTML it can no longer fetch is missed and silently ignored, leaving the operator on
+ * the default behaviour while `Pinning WhatsApp Web version …` still claims the pin was applied.
+ * `2.3000.1040641150-alpha` shipped in both `.env.example` and the troubleshooting FAQ and was
+ * withdrawn; nothing failed anywhere, which is exactly why it went unnoticed. Describing the
+ * setting and pointing at the registry's `html/` folder is fine — naming a build is not.
+ *
+ * Scope is deliberately operator-facing only. A spec assigning `process.env.WWEBJS_WEB_VERSION` a
+ * build id is a fixture, not guidance, and the CHANGELOG legitimately records builds that were
+ * current when an entry was written.
+ */
+
+const REPO_ROOT = path.join(__dirname, '..', '..');
+
+/** `WWEBJS_WEB_VERSION` assigned something starting with a digit — how the resolver reads an exact build. */
+const LITERAL_BUILD_PIN = /WWEBJS_WEB_VERSION\s*=\s*["']?\d/;
+
+const SETTING = 'WWEBJS_WEB_VERSION';
+
+function read(relativePath: string): string {
+  return fs.readFileSync(path.join(REPO_ROOT, relativePath), 'utf8');
+}
+
+function markdownUnder(dir: string): string[] {
+  return fs
+    .readdirSync(path.join(REPO_ROOT, dir), { withFileTypes: true })
+    .flatMap(entry =>
+      entry.isDirectory()
+        ? markdownUnder(path.join(dir, entry.name))
+        : entry.name.endsWith('.md')
+          ? [path.join(dir, entry.name)]
+          : [],
+    );
+}
+
+/** Everything an operator is expected to copy from. */
+function operatorFacingFiles(): string[] {
+  return ['.env.example', ...markdownUnder('docs')];
+}
+
+function filesNamingABuild(files: string[]): string[] {
+  return files.filter(relativePath => LITERAL_BUILD_PIN.test(read(relativePath)));
+}
+
+describe('operator-facing guidance never names a WhatsApp Web build to pin', () => {
+  const files = operatorFacingFiles();
+
+  it('names no build anywhere an operator copies from', () => {
+    expect(filesNamingABuild(files)).toEqual([]);
+  });
+
+  // Anti-vacuity: a corpus that lost the files, or a setting that was renamed out from under the
+  // pattern, would make the assertion above pass while checking nothing.
+  it('scans a corpus that still documents the setting', () => {
+    const documenting = files.filter(relativePath => read(relativePath).includes(SETTING));
+    expect(documenting).toContain('.env.example');
+    expect(documenting).toContain(path.join('docs', '12-troubleshooting-faq.md'));
+  });
+
+  // Self-mutation control: the check must be capable of firing.
+  it('fires on a document that names a build', () => {
+    expect(LITERAL_BUILD_PIN.test('WWEBJS_WEB_VERSION=2.3000.1040641150-alpha')).toBe(true);
+    expect(LITERAL_BUILD_PIN.test('WWEBJS_WEB_VERSION = "2.3000.1040641150-alpha"')).toBe(true);
+  });
+
+  it('does not fire on the forms that are safe to document', () => {
+    expect(LITERAL_BUILD_PIN.test('WWEBJS_WEB_VERSION=off')).toBe(false);
+    expect(LITERAL_BUILD_PIN.test('WWEBJS_WEB_VERSION=auto')).toBe(false);
+    expect(LITERAL_BUILD_PIN.test("WWEBJS_WEB_VERSION=<a build from that registry's html/ folder>")).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

`.env.example` and `docs/12-troubleshooting-faq.md` both told operators to pin `WWEBJS_WEB_VERSION=2.3000.1040641150-alpha`. That build has since been withdrawn from the wa-version registry, and its HTML now returns 404.

## Why it matters

Nothing fails when the named build disappears. whatsapp-web.js constructs the remote web cache non-strict, so `RemoteWebCache.resolve()` returns `null` on a failed fetch and the client quietly loads the live page instead — while the adapter has already logged `Pinning WhatsApp Web version …`.

So an operator who follows the FAQ's own workaround gets the default behaviour and a log line asserting the opposite. The FAQ recommends this as a remedy for a session stuck at `authenticating`, which means it is reached precisely by people already debugging something.

## Change

- Both places now point at the registry's `html/` folder instead of naming a build.
- The FAQ additionally states what happens if the chosen build stops being served, so the silent-fallback behaviour is documented rather than surprising.

## Not rotting again

Replacing one build id with a newer one only resets the clock. `src/config/wa-web-version-example-pin.spec.ts` scans `.env.example` and every file under `docs/` for a `WWEBJS_WEB_VERSION` assignment beginning with a digit, and fails if one reappears. Specs assigning `process.env.WWEBJS_WEB_VERSION` are fixtures rather than guidance and stay out of scope, as does the CHANGELOG, which legitimately records builds that were current when an entry was written.

The check carries its own controls: an anti-vacuity case asserting the scanned corpus still documents the setting (so renaming the variable cannot silently neuter the pattern), plus cases proving it fires on a named build and stays quiet on `off`, `auto` and the placeholder. Reintroducing the old value into either file was verified to turn the suite red, one file at a time.

Refs #1212