### PR TITLE
fix(sdk-go): stop an empty participant list acting on every join request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The Go SDK no longer approves or rejects every pending join request when handed an empty participant list: `omitempty` dropped the empty slice, so `[]string{}` reached the gateway as the bodyless "act on every request" rather than the `400` the other four clients receive. A nil slice still means every request.
 - The chart's optional ServiceMonitor now selects on a new `openwa.io/scrape-target` label, so it scrapes one target per pod instead of two; series previously collected through the headless target stop appearing, so check anything keyed on the `service` label.
 - The Helm chart's new startup probe stops the kubelet killing a pod that is still booting, allowing 295s (`periodSeconds: 5`, `failureThreshold: 60`) where the liveness settings allowed 50. It fires immediately, so a fast boot goes live sooner than before, not later — and it is not limited to auto-start, since the database connect retry alone can consume 30 of the old 50 seconds.
 - A Helm upgrade that changes only `env` or `secretEnv` now restarts the pod through ConfigMap and Secret checksums, so the new configuration reaches the running container. With `existingSecret` set the chart renders no Secret, so that path still needs `kubectl rollout restart`; `values.yaml` notes what publishing the Secret checksum as a pod annotation means.

--- a/sdk/go/groups.go
+++ b/sdk/go/groups.go
@@ -231,9 +231,13 @@ func (s *GroupsService) RejectMembershipRequests(
 func (s *GroupsService) membershipRequestAction(
 	ctx context.Context, sessionID, groupID, verb string, participants []string,
 ) (*ParticipantsResult, error) {
-	body := MembershipRequestActionRequest{}
+	// A nil slice means "every pending request", which the gateway reads from the ABSENCE of the
+	// key — `null` is not absence there, so the bodyless case sends an empty object rather than the
+	// struct. A non-nil slice always sends the key, empty included, so naming nobody stays a 400
+	// instead of collapsing into naming everybody.
+	var body any = struct{}{}
 	if participants != nil {
-		body.Participants = participants
+		body = MembershipRequestActionRequest{Participants: participants}
 	}
 	var out ParticipantsResult
 	err := s.client.do(

--- a/sdk/go/membership_request_test.go
+++ b/sdk/go/membership_request_test.go
@@ -1,0 +1,38 @@
+package openwa
+
+import (
+	"context"
+	"testing"
+)
+
+// Omitting `participants` tells the gateway to act on EVERY pending join request, so the empty
+// slice and the nil slice must not reach the wire as the same body. `membershipRequestAction`
+// already draws that line (`if participants != nil`), and every other client keys on null rather
+// than emptiness: the JavaScript, Python and PHP clients send `{"participants": []}` for an empty
+// list and the gateway answers 400 (`@ArrayNotEmpty`). An `omitempty` tag would erase the
+// distinction after the check had made it, turning "approve nobody" into "approve everybody" —
+// silently, and irreversibly for the group.
+func TestMembershipRequestActionDistinguishesEmptyFromOmitted(t *testing.T) {
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		name         string
+		participants []string
+		wantBody     string
+	}{
+		{"nil acts on every pending request", nil, `{}`},
+		{"empty slice names nobody", []string{}, `{"participants":[]}`},
+		{"one id names that id", []string{"628111@c.us"}, `{"participants":["628111@c.us"]}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := &recordTransport{status: 200, body: `{}`}
+			c := newTestClient(t, rt)
+			if _, err := c.Groups.ApproveMembershipRequests(ctx, "s1", "g1", tc.participants); err != nil {
+				t.Fatalf("ApproveMembershipRequests: %v", err)
+			}
+			if got := string(rt.lastRaw); got != tc.wantBody {
+				t.Errorf("body = %s, want %s", got, tc.wantBody)
+			}
+		})
+	}
+}

--- a/sdk/go/types_group.go
+++ b/sdk/go/types_group.go
@@ -36,10 +36,16 @@ type GroupMembershipRequest struct {
 	RequestedAt float64 `json:"requestedAt,omitempty"`
 }
 
-// MembershipRequestActionRequest is the body for approving or rejecting join requests. An empty
-// Participants slice acts on every pending request.
+// MembershipRequestActionRequest names the requesters to approve or reject. Acting on every pending
+// request is expressed by sending no body field at all, which membershipRequestAction does with an
+// empty body — not by this struct.
+//
+// No `omitempty`: it drops an empty slice as readily as a nil one, so "approve nobody" would reach
+// the gateway as the bodyless "approve everybody". The other four clients key on null rather than
+// emptiness and send `{"participants": []}` for an empty list, which the gateway rejects with 400;
+// the tag made Go the only client where that input silently admitted every pending requester.
 type MembershipRequestActionRequest struct {
-	Participants []string `json:"participants,omitempty"`
+	Participants []string `json:"participants"`
 }
 
 // GroupInfo is the full group detail.


### PR DESCRIPTION
## Problem

`MembershipRequestActionRequest.Participants` carried `json:"participants,omitempty"`. Go's encoder drops an empty slice as readily as a nil one, so:

```go
client.Groups.ApproveMembershipRequests(ctx, sessionID, groupID, []string{})
```

marshalled to `{}` — the body the gateway reads as *act on every pending request*. The caller named nobody and every pending requester was admitted to the group. The action is not reversible from this API.

`membershipRequestAction` already drew the line correctly (`if participants != nil`); the struct tag erased the distinction after the check had made it.

## Why this is a defect rather than a documented shape

The other four clients key on null, not emptiness, and all send the key for an empty list:

| Client | Empty list on the wire | Gateway |
|---|---|---|
| JavaScript | `{"participants":[]}` | 400 |
| Python | `{"participants":[]}` | 400 |
| PHP | `{"participants":[]}` | 400 |
| Java | `{"participants":[]}` | 400 |
| Go (before) | `{}` | **acts on every request** |

Go was the only client where the same input was destructive instead of refused.

## Change

- The struct always carries `participants`, so an empty list is refused with 400 like everywhere else.
- "Every pending request" is now expressed by sending an empty object explicitly, because the gateway reads it from the *absence* of the key — `null` is not absence there, and `@ValidateIf(o => o.participants !== undefined)` would run `@IsArray` against it and answer 400.

## Verification

`sdk/go/membership_request_test.go` pins all three shapes at the transport layer. It was confirmed red on the empty-slice case before the change and green on the other two, so it discriminates this defect rather than the surrounding behaviour.

`go test ./...`, `go vet ./...`, `gofmt`, and `check:sdk-routes` / `check:sdk-coverage` / `check:sdk-events` / `check:sdk-docs` all pass.