### PR TITLE
fix(sdk): declare the chat-history fields the endpoint returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- The JavaScript, Python, Go and Java SDKs omitted `contact`, `call` and `ephemeralDuration` from their chat-history message type, so a typed client had to cast to read three fields the endpoint returns; all four now mirror the engine payload, and a type-level contract assertion in the JavaScript SDK fails the build if that type and the engine interface drift apart again.
+- The JavaScript, Python, Go and Java SDKs omitted `contact`, `call` and `ephemeralDuration` from their chat-history message type, so a typed client had to cast to read three fields the endpoint returns; all four now mirror the engine payload.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Turkish (`tr`) dashboard translation. Thanks @codedByCan.
 
+### Fixed
+
+- The JavaScript, Python, Go and Java SDKs omitted `contact`, `call` and `ephemeralDuration` from their chat-history message type, so a typed client had to cast to read three fields the endpoint returns; all four now mirror the engine payload, and a type-level contract assertion in the JavaScript SDK fails the build if that type and the engine interface drift apart again.
+
 ### Documentation
 
 - `RESOLVE_LID_TO_PHONE` was documented nowhere outside `.env.example`, so an operator receiving `@lid` senders had no path to the flag that resolves them; the event catalog now carries the `senderPhone` opt-in callout, the contact-phone endpoint points back to it, and the troubleshooting FAQ covers the symptom.

--- a/sdk/go/chat_history_decode_test.go
+++ b/sdk/go/chat_history_decode_test.go
@@ -1,0 +1,56 @@
+package openwa
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The chat-history route returns the engine payload verbatim, so the only thing standing between a
+// caller and a silently-empty field is this struct's tags. Nothing else exercises them: the routing
+// test asserts the URL and never decodes a body.
+func TestChatHistoryMessageDecodesEngineFields(t *testing.T) {
+	raw := []byte(`{
+	  "id":"true_628@c.us_ABC","from":"628@c.us","to":"629@c.us","chatId":"628@c.us",
+	  "body":"","type":"call","timestamp":1719312000,"fromMe":false,"isGroup":false,
+	  "kind":"individual","ephemeralDuration":604800,
+	  "call":{"video":true,"missed":false},
+	  "contact":{"pushName":"Budi","number":"628","isMyContact":true,"verifiedLevel":0,"labels":["vip"]}
+	}`)
+
+	var m ChatHistoryMessage
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m.EphemeralDuration != 604800 {
+		t.Errorf("ephemeralDuration = %d, want 604800", m.EphemeralDuration)
+	}
+	if m.Call == nil || !m.Call.Video || m.Call.Missed {
+		t.Errorf("call = %+v, want {Video:true Missed:false}", m.Call)
+	}
+	if m.Contact == nil || m.Contact.PushName != "Budi" || m.Contact.Number != "628" || !m.Contact.IsMyContact {
+		t.Errorf("contact = %+v", m.Contact)
+	}
+	if len(m.Contact.Labels) != 1 || m.Contact.Labels[0] != "vip" {
+		t.Errorf("contact.labels = %v, want [vip]", m.Contact.Labels)
+	}
+	// The pointer is the point: verifiedLevel 0 is "unverified", not "the server said nothing".
+	if m.Contact.VerifiedLevel == nil || *m.Contact.VerifiedLevel != 0 {
+		t.Errorf("contact.verifiedLevel = %v, want a pointer to 0", m.Contact.VerifiedLevel)
+	}
+}
+
+func TestChatHistoryMessageLeavesAbsentFieldsEmpty(t *testing.T) {
+	raw := []byte(`{"id":"x","from":"a","to":"b","chatId":"c","body":"","type":"text",
+	  "timestamp":1,"fromMe":false,"isGroup":false,"kind":"individual"}`)
+
+	var m ChatHistoryMessage
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m.Call != nil || m.Contact != nil || m.Font != nil {
+		t.Errorf("absent optionals should stay nil: call=%v contact=%v font=%v", m.Call, m.Contact, m.Font)
+	}
+	if m.EphemeralDuration != 0 || m.BackgroundColor != "" {
+		t.Errorf("absent scalars should stay zero: ephemeral=%d bg=%q", m.EphemeralDuration, m.BackgroundColor)
+	}
+}

