### PR TITLE
docs(security): scope the webhook-secret "never returned" claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The chat-history response example advertised a `senderPhone` field that endpoint has never returned, and showed it on a plain `@c.us` sender that not even the inbound path would resolve; the example now matches what the route emits, and points at the contact-phone endpoint instead.
 - `WEBHOOK_CONTACT_DETAILS` was absent from `docs/`; the event catalog now names the twelve fields it adds to `contact` on `message.received`, notes that opting in costs no extra WhatsApp lookup, and records that only the whatsapp-web.js path reads the flag — which `.env.example` now says too.
 - The chat-history field list omitted `ephemeralDuration` and its `type` union omitted `poll`, both of which that route emits; `[Unreleased]` also carried two `### Fixed` headings after two branches added one each without conflicting.
+- `docs/04-security-design.md` stated in two places that webhook secrets are never returned by any API response, contradicting `docs/06`, which documents `GET /api/infra/export-data` returning them in cleartext; both now name that route as the exception, the way the neighbouring proxy-credential row already scopes its claim to the session read DTOs.
 
 ## [0.16.0] - 2026-08-11
 

--- a/docs/04-security-design.md
+++ b/docs/04-security-design.md
@@ -171,14 +171,14 @@ OpenWA serves plain HTTP on its port; terminate **TLS at your reverse proxy / lo
 
 > **There is currently no application-level encryption at rest.** API keys are stored **hashed** (one-way), but other sensitive values are stored as plaintext in the database / on disk and are protected by filesystem and database permissions, not by encryption. Encryption at rest for these fields is a roadmap item, not a shipped feature — do not assume it.
 
