### PR TITLE
test(docs): bind the API specification headings to the OpenAPI contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- `check:sdk-routes` scanned the JavaScript client for backtick-delimited paths only, while its PHP and Python rules already accepted every quote style, so the nine routes that client writes as single-quoted strings were never compared to the contract — `/api/health/ready` among them, which is also the container healthcheck and Kubernetes readiness path. Renaming one of those server-side passed every gate and the JS suite, and the published client would have 404'd with CI green.
-
 ### Added
 
 - Turkish (`tr`) dashboard translation. Thanks @codedByCan.
 
 ### Fixed
 
+- `check:sdk-routes` scanned the JavaScript client for backtick-delimited paths only, while its PHP and Python rules already accepted every quote style, so the nine routes that client writes as single-quoted strings were never compared to the contract — `/api/health/ready` among them, which is also the container healthcheck and Kubernetes readiness path. Renaming one of those server-side passed every gate and the JS suite, and the published client would have 404'd with CI green.
 - The JavaScript, Python, Go and Java SDKs omitted `contact`, `call` and `ephemeralDuration` from their chat-history message type, so a typed client had to cast to read three fields the endpoint returns; all four now mirror the engine payload.
 
 ### Documentation
 
+- `docs/06-api-specification.md` restated the published contract by hand with nothing binding the two, so operations shipped without ever reaching it — the integration redrive route was documented nowhere at all. It now has a section, and a new spec compares the document's route headings to `openapi.json` in both directions; an operation deliberately documented elsewhere carries an allowlist entry naming that file, and the gate reads the file to confirm the route is really there.
 - `.env.example` calls itself the single source of truth for configuration, and the Helm chart and `docs/10` both defer to it, but seven live operator knobs were missing from it — including `SERVE_DASHBOARD`, which the bundled compose forwards explicitly, so an operator wanting an API-only deployment was told the capability did not exist. A new spec binds the file to the key lists `env.validation.ts`, `env-precedence.ts` and compose already maintain, so the next one cannot go missing quietly.
 - `RESOLVE_LID_TO_PHONE` was documented nowhere outside `.env.example`, so an operator receiving `@lid` senders had no path to the flag that resolves them; the event catalog now carries the `senderPhone` opt-in callout, the contact-phone endpoint points back to it, and the troubleshooting FAQ covers the symptom.
 - The chat-history response example advertised a `senderPhone` field that endpoint has never returned, and showed it on a plain `@c.us` sender that not even the inbound path would resolve; the example now matches what the route emits, and points at the contact-phone endpoint instead.

