### PR TITLE
docs: document RESOLVE_LID_TO_PHONE at the surfaces it changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Turkish (`tr`) dashboard translation. Thanks @codedByCan.
 
+### Documentation
+
+- `RESOLVE_LID_TO_PHONE` was documented nowhere outside `.env.example`, so an operator receiving `@lid` senders had no path to the flag that resolves them; the event catalog now carries the `senderPhone` opt-in callout, the contact-phone endpoint points back to it, and the troubleshooting FAQ covers the symptom.
+
 ## [0.16.0] - 2026-08-11
 
 ### Added

--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -2266,6 +2266,8 @@ Resolve a contact id (e.g. an `@lid`) to a phone number (MSISDN digits), best-ef
 
 `phone` is `null` when the engine cannot map the id (e.g. an `@lid` the account has never seen).
 
+For inbound messages the gateway can attach this automatically instead: `RESOLVE_LID_TO_PHONE=true` adds `senderPhone` to every `message.received` payload (§6.6). It is off by default; this endpoint works either way.
+
 **Errors:** `400` session is not started · `401` missing/invalid API key
 
 #### PUT /api/sessions/:sessionId/contacts/:contactId
@@ -6504,6 +6506,8 @@ These are the events OpenWA actually emits. A webhook is registered with an `eve
 > **`status.received` is opt-in and carries no media blob.** Unlike every other event above, `status.received` is only delivered to a webhook whose `events` list explicitly includes `"status.received"` (or `"*"`) — registering for other events does not implicitly subscribe you to it. The payload never embeds media bytes: when `hasMedia` is `true`, fetch the file separately via `GET /api/sessions/:sessionId/status/:statusId/media`. Your own posted statuses never trigger this event — only inbound stories from contacts (an own-send echo is dropped before ingest).
 
 > **`STORE_EPHEMERAL_MESSAGES=false` affects `message.received`.** When `STORE_EPHEMERAL_MESSAGES` is set to `false`, incoming disappearing messages (those with `ephemeralDuration > 0`) are **not** persisted nor dispatched — no DB insert, no webhook delivery, and no websocket event. Downstream consumers and the dashboard both stop seeing them. Default is `true` (backward compatible — store and dispatch everything).
+
+> **`senderPhone` on `message.received` is opt-in (`RESOLVE_LID_TO_PHONE`).** When a sender is identified by a WhatsApp privacy id (`…@lid`) rather than a phone number, setting `RESOLVE_LID_TO_PHONE=true` attaches a best-effort `senderPhone` — MSISDN digits, or `null` when the engine cannot map the id — before dispatch, so the webhook and the websocket event both carry it in the same pass. Default is **off**, and while it is off the field is absent from every payload: resolving costs a per-sender lookup (cached). Only inbound privacy-id senders are resolved — a sender that already is a phone number needs no lookup, and own-sends are skipped. The on-demand `GET /api/sessions/:sessionId/contacts/:contactId/phone` works regardless of this flag.
 
 > **Large media is not inlined into webhook payloads.** A `media` blob whose decoded size exceeds `WEBHOOK_MEDIA_INLINE_MAX_BYTES` (default **1 MiB**; `0` = never inline) is replaced — before the payload is fanned out to your webhook — with the marker form `media: { mimetype, filename?, omitted: true, sizeBytes }`, the same shape the engine emits for capped inbound media. Media at or under the cap stays inline unchanged. Additionally, if the serialized body still exceeds `WEBHOOK_MAX_PAYLOAD_BYTES` (default **1 MiB**) after `webhook:before` hooks ran, any remaining inline media is shed the same way so the event is still delivered; only a payload that is over budget _without_ inline media is dropped (recorded in `GET /api/webhooks/delivery-failures`). Because shedding happens before enqueue, queued and failed BullMQ jobs in Redis never carry the blob either — failed-job retention is bounded by the queue's `removeOnComplete`/`removeOnFail` windows (1h/1000 completed, 24h/5000 failed). Fetch the media itself afterwards via `GET /api/sessions/:sessionId/messages/:chatId/history?includeMedia=true` when you need it.
 

--- a/docs/12-troubleshooting-faq.md
+++ b/docs/12-troubleshooting-faq.md
@@ -772,6 +772,35 @@ WEBHOOK_TIMEOUT=10000      # per-attempt HTTP timeout in ms (default 10000)
 WEBHOOK_RETRY_DELAY=5000   # base retry backoff in ms (default 5000)
 ```
 
+### Issue: An inbound sender arrives as an `@lid` id instead of a phone number
+
+**Symptoms:**
+
+- `message.received` carries `from` (or `author`, in a group) as `162878178984075@lid` rather than `628123456789@c.us`
+- The number cannot be matched against your own contact records, and replies have to be addressed by the `@lid` id
+- `contact.number` on the payload repeats the lid digits, so it is not the phone number either
+
+**Cause:** WhatsApp identifies some accounts by a privacy id (`@lid`) instead of their phone number,
+and the message itself carries no phone number to read. Mapping one back costs a lookup against the
+engine, so the gateway does not do it on every message unless you ask for it.
+
+**Solution:**
+
+```bash
+# Resolve a single id on demand — works whether or not the flag below is set
+curl -H "X-API-Key: $API_KEY" \
+  http://localhost:2785/api/sessions/{sessionId}/contacts/{contactId}/phone
+
+# Or have every inbound message carry it: adds `senderPhone` to the message.received webhook
+# and the websocket event. Set it in the `.env` next to docker-compose.yml (both compose files
+# already forward the variable), then restart the process — an env change is not picked up by a
+# session reload.
+RESOLVE_LID_TO_PHONE=true
+```
+
+`senderPhone` is `null` when the engine cannot map the id — an `@lid` the account has never seen has
+no mapping to return. Both engines support the lookup.
+
 ## 12.5 Performance Issues
 
 ### Issue: High Memory Usage


### PR DESCRIPTION
## Description

`RESOLVE_LID_TO_PHONE` shipped in v0.2.8 (#263) but appears in no file under `docs/` and none in `README.md` — it exists only in `.env.example`, the two compose files, and one CHANGELOG line. An operator whose inbound messages arrive from `@lid` privacy ids therefore has no documented route to the setting that resolves them, nor to the on-demand endpoint that does the same job per contact.

This adds the flag at the three surfaces it actually affects, following the existing convention of an inline callout at the contract surface rather than a new environment table (`docs/10` §10.5 names `.env.example` as canonical and forbids duplicating keys into it).

- `docs/06` §6.6 — a `senderPhone` opt-in callout in the event catalog, placed in the existing callout run beside the `STORE_EPHEMERAL_MESSAGES` one, which gates the same event.
- `docs/06` §6.4.3 — the on-demand `GET /sessions/:sessionId/contacts/:contactId/phone` now points back to the flag, so a reader arriving at either finds the other.
- `docs/12` §12.4 — a troubleshooting entry written from the symptom an operator sees, noting that the variable belongs in `.env` and needs a process restart rather than a session reload.

No behaviour changes; documentation only.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [x] Tests added/updated — n/a, no code changes
- [x] Documentation updated
- [x] Lint passes
- [x] Self-reviewed

## Verification

All ten steps of the CI `Lint` job were run locally against this branch: `lint`, `tsc --noEmit`, `format:check`, `check:versions`, `check:dockerignore`, `openapi:check`, and the four `check:sdk-*` gates — all exit 0.

## Related Issues

Refs #263