### PR TITLE
test(message): assert the stored-media download security headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Turkish (`tr`) dashboard translation. Thanks @codedByCan.
 - `AUDIT_RETENTION_DAYS` is checked at boot, so a typo fails startup with a named error instead of silently reverting to the 90-day default. It is validated as non-negative rather than positive, because `0` is the documented switch that disables audit-log pruning entirely.
+- `message.controller.spec.ts` holds the two headers the stored-media download sends, `X-Content-Type-Options: nosniff` and `Content-Disposition: attachment`; deleting either had passed every suite in the repo.
 
 ### Fixed
 

--- a/src/modules/message/message.controller.spec.ts
+++ b/src/modules/message/message.controller.spec.ts
@@ -1,0 +1,38 @@
+import { MessageController } from './message.controller';
+import type { MessageService } from './message.service';
+import type { BulkMessageService } from './bulk-message.service';
+import type { Response } from 'express';
+
+/**
+ * `getChatMedia` serves third-party bytes from the API origin. The route shape, the roles and the
+ * status codes are already held by the OpenAPI snapshot and the route-fence gates; the two headers
+ * that keep those bytes inert in a browser were held by nothing — deleting either line from the
+ * controller passed every suite in the repo.
+ */
+describe('MessageController — stored media download', () => {
+  const getChatMedia = jest.fn().mockResolvedValue({ buffer: Buffer.from('GIF89a'), mimetype: 'image/gif' });
+  const controller = new MessageController(
+    { getChatMedia } as unknown as MessageService,
+    {} as unknown as BulkMessageService,
+  );
+
+  /**
+   * Express merges the object form of `res.set` into the header bag, so accumulating is both closer
+   * to the real thing than recording the last call and independent of how many calls the handler
+   * splits its headers across.
+   */
+  const mediaResponseHeaders = async (): Promise<Record<string, string>> => {
+    const headers: Record<string, string> = {};
+    const res = { set: (fields: Record<string, string>) => Object.assign(headers, fields) } as unknown as Response;
+    await controller.getChatMedia('session-1', '628123@c.us', 'msg-1', res);
+    return headers;
+  };
+
+  it('sends nosniff, so a wrong Content-Type cannot be re-interpreted as active content', async () => {
+    expect((await mediaResponseHeaders())['X-Content-Type-Options']).toBe('nosniff');
+  });
+
+  it('sends the media as an attachment, so it is never rendered on the API origin', async () => {
+    expect((await mediaResponseHeaders())['Content-Disposition']).toBe('attachment');
+  });
+});


### PR DESCRIPTION
## What

Adds `src/modules/message/message.controller.spec.ts`, asserting the two response headers `getChatMedia` sets on the stored-media download:

- `X-Content-Type-Options: nosniff`
- `Content-Disposition: attachment`

## Why

That route serves bytes that arrived from a third party, from the API origin. The two headers together are what keep those bytes inert in a browser: the disposition forces a download rather than a render, and `nosniff` stops a wrong `Content-Type` from being re-interpreted as active content.

`MessageController` had no spec. Its other 25 routes are covered indirectly — the route shapes are locked by the OpenAPI snapshot gate and the route-fence gate, the roles by the auth metadata, and the handlers carry no control flow. These two headers were the exception: they are a side effect on the `@Res({ passthrough: true })` response object, so they appear in no return type, no contract snapshot and no route gate.

That the gap was real was measured rather than assumed: with the `nosniff` line deleted and this spec absent, the pre-existing suite passed in full — 5,529 passed, 5 skipped, 0 failed.

## Verification

Each header is asserted separately, so a failure names the one that went missing, and each line was removed on its own to confirm the spec actually fails without it:

| Mutation | Result |
| --- | --- |
| baseline, controller untouched | GREEN — 2 passed |
| delete `'X-Content-Type-Options': 'nosniff',` | RED — 1 failed, 1 passed |
| restore | GREEN — 2 passed |
| delete `'Content-Disposition': 'attachment',` | RED — 1 failed, 1 passed |
| restore | GREEN — 2 passed |

Each mutation fails exactly one test rather than both, so the two assertions discriminate between the headers instead of merely reacting to any change. The controller was confirmed byte-identical to its original after the run.

Full suite with the spec in place, rebased onto b2538e3f: 5,532 passed, 5 skipped, 0 failed. `lint`, `tsc --noEmit`, `format:check` and `build` all clean.

## Scope

Test-only. No production code is touched.