### PR TITLE
test(docs): bind .env.example to the maintained env key enumerations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -159,8 +159,9 @@ OPENWA_PIDS_LIMIT=2048
 # WWEBJS_WEB_VERSION=<a build from that registry's html/ folder>
 # WWEBJS_WEB_VERSION=off
 
-# Remote path the whatsapp-web.js web-version registry is fetched from.
-# WWEBJS_WEB_VERSION_REMOTE_PATH=
+# The HTML URL template the pinned build is fetched from (see the note above). `{version}` is the
+# placeholder. Point it at an operator-controlled mirror to avoid trusting the public registry.
+# WWEBJS_WEB_VERSION_REMOTE_PATH=https://raw.githubusercontent.com/wppconnect-team/wa-version/main/html/{version}.html
 
 # Extend the initial boot/inject wait (milliseconds) before QR generation. On slow first boots
 # (WSL2 or low-resource containers) the default 30000ms can expire before WhatsApp Web finishes

--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,8 @@ NODE_ENV=production
 PORT=2785
 # Docker Compose only: the host-side port mapped to the container's 2785 (no effect on a bare-metal run).
 API_PORT=2785
+# Serve the bundled dashboard from the API process. Set false for an API-only deployment.
+# SERVE_DASHBOARD=true
 LOG_LEVEL=info                      # error | warn | info | debug
 # Console output format. Default: json in production (containers, log aggregators),
 # human-readable pretty otherwise. Force one with: json | pretty
@@ -63,6 +65,11 @@ MAX_CONCURRENT_SESSIONS=0
 # production, 0 elsewhere (a dev hot-reload/Ctrl+C is not slowed). Capped at 30000. A second signal
 # forces an immediate exit. In Docker, keep `stop_grace_period` >= this + your worst-case teardown.
 # SHUTDOWN_DELAY_MS=3000
+
+# HTTP server timeouts. Raise these when a reverse proxy in front holds connections longer.
+# REQUEST_TIMEOUT_MS=300000
+# HEADERS_TIMEOUT_MS=65000
+# KEEPALIVE_TIMEOUT_MS=5000
 
 # Domain Configuration
 DOMAIN=localhost
@@ -151,6 +158,9 @@ OPENWA_PIDS_LIMIT=2048
 # Infrastructure page.
 # WWEBJS_WEB_VERSION=<a build from that registry's html/ folder>
 # WWEBJS_WEB_VERSION=off
+
+# Remote path the whatsapp-web.js web-version registry is fetched from.
+# WWEBJS_WEB_VERSION_REMOTE_PATH=
 
 # Extend the initial boot/inject wait (milliseconds) before QR generation. On slow first boots
 # (WSL2 or low-resource containers) the default 30000ms can expire before WhatsApp Web finishes
@@ -267,12 +277,16 @@ POSTGRES_BUILTIN=false              # Use built-in PostgreSQL container?
 # DATABASE_PASSWORD=
 DATABASE_SYNCHRONIZE=false          # WARNING: Set false in production! (data DB)
 # DATABASE_LOGGING=false
+# SQLite file for the 'main' (auth/audit) connection. Must not resolve to DATABASE_NAME.
+# MAIN_DATABASE_NAME=./data/main.sqlite
 # Auth/audit (main) DB schema management. Default ON (zero-config first boot).
 # Set to "false" to manage the api_keys/audit_logs schema via the bundled main-owned
 # migration instead of synchronize (migrationsRun creates them at boot).
 # MAIN_DATABASE_SYNCHRONIZE=true
 DATABASE_SSL=false                   # Set true for managed Postgres (Supabase, Heroku, Render, Railway)
 DATABASE_SSL_REJECT_UNAUTHORIZED=true # Set false to allow self-signed certs (only when DATABASE_SSL=true)
