### PR TITLE
fix(config): boot-validate AUDIT_RETENTION_DAYS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Turkish (`tr`) dashboard translation. Thanks @codedByCan.
+- `AUDIT_RETENTION_DAYS` is checked at boot, so a typo fails startup with a named error instead of silently reverting to the 90-day default. It is validated as non-negative rather than positive, because `0` is the documented switch that disables audit-log pruning entirely.
 
 ### Fixed
 

--- a/src/config/env.validation.spec.ts
+++ b/src/config/env.validation.spec.ts
@@ -107,6 +107,14 @@ describe('validateEnv', () => {
     expect(() => validateEnv({ WEBHOOK_MAX_PER_SESSION: '0', WEBHOOK_MEDIA_INLINE_MAX_BYTES: '0' })).not.toThrow();
   });
 
+  it('rejects a non-integer audit retention (0 is the documented retention-off switch)', () => {
+    expect(() => validateEnv({ AUDIT_RETENTION_DAYS: 'ninety' })).toThrow(/AUDIT_RETENTION_DAYS/);
+    expect(() => validateEnv({ AUDIT_RETENTION_DAYS: '90.5' })).toThrow(/AUDIT_RETENTION_DAYS/);
+    // 0 disables pruning in audit.service.ts, so this knob must never become positive-only.
+    expect(() => validateEnv({ AUDIT_RETENTION_DAYS: '0' })).not.toThrow();
+    expect(() => validateEnv({ AUDIT_RETENTION_DAYS: '90' })).not.toThrow();
+  });
+
   it('rejects a non-positive / non-integer WEBHOOK_MAX_PAYLOAD_BYTES (0 would reject every dispatch)', () => {
     expect(() => validateEnv({ WEBHOOK_MAX_PAYLOAD_BYTES: '0' })).toThrow(/WEBHOOK_MAX_PAYLOAD_BYTES/);
     expect(() => validateEnv({ WEBHOOK_MAX_PAYLOAD_BYTES: 'abc' })).toThrow(/WEBHOOK_MAX_PAYLOAD_BYTES/);

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -173,6 +173,7 @@ export function validateEnv(config: EnvConfig): EnvConfig {
     'AUTOMATION_MAX_PER_SESSION', // 0 = unlimited
     'WEBHOOK_MEDIA_INLINE_MAX_BYTES', // 0 = never inline media
     'EXPORT_INLINE_MEDIA_BUDGET_BYTES', // 0 = a data export carries no inline media at all
+    'AUDIT_RETENTION_DAYS', // 0 = retention disabled, so this cannot be positive-only
   ]) {
     checkNonNegativeInt(key);
   }


### PR DESCRIPTION
## What

`AUDIT_RETENTION_DAYS` is read at `src/modules/audit/audit.service.ts:53` with no boot check and no spec behind it:

```ts
const parsed = Number.parseInt(process.env.AUDIT_RETENTION_DAYS ?? '', 10);
const retentionDays = Number.isInteger(parsed) ? Math.max(0, parsed) : 90;
```

A typo (`30d`, `ninety`, `9O`) parses to `NaN` and falls through to the 90-day default. The operator asked for one retention policy and silently got another, with nothing in the logs saying so.

## Why non-negative and not positive

It joins the **`checkNonNegativeInt`** list, not `checkPositiveInt`. The read site treats `0` as the deliberate off switch:

```ts
if (retentionDays <= 0) {
  this.logger.log('Audit-log retention disabled (AUDIT_RETENTION_DAYS <= 0)');
  return;
}
```

and `.env.example:252` documents exactly that — *"set to 0 to keep audit logs forever (disable pruning)"*. A positive-only check would reject a documented, supported value and turn "keep my audit logs forever" into a boot failure.

## Verification

The new spec pins both halves of the contract, and was **mutation-tested on each axis separately** — one green mutation would only have proved one of them:

| Mutation | Expected | Result |
|---|---|---|
| baseline, unmutated | pass | `exit=0` |
| remove the list entry entirely | reject assertions go red | `exit=1` |
| move the key to `checkPositiveInt` | the `0` assertion goes red | `exit=1` |

`env.validation.ts` was restored from a saved copy afterwards and diffed to confirm it matches byte-for-byte.

### Reach of the `.env.example` gate

`docs-env-example.spec.ts` derives its expected key set from this same array literal, so the knob now falls inside that gate too. `.env.example` already lists it, so nothing needed adding — but the claim is measured, not assumed:

| Scenario | Gate result |
|---|---|
| key dropped from `.env.example`, **with** this change | **fails**, naming `+ "AUDIT_RETENTION_DAYS"` |
| key dropped from `.env.example`, **without** this change | passes — the knob was outside its reach |

### Gate output

```
npm run lint                        EXIT=0
npx tsc --noEmit -p tsconfig.json   EXIT=0
npm run format:check                EXIT=0  All matched files use Prettier code style!
npm run check:versions              EXIT=0  Version consistency OK (package.json = 0.16.0).
npm test                            EXIT=0  326 passed, 5530 tests (+1 vs base — the new spec ran)
npm run build                       EXIT=0
```

## Note for review

`audit.service.ts:48` and `:56` describe the switch as `<= 0`, while `.env.example` documents `0`. This change validates against the operator-facing spelling, so a negative value — never advertised outside those two internal comments — now fails boot rather than being clamped to 0. Flagging rather than fixing: it is a comment change in another module's file and belongs in its own PR.