### PR TITLE
fix(scripts): stop a path-parameter wildcard covering its route siblings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `check:sdk-coverage` no longer passes when a client drops a route entirely: a wildcard the client built for a path parameter — `contacts/${contactId}` — was read as a one-builder family and stood in for every concrete sibling under it, so removing `contacts/blocked` from a client left the gate green. A wildcard now counts as a family only where the contract publishes no route of that shape.
 - The Go SDK no longer approves or rejects every pending join request when handed an empty participant list: `omitempty` dropped the empty slice, so `[]string{}` reached the gateway as the bodyless "act on every request" rather than the `400` the other four clients receive. A nil slice still means every request.
 - The chart's optional ServiceMonitor now selects on a new `openwa.io/scrape-target` label, so it scrapes one target per pod instead of two; series previously collected through the headless target stop appearing, so check anything keyed on the `service` label.
 - The Helm chart's new startup probe stops the kubelet killing a pod that is still booting, allowing 295s (`periodSeconds: 5`, `failureThreshold: 60`) where the liveness settings allowed 50. It fires immediately, so a fast boot goes live sooner than before, not later — and it is not limited to auto-start, since the database connect retry alone can consume 30 of the old 50 seconds.

--- a/scripts/check-sdk-coverage.mjs
+++ b/scripts/check-sdk-coverage.mjs
@@ -179,14 +179,29 @@ const resourceOf = (path) =>
   /^\/api\/sessions\/\*\/([^/]+)/.exec(path)?.[1] ?? /^\/api\/([^/*]+)/.exec(path)?.[1] ?? '';
 
 /**
- * A harvested path whose final segment is a wildcard covers its concrete siblings: the client
- * reaches that family through one builder with the last segment as a variable (`send-image`,
- * `membership-requests/approve`). The forward gate makes the same concession explicitly.
+ * A harvested path whose final segment is a wildcard MAY cover its concrete siblings: the client
+ * reaches that family through one builder with the last segment as a variable (`send-${type}`).
+ * The forward gate makes the same concession explicitly.
+ *
+ * But only when the wildcard is a route NAME. A client that builds `…/contacts/${contactId}` also
+ * produces `…/contacts/*`, and reading that as a family let it stand in for every concrete sibling
+ * — `contacts/blocked` among them — so removing a route from a client entirely still passed. The
+ * two cases are told apart by the contract itself: if it publishes a route OF THAT SHAPE, the
+ * wildcard is that route's path parameter and covers nothing but it (which `exact` already does).
+ * `…/messages/*` is published by no route, so a wildcard there can only be a verb.
  */
-const covers = (built, path) => built.exact.has(path) || built.families.has(path.replace(/\/[^/]+$/, '/*'));
+const isRouteNameFamily = (family) => !contractShapes.has(family);
+const covers = (built, path) => {
+  if (built.exact.has(path)) return true;
+  const family = path.replace(/\/[^/]+$/, '/*');
+  return isRouteNameFamily(family) && built.families.has(family);
+};
 
 const excluded = excludedResources();
 const contract = [...new Set(Object.keys(JSON.parse(readFileSync(join(root, 'openapi.json'), 'utf8')).paths).map(normalize))];
+/** Every shape the contract publishes, including the excluded resources — a wildcard is explained by
+ *  a by-id route whether or not the SDKs are asked to expose it. */
+const contractShapes = new Set(contract);
 const inScope = contract.filter((p) => {
   const resource = resourceOf(p);
   return !excluded.has(resource) && !excluded.has(resource.replace(/-rules$/, ''));


### PR DESCRIPTION
## Problem

`check:sdk-coverage` shipped this release to catch "the contract publishes a route no client exposes". It could not.

`covers()` treated **any** harvested path ending in a wildcard as a one-builder family standing in for every concrete sibling. That is right for `messages/send-${type}`. It is wrong for `contacts/${contactId}` — an ordinary by-id route — whose harvested `contacts/*` then vouched for `contacts/blocked`, `contacts/check` and every other sibling.

Measured before the change: deleting `/contacts/blocked` from the Python client entirely still gave

```
✓ SDK contract coverage OK (117 in-scope contract paths reachable from all 5 clients).
```

## Fix

The two cases are separated by the contract itself rather than by a heuristic on variable names:

> A wildcard is a route-name family only where the contract publishes **no** route of that shape. If it does, the wildcard is that route's path parameter, and `exact` already covers it.

| Family shape | Published as a route? | Treated as a family |
|---|---|---|
| `/api/sessions/*/messages/*` | no | yes — `send-${type}` |
| `/api/sessions/*/contacts/*` | yes (`{contactId}`) | no |
| `/api/sessions/*/groups/*` | yes (`{groupId}`) | no |
| `/api/sessions/*/channels/*` | yes (`{channelId}`) | no |

## Verification

| Case | Before | After |
|---|---|---|
| Clean tree | pass | pass — same 117 paths, no new failures |
| `/contacts/blocked` removed from Python | **pass** | fails, names `python` |
| `/calls/link` removed from JavaScript | fails | fails, names `javascript` |

Family-only coverage across the five clients is five paths — `messages/send-image|video|audio|document|sticker` — and all five remain covered, so the deliberate concession is intact and nothing else depended on the wider rule.

`format:check`, `test:scripts`, `check:sdk-routes`, `check:sdk-events` and `check:sdk-docs` pass.

## Follow-up

The script keeps its whole body at top level, so its predicates cannot be imported the way `check-sdk-docs.mjs` exports its helpers for `check-sdk-docs.spec.mjs`. Giving this script the same `main()` guard and a spec that pins the family rule is worth doing, but it is a testability refactor rather than part of this fix.