### PR TITLE
fix(infra): validate the import-data body with a DTO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `check:sdk-routes` scanned the JavaScript client for backtick-delimited paths only, while its PHP and Python rules already accepted every quote style, so the nine routes that client writes as single-quoted strings were never compared to the contract — `/api/health/ready` among them, which is also the container healthcheck and Kubernetes readiness path. Renaming one of those server-side passed every gate and the JS suite, and the published client would have 404'd with CI green.
 - The JavaScript, Python, Go and Java SDKs omitted `contact`, `call` and `ephemeralDuration` from their chat-history message type, so a typed client had to cast to read three fields the endpoint returns; all four now mirror the engine payload.
+- `POST /api/infra/import-data` bound its body to an inline type, which erases at runtime, so on the replace-all restore the global ValidationPipe's `whitelist` and `forbidNonWhitelisted` never ran: a body carrying no `tables` failed as a 500 from inside the import, and a misspelled key was accepted in silence. It now takes a DTO — a missing `tables` answers 400 naming the field, an unknown key is refused, and `force`/`stopOrphans` accept only a real boolean or an exact `'true'`/`'false'`, so an ambiguous spelling cannot open the orphan-engine escape.
 
 ### Documentation
 

--- a/openapi.json
+++ b/openapi.json
@@ -3938,65 +3938,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "force": {
-                    "type": "boolean",
-                    "description": "Allow the replace to proceed even while engines are running for sessions the backup does not contain (they keep running until restart; see restartRequired). Prefer stopOrphans, which closes that window inside this request instead."
-                  },
-                  "stopOrphans": {
-                    "type": "boolean",
-                    "description": "Stop the running engines for sessions the backup does not contain, inside this request and before the replace runs. Supersedes force for the orphan case: with stopOrphans the engines no longer need a process restart to reconcile, so restartRequired stays false on the success path."
-                  },
-                  "tables": {
-                    "type": "object",
-                    "description": "Every one of the 14 migration tables is emptied before the restore runs, so a key omitted here is restored EMPTY rather than left untouched. Post the whole GET /api/infra/export-data payload, not a hand-built subset.",
-                    "properties": {
-                      "sessions": {
-                        "type": "array"
-                      },
-                      "webhooks": {
-                        "type": "array"
-                      },
-                      "messages": {
-                        "type": "array"
-                      },
-                      "messageBatches": {
-                        "type": "array"
-                      },
-                      "templates": {
-                        "type": "array"
-                      },
-                      "baileysStoredMessages": {
-                        "type": "array"
-                      },
-                      "lidMappings": {
-                        "type": "array"
-                      },
-                      "pluginInstances": {
-                        "type": "array"
-                      },
-                      "conversationMappings": {
-                        "type": "array"
-                      },
-                      "ingressEvents": {
-                        "type": "array"
-                      },
-                      "webhookDeliveryFailures": {
-                        "type": "array"
-                      },
-                      "integrationDeliveryFailures": {
-                        "type": "array"
-                      },
-                      "statusUpdates": {
-                        "type": "array"
-                      },
-                      "automationRules": {
-                        "type": "array"
-                      }
-                    }
-                  }
-                }
+                "$ref": "#/components/schemas/ImportDataDto"
               }
             }
           }
@@ -12544,6 +12486,70 @@
           "counts",
           "skippedTables",
           "omittedInlineMedia"