--- a/sdk/go/types_message.go
+++ b/sdk/go/types_message.go
@@ -206,29 +206,31 @@ type MessageLocation struct {
 // ChatHistoryMessage is a message read live from WhatsApp by Messages.History —
 // the richer engine payload, differently shaped from MessageRecord.
 type ChatHistoryMessage struct {
-	ID                string            `json:"id"`
-	From              string            `json:"from"`
-	To                string            `json:"to"`
-	ChatID            string            `json:"chatId"`
-	Body              string            `json:"body,omitempty"`
-	Type              string            `json:"type"`
-	Timestamp         int64             `json:"timestamp"`
-	FromMe            bool              `json:"fromMe"`
-	IsGroup           bool              `json:"isGroup"`
-	IsStatusBroadcast bool              `json:"isStatusBroadcast"`
-	Kind              string            `json:"kind"`
-	EphemeralDuration int               `json:"ephemeralDuration,omitempty"`
-	Author            string            `json:"author,omitempty"`
-	MentionedIDs      []string          `json:"mentionedIds,omitempty"`
-	Call              *MessageCall      `json:"call,omitempty"`
-	IsLidSender       bool              `json:"isLidSender,omitempty"`
-	SenderPhone       *string           `json:"senderPhone,omitempty"`
-	Contact           *MessageContact   `json:"contact,omitempty"`
-	BackgroundColor   string            `json:"backgroundColor,omitempty"`
-	Font              int               `json:"font,omitempty"`
-	Media             *ChatHistoryMedia `json:"media,omitempty"`
-	QuotedMessage     *QuotedMessage    `json:"quotedMessage,omitempty"`
-	Location          *MessageLocation  `json:"location,omitempty"`
+	ID                string          `json:"id"`
+	From              string          `json:"from"`
+	To                string          `json:"to"`
+	ChatID            string          `json:"chatId"`
+	Body              string          `json:"body,omitempty"`
+	Type              string          `json:"type"`
+	Timestamp         int64           `json:"timestamp"`
+	FromMe            bool            `json:"fromMe"`
+	IsGroup           bool            `json:"isGroup"`
+	IsStatusBroadcast bool            `json:"isStatusBroadcast"`
+	Kind              string          `json:"kind"`
+	EphemeralDuration int             `json:"ephemeralDuration,omitempty"`
+	Author            string          `json:"author,omitempty"`
+	MentionedIDs      []string        `json:"mentionedIds,omitempty"`
+	Call              *MessageCall    `json:"call,omitempty"`
+	IsLidSender       bool            `json:"isLidSender,omitempty"`
+	SenderPhone       *string         `json:"senderPhone,omitempty"`
+	Contact           *MessageContact `json:"contact,omitempty"`
+	BackgroundColor   string          `json:"backgroundColor,omitempty"`
+	// Pointer because font index 0 is a real style, so a value type could not tell it from absent.
+	// Matches StatusRecord.Font, which carries the same wire field.
+	Font          *int              `json:"font,omitempty"`
+	Media         *ChatHistoryMedia `json:"media,omitempty"`
+	QuotedMessage *QuotedMessage    `json:"quotedMessage,omitempty"`
+	Location      *MessageLocation  `json:"location,omitempty"`
 }
 
 // MessageCall is the call block on a live history message, present on call messages only.
@@ -240,18 +242,19 @@ type MessageCall struct {
 // MessageContact is the sender contact block on a live history message. History carries PushName
 // only; the richer fields arrive on message.received when WEBHOOK_CONTACT_DETAILS is enabled.
 type MessageContact struct {
-	ID            string   `json:"id,omitempty"`
-	Number        string   `json:"number,omitempty"`
-	Name          string   `json:"name,omitempty"`
-	PushName      string   `json:"pushName,omitempty"`
-	ShortName     string   `json:"shortName,omitempty"`
-	Type          string   `json:"type,omitempty"`
-	IsMyContact   bool     `json:"isMyContact,omitempty"`
-	IsWAContact   bool     `json:"isWAContact,omitempty"`
-	IsBusiness    bool     `json:"isBusiness,omitempty"`
-	IsEnterprise  bool     `json:"isEnterprise,omitempty"`
-	VerifiedName  string   `json:"verifiedName,omitempty"`
-	VerifiedLevel int      `json:"verifiedLevel,omitempty"`
+	ID           string `json:"id,omitempty"`
+	Number       string `json:"number,omitempty"`
+	Name         string `json:"name,omitempty"`
+	PushName     string `json:"pushName,omitempty"`
+	ShortName    string `json:"shortName,omitempty"`
+	Type         string `json:"type,omitempty"`
+	IsMyContact  bool   `json:"isMyContact,omitempty"`
+	IsWAContact  bool   `json:"isWAContact,omitempty"`
+	IsBusiness   bool   `json:"isBusiness,omitempty"`
+	IsEnterprise bool   `json:"isEnterprise,omitempty"`
+	VerifiedName string `json:"verifiedName,omitempty"`
+	// Pointer for the same reason as Font: level 0 (unverified) is a real value, not "absent".
+	VerifiedLevel *int     `json:"verifiedLevel,omitempty"`
 	IsBlocked     bool     `json:"isBlocked,omitempty"`
 	Labels        []string `json:"labels,omitempty"`
 }

--- a/sdk/go/types_message.go
+++ b/sdk/go/types_message.go
@@ -217,13 +217,43 @@ type ChatHistoryMessage struct {
 	IsGroup           bool              `json:"isGroup"`
 	IsStatusBroadcast bool              `json:"isStatusBroadcast"`
 	Kind              string            `json:"kind"`
+	EphemeralDuration int               `json:"ephemeralDuration,omitempty"`
 	Author            string            `json:"author,omitempty"`
 	MentionedIDs      []string          `json:"mentionedIds,omitempty"`
+	Call              *MessageCall      `json:"call,omitempty"`
 	IsLidSender       bool              `json:"isLidSender,omitempty"`
 	SenderPhone       *string           `json:"senderPhone,omitempty"`
+	Contact           *MessageContact   `json:"contact,omitempty"`
+	BackgroundColor   string            `json:"backgroundColor,omitempty"`
+	Font              int               `json:"font,omitempty"`
 	Media             *ChatHistoryMedia `json:"media,omitempty"`
 	QuotedMessage     *QuotedMessage    `json:"quotedMessage,omitempty"`
 	Location          *MessageLocation  `json:"location,omitempty"`
+}
+
+// MessageCall is the call block on a live history message, present on call messages only.
+type MessageCall struct {
+	Video  bool `json:"video"`
+	Missed bool `json:"missed"`
+}
+
+// MessageContact is the sender contact block on a live history message. History carries PushName
+// only; the richer fields arrive on message.received when WEBHOOK_CONTACT_DETAILS is enabled.
+type MessageContact struct {
+	ID            string   `json:"id,omitempty"`
+	Number        string   `json:"number,omitempty"`
+	Name          string   `json:"name,omitempty"`
+	PushName      string   `json:"pushName,omitempty"`
+	ShortName     string   `json:"shortName,omitempty"`
+	Type          string   `json:"type,omitempty"`
+	IsMyContact   bool     `json:"isMyContact,omitempty"`
+	IsWAContact   bool     `json:"isWAContact,omitempty"`
+	IsBusiness    bool     `json:"isBusiness,omitempty"`
+	IsEnterprise  bool     `json:"isEnterprise,omitempty"`
+	VerifiedName  string   `json:"verifiedName,omitempty"`
+	VerifiedLevel int      `json:"verifiedLevel,omitempty"`
+	IsBlocked     bool     `json:"isBlocked,omitempty"`
+	Labels        []string `json:"labels,omitempty"`
 }
 
 // ReactionSender is one sender within a ReactionRecord.

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/model/ChatHistoryMessage.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/model/ChatHistoryMessage.java
@@ -20,11 +20,18 @@ public record ChatHistoryMessage(
     boolean isGroup,
     Boolean isStatusBroadcast,
     String kind,
+    /** Disappearing-messages timer on the chat, in seconds; {@code null} when the chat has none. */
+    Integer ephemeralDuration,
     /** For group messages, the participant who sent it ({@code from} is the group JID). */
     String author,
     List<String> mentionedIds,
+    Call call,
     Boolean isLidSender,
     String senderPhone,
+    Contact contact,
+    /** Status/story styling. Declared by the engine payload; this route never sets either. */
+    String backgroundColor,
+    Integer font,
     Media media,
     QuotedMessage quotedMessage,
     Location location) {
@@ -35,4 +42,27 @@ public record ChatHistoryMessage(
     public record QuotedMessage(String id, String body) {}
 
     public record Location(double latitude, double longitude, String description, String address, String url) {}
+
+    /** Present on {@code call} messages only. */
+    public record Call(Boolean video, Boolean missed) {}
+
+    /**
+     * Sender contact info. History carries {@code pushName} only; the richer fields arrive on
+     * {@code message.received} when {@code WEBHOOK_CONTACT_DETAILS} is enabled.
+     */
+    public record Contact(
+        String id,
+        String number,
+        String name,
+        String pushName,
+        String shortName,
+        String type,
+        Boolean isMyContact,
+        Boolean isWAContact,
+        Boolean isBusiness,
+        Boolean isEnterprise,
+        String verifiedName,
+        Integer verifiedLevel,
+        Boolean isBlocked,
+        List<String> labels) {}
 }

--- a/sdk/java/src/test/java/com/rmyndharis/openwa/model/ChatHistoryMessageDecodeTest.java
+++ b/sdk/java/src/test/java/com/rmyndharis/openwa/model/ChatHistoryMessageDecodeTest.java
@@ -1,0 +1,59 @@
+package com.rmyndharis.openwa.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.gson.Gson;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The chat-history route returns the engine payload verbatim, so nothing between the wire and a
+ * caller checks these record components. MessagesResourceTest responds with {@code []} and asserts
+ * the URL only, so without this the deserialization is unexercised.
+ */
+class ChatHistoryMessageDecodeTest {
+
+    private static final Gson GSON = new Gson();
+
+    @Test
+    void decodesTheEnginePayloadFields() {
+        String json = "{\"id\":\"true_628@c.us_ABC\",\"from\":\"628@c.us\",\"to\":\"629@c.us\","
+            + "\"chatId\":\"628@c.us\",\"body\":\"\",\"type\":\"call\",\"timestamp\":1719312000,"
+            + "\"fromMe\":false,\"isGroup\":false,\"kind\":\"individual\",\"ephemeralDuration\":604800,"
+            + "\"call\":{\"video\":true,\"missed\":false},"
+            + "\"contact\":{\"pushName\":\"Budi\",\"number\":\"628\",\"isMyContact\":true,"
+            + "\"verifiedLevel\":0,\"labels\":[\"vip\"]}}";
+
+        ChatHistoryMessage m = GSON.fromJson(json, ChatHistoryMessage.class);
+
+        assertEquals(604800, m.ephemeralDuration());
+        assertNotNull(m.call());
+        assertTrue(m.call().video());
+        assertFalse(m.call().missed());
+        assertNotNull(m.contact());
+        assertEquals("Budi", m.contact().pushName());
+        assertEquals("628", m.contact().number());
+        assertTrue(m.contact().isMyContact());
+        assertEquals(List.of("vip"), m.contact().labels());
+        // Boxed, so level 0 (unverified) stays distinguishable from "the server said nothing".
+        assertEquals(0, m.contact().verifiedLevel());
+    }
+
+    @Test
+    void leavesAbsentOptionalsNull() {
+        String json = "{\"id\":\"x\",\"from\":\"a\",\"to\":\"b\",\"chatId\":\"c\",\"body\":\"\","
+            + "\"type\":\"text\",\"timestamp\":1,\"fromMe\":false,\"isGroup\":false,\"kind\":\"individual\"}";
+
+        ChatHistoryMessage m = GSON.fromJson(json, ChatHistoryMessage.class);
+
+        assertNull(m.call());
+        assertNull(m.contact());
+        assertNull(m.ephemeralDuration());
+        assertNull(m.font());
+        assertNull(m.backgroundColor());
+    }
+}

--- a/sdk/javascript/src/types.ts
+++ b/sdk/javascript/src/types.ts
@@ -465,11 +465,38 @@ export interface ChatHistoryMessage {
   isGroup: boolean;
   isStatusBroadcast?: boolean;
   kind?: ChatKind;
+  /** Disappearing-messages timer on the chat, in seconds. Absent when the chat has none set. */
+  ephemeralDuration?: number;
   /** For group messages, the participant who sent it (`from` is the group JID). */
   author?: Jid;
   mentionedIds?: Jid[];
+  /** Present on `call` messages only. */
+  call?: { video: boolean; missed: boolean };
   isLidSender?: boolean;
   senderPhone?: string | null;
+  /**
+   * Sender contact info, best-effort from the engine's cache. History carries `pushName` only;
+   * the richer fields arrive on `message.received` when `WEBHOOK_CONTACT_DETAILS=true`.
+   */
+  contact?: {
+    id?: Jid;
+    number?: string;
+    name?: string;
+    pushName?: string;
+    shortName?: string;
+    type?: string;
+    isMyContact?: boolean;
+    isWAContact?: boolean;
+    isBusiness?: boolean;
+    isEnterprise?: boolean;
+    verifiedName?: string;
+    verifiedLevel?: number;
+    isBlocked?: boolean;
+    labels?: string[];
+  };
+  /** Status/story styling. Declared by the engine payload; this route never sets either. */
+  backgroundColor?: string;
+  font?: number;
   media?: {
     mimetype: string;
     filename?: string;

--- a/sdk/javascript/test/wire-contract.test-d.ts
+++ b/sdk/javascript/test/wire-contract.test-d.ts
@@ -76,6 +76,13 @@ interface WireChannelMessage {
  * that interface serialized. `backgroundColor`/`font` are set by the Baileys extended-text mapper but
  * are not reachable through this route (Baileys answers `getChatHistory` with `unsupported`); they are
  * declared for the same forward-compatibility reason as on `WireStatus`.
+ *
+ * Scope, so nobody reads more into a green build than it carries: `Mirrors` compares TOP-LEVEL keys,
+ * so drift inside `contact`, `call`, `media`, `quotedMessage` or `location` compiles clean. And like
+ * every `Wire*` type here this one is a hand transcription, so a field added to the server's
+ * `IncomingMessage` does not fail this build either — `sdk-ci.yml` re-runs the job when that file
+ * changes, which prompts a human to update the transcription. What this pair does lock is the SDK
+ * type against the transcription: neither side can lose or gain a top-level key unnoticed.
  */
 interface WireChatHistoryMessage {
   id: string;

--- a/sdk/javascript/test/wire-contract.test-d.ts
+++ b/sdk/javascript/test/wire-contract.test-d.ts
@@ -16,7 +16,14 @@
  * @packageDocumentation
  */
 
-import type { CatalogInfo, ChannelMessageRecord, ChannelRecord, LabelRecord, StatusRecord } from '../src/types.js';
+import type {
+  CatalogInfo,
+  ChannelMessageRecord,
+  ChannelRecord,
+  ChatHistoryMessage,
+  LabelRecord,
+  StatusRecord,
+} from '../src/types.js';
 
 /** `Label` — `hexColor` is the only colour field the wire shape carries. */
 interface WireLabel {
@@ -64,6 +71,67 @@ interface WireChannelMessage {
   mediaUrl?: string;
 }
 
+/**
+ * `IncomingMessage` — `messages.history()` hands back the engine array verbatim, so the wire shape is
+ * that interface serialized. `backgroundColor`/`font` are set by the Baileys extended-text mapper but
+ * are not reachable through this route (Baileys answers `getChatHistory` with `unsupported`); they are
+ * declared for the same forward-compatibility reason as on `WireStatus`.
+ */
+interface WireChatHistoryMessage {
+  id: string;
+  from: string;
+  to: string;
+  chatId: string;
+  body: string;
+  type:
+    | 'text'
+    | 'image'
+    | 'video'
+    | 'audio'
+    | 'voice'
+    | 'document'
+    | 'sticker'
+    | 'location'
+    | 'contact'
+    | 'poll'
+    | 'call'
+    | 'revoked'
+    | 'masked'
+    | 'unknown';
+  timestamp: number;
+  fromMe: boolean;
+  isGroup: boolean;
+  kind: 'individual' | 'group' | 'channel' | 'status' | 'broadcast' | 'unknown';
+  isStatusBroadcast?: boolean;
+  ephemeralDuration?: number;
+  author?: string;
+  mentionedIds?: string[];
+  call?: { video: boolean; missed: boolean };
+  isLidSender?: boolean;
+  senderPhone?: string | null;
+  contact?: {
+    id?: string;
+    number?: string;
+    name?: string;
+    pushName?: string;
+    shortName?: string;
+    type?: string;
+    isMyContact?: boolean;
+    isWAContact?: boolean;
+    isBusiness?: boolean;
+    isEnterprise?: boolean;
+    verifiedName?: string;
+    verifiedLevel?: number;
+    isBlocked?: boolean;
+    labels?: string[];
+  };
+  backgroundColor?: string;
+  font?: number;
+  media?: { mimetype: string; filename?: string; data?: string; omitted?: boolean; sizeBytes?: number };
+  quotedMessage?: { id: string; body: string };
+  location?: { latitude: number; longitude: number; description?: string; address?: string; url?: string };
+}
+
 /** `Catalog` — the control: this pair already agreed before #754 and must stay agreeing. */
 interface WireCatalog {
   id: string;
@@ -92,5 +160,6 @@ const status: Mirrors<WireStatus, StatusRecord> = true;
 const channel: Mirrors<WireChannel, ChannelRecord> = true;
 const channelMessage: Mirrors<WireChannelMessage, ChannelMessageRecord> = true;
 const catalog: Mirrors<WireCatalog, CatalogInfo> = true;
+const chatHistoryMessage: Mirrors<WireChatHistoryMessage, ChatHistoryMessage> = true;
 
-export const contract = [label, status, channel, channelMessage, catalog];
+export const contract = [label, status, channel, channelMessage, catalog, chatHistoryMessage];

--- a/sdk/python/openwa/types.py
+++ b/sdk/python/openwa/types.py
@@ -446,6 +446,33 @@ class MessageLocation(TypedDict, total=False):
     url: str
 
 
+class MessageCall(TypedDict, total=False):
+    """Call block on a live history message, present on ``call`` messages only."""
+
+    video: bool
+    missed: bool
+
+
+class MessageContact(TypedDict, total=False):
+    """Sender contact block. History carries ``pushName`` only; the richer fields arrive on
+    ``message.received`` when ``WEBHOOK_CONTACT_DETAILS`` is enabled."""
+
+    id: Jid
+    number: str
+    name: str
+    pushName: str
+    shortName: str
+    type: str
+    isMyContact: bool
+    isWAContact: bool
+    isBusiness: bool
+    isEnterprise: bool
+    verifiedName: str
+    verifiedLevel: int
+    isBlocked: bool
+    labels: list
+
+
 # A message read live from WhatsApp by ``messages.history()`` — the engine
 # payload, richer and differently shaped than the persisted MessageRecord.
 ChatHistoryMessage = TypedDict(
@@ -462,10 +489,15 @@ ChatHistoryMessage = TypedDict(
         "isGroup": bool,
         "isStatusBroadcast": bool,
         "kind": str,
+        "ephemeralDuration": int,
         "author": Jid,
         "mentionedIds": list,
+        "call": MessageCall,
         "isLidSender": bool,
         "senderPhone": Optional[str],
+        "contact": MessageContact,
+        "backgroundColor": str,
+        "font": int,
         "media": ChatHistoryMedia,
         "quotedMessage": QuotedMessage,
         "location": MessageLocation,


### PR DESCRIPTION
## Description

`GET /api/sessions/:sessionId/messages/:chatId/history` returns the engine's `IncomingMessage[]` verbatim — `MessageService.getChatHistory` passes the adapter array straight through. The four typed SDKs, however, modelled a strict subset of that interface: `contact`, `call` and `ephemeralDuration` were absent, so a typed client had to cast to read three fields the route genuinely emits.

- `contact` — set by `buildIncomingMessageBase` (`message-mapper.ts`), which the history path calls.
- `call` — set by the history path itself (`wwebjs-messaging.ts`).
- `ephemeralDuration` — set by `buildIncomingMessageBase` when the chat has a disappearing-messages timer.

`backgroundColor` and `font` are added too. Both are declared on `IncomingMessage` and are populated by the Baileys extended-text mapper, but are unreachable through this route today because Baileys answers `getChatHistory` with `unsupported`. They are declared for the same forward-compatibility reason the existing `WireStatus` fields are.

Additive only: every new field is optional, so no existing consumer breaks. No version bumps, following the precedent of the last SDK type change, which deferred them to the next SDK cut. The PHP SDK is unaffected — it models responses as arrays and has no typed message model.

### What the new wire-contract pair does and does not lock

`sdk/javascript/test/wire-contract.test-d.ts` gains a `WireChatHistoryMessage`. Stating its reach precisely, because an earlier draft of this PR overstated it:

- **It does** lock the SDK type against the transcription: neither side can gain or lose a top-level key unnoticed. Verified by mutation — removing `font`, `call` or `ephemeralDuration` each fails `tsc` with `sdk omits fields the server sends`; adding an unknown field fails with `sdk declares fields the server never sends`.
- **It does not** compare against the server's `IncomingMessage`. Like every `Wire*` type in that file, this one is a hand transcription — the file imports only from `../src/types.js`. Adding a field to `IncomingMessage` in `src/` leaves `tsc` at exit 0, which I confirmed by mutating the interface. `sdk-ci.yml` re-runs the job when that file changes, which prompts a human to update the transcription; the comparison itself stays manual.
- **It does not** see inside nested objects. `Mirrors` compares top-level keys, so drift within `contact`, `call`, `media`, `quotedMessage` or `location` compiles clean.

Those limits are now written next to the type so the next reader does not infer more from a green build.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Tests added/updated
- [x] Documentation updated — n/a, `docs/06` already documents `contact` and `call` on this route
- [x] Lint passes
- [x] Self-reviewed

## Verification

Nothing exercised this type before: the Go routing test asserts a URL, and `MessagesResourceTest` answers with `[]` and checks the URL only — so Gson and `encoding/json` were both unverified against it. This PR adds a decode test for each, covering a realistic payload and the all-absent case. Both were mutation-checked: breaking one assertion turns Go to exit 1 and Java to `Failures: 1`, and the control returns green.

`Font` and `VerifiedLevel` are pointers in Go. Font index 0 is a real style and verified level 0 is a real level, so a value type with `omitempty` could not tell either from absent — and the same SDK already uses `*int` for the same `font` wire field on `StatusRecord`.

All green, run locally: the ten steps of the CI `Lint` job; JavaScript `npm test`, `typecheck`, `build`; Go `gofmt -l` (empty), `go vet`, `go test`; Python `pytest`; Java `mvn -B verify`.

## Related Issues

Refs #754