-| Data                                      | At rest                                                                       | How it is protected                                                                                              |
-| ----------------------------------------- | ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| API keys                                  | **Hashed** — SHA-256 with an optional `API_KEY_PEPPER` HMAC; never reversible | A database leak alone cannot recover the keys; with a pepper set, hashes can't be precomputed offline. See §4.2. |
-| Session auth state (WhatsApp credentials) | Plaintext on disk (the engine's auth store under the data volume)             | Filesystem permissions on the data volume — keep it private.                                                     |
-| Webhook secrets                           | Plaintext — `webhooks.secret` (`varchar`)                                     | Database access control; never returned by any API response (write-only response DTO).                           |
-| Proxy credentials                         | Plaintext — `sessions.proxyUrl` may embed `user:pass`                         | Database access control; never returned by the session read DTOs.                                                |
-| Generated config (`data/.env.generated`)  | Plaintext file, written `0600`                                                | Owner-only file permissions.                                                                                     |
-| Message content                           | Plaintext in the `messages` table                                             | Database access control.                                                                                         |
+| Data                                      | At rest                                                                       | How it is protected                                                                                                                                    |
+| ----------------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| API keys                                  | **Hashed** — SHA-256 with an optional `API_KEY_PEPPER` HMAC; never reversible | A database leak alone cannot recover the keys; with a pepper set, hashes can't be precomputed offline. See §4.2.                                       |
+| Session auth state (WhatsApp credentials) | Plaintext on disk (the engine's auth store under the data volume)             | Filesystem permissions on the data volume — keep it private.                                                                                           |
+| Webhook secrets                           | Plaintext — `webhooks.secret` (`varchar`)                                     | Database access control; never returned by the webhook read DTOs (write-only) — except `GET /api/infra/export-data`, which dumps the row in cleartext. |
+| Proxy credentials                         | Plaintext — `sessions.proxyUrl` may embed `user:pass`                         | Database access control; never returned by the session read DTOs.                                                                                      |
+| Generated config (`data/.env.generated`)  | Plaintext file, written `0600`                                                | Owner-only file permissions.                                                                                                                           |
+| Message content                           | Plaintext in the `messages` table                                             | Database access control.                                                                                                                               |
 
 **Hardening you can apply today:** set `API_KEY_PEPPER`; restrict the data volume and database to the app's user; and encrypt at the infrastructure layer (LUKS / cloud-provider encrypted volumes / an encrypted managed Postgres) rather than relying on application-level field encryption, which is not implemented.
 
@@ -516,14 +516,14 @@ flowchart TB
 
 ### Secrets Inventory
 
-| Secret                            | Storage                                             | Rotation guidance                               |
-| --------------------------------- | --------------------------------------------------- | ----------------------------------------------- |
-| Database credentials              | Environment variable                                | 90 days                                         |
-| Redis password                    | Environment variable                                | 90 days                                         |
-| API master key (`API_MASTER_KEY`) | Environment variable                                | 180 days                                        |
-| API key pepper (`API_KEY_PEPPER`) | Environment variable                                | Rotating it invalidates all existing key hashes |
-| Webhook secrets                   | Database — **plaintext**; never returned by the API | Per webhook                                     |
-| Session auth state                | File system (data volume) — **not encrypted**       | Never (tied to the WA session)                  |
+| Secret                            | Storage                                                                                                          | Rotation guidance                               |
+| --------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| Database credentials              | Environment variable                                                                                             | 90 days                                         |
+| Redis password                    | Environment variable                                                                                             | 90 days                                         |
+| API master key (`API_MASTER_KEY`) | Environment variable                                                                                             | 180 days                                        |
+| API key pepper (`API_KEY_PEPPER`) | Environment variable                                                                                             | Rotating it invalidates all existing key hashes |
+| Webhook secrets                   | Database — **plaintext**; not in the webhook read DTOs, but `GET /api/infra/export-data` returns it in cleartext | Per webhook                                     |
+| Session auth state                | File system (data volume) — **not encrypted**                                                                    | Never (tied to the WA session)                  |
 
 > There is no application `ENCRYPTION_KEY` — OpenWA does not encrypt data at rest (see §4.4). The rotation cadences above are operational recommendations, not enforced by the app.
 


### PR DESCRIPTION
## What

`docs/04-security-design.md` claimed in two places that webhook secrets are never returned by an API response:

- §4.4 "At Rest" table (`:178`) — *"never returned by any API response (write-only response DTO)"*
- §4.12 "Secrets Inventory" (`:525`) — *"never returned by the API"*

Both are wrong. `GET /api/infra/export-data` dumps the `webhooks` rows verbatim, secret included. `docs/06-api-specification.md:5380` already documents this accurately — **"`webhooks` rows include `secret` in cleartext … treat the payload as a credential dump"** — so the two documents contradicted each other, and the one that reads as the authoritative security reference was the one that was wrong.

## How

Both rows now name the export route as the exception. The wording follows the pattern the adjacent proxy-credential row (`:179`) already uses — *"never returned by the session read DTOs"* — which is accurate precisely because it is bounded to the read DTOs rather than to the API as a whole.

| | Before | After |
|---|---|---|
| §4.4 | never returned by any API response | never returned by the webhook read DTOs (write-only) — except `GET /api/infra/export-data`, which dumps the row in cleartext |
| §4.12 | never returned by the API | not in the webhook read DTOs, but `GET /api/infra/export-data` returns it in cleartext |

A sweep of the rest of the file found no further unqualified absolutes of this shape; `:179` is correct as written and is untouched.

## Scope

Documentation only. The export route is **not** changed — it keeps its `ADMIN` role and `@RequireUnscopedKey` fence, and `infra-access-control.spec.ts:42` already pins that it exposes webhook secrets. This PR makes the security document agree with the behaviour that is already audited and already documented in `docs/06`.

The tables show a wider diff than the two edited cells: the new cell is longer, so Prettier realigned both tables' column padding. 16 of the 32 changed lines are whitespace-only realignment.

## Verification

```
npm run lint                        EXIT=0
npx tsc --noEmit -p tsconfig.json   EXIT=0
npm run format:check                EXIT=0  All matched files use Prettier code style!
npm run check:versions              EXIT=0  Version consistency OK (package.json = 0.16.0).
npm run openapi:check               EXIT=0  158 paths, no diff
npm test                            EXIT=0  326 passed, 5529 tests
npm run build                       EXIT=0
```