+        ]
+      },
+      "ImportDataDto": {
+        "type": "object",
+        "properties": {
+          "tables": {
+            "type": "object",
+            "description": "Every one of the 14 migration tables is emptied before the restore runs, so a key omitted here is restored EMPTY rather than left untouched. Post the whole GET /api/infra/export-data payload, not a hand-built subset.",
+            "properties": {
+              "sessions": {
+                "type": "array"
+              },
+              "webhooks": {
+                "type": "array"
+              },
+              "messages": {
+                "type": "array"
+              },
+              "messageBatches": {
+                "type": "array"
+              },
+              "templates": {
+                "type": "array"
+              },
+              "baileysStoredMessages": {
+                "type": "array"
+              },
+              "lidMappings": {
+                "type": "array"
+              },
+              "pluginInstances": {
+                "type": "array"
+              },
+              "conversationMappings": {
+                "type": "array"
+              },
+              "ingressEvents": {
+                "type": "array"
+              },
+              "webhookDeliveryFailures": {
+                "type": "array"
+              },
+              "integrationDeliveryFailures": {
+                "type": "array"
+              },
+              "statusUpdates": {
+                "type": "array"
+              },
+              "automationRules": {
+                "type": "array"
+              }
+            }
+          },
+          "force": {
+            "type": "boolean",
+            "description": "Allow the replace to proceed even while engines are running for sessions the backup does not contain (they keep running until restart; see restartRequired). Prefer stopOrphans, which closes that window inside this request instead."
+          },
+          "stopOrphans": {
+            "type": "boolean",
+            "description": "Stop the running engines for sessions the backup does not contain, inside this request and before the replace runs. Supersedes force for the orphan case: with stopOrphans the engines no longer need a process restart to reconcile, so restartRequired stays false on the success path."
+          }
+        },
+        "required": [
+          "tables"
         ]
       },
       "InfraImportDataResponseDto": {

--- a/src/modules/infra/dto/import-data.dto.spec.ts
+++ b/src/modules/infra/dto/import-data.dto.spec.ts
@@ -1,0 +1,68 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { ImportDataDto } from './import-data.dto';
+import { TABLE_IMPORTERS } from '../table-importers';
+
+// Mirrors the real pipe from src/config/app-validation.ts: whitelist + forbidNonWhitelisted, and the
+// enableImplicitConversion transform option. Both halves matter here — the whitelist is the reason
+// this DTO exists, and the implicit conversion is what makes a plain `boolean` property unsafe.
+const PIPE_TRANSFORM_OPTS = { enableImplicitConversion: true };
+const PIPE_VALIDATOR_OPTS = { whitelist: true, forbidNonWhitelisted: true };
+
+async function run(payload: unknown) {
+  const instance = plainToInstance(ImportDataDto, payload as object, PIPE_TRANSFORM_OPTS);
+  const errors = await validate(instance, PIPE_VALIDATOR_OPTS);
+  return { instance, errors };
+}
+
+/** A minimal but complete payload: every table the importer registry knows, each empty. */
+function fullTables(): Record<string, unknown[]> {
+  return Object.fromEntries(TABLE_IMPORTERS.map(importer => [importer.key, []]));
+}
+
+describe('ImportDataDto', () => {
+  it('rejects a body with no tables, naming the field', async () => {
+    const { errors } = await run({ force: true });
+    // Before this DTO the inline `@Body()` type erased, so this body reached the restore and threw
+    // from inside it — a 500 on the replace-all route, with nothing pointing at the missing field.
+    expect(errors.map(e => e.property)).toEqual(['tables']);
+  });
+
+  it('rejects an unknown key', async () => {
+    const { errors } = await run({ tables: fullTables(), stopOrphan: true });
+    expect(errors.map(e => e.property)).toEqual(['stopOrphan']);
+  });
+
+  it('accepts a valid body and leaves every table array intact', async () => {
+    // Load-bearing: whitelist strips undecorated properties from the object it validates, and every
+    // table key omitted from a restore is written EMPTY. If validation reached inside `tables`, a
+    // restore would silently blank the database instead of restoring it.
+    const tables = { ...fullTables(), sessions: [{ id: 's1', name: 'main' }], messages: [{ id: 'm1' }] };
+    const { instance, errors } = await run({ tables, force: false, stopOrphans: false });
+    expect(errors).toEqual([]);
+    expect(instance.tables).toEqual(tables);
+    expect(Object.keys(instance.tables as object)).toHaveLength(TABLE_IMPORTERS.length);
+  });
+
+  it.each(['force', 'stopOrphans'] as const)("maps a form-encoded 'false' on %s to a real false", async flag => {
+    // Both flags only ever OPEN the escape from the orphan-engine refusal. Under implicit conversion
+    // a plain boolean property casts 'false' to true, which would open that escape for a caller who
+    // spelled the opposite — the one direction this change must not introduce.
+    const { instance, errors } = await run({ tables: fullTables(), [flag]: 'false' });
+    expect(errors).toEqual([]);
+    expect(instance[flag]).toBe(false);
+  });
+
+  it.each(['force', 'stopOrphans'] as const)('rejects an ambiguous spelling on %s', async flag => {
+    const { errors } = await run({ tables: fullTables(), [flag]: 'yes' });
+    expect(errors.map(e => e.property)).toEqual([flag]);
+  });
+
+  it('leaves an omitted flag absent, so the default orphan refusal still applies', async () => {
+    const { instance, errors } = await run({ tables: fullTables() });
+    expect(errors).toEqual([]);
+    expect(instance.force).toBeUndefined();
+    expect(instance.stopOrphans).toBeUndefined();
+  });
+});

--- a/src/modules/infra/dto/import-data.dto.ts
+++ b/src/modules/infra/dto/import-data.dto.ts
@@ -1,0 +1,61 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsBoolean, IsObject, IsOptional } from 'class-validator';
+import { ToStrictBoolean } from '../../../common/utils/strict-boolean';
+import type { MigrationTables } from '../migration-tables.types';
+import { TABLE_IMPORTERS } from '../table-importers';
+
+/**
+ * The table keys the restore actually reads, derived from the importer registry rather than restated,
+ * so a table added to TABLE_IMPORTERS cannot go missing from the published body schema.
+ */
+const TABLE_PROPERTIES: Record<string, { type: 'array' }> = Object.fromEntries(
+  TABLE_IMPORTERS.map((importer): [string, { type: 'array' }] => [importer.key, { type: 'array' }]),
+);
+
+/**
+ * Body for POST /infra/import-data, the replace-all restore. A class (not an inline object literal)
+ * so the global ValidationPipe's whitelist/forbidNonWhitelisted actually runs — the same reason
+ * ImportStorageDto is one. An inline `@Body()` type erases at runtime, so on the most destructive
+ * route in the product a body carrying no `tables` reached the handler and failed as a 500 from
+ * inside the restore, and a misspelled key was accepted in silence.
+ *
+ * `tables` is validated as an object and not descended into: without @ValidateNested the fourteen
+ * row arrays are leaf values, so whitelist cannot strip them. That is load-bearing, not incidental —
+ * every key omitted here is restored EMPTY, so a whitelist that reached inside would silently blank
+ * the database it was asked to restore.
+ *
+ * Both flags only ever OPEN an escape from the orphan-engine refusal, so they are kept strict. Under
+ * the pipe's enableImplicitConversion a plain `boolean` property casts every non-empty string —
+ * `'false'` among them — to `true` before @IsBoolean() can object, which would open that escape for
+ * a caller who spelled the opposite. @ToStrictBoolean accepts only a real boolean or an exact
+ * 'true'/'false' and leaves anything else to be refused. An absent flag stays absent, so the default
+ * path is still the visible 409 IMPORT_WOULD_ORPHAN_ENGINES.
+ */
+export class ImportDataDto {
+  @ApiProperty({
+    type: 'object',
+    description:
+      'Every one of the 14 migration tables is emptied before the restore runs, so a key omitted here is restored EMPTY rather than left untouched. Post the whole GET /api/infra/export-data payload, not a hand-built subset.',
+    properties: TABLE_PROPERTIES,
+  })
+  @IsObject()
+  tables!: Partial<MigrationTables>;
+
+  @ApiPropertyOptional({
+    description:
+      'Allow the replace to proceed even while engines are running for sessions the backup does not contain (they keep running until restart; see restartRequired). Prefer stopOrphans, which closes that window inside this request instead.',
+  })
+  @ToStrictBoolean()
+  @IsOptional()
+  @IsBoolean()
+  force?: boolean;
+
+  @ApiPropertyOptional({
+    description:
+      'Stop the running engines for sessions the backup does not contain, inside this request and before the replace runs. Supersedes force for the orphan case: with stopOrphans the engines no longer need a process restart to reconcile, so restartRequired stays false on the success path.',
+  })
+  @ToStrictBoolean()
+  @IsOptional()
+  @IsBoolean()
+  stopOrphans?: boolean;
+}

