### PR TITLE
docs: correct the chat-history response example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Documentation
 
 - `RESOLVE_LID_TO_PHONE` was documented nowhere outside `.env.example`, so an operator receiving `@lid` senders had no path to the flag that resolves them; the event catalog now carries the `senderPhone` opt-in callout, the contact-phone endpoint points back to it, and the troubleshooting FAQ covers the symptom.
+- The chat-history response example advertised a `senderPhone` field that endpoint has never returned, and showed it on a plain `@c.us` sender that not even the inbound path would resolve; the example now matches what the route emits, and points at the contact-phone endpoint instead.
 
 ## [0.16.0] - 2026-08-11
 

--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -1157,13 +1157,12 @@ Returns a bare array of engine-neutral `IncomingMessage` objects:
     "fromMe": false,
     "isGroup": false,
     "kind": "individual",
-    "author": "628123456789@c.us",
-    "senderPhone": "628123456789"
+    "author": "628123456789@c.us"
   }
 ]
 ```
 
-Each item may also include `isStatusBroadcast`, `mentionedIds`, `isLidSender`, `contact`, `media { mimetype, filename?, data?, omitted?, sizeBytes? }`, `quotedMessage { id, body }`, `call { video, missed }` (for `call` messages), and `location { latitude, longitude, description?, address?, url? }`. `type` is one of `text|image|video|audio|voice|document|sticker|location|contact|call|revoked|masked|unknown`. A `masked` message is one WhatsApp deliberately withholds from linked/companion devices — e.g. a high-security business OTP — so its `body` is empty by design (the content is only available on the primary phone) rather than a parsing failure; this occurs on the Baileys engine. `kind` is the user-facing chat discriminator of `chatId` — one of `individual|group|channel|status|broadcast|unknown`; it supersedes `isStatusBroadcast` (equivalent to `kind === 'status'`), which is retained for back-compat.
+Each item may also include `isStatusBroadcast`, `mentionedIds`, `isLidSender`, `contact`, `media { mimetype, filename?, data?, omitted?, sizeBytes? }`, `quotedMessage { id, body }`, `call { video, missed }` (for `call` messages), and `location { latitude, longitude, description?, address?, url? }`. `senderPhone` is **not** among them: this endpoint reads live from the engine and performs no privacy-id resolution, which runs only on the inbound `message.received` path (§6.6). To map an `@lid` sender seen here, call `GET /api/sessions/:sessionId/contacts/:contactId/phone`. `type` is one of `text|image|video|audio|voice|document|sticker|location|contact|call|revoked|masked|unknown`. A `masked` message is one WhatsApp deliberately withholds from linked/companion devices — e.g. a high-security business OTP — so its `body` is empty by design (the content is only available on the primary phone) rather than a parsing failure; this occurs on the Baileys engine. `kind` is the user-facing chat discriminator of `chatId` — one of `individual|group|channel|status|broadcast|unknown`; it supersedes `isStatusBroadcast` (equivalent to `kind === 'status'`), which is retained for back-compat.
 
 **Errors:** `400` session not active · `401` missing/invalid API key · `500` engine error
 


### PR DESCRIPTION
## Description

The 200 example for `GET /api/sessions/:sessionId/messages/:chatId/history` advertised a `senderPhone` field the endpoint has never returned.

That route reads live from the engine (`MessageService.getChatHistory` returns the adapter's `IncomingMessage[]` unchanged) and performs no privacy-id resolution. The only assignment of `senderPhone` anywhere in `src/` is `message-projector.service.ts`, on the inbound `message.received` path. The example was wrong a second time as well: it showed the field on a plain `@c.us` sender, whereas even the inbound path guards on `isLidSender` and would never populate it there.

- Removes `senderPhone` from the example.
- States that the endpoint does not resolve privacy ids, and points at `GET /sessions/:sessionId/contacts/:contactId/phone`, which does.

Deliberately **not** changed: the typed SDKs keep `senderPhone` on `ChatHistoryMessage`. That type mirrors `IncomingMessage`, the declared return type of `getChatHistory`, and the field is genuinely on that interface. `sdk/javascript/test/wire-contract.test-d.ts` already sets the precedent for this exact shape — `WireStatus` retains three engine-interface fields no adapter populates, "for forward-compatibility rather than because a response carries them today" — and its `Mirrors` assertion is bidirectional, so dropping the field would later read as "sdk omits fields the server sends".

No behaviour changes; documentation only.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [x] Tests added/updated — n/a, no code changes
- [x] Documentation updated
- [x] Lint passes
- [x] Self-reviewed

## Verification

All ten steps of the CI `Lint` job were run locally against this branch — all exit 0. The edited JSON fence was also parsed to confirm the trailing comma was dropped with the removed line; Prettier formats embedded JSON in markdown and fails otherwise.

## Related Issues

Refs #263

---

Note for the merger: this shares the `[Unreleased]` CHANGELOG anchor with #1266 and will need a rebase once that one lands.