+# PostgreSQL connection pool size.
+# DATABASE_POOL_SIZE=10
 # Postgres pool/query timeouts (ms). Defaults are conservative; set any to 0 to disable.
 DATABASE_STATEMENT_TIMEOUT_MS=30000  # Aborts a single runtime query that runs longer (server-side; not applied to migrations)
 DATABASE_IDLE_TIMEOUT_MS=30000       # Closes idle pooled connections after this long

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- `.env.example` calls itself the single source of truth for configuration, and the Helm chart and `docs/10` both defer to it, but seven live operator knobs were missing from it — including `SERVE_DASHBOARD`, which the bundled compose forwards explicitly, so an operator wanting an API-only deployment was told the capability did not exist. A new spec binds the file to the key lists `env.validation.ts`, `env-precedence.ts` and compose already maintain, so the next one cannot go missing quietly.
 - `RESOLVE_LID_TO_PHONE` was documented nowhere outside `.env.example`, so an operator receiving `@lid` senders had no path to the flag that resolves them; the event catalog now carries the `senderPhone` opt-in callout, the contact-phone endpoint points back to it, and the troubleshooting FAQ covers the symptom.
 - The chat-history response example advertised a `senderPhone` field that endpoint has never returned, and showed it on a plain `@c.us` sender that not even the inbound path would resolve; the example now matches what the route emits, and points at the contact-phone endpoint instead.
 