--- a/src/modules/infra/infra-data.controller.ts
+++ b/src/modules/infra/infra-data.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, Post, Body, ConflictException, HttpCode, HttpStatus, Optional } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBody } from '@nestjs/swagger';
 import { InfraExportDataResponseDto, InfraImportDataResponseDto } from './dto/infra-response.dto';
+import { ImportDataDto } from './dto/import-data.dto';
 import { ConfigService } from '@nestjs/config';
 import { DataSource, QueryRunner } from 'typeorm';
 import { InjectDataSource } from '@nestjs/typeorm';
@@ -474,66 +475,16 @@ export class InfraDataController {
   @HttpCode(HttpStatus.OK)
   @RequireRole(ApiKeyRole.ADMIN)
   @ApiOperation({ summary: 'Import data to Data DB (replaces existing data)' })
-  @ApiBody({
-    description: 'Exported data from export-data endpoint',
-    schema: {
-      type: 'object',
-      properties: {
-        force: {
-          type: 'boolean',
-          description:
-            'Allow the replace to proceed even while engines are running for sessions the backup does not contain (they keep running until restart; see restartRequired). Prefer stopOrphans, which closes that window inside this request instead.',
-        },
-        stopOrphans: {
-          type: 'boolean',
-          description:
-            'Stop the running engines for sessions the backup does not contain, inside this request and before the replace runs. Supersedes force for the orphan case: with stopOrphans the engines no longer need a process restart to reconcile, so restartRequired stays false on the success path.',
-        },
-        tables: {
-          type: 'object',
-          description:
-            'Every one of the 14 migration tables is emptied before the restore runs, so a key omitted here is restored EMPTY rather than left untouched. Post the whole GET /api/infra/export-data payload, not a hand-built subset.',
-          properties: {
-            sessions: { type: 'array' },
-            webhooks: { type: 'array' },
-            messages: { type: 'array' },
-            messageBatches: { type: 'array' },
-            templates: { type: 'array' },
-            baileysStoredMessages: { type: 'array' },
-            lidMappings: { type: 'array' },
-            pluginInstances: { type: 'array' },
-            conversationMappings: { type: 'array' },
-            ingressEvents: { type: 'array' },
-            webhookDeliveryFailures: { type: 'array' },
-            integrationDeliveryFailures: { type: 'array' },
-            statusUpdates: { type: 'array' },
-            automationRules: { type: 'array' },
-          },
-        },
-      },
-    },
-  })
+  // `type` is explicit: an @ApiBody carrying only a description does NOT fall back to the handler's
+  // parameter type — it publishes `{"type": "string"}` for the whole body.
+  @ApiBody({ description: 'Exported data from export-data endpoint', type: ImportDataDto })
   @ApiResponse({ status: 200, description: 'Data imported successfully', type: InfraImportDataResponseDto })
   @ApiResponse({
     status: 409,
     description:
       'Refused, with the reason in `code`. IMPORT_ALREADY_RUNNING: another import is running — wait for it. IMPORT_NESTED_TRANSACTION: another database transaction holds this connection, so a restore could not be made durable — retry with nothing else in flight. IMPORT_WOULD_ORPHAN_ENGINES: live engines exist for sessions the backup would remove — retry with stopOrphans=true to stop them in-request, or force=true to proceed and restart after. Only the last of these is retryable with stopOrphans; the others leave nothing to decide',
   })
-  async importData(
-    @Body()
-    data: {
-      tables: Partial<MigrationTables>;
-      force?: boolean;
-      /**
-       * Stop the running engines for sessions the backup does not contain, inside this request and
-       * before the replace runs (best-effort, time-bounded per engine). Supersedes force=true for the
-       * orphan case: with stopOrphans the engines no longer need a process restart to reconcile, so
-       * restartRequired stays false on the success path. Without it the pre-existing behavior holds —
-       * refuse with 409, or proceed with force=true and leave the engines running until restart.
-       */
-      stopOrphans?: boolean;
-    },
-  ): Promise<{
+  async importData(@Body() data: ImportDataDto): Promise<{
     imported: boolean;
     counts: TableCounts;
     warnings: string[];


### PR DESCRIPTION
`POST /api/infra/import-data` bound `@Body()` to an inline object-literal type. TypeScript types erase at runtime, so there was nothing for the global `ValidationPipe` to reflect over and its `whitelist` / `forbidNonWhitelisted` never ran — on the replace-all database restore, which is the most destructive route in the product. A body carrying no `tables` reached the handler and threw from inside the import at `data.tables.sessions`, surfacing as a 500 with nothing pointing at the missing field, and a misspelled key was accepted in silence.

`CONTRIBUTING.md` already states the convention ("validate request bodies with DTOs + `class-validator`"), and `src/modules/infra/dto/import-storage.dto.ts` is the same fix applied to the neighbouring route.

## What changed

- `ImportDataDto` with `tables` required, `force` and `stopOrphans` optional. A missing `tables` answers 400 naming the field; an unknown key is refused.
- `tables` is validated as an object and deliberately not descended into. Without `@ValidateNested` the fourteen row arrays are leaf values, so `whitelist` cannot strip them — that is load-bearing rather than incidental, because every table key omitted from a restore is written EMPTY, so a whitelist reaching inside would silently blank the database it was asked to restore. There is a test pinning it.
- Both flags use `@ToStrictBoolean`. Under the pipe's `enableImplicitConversion` a plain `boolean` property casts every non-empty string — `'false'` among them — to `true` before `@IsBoolean()` can object. Since `force` and `stopOrphans` only ever *open* the escape from the orphan-engine refusal, a plain boolean would have opened it for a caller who spelled the opposite. An omitted flag stays absent, so the default 409 `IMPORT_WOULD_ORPHAN_ENGINES` path is unchanged.
- The published body schema keeps its fourteen table keys, now derived from `TABLE_IMPORTERS` rather than restated, so a table added to the importer registry cannot go missing from the contract.

## A note on `@ApiBody`

`@ApiBody` carries an explicit `type` here. An `@ApiBody` that supplies only a `description` does not fall back to the handler's parameter type — it publishes `{"type": "string"}` for the whole body. That is what `/api/infra/storage/import` currently publishes in `openapi.json`, and it is left alone in this PR rather than fixed alongside an unrelated change.

## Verification

Mutations applied and reverted separately:

- Dropping `@ToStrictBoolean()` from `force` fails `maps a form-encoded 'false' on force to a real false` and `rejects an ambiguous spelling on force`.
- Dropping `@IsObject()` from `tables` fails `rejects a body with no tables, naming the field`.

The repo's own coercion drift gate picks the new properties up automatically and would have caught the permissive variant on its own:

```
● DTO input-coercion drift gate › ImportDataDto.force refuses a value the pipe would otherwise coerce
  Received: "ImportDataDto.force accepted \"yes\" — implicit conversion turns any
             non-empty string into true. Add @ToStrictBoolean() from common/utils/strict-boolean."
```

`openapi.json` is regenerated and committed; the snapshot diff touches only this route and adds the `ImportDataDto` component, with `required: ["tables"]` now published and all fourteen table keys intact.

Full gate green: lint, `tsc --noEmit`, `format:check`, 5539 tests, build, `openapi:check`, and the four SDK contract gates.