--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -5913,12 +5913,17 @@ Note: this DELETE returns `200` with a body (not the usual `204`).
 #### POST /api/integration/instances/:pluginId/:instanceId/redrive
 
 Re-dispatch one bounded batch of dead-lettered inbound deliveries for an integration instance (see
-**doc 25, Integration Fabric** for the DLQ and redrive design). Rows are drained oldest-first up to the
-batch size; `remaining` reports the DLQ depth still outstanding after this batch.
+**doc 25, Integration Fabric** for the DLQ and redrive design). Rows are drained fewest-attempts-first,
+then oldest-first, up to `batchSize` (100) — so a row that keeps failing moves behind never-retried
+rows instead of livelocking the window, while staying redrivable. `remaining` reports the DLQ depth
+still outstanding after this batch.
 
 **Auth:** API key (ADMIN) · **Scope:** session-scoped (a key restricted to `allowedSessions` may only
 redrive an instance whose current `sessionScope` is inside that allowlist; out of scope and missing
-instances both answer `404`, so redrive can't be used to probe other sessions)
+instances both answer `404`, so redrive can't be used to probe other sessions). An unrestricted key is
+not fenced this way: it may drain retained rows for an instance that no longer exists, which is
+deliberate — those rows still carry the deleted binding's `sessionId` and only an unscoped caller may
+replay them.
 
 **Path parameters**
 
@@ -5933,7 +5938,7 @@ instances both answer `404`, so redrive can't be used to probe other sessions)
 { "redriven": 3, "remaining": 0, "batchSize": 100 }
 ```
 
-**Errors:** `401` · `403` key role < ADMIN · `404` unknown instance, or a scoped key's instance outside its `allowedSessions`
+**Errors:** `401` · `403` key role < ADMIN · `404` a **scoped** key's instance that is missing or outside its `allowedSessions` (an unrestricted key gets `201` with `redriven: 0` instead)
 
 ---
 

--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -5910,6 +5910,33 @@ Note: this DELETE returns `200` with a body (not the usual `204`).
 
 ---
 
+#### POST /api/integration/instances/:pluginId/:instanceId/redrive
+
+Re-dispatch one bounded batch of dead-lettered inbound deliveries for an integration instance (see
+**doc 25, Integration Fabric** for the DLQ and redrive design). Rows are drained oldest-first up to the
+batch size; `remaining` reports the DLQ depth still outstanding after this batch.
+
+**Auth:** API key (ADMIN) · **Scope:** session-scoped (a key restricted to `allowedSessions` may only
+redrive an instance whose current `sessionScope` is inside that allowlist; out of scope and missing
+instances both answer `404`, so redrive can't be used to probe other sessions)
+
+**Path parameters**
+
+| Name         | Type   | Description                   |
+| ------------ | ------ | ----------------------------- |
+| `pluginId`   | string | Plugin id owning the instance |
+| `instanceId` | string | Instance id to redrive        |
+
+**Response** `201`
+
+```json
+{ "redriven": 3, "remaining": 0, "batchSize": 100 }
+```
+
+**Errors:** `401` · `403` key role < ADMIN · `404` unknown instance, or a scoped key's instance outside its `allowedSessions`
+
+---
+
 #### POST /mcp
 
 MCP Streamable-HTTP / JSON-RPC 2.0 transport that exposes the agent-tool registry over the Model Context Protocol. **This is a transport, not a REST resource** — there is no NestJS controller, no DTO, and no `{success,data}` shape.

--- a/src/common/openapi/docs-06-contract.spec.ts
+++ b/src/common/openapi/docs-06-contract.spec.ts
@@ -1,0 +1,154 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * `docs/06-api-specification.md` is the reference a REST consumer reads when there is no SDK — curl,
+ * Postman, n8n. It restates the published contract by hand, and nothing bound the two, so operations
+ * shipped without ever reaching it: `GET`/`PATCH /api/sessions/{id}/config` are implemented by all
+ * five SDKs and documented only in `docs/05`, and the integration redrive route was documented
+ * nowhere at all.
+ *
+ * This gate compares the document's route headings to `openapi.json` in both directions. An
+ * operation added without a heading, a heading left behind after a route is renamed, and a stale
+ * allowlist entry all fail here.
+ *
+ * Operations deliberately documented in another file carry an allowlist entry naming that file, and
+ * the gate reads the file to confirm the path is really there — otherwise "documented in docs/25"
+ * would be an unchecked claim, which is the exact failure this gate exists to prevent.
+ */
+describe('docs/06 matches the published contract', () => {
+  const REPO = join(__dirname, '..', '..', '..');
+  const read = (...parts: string[]): string => readFileSync(join(REPO, ...parts), 'utf8');
+
+  const METHODS = ['get', 'post', 'put', 'patch', 'delete'];
+
+  /** The contract writes `{id}`, the prose writes `:id`. Normalise both to `:id`. */
+  const normalise = (path: string): string => path.replace(/\{(\w+)\}/g, ':$1').replace(/\/+$/, '');
+
+  /**
+   * A path with its parameter segments collapsed. Used only for the allowlist backing check: the
+   * contract names a segment `{path}` where docs/25 names the same segment `:route`, and a parameter
+   * name is a documentation choice rather than part of the route's identity.
+   */
+  const shape = (path: string): string =>
+    path
+      .split('/')
+      .map(segment => (segment.startsWith(':') || segment.startsWith('{') ? ':*' : segment))
+      .join('/');
+
+  const contractOperations = (): Set<string> => {
+    const spec = JSON.parse(read('openapi.json')) as { paths: Record<string, Record<string, unknown>> };
+    const operations = new Set<string>();
+    for (const [path, item] of Object.entries(spec.paths)) {
+      for (const method of Object.keys(item)) {
+        if (METHODS.includes(method)) operations.add(`${method.toUpperCase()} ${normalise(path)}`);
+      }
+    }
+    return operations;
+  };
+
+  const documentedHeadings = (): Set<string> =>
+    new Set(
+      [...read('docs', '06-api-specification.md').matchAll(/^#### (GET|POST|PUT|PATCH|DELETE) (\S+)/gm)].map(
+        match => `${match[1]} ${normalise(match[2])}`,
+      ),
+    );
+
+  /**
+   * Operations documented outside docs/06, each naming the file that documents it. The backing check
+   * below reads that file, so an entry cannot become a silent exemption.
+   */
+  const DOCUMENTED_ELSEWHERE = new Map<string, string>([
+    ['GET /api/ingress/:pluginId/:instanceId/:path', 'docs/25-integration-fabric.md'],
+    ['POST /api/ingress/:pluginId/:instanceId/:path', 'docs/25-integration-fabric.md'],
+    ['PUT /api/ingress/:pluginId/:instanceId/:path', 'docs/25-integration-fabric.md'],
+    ['PATCH /api/ingress/:pluginId/:instanceId/:path', 'docs/25-integration-fabric.md'],
+    ['DELETE /api/ingress/:pluginId/:instanceId/:path', 'docs/25-integration-fabric.md'],
+    ['GET /api/integration/plugins/:pluginId/instances', 'docs/25-integration-fabric.md'],
+    ['POST /api/integration/plugins/:pluginId/instances', 'docs/25-integration-fabric.md'],
+    ['GET /api/integration/plugins/:pluginId/instances/:instanceId', 'docs/25-integration-fabric.md'],
+    ['PATCH /api/integration/plugins/:pluginId/instances/:instanceId', 'docs/25-integration-fabric.md'],
+    ['DELETE /api/integration/plugins/:pluginId/instances/:instanceId', 'docs/25-integration-fabric.md'],
+    [
+      'POST /api/integration/plugins/:pluginId/instances/:instanceId/regenerate-secret',
+      'docs/25-integration-fabric.md',
+    ],
+    ['GET /api/sessions/:id/config', 'docs/05-database-design.md'],
+    ['PATCH /api/sessions/:id/config', 'docs/05-database-design.md'],
+  ]);
+
+  /**
+   * Headings with no contract operation, and why the contract cannot carry them. `POST /mcp` is
+   * mounted on raw Express outside Nest, so the Swagger scanner never sees it.
+   */
+  const NOT_IN_CONTRACT = new Set(['POST /mcp']);
+
+  /** True when `file` contains a path of the same shape as `operation`. */
+  const backs = (file: string, operation: string): boolean => {
+    const wanted = shape(operation.slice(operation.indexOf(' ') + 1));
+    const body = read(...file.split('/'));
+    return [...body.matchAll(/\/api\/[A-Za-z0-9:{}_\-/]+/g)].some(match => shape(normalise(match[0])) === wanted);
+  };
+
+  it('documents every contract operation, or allowlists it to a file that really documents it', () => {
+    const operations = contractOperations();
+    const headings = documentedHeadings();
+
+    expect(operations.size).toBeGreaterThan(150);
+    expect(headings.size).toBeGreaterThan(150);
+
+    const undocumented = [...operations]
+      .filter(operation => !headings.has(operation) && !DOCUMENTED_ELSEWHERE.has(operation))
+      .sort();
+    expect(undocumented).toEqual([]);
+  });
+
+  it('every allowlisted operation is really documented in the file it names', () => {
+    expect(DOCUMENTED_ELSEWHERE.size).toBeGreaterThan(5);
+
+    const unbacked = [...DOCUMENTED_ELSEWHERE]
+      .filter(([operation, file]) => !backs(file, operation))
+      .map(([operation, file]) => `${operation} claims ${file}, which does not contain that path`);
+    expect(unbacked).toEqual([]);
+  });
+
+  it('has no heading for a route the contract no longer publishes', () => {
+    const operations = contractOperations();
+    const stale = [...documentedHeadings()]
+      .filter(heading => !operations.has(heading) && !NOT_IN_CONTRACT.has(heading))
+      .sort();
+    expect(stale).toEqual([]);
+  });
+
+  it('has no stale allowlist entry', () => {
+    const operations = contractOperations();
+    const headings = documentedHeadings();
+
+    const stale = [...DOCUMENTED_ELSEWHERE.keys()]
+      .filter(operation => !operations.has(operation) || headings.has(operation))
+      .sort();
+    expect(stale).toEqual([]);
+  });
+
+  // The gate's own controls. Without these, a matcher that silently stops working is
+  // indistinguishable from a document that is correct.
+  describe('the checks themselves can fail', () => {
+    it('reports an operation with neither a heading nor an allowlist entry', () => {
+      const operations = new Set(['GET /api/widgets']);
+      const headings = new Set<string>();
+      const undocumented = [...operations].filter(
+        operation => !headings.has(operation) && !DOCUMENTED_ELSEWHERE.has(operation),
+      );
+      expect(undocumented).toEqual(['GET /api/widgets']);
+    });
+
+    it('reports an allowlist entry whose file does not contain the path', () => {
+      expect(backs('docs/05-database-design.md', 'GET /api/nowhere/:id')).toBe(false);
+    });
+
+    it('accepts a documenting file that spells the parameter differently', () => {
+      // docs/25 writes `:route` where the contract writes `{path}`.
+      expect(backs('docs/25-integration-fabric.md', 'GET /api/ingress/:pluginId/:instanceId/:path')).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
`docs/06-api-specification.md` is the reference a REST consumer reads when there is no SDK — curl, Postman, n8n. It restates the published contract by hand, and nothing bound the two, so operations shipped without ever reaching it.

`POST /api/integration/instances/:pluginId/:instanceId/redrive` was documented nowhere at all. It now has a section.

## The gate

`src/common/openapi/docs-06-contract.spec.ts` compares the document's route headings to `openapi.json` in both directions. An operation added without a heading, a heading left behind after a route is renamed, and a stale allowlist entry all fail.

Operations deliberately documented in another file carry an allowlist entry naming that file, and the gate reads that file to confirm the path is really there — otherwise "documented in docs/25" would be an unchecked claim, which is the failure this gate exists to prevent. The backing check compares path *shapes* with parameter segments collapsed, because `docs/25` names the ingress route's last segment `:route` where the contract names it `{path}`; a parameter name is a documentation choice, not part of the route's identity.

Thirteen operations are allowlisted (eleven ingress/integration to `docs/25`, the two `sessions/:id/config` operations to `docs/05`). `POST /mcp` is headed but absent from the contract by design — it is mounted on raw Express outside Nest, so the Swagger scanner never sees it.

## Two corrections to the new section

Both came from tracing the route to source rather than re-reading the prose, and both are in their own commit:

- The section said rows drain oldest-first. The query orders by `attempts ASC, createdAt ASC` — fewest attempts first, creation time only as the tiebreak. That is load-bearing: a row that keeps failing moves behind never-retried rows so one permanent failure cannot livelock the bounded window.
- The errors line listed `404` for an unknown instance unconditionally. The guard sits inside the scoped branch, so an unrestricted key reaching a missing instance is not refused — it drains the retained rows, which is deliberate, because those rows still carry the deleted binding's `sessionId`.

## Verification

The gate was confirmed red before the route was documented, naming exactly the redrive operation. Removing the new heading turns it red again naming that route; restoring returns it green. It carries controls for each assertion, including one proving the shape matcher accepts `docs/25`'s differently-named parameter, and size floors so a parser that stops matching fails rather than passes.

Known limitation, recorded rather than fixed here: the heading set is a `Set`, so a duplicate heading collapses and is invisible to the gate. `docs/06` currently has one — `GET /api/sessions/:sessionId/groups` appears at lines 299 and 2368. Worth a follow-up; it is not a contract mismatch, so it is out of scope for this change.

Full unit suite, e2e, lint, tsc, format, `openapi:check` and all four SDK contract gates pass.