### PR TITLE
fix(scripts): harvest JS SDK route literals in every quote style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `check:sdk-routes` scanned the JavaScript client for backtick-delimited paths only, while its PHP and Python rules already accepted every quote style, so the nine routes that client writes as single-quoted strings were never compared to the contract — `/api/health/ready` among them, which is also the container healthcheck and Kubernetes readiness path. Renaming one of those server-side passed every gate and the JS suite, and the published client would have 404'd with CI green.
+
 ### Added
 
 - Turkish (`tr`) dashboard translation. Thanks @codedByCan.

--- a/scripts/check-sdk-coverage.mjs
+++ b/scripts/check-sdk-coverage.mjs
@@ -70,8 +70,9 @@ const CHAIN = new RegExp(`${TERM}(?:\\s*\\+\\s*${TERM})*`, 'g');
  *
  * `baseValue` is a resolved `…Service.base()` body (Go). Each rule exists because its absence
  * produced a false positive:
- *   (a) quoted literals in any quote style — the JS client writes some paths in single quotes, and
- *       a backtick-only scan silently skips them (the shipped forward gate still does).
+ *   (a) quoted literals in any quote style — the JS client writes some paths in single quotes, which
+ *       a backtick-only scan silently skips. The forward gate (check-sdk-routes.mjs) was blind to
+ *       exactly those nine literals until it was widened to match this one.
  *   (b) `+`-chains — Java and Go assemble paths rather than writing them whole.
  *   (c) base plus a bare suffix, with and without an interposed id segment — Go's per-service
  *       helpers take `"/read"` or `"reply"` and the caller never names the whole path.

--- a/scripts/check-sdk-routes.mjs
+++ b/scripts/check-sdk-routes.mjs
@@ -52,7 +52,14 @@ const walk = (dir, exts, out = []) => {
 // Source directories only — test files assert against fixtures and may legitimately name paths the
 // package never builds.
 const SDKS = [
-  { name: 'javascript', dir: 'sdk/javascript/src', exts: ['.ts'], re: /`(\/api\/[^`]*)`/g },
+  // Any quote style, not just backticks. The JS client writes its parameterless routes as
+  // single-quoted strings — nine of them, including the `/api/health/ready` path Kubernetes and the
+  // container HEALTHCHECK probe — and a backtick-only scan never saw one. Renaming any of those on
+  // the server regenerated openapi.json, passed `openapi:check`, passed this gate (which never
+  // harvested the literal), and passed the JS suite (whose oracle is the URL the SDK itself built),
+  // so the published client would 404 with CI fully green. check-sdk-coverage.mjs already harvests
+  // every quote style; this brings the forward gate level with it.
+  { name: 'javascript', dir: 'sdk/javascript/src', exts: ['.ts'], re: /[`"'](\/api\/[^`"']*)[`"']/g },
   { name: 'php', dir: 'sdk/php/src', exts: ['.php'], re: /["'](\/api\/[^"']*)["']/g },
   { name: 'python', dir: 'sdk/python/openwa', exts: ['.py'], re: /["'](\/api\/[^"']*)["']/g },
 ];


### PR DESCRIPTION
`scripts/check-sdk-routes.mjs` scanned the JavaScript SDK for backtick-delimited paths only, while its PHP and Python rules already accepted both quote styles. The JS client writes its nine parameterless routes as single-quoted strings, so none of them was ever compared to the contract.

The nine: `/api/search`, `/api/auth/validate`, `/api/webhooks`, `/api/webhooks/delivery-failures`, `/api/sessions`, `/api/sessions/stats/overview`, `/api/health`, `/api/health/live`, `/api/health/ready`.

## Why it mattered

Renaming any of those server-side would have regenerated `openapi.json`, passed `openapi:check`, passed this gate (which never harvested the literal), passed `check-sdk-coverage` — which asks whether a contract route is reachable from each client, not whether a client route exists — and passed the JS suite, whose oracle is the URL the SDK itself constructed against a mock transport. The published client would have 404'd with CI fully green, which is the exact failure this gate was written to prevent.

`/api/health/ready` is among them, and is also the container `HEALTHCHECK` and the Kubernetes readiness path.

The hole was already known: `check-sdk-coverage.mjs` says in its own docblock that a backtick-only scan skips these literals and that the forward gate still does. That comment is updated here to record that it no longer does.

## Verification

Harvest rises from 106 to 115 literals for the JS client (340 across the three scanned SDKs). The new rule is a strict superset — it gains exactly the nine expected routes and loses none.

Pointing a single-quoted route at a path absent from the contract now fails the gate; before this change the same break passed silently.

Adversarial probe of the widened rule: absolute URLs (`"https://host/api/docs"`), paths mid-string (`'bad path: /api/x'`), line comments and block comments are all correctly rejected, because the rule requires a quote character immediately before `/api/` and comments are stripped first.

Residual exposure, stated rather than hidden: a `/api/...` path quoted inside an ordinary string — an error message, say — would now be harvested and could fail the gate. The PHP and Python rules have always carried that exposure, so this is the JS client joining a trade-off already made for the other two, and the failure is a loud CI error naming the path rather than a silent pass.

Full unit suite, e2e, lint, tsc, format and all four SDK contract gates pass.