### PR TITLE
fix(scripts): resolve the gate root from the file URL, not URL.pathname

### DIFF
--- a/scripts/check-sdk-coverage.mjs
+++ b/scripts/check-sdk-coverage.mjs
@@ -27,8 +27,12 @@
  */
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const root = new URL('../', import.meta.url).pathname;
+// fileURLToPath, not URL.pathname: the latter stays percent-encoded, so a checkout under a path
+// containing a space resolves to a directory that does not exist and every read here fails with
+// ENOENT. check-sdk-docs.mjs and check-chart-behaviour.mjs already resolve it this way.
+const root = fileURLToPath(new URL('../', import.meta.url));
 
 /** Every interpolation form collapses to the same wildcard as an OpenAPI `{param}`. */
 const normalize = (path) =>

--- a/scripts/check-sdk-events.mjs
+++ b/scripts/check-sdk-events.mjs
@@ -21,8 +21,12 @@
  */
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const root = new URL('../', import.meta.url).pathname;
+// fileURLToPath, not URL.pathname: the latter stays percent-encoded, so a checkout under a path
+// containing a space resolves to a directory that does not exist and every read here fails with
+// ENOENT. check-sdk-docs.mjs and check-chart-behaviour.mjs already resolve it this way.
+const root = fileURLToPath(new URL('../', import.meta.url));
 const read = (...parts) => readFileSync(join(root, ...parts), 'utf8');
 
 const contract = JSON.parse(read('openapi.json'));

--- a/scripts/check-sdk-routes.mjs
+++ b/scripts/check-sdk-routes.mjs
@@ -22,8 +22,12 @@
  */
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const root = new URL('../', import.meta.url).pathname;
+// fileURLToPath, not URL.pathname: the latter stays percent-encoded, so a checkout under a path
+// containing a space resolves to a directory that does not exist and every read here fails with
+// ENOENT. check-sdk-docs.mjs and check-chart-behaviour.mjs already resolve it this way.
+const root = fileURLToPath(new URL('../', import.meta.url));
 
 /** Every interpolation form the three SDKs use collapses to the same wildcard as an OpenAPI param. */
 const normalize = (path) =>


### PR DESCRIPTION
## Problem

Three of the gate scripts build their repo root as:

```js
const root = new URL('../', import.meta.url).pathname;
```

`URL.pathname` stays percent-encoded. For a module at `/a/b%20c/d/x.mjs` it yields `/a/b%20c/` where `fileURLToPath` yields `/a/b c/`. So a checkout under any path containing a space — or any other character a file URL escapes — resolves to a directory that does not exist, and every `readFileSync` in the gate fails with `ENOENT` before a single check runs.

`check-sdk-docs.mjs` and `check-chart-behaviour.mjs` already use `fileURLToPath`. These three were the outliers:

| Script | Before |
|---|---|
| `check-sdk-routes.mjs:26` | `URL.pathname` |
| `check-sdk-events.mjs:25` | `URL.pathname` |
| `check-sdk-coverage.mjs:31` | `URL.pathname` |

## Verification

Reproduced end to end rather than argued: the tree was copied into a directory whose name contains a space and the coverage gate run from there.

- old form → Node stack trace, no check performed
- new form → `✓ SDK contract coverage OK (117 in-scope contract paths reachable from all 5 clients)`

The three gates, `lint`, `format:check` and `test:scripts` all pass unchanged from the normal checkout path.

## Note

This is latent for CI, which checks out to a space-free path, and bites a developer whose clone sits under something like `~/My Projects/`. The failure mode is the bad kind: the gate does not report a problem, it fails to run at all.