### PR TITLE
ci(release): run the four gates the tag path was missing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,11 +84,21 @@ jobs:
       - name: Check OpenAPI snapshot is up to date
         run: npm run openapi:check
 
-      # The same gate ci.yml runs. Its comment there notes this workflow never ran it, which is the
-      # gap: a tag pushed with `--follow-tags` starts both workflows, and only the branch one could
-      # see an SDK left behind by a contract change. The release path has to stand on its own.
+      # The same gates ci.yml runs. Its comment there notes this workflow never ran them, which is
+      # the gap: a tag pushed with `--follow-tags` starts both workflows, and only the branch one
+      # could see an SDK left behind by a contract change. The release path has to stand on its own,
+      # and it is the path that actually publishes the image and the chart.
       - name: Check SDK routes against the contract
         run: npm run check:sdk-routes
+
+      - name: Check the contract is covered by every SDK
+        run: npm run check:sdk-coverage
+
+      - name: Check SDK webhook events against the contract
+        run: npm run check:sdk-events
+
+      - name: Check SDK docs cover the shipped client surface
+        run: npm run check:sdk-docs
 
   test:
     name: Test
@@ -254,6 +264,13 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
+      # For the behaviour check below. No `npm ci`: it imports only node: builtins, so pinning the
+      # runtime is the whole dependency — without this the step would silently take whatever Node the
+      # runner image happens to ship.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
       - name: helm lint
         run: docker run --rm -v "$PWD/charts:/charts:ro" alpine/helm:4.2.3 lint /charts/openwa
 
@@ -276,6 +293,13 @@ jobs:
         run: |
           docker run --rm -v "$PWD/rendered:/w:ro" ghcr.io/yannh/kubeconform:v0.8.0 \
             -strict -ignore-missing-schemas -summary /w/default.yaml /w/toggled.yaml
+
+      # What the rendered chart would DO in a cluster, which neither helm lint nor kubeconform can
+      # see: config changes roll the pods, the startup budget exceeds the liveness budget, the
+      # metrics selector names one Service. This is the path that publishes the chart, so a chart
+      # that renders validly but misbehaves must not get past it.
+      - name: Check chart behaviour
+        run: npm run check:chart
 
       - name: actionlint
         run: docker run --rm -v "$PWD:/repo:ro" -w /repo rhysd/actionlint:1.7.12 -color


### PR DESCRIPTION
## Problem

Four gates run in `ci.yml` and in no other workflow:

| Gate | ci.yml | release.yml |
|---|---|---|
| `check:sdk-coverage` | yes (added this release) | **no** |
| `check:chart` | yes (added this release) | **no** |
| `check:sdk-events` | yes | **no** |
| `check:sdk-docs` | yes | **no** |

So the workflow that publishes the image and the chart passed with a weaker gate than an ordinary pull request. `8a46811b` gave the release path a chart job, but that job stops at `helm lint` + `kubeconform` — both of which only prove the chart *renders*. `check:chart` is the one asserting what it would DO in a cluster: config changes roll the pods, the startup budget exceeds the liveness budget, the metrics selector names one Service.

The same reasoning `check:sdk-routes` was added to this workflow for applies unchanged to the other three: a tag started with `--follow-tags` runs both workflows, but the release path has to stand on its own.

## Change

- Lint job: the three remaining `check:sdk-*` gates, in the order `ci.yml` runs them.
- Chart job: `check:chart`, plus the pinned `setup-node` its ci.yml counterpart carries. No `npm ci` — the script imports only `node:` builtins, so pinning the runtime is the whole dependency.

## Verification

`actionlint` (the same pinned image the workflow runs) exits 0. `npm run check:chart` passes locally against the current chart.

`docs-ci-jobs.spec.ts` reads `ci.yml` only, so its job table is unaffected.

No CHANGELOG entry, matching `8a46811b` — the previous release-workflow change.