### PR TITLE
chore: stop format:check failing on installed SDK dependencies

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,22 @@
+# Prettier resolves its default ignore files at the CWD only — it does not walk directories the way
+# git does, so the nested .gitignore files under sdk/* are never opened. Anything installed or built
+# below them therefore reaches the `**/*.md` glob in `format` / `format:check`, and a plain
+# `composer install` is enough to fail the check on markdown this repository does not own.
+#
+# Keep in step with those nested .gitignore files. The root .gitignore is read by default, so rules
+# already there (node_modules/, dist/, coverage/) do not need repeating.
+
+# sdk/php/.gitignore
+sdk/php/vendor/
+sdk/php/.phpunit.cache/
+
+# sdk/python/.gitignore
+sdk/python/.pytest_cache/
+sdk/python/__pycache__/
+sdk/python/build/
+sdk/python/dist/
+sdk/python/.venv/
+sdk/python/*.egg-info/
+
+# sdk/java/.gitignore
+sdk/java/target/


### PR DESCRIPTION
`npm run format:check` fails on files this repository does not own, as soon as anyone installs an SDK's dependencies locally — which is exactly what running the per-SDK test suites requires.

**Prettier resolves its default ignore files at the CWD only.** Its default `--ignore-path` is `[.gitignore, .prettierignore]`, but it does not implement git's walk-every-directory semantics, so `sdk/php/.gitignore`, `sdk/python/.gitignore` and `sdk/java/.gitignore` are never opened. Everything below them reaches the `**/*.md` glob in `format` / `format:check`.

The root `.gitignore` *is* read, which is why `node_modules/` needs no entry here — and why the problem stays invisible until someone runs `composer install`.

**CI is green for a reason unrelated to the check.** The lint job runs `npm ci` at the root and never materialises `sdk/php/vendor`, so the glob is never exercised against it.

---

Proven in both directions rather than asserted, because "the check passes" is what both a working ignore and an empty directory look like:

```
badly-formatted .md under sdk/php/vendor/   →  ignored      (the fix works)
the same content under docs/                →  still warns  (the fix is not over-broad)
```

That second line is the one that matters. Without it, an ignore rule wide enough to silence the whole repository would look identical to a correct one.

**No CHANGELOG entry**: this changes nothing a user or the built artefacts can observe, and nothing about the scripts' behaviour on a clean checkout — only whether a contributor's local `format:check` reports files from `vendor/`.