--- a/src/config/docs-env-example.spec.ts
+++ b/src/config/docs-env-example.spec.ts
@@ -1,0 +1,93 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * `.env.example` calls itself "the Single Source of Truth for all configuration", and both
+ * `charts/openwa/values.yaml` and `docs/10-devops-infrastructure.md` defer to it as the canonical
+ * list. Nothing kept it complete, and it drifted: seven live operator knobs were missing, including
+ * `SERVE_DASHBOARD`, which `docker-compose.yml` forwards explicitly. An operator who wanted to run
+ * API-only was told the canonical list was this file, found no toggle, and concluded the capability
+ * did not exist.
+ *
+ * The expected set is the union of three enumerations this repo already maintains by hand. It is
+ * deliberately NOT derived by scanning read sites: environment variables are read through at least
+ * four distinct shapes (`process.env.X`, `process.env['X']`, `env.X`, `env['X']`) plus bare string
+ * literals, and a four-pattern scan measured during design still missed six keys that are
+ * demonstrably live while dragging in enum members as false positives. The enumerations are exact,
+ * so precision is chosen over recall — a key outside all three is simply not yet claimed by this
+ * gate, and adding it to `env.validation.ts` brings it in.
+ *
+ * One knob sits outside that reach today: `MAIN_DATABASE_NAME` is read in `env.validation.ts` as
+ * `read('MAIN_DATABASE_NAME')`, a call argument rather than a listed array element, so none of the
+ * three enumerations see it. It is a genuine operator knob and is listed in `.env.example` below
+ * anyway, but this gate does not — and cannot, by its own design — require it to be. Bringing it
+ * into the gate's reach means adding it to one of the three enumerations, not widening the
+ * extractor to also recognize call arguments.
+ */
+describe('.env.example lists the keys the codebase claims', () => {
+  const REPO = join(__dirname, '..', '..');
+  const read = (...parts: string[]): string => readFileSync(join(REPO, ...parts), 'utf8');
+
+  /**
+   * Documented legacy aliases. `.env.example` carries the canonical `S3_ACCESS_KEY_ID` /
+   * `S3_SECRET_ACCESS_KEY`; these two spellings are accepted for backward compatibility and are
+   * deliberately not advertised to new operators.
+   */
+  const LEGACY_ALIASES = new Set(['S3_ACCESS_KEY', 'S3_SECRET_KEY']);
+
+  /** Keys enumerated as array elements, one per line — the shape both config files use. */
+  const arrayLiteralKeys = (...parts: string[]): Set<string> =>
+    new Set([...read(...parts).matchAll(/^\s*'([A-Z][A-Z0-9_]{2,})',/gm)].map(match => match[1]));
+
+  /**
+   * Keys compose forwarded as `${KEY:-}`. Comment lines are skipped: docker-compose.yml explains the
+   * convention using a literal `${VAR:-}`, which an unfiltered scan reads as a key named `VAR`.
+   */
+  const composeForwardedKeys = (): Set<string> => {
+    const keys = new Set<string>();
+    for (const line of read('docker-compose.yml').split('\n')) {
+      if (line.trim().startsWith('#')) continue;
+      for (const match of line.matchAll(/\$\{([A-Z][A-Z0-9_]*):-/g)) keys.add(match[1]);
+    }
+    return keys;
+  };
+
+  /** Keys the example file assigns, whether commented out or live. */
+  const exampleKeys = (): Set<string> =>
+    new Set([...read('.env.example').matchAll(/^#?\s*([A-Z][A-Z0-9_]*)=/gm)].map(match => match[1]));
+
+  const missingFrom = (expected: Set<string>, listed: Set<string>): string[] =>
+    [...expected].filter(key => !listed.has(key) && !LEGACY_ALIASES.has(key)).sort();
+
+  it('lists every key the validator, the precedence list or compose knows about', () => {
+    const validated = arrayLiteralKeys('src', 'config', 'env.validation.ts');
+    const precedence = arrayLiteralKeys('src', 'config', 'env-precedence.ts');
+    const forwarded = composeForwardedKeys();
+    const listed = exampleKeys();
+
+    // Guard every extractor on both sides: one that silently matched nothing would make this vacuous.
+    expect(validated.size).toBeGreaterThan(50);
+    expect(precedence.size).toBeGreaterThan(50);
+    expect(forwarded.size).toBeGreaterThan(50);
+    expect(listed.size).toBeGreaterThan(150);
+
+    const expected = new Set([...validated, ...precedence, ...forwarded]);
+    expect(expected.size).toBeGreaterThan(100);
+
+    expect(missingFrom(expected, listed)).toEqual([]);
+  });
+
+  // The gate's own control: drop a key that is definitely listed and assert the comparison names it.
+  it('reports a key dropped from the example file', () => {
+    const listed = exampleKeys();
+    const victim = 'PORT';
+    expect(listed.has(victim)).toBe(true);
+
+    const without = new Set([...listed].filter(key => key !== victim));
+    expect(missingFrom(new Set([victim]), without)).toEqual([victim]);
+  });
+
+  it('does not report a legacy alias', () => {
+    expect(missingFrom(new Set(['S3_ACCESS_KEY']), new Set())).toEqual([]);
+  });
+});


### PR DESCRIPTION
`.env.example` describes itself as the single source of truth for configuration, and both `charts/openwa/values.yaml` and `docs/10` defer to it as the canonical list. Nothing kept it complete, and seven live operator knobs were missing.

The sharpest is `SERVE_DASHBOARD`: `docker-compose.yml` forwards it explicitly, so an operator who wanted an API-only deployment was told the canonical list was this file, found no toggle, and could reasonably conclude the capability did not exist. The others are `MAIN_DATABASE_NAME`, `DATABASE_POOL_SIZE`, `REQUEST_TIMEOUT_MS`, `HEADERS_TIMEOUT_MS`, `KEEPALIVE_TIMEOUT_MS` and `WWEBJS_WEB_VERSION_REMOTE_PATH`. All are added commented out, matching the file's convention, so copying the template still changes nothing.

## The gate

`src/config/docs-env-example.spec.ts` derives the expected key set from three enumerations the repo already maintains by hand — the array literals in `env.validation.ts` and `env-precedence.ts`, and the `\${KEY:-}` forwards in `docker-compose.yml` — and fails when any of them names a key the example file does not list.

It deliberately does **not** scan read sites. Environment variables are read through at least four distinct shapes (`process.env.X`, `process.env['X']`, `env.X`, `env['X']`); a four-pattern scan measured during development still missed six keys that are demonstrably live, while dragging in enum members as false positives. The enumerations are exact, so precision was chosen over recall. A knob outside all three is simply outside the gate's reach today, and the way to bring one in is to add it to `env.validation.ts` rather than to widen a regex — the docblock says so.

Scope is stated in the source: the gate covers six of the seven keys added here. `MAIN_DATABASE_NAME` is read as a call argument rather than a listed key, so no enumeration sees it; it is included for completeness and the file records that it is not enforced.

## Verification

The gate was written first and confirmed red against the tree, naming exactly the six keys it derives, before the knobs were added. It carries a control that drops a known key and asserts the comparison reports it, plus size floors on every extractor so a parser that silently stops matching fails rather than passes.

Two of the values originally drafted for this change were wrong — `REQUEST_TIMEOUT_MS` and `HEADERS_TIMEOUT_MS` were written as 120000/60000 against real defaults of 300000/65000 in `configuration.ts`. Every value here was checked against source before committing, which is the point: a completeness fix that plants wrong values is worse than the gap it closes.

Full unit suite, e2e, lint, tsc, format, and all four SDK contract gates pass.