### PR TITLE
feat(message): accept an optional quotedMessageId on the send endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Turkish (`tr`) dashboard translation. Thanks @codedByCan.
 - `AUDIT_RETENTION_DAYS` is checked at boot, so a typo fails startup with a named error instead of silently reverting to the 90-day default. It is validated as non-negative rather than positive, because `0` is the documented switch that disables audit-log pruning entirely.
 - `message.controller.spec.ts` holds the two headers the stored-media download sends, `X-Content-Type-Options: nosniff` and `Content-Disposition: attachment`; deleting either had passed every suite in the repo.
+- Optional `quotedMessageId` on every `send-*` message endpoint and its MCP tool, so a reply can carry media, a location, a contact card or a poll instead of only text. An id the engine cannot resolve now fails the send rather than delivering the message unquoted. Thanks @nirizr for the report.
 
 ### Fixed
 

--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -1439,6 +1439,7 @@ Send a plain text message.
 | mentions          | string[] | No       | array of WIDs                  | WIDs to @mention (e.g. `["62811@c.us"]`). See **Mentions** below                             |
 | linkPreview       | boolean  | No       | —                              | `false` suppresses it; on Baileys `true` is required to get one. See **Link previews** below |
 | customLinkPreview | object   | No       | `{ url, title, description? }` | Attach a preview you supply. **Baileys only.** See **Link previews** below                   |
+| quotedMessageId   | string   | No       | non-empty                      | Quote an earlier message, making this a reply. See [Quoted sends](#quoted-sends) below       |
 
 ```json
 { "chatId": "628123456789@c.us", "text": "Hello from OpenWA!" }
@@ -1493,6 +1494,40 @@ rejected with `400` rather than guessing which half was meant.
 
 **Errors:** `400` unknown body field, validation failure, or session not active / blocked by a plugin hook · `401` missing/invalid API key · `403` key role below OPERATOR · `404` session not found · `500` engine error
 
+##### Quoted sends
+
+Every `send-*` route above accepts an optional `quotedMessageId`. Supplying it turns that send into a
+reply, so a reply can carry media, a location, a contact card or a poll — not only text.
+`POST .../messages/reply` is unchanged and remains the text shorthand.
+
+```json
+{
+  "chatId": "628123456789@c.us",
+  "contactName": "Alice",
+  "contactNumber": "628999888777",
+  "quotedMessageId": "true_628123456789@c.us_3EB0ABCD"
+}
+```
+
+**The id is engine-specific and is deliberately not harmonised.**
+
+|                      | whatsapp-web.js                                  | Baileys                           |
+| -------------------- | ------------------------------------------------ | --------------------------------- |
+| id to supply         | the serialized message id (`true_<chat>_<hash>`) | the raw message key id            |
+| where it is resolved | in the WhatsApp Web page                         | the gateway's local message store |
+| message not found    | `404` — the send is refused                      | `404` — the send is refused       |
+
+An id the engine cannot resolve **fails the send** rather than delivering the message unquoted. On
+whatsapp-web.js that is a deliberate choice: the library's default is to send anyway and report
+success, which would hand back `201` for a message that is not a reply.
+
+One upstream gap remains on whatsapp-web.js and cannot be switched off from here: if the quoted
+message resolves but the page decides it is not replyable, the message is sent without the quote and
+the call still succeeds.
+
+Quoting a message from a **different chat** is not validated on either engine; the id is passed
+through as given.
+
 #### POST /api/sessions/:sessionId/messages/send-template
 
 Render a stored text template (header/body/footer joined by blank lines, `{{vars}}` substituted) and send it as text.
@@ -1546,14 +1581,15 @@ Send an image (by URL or base64) with an optional caption.
 
 **Request body** — `SendMediaMessageDto`
 
-| Field    | Type   | Required    | Constraints                           | Description                                                               |
-| -------- | ------ | ----------- | ------------------------------------- | ------------------------------------------------------------------------- |
-| chatId   | string | Yes         | non-empty                             | Target chat                                                               |
-| url      | string | Conditional | URL; required when `base64` is absent | http/https media URL (SSRF-guarded; a blocked internal URL maps to `400`) |
-| base64   | string | Conditional | string; required when `url` is absent | Base64 media data (capped to the media byte limit)                        |
-| mimetype | string | Conditional | string; required when using `base64`  | MIME type of the media                                                    |
-| filename | string | No          | max 255                               | File name                                                                 |
-| caption  | string | No          | max 1024                              | Caption text                                                              |
+| Field           | Type   | Required    | Constraints                           | Description                                                                       |
+| --------------- | ------ | ----------- | ------------------------------------- | --------------------------------------------------------------------------------- |
+| chatId          | string | Yes         | non-empty                             | Target chat                                                                       |
+| url             | string | Conditional | URL; required when `base64` is absent | http/https media URL (SSRF-guarded; a blocked internal URL maps to `400`)         |
+| base64          | string | Conditional | string; required when `url` is absent | Base64 media data (capped to the media byte limit)                                |
+| mimetype        | string | Conditional | string; required when using `base64`  | MIME type of the media                                                            |
+| filename        | string | No          | max 255                               | File name                                                                         |
+| caption         | string | No          | max 1024                              | Caption text                                                                      |
+| quotedMessageId | string | No          | non-empty                             | Quote an earlier message, making this a reply — see [Quoted sends](#quoted-sends) |
 
 ```json
 { "chatId": "628123456789@c.us", "url": "https://example.com/image.jpg", "caption": "Check out this image!" }
@@ -1579,7 +1615,7 @@ Send a video (by URL or base64) with an optional caption. Uses the same `SendMed
 | --------- | ------ | ----------- |
 | sessionId | string | Session ID  |
 
-**Request body** — `SendMediaMessageDto` (fields `chatId`, `url`, `base64`, `mimetype`, `filename`, `caption` — see `send-image`)
+**Request body** — `SendMediaMessageDto` (fields `chatId`, `url`, `base64`, `mimetype`, `filename`, `caption`, `quotedMessageId` — see `send-image`)
 
 ```json
 { "chatId": "628123456789@c.us", "url": "https://example.com/clip.mp4", "caption": "video" }
@@ -1631,7 +1667,7 @@ Send a document/file (by URL or base64). Uses `SendMediaMessageDto`; `filename` 
 | --------- | ------ | ----------- |
 | sessionId | string | Session ID  |
 
-**Request body** — `SendMediaMessageDto` (fields `chatId`, `url`, `base64`, `mimetype`, `filename`, `caption` — see `send-image`)
+**Request body** — `SendMediaMessageDto` (fields `chatId`, `url`, `base64`, `mimetype`, `filename`, `caption`, `quotedMessageId` — see `send-image`)
 
 ```json
 {
@@ -1666,13 +1702,14 @@ Send a location pin.
 
 **Request body** — `SendLocationDto`
 
-| Field       | Type   | Required | Constraints     | Description                      |
-| ----------- | ------ | -------- | --------------- | -------------------------------- |
-| chatId      | string | Yes      | non-empty       | Target chat                      |
-| latitude    | number | Yes      | valid latitude  | Latitude (out-of-range → `400`)  |
-| longitude   | number | Yes      | valid longitude | Longitude (out-of-range → `400`) |
-| description | string | No       | string          | Pin description                  |
-| address     | string | No       | string          | Pin address                      |
+| Field           | Type   | Required | Constraints     | Description                                                                       |
+| --------------- | ------ | -------- | --------------- | --------------------------------------------------------------------------------- |
+| chatId          | string | Yes      | non-empty       | Target chat                                                                       |
+| latitude        | number | Yes      | valid latitude  | Latitude (out-of-range → `400`)                                                   |
+| longitude       | number | Yes      | valid longitude | Longitude (out-of-range → `400`)                                                  |
+| description     | string | No       | string          | Pin description                                                                   |
+| address         | string | No       | string          | Pin address                                                                       |
+| quotedMessageId | string | No       | non-empty       | Quote an earlier message, making this a reply — see [Quoted sends](#quoted-sends) |
 
 ```json
 {
@@ -1706,11 +1743,12 @@ Send a contact card (vCard).
 
 **Request body** — `SendContactDto`
 
-| Field         | Type   | Required | Constraints | Description                       |
-| ------------- | ------ | -------- | ----------- | --------------------------------- |
-| chatId        | string | Yes      | non-empty   | Target chat                       |
-| contactName   | string | Yes      | non-empty   | Display name for the contact card |
-| contactNumber | string | Yes      | non-empty   | Contact phone number              |
+| Field           | Type   | Required | Constraints | Description                                                                       |
+| --------------- | ------ | -------- | ----------- | --------------------------------------------------------------------------------- |
+| chatId          | string | Yes      | non-empty   | Target chat                                                                       |
+| contactName     | string | Yes      | non-empty   | Display name for the contact card                                                 |
+| contactNumber   | string | Yes      | non-empty   | Contact phone number                                                              |
+| quotedMessageId | string | No       | non-empty   | Quote an earlier message, making this a reply — see [Quoted sends](#quoted-sends) |
 
 ```json
 { "chatId": "628123456789@c.us", "contactName": "John Doe", "contactNumber": "628987654321" }
@@ -1736,7 +1774,7 @@ Send a sticker (by URL or base64; typically webp). Reuses `SendMediaMessageDto`.
 | --------- | ------ | ----------- |
 | sessionId | string | Session ID  |
 
-**Request body** — `SendMediaMessageDto` (fields `chatId`, `url`, `base64`, `mimetype`, `filename`, `caption` — see `send-image`)
+**Request body** — `SendMediaMessageDto` (fields `chatId`, `url`, `base64`, `mimetype`, `filename`, `caption`, `quotedMessageId` — see `send-image`)
 
 ```json
 { "chatId": "628123456789@c.us", "url": "https://example.com/sticker.webp", "mimetype": "image/webp" }
@@ -1764,12 +1802,13 @@ Send a native WhatsApp poll.
 
 **Request body** — `SendPollDto`
 
-| Field                | Type     | Required | Constraints                               | Description                                           |
-| -------------------- | -------- | -------- | ----------------------------------------- | ----------------------------------------------------- |
-| chatId               | string   | Yes      | non-empty                                 | Target chat                                           |
-| name                 | string   | Yes      | max 255                                   | Poll question / title                                 |
-| options              | string[] | Yes      | 2–12 items, each non-empty, max 100 chars | Options to vote on                                    |
-| allowMultipleAnswers | boolean  | No       | —                                         | Allow picking several options (default single choice) |
+| Field                | Type     | Required | Constraints                               | Description                                                  |
+| -------------------- | -------- | -------- | ----------------------------------------- | ------------------------------------------------------------ |
+| chatId               | string   | Yes      | non-empty                                 | Target chat                                                  |
+| name                 | string   | Yes      | max 255                                   | Poll question / title                                        |
+| options              | string[] | Yes      | 2–12 items, each non-empty, max 100 chars | Options to vote on                                           |
+| allowMultipleAnswers | boolean  | No       | —                                         | Allow picking several options (default single choice)        |
+| quotedMessageId      | string   | No       | non-empty                                 | Quote an earlier message — see [Quoted sends](#quoted-sends) |
 
 ```json
 {

--- a/openapi.json
+++ b/openapi.json
@@ -2501,6 +2501,17 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SendLocationDto"
+              },
+              "examples": {
+                "minimal": {
+                  "summary": "Share a location",
+                  "value": {
+                    "chatId": "628123456789@c.us",
+                    "latitude": -6.2088,
+                    "longitude": 106.8456,
+                    "description": "Jakarta"
+                  }
+                }
               }
             }
           }
@@ -2549,6 +2560,16 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SendContactDto"
+              },
+              "examples": {
+                "minimal": {
+                  "summary": "Share a contact card",
+                  "value": {
+                    "chatId": "628123456789@c.us",
+                    "contactName": "Alice",
+                    "contactNumber": "628999888777"
+                  }
+                }
               }
             }
           }
@@ -2657,6 +2678,19 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SendPollDto"
+              },
+              "examples": {
+                "minimal": {
+                  "summary": "Ask a single-choice poll",
+                  "value": {
+                    "chatId": "120363000000000000@g.us",
+                    "name": "Where should we meet?",
+                    "options": [
+                      "Park",
+                      "Beach"
+                    ]
+                  }
+                }
               }
             }
           }
@@ -10570,6 +10604,11 @@
                 "$ref": "#/components/schemas/CustomLinkPreviewDto"
               }
             ]
+          },
+          "quotedMessageId": {
+            "type": "string",
+            "description": "Quote an earlier message, turning this send into a reply. The id is engine-specific: whatsapp-web.js matches the serialized message id, Baileys matches the raw message key id and can only quote a message it has already stored. An id that cannot be resolved fails the send rather than delivering it unquoted.",
+            "example": "true_628123456789@c.us_3EB0ABCD"
           }
         },
         "required": [
@@ -10669,6 +10708,11 @@
             "items": {
               "type": "string"
             }
+          },
+          "quotedMessageId": {
+            "type": "string",
+            "description": "Quote an earlier message, turning this send into a reply. The id is engine-specific: whatsapp-web.js matches the serialized message id, Baileys matches the raw message key id and can only quote a message it has already stored. An id that cannot be resolved fails the send rather than delivering it unquoted.",
+            "example": "true_628123456789@c.us_3EB0ABCD"
           }
         },
         "required": [
@@ -10718,6 +10762,11 @@
               "type": "string"
             }
           },
+          "quotedMessageId": {
+            "type": "string",
+            "description": "Quote an earlier message, turning this send into a reply. The id is engine-specific: whatsapp-web.js matches the serialized message id, Baileys matches the raw message key id and can only quote a message it has already stored. An id that cannot be resolved fails the send rather than delivering it unquoted.",
+            "example": "true_628123456789@c.us_3EB0ABCD"
+          },
           "ptt": {
             "type": "boolean",
             "description": "Send as a WhatsApp voice note (PTT — mic bubble + waveform). Provide audio/ogg; codecs=opus bytes for reliable playback; when the mimetype is omitted it defaults to that for voice notes. Expects a JSON boolean. Default false = plain audio file. Only valid on send-audio."
@@ -10749,6 +10798,11 @@
           "address": {
             "type": "string",
             "maxLength": 1024
+          },
+          "quotedMessageId": {
+            "type": "string",
+            "description": "Quote an earlier message, turning this send into a reply. The id is engine-specific: whatsapp-web.js matches the serialized message id, Baileys matches the raw message key id and can only quote a message it has already stored. An id that cannot be resolved fails the send rather than delivering it unquoted.",
+            "example": "true_628123456789@c.us_3EB0ABCD"
           }
         },
         "required": [
@@ -10770,6 +10824,11 @@
           "contactNumber": {
             "type": "string",
             "maxLength": 30
+          },
+          "quotedMessageId": {
+            "type": "string",
+            "description": "Quote an earlier message, turning this send into a reply. The id is engine-specific: whatsapp-web.js matches the serialized message id, Baileys matches the raw message key id and can only quote a message it has already stored. An id that cannot be resolved fails the send rather than delivering it unquoted.",
+            "example": "true_628123456789@c.us_3EB0ABCD"
           }
         },
         "required": [
@@ -10806,6 +10865,11 @@
           "allowMultipleAnswers": {
             "type": "boolean",
             "description": "Allow voters to pick several options (default single choice)"
+          },
+          "quotedMessageId": {
+            "type": "string",
+            "description": "Quote an earlier message, turning this send into a reply. The id is engine-specific: whatsapp-web.js matches the serialized message id, Baileys matches the raw message key id and can only quote a message it has already stored. An id that cannot be resolved fails the send rather than delivering it unquoted.",
+            "example": "true_628123456789@c.us_3EB0ABCD"
           }
         },
         "required": [

--- a/src/core/agent-tools/tools/message.tools.ts
+++ b/src/core/agent-tools/tools/message.tools.ts
@@ -12,6 +12,19 @@ import { defineTool, type AnyToolDescriptor } from '../tool-descriptor';
 
 const sessionId = z.string().min(1).describe('Session UUID (the session id, not the name)');
 
+/**
+ * Mirrors the REST `quotedMessageId` field so an agent can reply with media, a location, a contact
+ * card or a poll — the same capability, on the same endpoints, through the MCP surface.
+ */
+const quotedMessageIdSchema = z
+  .string()
+  .min(1)
+  .optional()
+  .describe(
+    'Quote an earlier message, making this send a reply. Engine-specific: whatsapp-web.js takes ' +
+      'the serialized message id, Baileys the raw key id of a message it has already stored.',
+  );
+
 export function messageTools(message: MessageService): AnyToolDescriptor[] {
   return [
     defineTool({
@@ -86,12 +99,14 @@ export function messageTools(message: MessageService): AnyToolDescriptor[] {
             'Set false to suppress the URL preview. Guaranteed only in that direction — leaving it ' +
               'unset means the engine default, and the engines differ.',
           ),
+        quotedMessageId: quotedMessageIdSchema,
       }),
       handler: input =>
         message.sendText(input.sessionId, {
           chatId: input.chatId,
           text: input.text,
           ...(input.linkPreview === undefined ? {} : { linkPreview: input.linkPreview }),
+          quotedMessageId: input.quotedMessageId,
         }),
     }),
     defineTool({
@@ -108,6 +123,7 @@ export function messageTools(message: MessageService): AnyToolDescriptor[] {
         mimetype: z.string().optional().describe('MIME type (required when using base64)'),
         filename: z.string().max(255).optional(),
         caption: z.string().max(1024).optional(),
+        quotedMessageId: quotedMessageIdSchema,
       }),
       handler: input =>
         message.sendImage(input.sessionId, {
@@ -117,6 +133,7 @@ export function messageTools(message: MessageService): AnyToolDescriptor[] {
           mimetype: input.mimetype,
           filename: input.filename,
           caption: input.caption,
+          quotedMessageId: input.quotedMessageId,
         }),
     }),
     defineTool({
@@ -133,6 +150,7 @@ export function messageTools(message: MessageService): AnyToolDescriptor[] {
         mimetype: z.string().optional().describe('MIME type (required when using base64)'),
         filename: z.string().max(255).optional(),
         caption: z.string().max(1024).optional(),
+        quotedMessageId: quotedMessageIdSchema,
       }),
       handler: input =>
         message.sendVideo(input.sessionId, {
@@ -142,6 +160,7 @@ export function messageTools(message: MessageService): AnyToolDescriptor[] {
           mimetype: input.mimetype,
           filename: input.filename,
           caption: input.caption,
+          quotedMessageId: input.quotedMessageId,
         }),
     }),
     defineTool({
@@ -159,6 +178,7 @@ export function messageTools(message: MessageService): AnyToolDescriptor[] {
         filename: z.string().max(255).optional(),
         caption: z.string().max(1024).optional(),
         ptt: z.boolean().optional().describe('Send as a WhatsApp voice note (PTT)'),
+        quotedMessageId: quotedMessageIdSchema,
       }),
       handler: input =>
         message.sendAudio(input.sessionId, {
@@ -169,6 +189,7 @@ export function messageTools(message: MessageService): AnyToolDescriptor[] {
           filename: input.filename,
           caption: input.caption,
           ptt: input.ptt,
+          quotedMessageId: input.quotedMessageId,
         }),
     }),
     defineTool({
@@ -185,6 +206,7 @@ export function messageTools(message: MessageService): AnyToolDescriptor[] {
         mimetype: z.string().optional().describe('MIME type (required when using base64)'),
         filename: z.string().max(255).optional(),
         caption: z.string().max(1024).optional(),
+        quotedMessageId: quotedMessageIdSchema,
       }),
       handler: input =>
         message.sendDocument(input.sessionId, {
@@ -194,6 +216,7 @@ export function messageTools(message: MessageService): AnyToolDescriptor[] {
           mimetype: input.mimetype,
           filename: input.filename,
           caption: input.caption,
+          quotedMessageId: input.quotedMessageId,
         }),
     }),
     defineTool({
@@ -209,6 +232,7 @@ export function messageTools(message: MessageService): AnyToolDescriptor[] {
         longitude: z.number().min(-180).max(180).describe('Longitude coordinate'),
         description: z.string().max(LOCATION_TEXT_MAX_LENGTH).optional().describe('Location label/description'),
         address: z.string().max(LOCATION_TEXT_MAX_LENGTH).optional().describe('Street address'),
+        quotedMessageId: quotedMessageIdSchema,
       }),
       handler: input =>
         message.sendLocation(input.sessionId, {
@@ -217,6 +241,7 @@ export function messageTools(message: MessageService): AnyToolDescriptor[] {
           longitude: input.longitude,
           description: input.description,
           address: input.address,
+          quotedMessageId: input.quotedMessageId,
         }),
     }),
     defineTool({
@@ -234,12 +259,14 @@ export function messageTools(message: MessageService): AnyToolDescriptor[] {
           .min(1)
           .max(CONTACT_NUMBER_MAX_LENGTH)
           .describe('Phone number of the contact to share'),
+        quotedMessageId: quotedMessageIdSchema,
       }),
       handler: input =>
         message.sendContact(input.sessionId, {
           chatId: input.chatId,
           contactName: input.contactName,
           contactNumber: input.contactNumber,
+          quotedMessageId: input.quotedMessageId,
         }),
     }),
     defineTool({
@@ -256,6 +283,7 @@ export function messageTools(message: MessageService): AnyToolDescriptor[] {
         mimetype: z.string().optional().describe('MIME type (required when using base64)'),
         filename: z.string().max(255).optional(),
         caption: z.string().max(1024).optional(),
+        quotedMessageId: quotedMessageIdSchema,
       }),
       handler: input =>
         message.sendSticker(input.sessionId, {
@@ -265,6 +293,7 @@ export function messageTools(message: MessageService): AnyToolDescriptor[] {
           mimetype: input.mimetype,
           filename: input.filename,
           caption: input.caption,
+          quotedMessageId: input.quotedMessageId,
         }),
     }),
     defineTool({

--- a/src/engine/adapters/baileys-messaging.ts
+++ b/src/engine/adapters/baileys-messaging.ts
@@ -14,6 +14,7 @@ import {
   MessageResult,
   PollInput,
   Product,
+  Quotable,
 } from '../interfaces/whatsapp-engine.interface';
 import { toEngineParticipants } from './baileys-groups';
 import { buildVCard } from './vcard';
@@ -148,7 +149,7 @@ export class BaileysMessaging {
     chatId: string,
     text: string,
     mentions?: string[],
-    sendOptions?: { linkPreview?: boolean; customPreview?: CustomLinkPreview },
+    sendOptions?: { linkPreview?: boolean; customPreview?: CustomLinkPreview } & Quotable,
   ): Promise<MessageResult> {
     this.host.ensureReady();
     const jid = await this.toDeliverableJid(chatId);
@@ -159,6 +160,9 @@ export class BaileysMessaging {
     const options = {
       ...(this.withEphemeral(jid) ?? {}),
       getUrlInfo: (text: string) => generateSafeLinkPreview(text),
+      // Merged rather than assigned: getUrlInfo above must survive, or the library's own vulnerable
+      // preview generator becomes reachable again on quoted sends only.
+      ...((await this.quoteOption(sendOptions?.quotedMessageId)) ?? {}),
     };
     // `linkPreview: null` is Baileys' explicit "no preview": with the key absent it instead calls the
     // configured generator (Utils/messages.js:279-281), which for us means a blocking outbound fetch
@@ -291,41 +295,57 @@ export class BaileysMessaging {
   async sendImageMessage(chatId: string, media: MediaInput): Promise<MessageResult> {
     this.host.ensureReady();
     const { data, mimetype } = await resolveMediaBuffer(media);
-    return this.sendContent(chatId, {
-      image: data,
-      caption: media.caption,
-      mimetype,
-      ...this.withMentions(media.mentions),
-    });
+    return this.sendContent(
+      chatId,
+      {
+        image: data,
+        caption: media.caption,
+        mimetype,
+        ...this.withMentions(media.mentions),
+      },
+      await this.quoteOption(media.quotedMessageId),
+    );
   }
 
   async sendVideoMessage(chatId: string, media: MediaInput): Promise<MessageResult> {
     this.host.ensureReady();
     const { data, mimetype } = await resolveMediaBuffer(media);
-    return this.sendContent(chatId, {
-      video: data,
-      caption: media.caption,
-      mimetype,
-      ...this.withMentions(media.mentions),
-    });
+    return this.sendContent(
+      chatId,
+      {
+        video: data,
+        caption: media.caption,
+        mimetype,
+        ...this.withMentions(media.mentions),
+      },
+      await this.quoteOption(media.quotedMessageId),
+    );
   }
 
   async sendAudioMessage(chatId: string, media: MediaInput): Promise<MessageResult> {
     this.host.ensureReady();
     const { data, mimetype } = await resolveMediaBuffer(media);
-    return this.sendContent(chatId, { audio: data, mimetype, ptt: media.ptt ?? false });
+    return this.sendContent(
+      chatId,
+      { audio: data, mimetype, ptt: media.ptt ?? false },
+      await this.quoteOption(media.quotedMessageId),
+    );
   }
 
   async sendDocumentMessage(chatId: string, media: MediaInput): Promise<MessageResult> {
     this.host.ensureReady();
     const { data, mimetype } = await resolveMediaBuffer(media);
-    return this.sendContent(chatId, {
-      document: data,
-      mimetype,
-      fileName: media.filename ?? 'file',
-      caption: media.caption,
-      ...this.withMentions(media.mentions),
-    });
+    return this.sendContent(
+      chatId,
+      {
+        document: data,
+        mimetype,
+        fileName: media.filename ?? 'file',
+        caption: media.caption,
+        ...this.withMentions(media.mentions),
+      },
+      await this.quoteOption(media.quotedMessageId),
+    );
   }
 
   async createCallLink(type: CallLinkType, startTime: number): Promise<string> {
@@ -353,39 +373,55 @@ export class BaileysMessaging {
   async sendStickerMessage(chatId: string, media: MediaInput): Promise<MessageResult> {
     this.host.ensureReady();
     const { data, mimetype } = await resolveMediaBuffer(media);
-    return this.sendContent(chatId, { sticker: await toWebpSticker(data, mimetype) });
+    return this.sendContent(
+      chatId,
+      { sticker: await toWebpSticker(data, mimetype) },
+      await this.quoteOption(media.quotedMessageId),
+    );
   }
 
   async sendLocationMessage(chatId: string, location: LocationInput): Promise<MessageResult> {
     this.host.ensureReady();
-    return this.sendContent(chatId, {
-      location: {
-        degreesLatitude: location.latitude,
-        degreesLongitude: location.longitude,
-        name: location.description,
-        address: location.address,
+    return this.sendContent(
+      chatId,
+      {
+        location: {
+          degreesLatitude: location.latitude,
+          degreesLongitude: location.longitude,
+          name: location.description,
+          address: location.address,
+        },
       },
-    });
+      await this.quoteOption(location.quotedMessageId),
+    );
   }
 
   async sendContactMessage(chatId: string, contact: ContactCard): Promise<MessageResult> {
     this.host.ensureReady();
-    return this.sendContent(chatId, {
-      contacts: { displayName: contact.name, contacts: [{ vcard: buildVCard(contact) }] },
-    });
+    return this.sendContent(
+      chatId,
+      {
+        contacts: { displayName: contact.name, contacts: [{ vcard: buildVCard(contact) }] },
+      },
+      await this.quoteOption(contact.quotedMessageId),
+    );
   }
 
   async sendPollMessage(chatId: string, poll: PollInput): Promise<MessageResult> {
     this.host.ensureReady();
     // selectableCount 1 = single choice; 0 = no limit, which is how WhatsApp expresses
     // "allow multiple answers". Baileys generates the poll's messageSecret itself.
-    return this.sendContent(chatId, {
-      poll: {
-        name: poll.name,
-        values: poll.options,
-        selectableCount: poll.allowMultipleAnswers ? 0 : 1,
+    return this.sendContent(
+      chatId,
+      {
+        poll: {
+          name: poll.name,
+          values: poll.options,
+          selectableCount: poll.allowMultipleAnswers ? 0 : 1,
+        },
       },
-    });
+      await this.quoteOption(poll.quotedMessageId),
+    );
   }
 
   async replyToMessage(chatId: string, quotedMsgId: string, text: string): Promise<MessageResult> {
@@ -556,6 +592,18 @@ export class BaileysMessaging {
         error: err instanceof Error ? err.message : String(err),
       });
     }
+  }
+
+  /**
+   * Turn an optional quoted-message id into Baileys' `quoted` send option.
+   *
+   * Baileys quotes by full stored message, never by id, so an id has to be resolved first — and an
+   * id we cannot resolve is a hard failure rather than a silent unquoted send: the caller asked for
+   * a reply, and a plain message delivered under that name is the wrong result reported as success.
+   */
+  private async quoteOption(quotedMessageId?: string): Promise<MiscMessageGenerationOptions | undefined> {
+    if (!quotedMessageId) return undefined;
+    return { quoted: await this.requireStored(quotedMessageId) };
   }
 
   /** Resolve a previously-seen message from the store, or throw a clear not-found error. */

--- a/src/engine/adapters/baileys-quoted-send.spec.ts
+++ b/src/engine/adapters/baileys-quoted-send.spec.ts
@@ -1,0 +1,133 @@
+import type { WASocket } from '@whiskeysockets/baileys';
+import { BaileysMessaging, type BaileysMessagingHost } from './baileys-messaging';
+import { MessageNotFoundError } from '../../common/errors/message-not-found.error';
+import { createLogger } from '../../common/services/logger.service';
+
+/**
+ * Baileys quotes by full stored message, not by id: `MiscMessageGenerationOptions.quoted` is a
+ * `WAMessage` (Types/Message.d.ts:246), and the contextInfo is attached after content generation
+ * with no per-content-type branch (Utils/messages.js), so every send kind can carry one.
+ *
+ * The adapter can therefore only quote a message it has already persisted. That store dependency is
+ * the whole reason these assertions check `getStoredMessage` traffic as well as the socket payload:
+ * a resolver that silently returned undefined would send an unquoted message and report success,
+ * which is exactly the failure this feature exists to avoid on the other engine.
+ */
+
+const logger = createLogger('baileys-quoted-send.spec');
+
+const STORED = {
+  key: { id: 'QUOTED-1', remoteJid: '628111@s.whatsapp.net', fromMe: false },
+  message: { conversation: 'the quoted text' },
+};
+
+const PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+// `null`, not `undefined`, for the not-found case: passing undefined to a defaulted parameter
+// selects the default, which would quietly turn that test into a second happy-path assertion.
+function makeMessaging(stored: unknown = STORED): {
+  messaging: BaileysMessaging;
+  sock: { sendMessage: jest.Mock };
+  getStoredMessage: jest.Mock;
+} {
+  const sock = { sendMessage: jest.fn().mockResolvedValue({ key: { id: 'M1' }, messageTimestamp: 1 }) };
+  const getStoredMessage = jest.fn().mockResolvedValue(stored);
+  const host = {
+    ensureReady: jest.fn(),
+    getSocket: () => sock as unknown as WASocket,
+    logger,
+    toNeutralJid: (j: string) => j,
+    toEngineJid: (j: string) => j,
+    normalizedSelfJid: () => '628177@s.whatsapp.net',
+    getEphemeralExpiration: () => undefined,
+    toUnixSeconds: () => 1,
+    loadLib: () => Promise.resolve({} as never),
+    getStoredMessage,
+    putStoredMessage: () => undefined,
+    recordLidMapping: () => undefined,
+    getOnMessageCreate: () => undefined,
+    mapMessage: () => Promise.resolve({} as never),
+  } as unknown as BaileysMessagingHost;
+  return { messaging: new BaileysMessaging(host), sock, getStoredMessage };
+}
+
+const optionsOf = (sock: { sendMessage: jest.Mock }): Record<string, unknown> => {
+  const [, , options] = sock.sendMessage.mock.calls[0] as unknown[];
+  return (options ?? {}) as Record<string, unknown>;
+};
+
+const CHAT = '628111@s.whatsapp.net';
+
+describe('BaileysMessaging — a quote rides along with every content kind', () => {
+  // One case per content kind rather than media alone: the poll, location and contact paths each
+  // build their own content object, so a thread that covered only the shared media helper would
+  // leave three senders silently unquoted while this file stayed green.
+  it.each([
+    [
+      'image',
+      (m: BaileysMessaging) =>
+        m.sendImageMessage(CHAT, { data: PNG, mimetype: 'image/png', quotedMessageId: 'QUOTED-1' }),
+    ],
+    [
+      'document',
+      (m: BaileysMessaging) =>
+        m.sendDocumentMessage(CHAT, { data: PNG, mimetype: 'application/pdf', quotedMessageId: 'QUOTED-1' }),
+    ],
+    [
+      'location',
+      (m: BaileysMessaging) => m.sendLocationMessage(CHAT, { latitude: 1, longitude: 2, quotedMessageId: 'QUOTED-1' }),
+    ],
+    [
+      'contact',
+      (m: BaileysMessaging) =>
+        m.sendContactMessage(CHAT, { name: 'Alice', number: '628999', quotedMessageId: 'QUOTED-1' }),
+    ],
+    [
+      'poll',
+      (m: BaileysMessaging) => m.sendPollMessage(CHAT, { name: 'Q', options: ['a', 'b'], quotedMessageId: 'QUOTED-1' }),
+    ],
+    ['text', (m: BaileysMessaging) => m.sendTextMessage(CHAT, 'hi', undefined, { quotedMessageId: 'QUOTED-1' })],
+  ])('%s send attaches the stored message as `quoted`', async (_kind, send) => {
+    const { messaging, sock } = makeMessaging();
+
+    await send(messaging);
+
+    expect(sock.sendMessage).toHaveBeenCalledTimes(1);
+    expect(optionsOf(sock).quoted).toBe(STORED);
+  });
+
+  // Known-negative control. Without it an implementation that attached the quote unconditionally —
+  // or that resolved the store on every send — would satisfy every assertion above.
+  it('sends unquoted, and never touches the store, when no id is supplied', async () => {
+    const { messaging, sock, getStoredMessage } = makeMessaging();
+
+    await messaging.sendImageMessage(CHAT, { data: PNG, mimetype: 'image/png' });
+
+    expect(optionsOf(sock).quoted).toBeUndefined();
+    expect(getStoredMessage).not.toHaveBeenCalled();
+  });
+
+  it('leaves the existing text options intact while adding the quote', async () => {
+    const { messaging, sock } = makeMessaging();
+
+    await messaging.sendTextMessage(CHAT, 'hi', undefined, { quotedMessageId: 'QUOTED-1' });
+
+    // getUrlInfo is passed on every text send so Baileys' own vulnerable preview generator stays
+    // unreachable; merging the quote must not displace it.
+    expect(typeof optionsOf(sock).getUrlInfo).toBe('function');
+  });
+
+  it('refuses an unresolvable id instead of sending unquoted', async () => {
+    const { messaging, sock } = makeMessaging(null);
+
+    await expect(
+      messaging.sendImageMessage(CHAT, { data: PNG, mimetype: 'image/png', quotedMessageId: 'MISSING' }),
+    ).rejects.toBeInstanceOf(MessageNotFoundError);
+    // Reporting success on a message that went out without its quote is the defect; failing after
+    // the send would not fix it.
+    expect(sock.sendMessage).not.toHaveBeenCalled();
+  });
+});

--- a/src/engine/adapters/wwebjs-messaging.ts
+++ b/src/engine/adapters/wwebjs-messaging.ts
@@ -9,6 +9,7 @@ import {
   MessageReaction,
   MessageResult,
   PollInput,
+  Quotable,
 } from '../interfaces/whatsapp-engine.interface';
 import { MessageWithReactions, SerializedWid } from '../types/whatsapp-web-js.types';
 import { BadRequestException } from '@nestjs/common';
@@ -247,6 +248,22 @@ export class WwebjsMessaging {
    * Error carries no status and no recipient, so letting it through produced an opaque 500 for what
    * is really a caller-visible fact the gateway already established: `getNumberId` returned null.
    */
+  /**
+   * The send options that attach a quote, or nothing at all when the caller asked for none.
+   *
+   * `ignoreQuoteErrors` defaults to TRUE in the library (documented at Client.js:1383, applied at
+   * :1480): with it left alone an id whatsapp-web.js cannot resolve sends the message ANYWAY,
+   * unquoted, and reports success. A caller who asked for a reply and received a loose message has
+   * no signal that anything went wrong, so this opts out and lets the failure surface.
+   *
+   * A second, narrower drop is NOT covered by that flag: if the message resolves but `canReplyMsg`
+   * is false, `quotedMsgOptions` stays empty and the send proceeds unquoted (Injected/Utils.js:
+   * 187-195). That one is upstream behaviour we cannot switch off from here.
+   */
+  private quoteOptions(quotedMessageId?: string): { quotedMessageId?: string; ignoreQuoteErrors?: boolean } {
+    return quotedMessageId ? { quotedMessageId, ignoreQuoteErrors: false } : {};
+  }
+
   private async sendResolved<T>(chatId: string, send: (to: string) => Promise<T>): Promise<T> {
     const to = await this.resolveSendId(chatId);
     try {
@@ -287,7 +304,7 @@ export class WwebjsMessaging {
     chatId: string,
     text: string,
     mentions?: string[],
-    options?: { linkPreview?: boolean; customPreview?: CustomLinkPreview },
+    options?: { linkPreview?: boolean; customPreview?: CustomLinkPreview } & Quotable,
   ): Promise<MessageResult> {
     this.host.ensureReady();
     // wwebjs accepts neutral `<phone>@c.us` WIDs directly as mentionedJidList, so no de-normalization
@@ -303,7 +320,12 @@ export class WwebjsMessaging {
     if (options?.customPreview) {
       throw new EngineNotSupportedError('sendTextMessage(customPreview)');
     }
-    const sendOptions: { mentions?: string[]; linkPreview?: boolean } = {};
+    const sendOptions: {
+      mentions?: string[];
+      linkPreview?: boolean;
+      quotedMessageId?: string;
+      ignoreQuoteErrors?: boolean;
+    } = this.quoteOptions(options?.quotedMessageId);
     if (mentions?.length) sendOptions.mentions = mentions;
     if (options?.linkPreview === false) sendOptions.linkPreview = false;
 
@@ -367,6 +389,7 @@ export class WwebjsMessaging {
         // sendAudioAsVoice only for audio, sendMediaAsDocument only for documents;
         // {...undefined} contributes no keys.
         ...extraOptions,
+        ...this.quoteOptions(media.quotedMessageId),
       }),
     );
 
@@ -383,7 +406,9 @@ export class WwebjsMessaging {
       name: location.description || '',
       address: location.address || '',
     });
-    const msg = await this.sendResolved(chatId, to => this.client().sendMessage(to, loc));
+    const msg = await this.sendResolved(chatId, to =>
+      this.client().sendMessage(to, loc, this.quoteOptions(location.quotedMessageId)),
+    );
     return toMessageResult(msg);
   }
 
@@ -396,6 +421,7 @@ export class WwebjsMessaging {
     const msg = await this.sendResolved(chatId, to =>
       this.client().sendMessage(to, vcard, {
         parseVCards: true,
+        ...this.quoteOptions(contact.quotedMessageId),
       }),
     );
     return toMessageResult(msg);
@@ -414,6 +440,7 @@ export class WwebjsMessaging {
     const msg = await this.sendResolved(chatId, to =>
       this.client().sendMessage(to, messageMedia, {
         sendMediaAsSticker: true,
+        ...this.quoteOptions(media.quotedMessageId),
       }),
     );
     return toMessageResult(msg);
@@ -433,7 +460,11 @@ export class WwebjsMessaging {
     type PollSendOptions = ConstructorParameters<typeof Poll>[2];
     const pollOptions = { allowMultipleAnswers: poll.allowMultipleAnswers === true } as PollSendOptions;
     const msg = await this.sendResolved(chatId, to =>
-      this.client().sendMessage(to, new Poll(poll.name, poll.options, pollOptions)),
+      this.client().sendMessage(
+        to,
+        new Poll(poll.name, poll.options, pollOptions),
+        this.quoteOptions(poll.quotedMessageId),
+      ),
     );
     return toMessageResult(msg);
   }

--- a/src/engine/adapters/wwebjs-quoted-send.spec.ts
+++ b/src/engine/adapters/wwebjs-quoted-send.spec.ts
@@ -1,0 +1,121 @@
+import type { Client } from 'whatsapp-web.js';
+import { WwebjsMessaging } from './wwebjs-messaging';
+import { createLogger } from '../../common/services/logger.service';
+import { type WwebjsEngineHost } from './wwebjs-host';
+
+/**
+ * whatsapp-web.js attaches a quote as a plain send option, orthogonal to the content kind:
+ * `quotedMessageId` is copied into `internalOptions` (Client.js:1475) BEFORE the content-kind
+ * dispatch that moves the payload into `.media` / `.location` / `.poll` / `.contactCard`, so a quote
+ * never competes with what is being sent.
+ *
+ * The reason these tests assert `ignoreQuoteErrors: false` rather than just the id: the library
+ * default is TRUE (Client.js:1383 documents `[ignoreQuoteErrors = true]`, applied at :1480), which
+ * makes an unresolvable quote send the message ANYWAY, unquoted, and report success. A caller who
+ * asked for a reply and got a loose message with a 201 has no way to detect it. Opting out turns
+ * that into an error the caller can see.
+ */
+
+const logger = createLogger('wwebjs-quoted-send.spec');
+
+const QUOTED = 'true_628111@c.us_3EB0ABCD';
+
+function makeMessaging(): { messaging: WwebjsMessaging; client: { sendMessage: jest.Mock } } {
+  const client = {
+    sendMessage: jest.fn().mockResolvedValue({ id: { _serialized: 'M1' }, timestamp: 1 }),
+  };
+  const host = {
+    ensureReady: jest.fn(),
+    ensureNotChannelRecipient: jest.fn(),
+    getClient: () => client as unknown as Client,
+    logger,
+    config: {},
+    getNumberId: jest.fn(),
+    capInboundMediaFor: jest.fn(),
+    isPageTransportError: () => false,
+    reportIfPageTransportError: jest.fn(),
+  } as unknown as WwebjsEngineHost;
+  return { messaging: new WwebjsMessaging(host), client };
+}
+
+const optionsOf = (client: { sendMessage: jest.Mock }): Record<string, unknown> => {
+  const [, , options] = client.sendMessage.mock.calls[0] as unknown[];
+  return (options ?? {}) as Record<string, unknown>;
+};
+
+const CHAT = '628111@c.us';
+// Base64 rather than a URL: a URL payload runs the real remote-media loader through the SSRF guard,
+// so the test would exercise the network instead of the option plumbing it is about.
+const IMAGE = {
+  data: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  mimetype: 'image/png',
+};
+
+describe('WwebjsMessaging — a quote rides along with every content kind', () => {
+  // Each of these builds its own options object (or, for location and poll, had none at all before
+  // this change), so covering only the shared media funnel would leave the others silently unquoted.
+  it.each([
+    ['image', (m: WwebjsMessaging) => m.sendImageMessage(CHAT, { ...IMAGE, quotedMessageId: QUOTED })],
+    ['document', (m: WwebjsMessaging) => m.sendDocumentMessage(CHAT, { ...IMAGE, quotedMessageId: QUOTED })],
+    ['sticker', (m: WwebjsMessaging) => m.sendStickerMessage(CHAT, { ...IMAGE, quotedMessageId: QUOTED })],
+    [
+      'location',
+      (m: WwebjsMessaging) => m.sendLocationMessage(CHAT, { latitude: 1, longitude: 2, quotedMessageId: QUOTED }),
+    ],
+    [
+      'contact',
+      (m: WwebjsMessaging) => m.sendContactMessage(CHAT, { name: 'Alice', number: '628999', quotedMessageId: QUOTED }),
+    ],
+    [
+      'poll',
+      (m: WwebjsMessaging) => m.sendPollMessage(CHAT, { name: 'Q', options: ['a', 'b'], quotedMessageId: QUOTED }),
+    ],
+    ['text', (m: WwebjsMessaging) => m.sendTextMessage(CHAT, 'hi', undefined, { quotedMessageId: QUOTED })],
+  ])('%s send forwards the quoted id with quote errors made visible', async (_kind, send) => {
+    const { messaging, client } = makeMessaging();
+
+    await send(messaging);
+
+    expect(client.sendMessage).toHaveBeenCalledTimes(1);
+    expect(optionsOf(client).quotedMessageId).toBe(QUOTED);
+    // The library would otherwise send unquoted and report success on a bad id.
+    expect(optionsOf(client).ignoreQuoteErrors).toBe(false);
+  });
+
+  // Known-negative control: without it an implementation that hardcoded the keys onto every send
+  // would satisfy every assertion above while changing behaviour for unquoted callers too.
+  it('adds no quote keys at all when no id is supplied', async () => {
+    const { messaging, client } = makeMessaging();
+
+    await messaging.sendImageMessage(CHAT, IMAGE);
+
+    expect(optionsOf(client)).not.toHaveProperty('quotedMessageId');
+    expect(optionsOf(client)).not.toHaveProperty('ignoreQuoteErrors');
+  });
+
+  it('keeps the caption and mentions it already sent alongside the quote', async () => {
+    const { messaging, client } = makeMessaging();
+
+    await messaging.sendImageMessage(CHAT, {
+      ...IMAGE,
+      caption: 'look',
+      mentions: ['628222@c.us'],
+      quotedMessageId: QUOTED,
+    });
+
+    expect(optionsOf(client)).toMatchObject({
+      caption: 'look',
+      mentions: ['628222@c.us'],
+      quotedMessageId: QUOTED,
+    });
+  });
+
+  it('keeps sendMediaAsDocument, which shares the options object with the quote', async () => {
+    const { messaging, client } = makeMessaging();
+
+    await messaging.sendDocumentMessage(CHAT, { ...IMAGE, quotedMessageId: QUOTED });
+
+    expect(optionsOf(client).sendMediaAsDocument).toBe(true);
+    expect(optionsOf(client).quotedMessageId).toBe(QUOTED);
+  });
+});

--- a/src/engine/interfaces/whatsapp-engine.interface.ts
+++ b/src/engine/interfaces/whatsapp-engine.interface.ts
@@ -31,7 +31,23 @@ export interface MessageResult {
   timestamp: number;
 }
 
-export interface MediaInput {
+/**
+ * A send payload that can quote an earlier message, turning the send into a reply.
+ *
+ * Deliberately a PROPERTY on the payload rather than a parameter on the engine methods: the parity
+ * gate reads call-shaped members out of this file, so a new method would demand a capability-matrix
+ * row while a property demands nothing (see engine-parity.spec.ts MEMBER_RE).
+ *
+ * The id is engine-specific and the adapters do NOT harmonize it: whatsapp-web.js matches the
+ * serialized message id, Baileys looks the raw key id up in its local store and can only quote a
+ * message it has already persisted.
+ */
+export interface Quotable {
+  /** Quote this message id in the send. Omit for a plain, unquoted send. */
+  quotedMessageId?: string;
+}
+
+export interface MediaInput extends Quotable {
   mimetype: string;
   data: Buffer | string; // Buffer or base64 or URL
   /** Caller-supplied filename wins. Document sends fall back to 'file' when omitted (wwebjs first derives the URL basename); image/video/audio sends carry no filename. */
@@ -301,19 +317,19 @@ export interface CustomLinkPreview {
   description?: string;
 }
 
-export interface ContactCard {
+export interface ContactCard extends Quotable {
   name: string;
   number: string;
 }
 
-export interface LocationInput {
+export interface LocationInput extends Quotable {
   latitude: number;
   longitude: number;
   description?: string;
   address?: string;
 }
 
-export interface PollInput {
+export interface PollInput extends Quotable {
   /** Poll question / title. */
   name: string;
   /** Options to vote on (WhatsApp accepts between 2 and 12). */
@@ -842,7 +858,7 @@ export interface IWhatsAppEngine {
     chatId: string,
     text: string,
     mentions?: string[],
-    options?: { linkPreview?: boolean; customPreview?: CustomLinkPreview },
+    options?: { linkPreview?: boolean; customPreview?: CustomLinkPreview } & Quotable,
   ): Promise<MessageResult>;
   sendImageMessage(chatId: string, media: MediaInput): Promise<MessageResult>;
   sendVideoMessage(chatId: string, media: MediaInput): Promise<MessageResult>;

--- a/src/modules/message/dto/message-actions.dto.ts
+++ b/src/modules/message/dto/message-actions.dto.ts
@@ -13,7 +13,7 @@ import {
   IsIn,
 } from 'class-validator';
 import { ToStrictBoolean, ToStrictNumber } from '../../../common/utils/strict-boolean';
-import { MESSAGE_TEXT_MAX_LENGTH } from './send-message.dto';
+import { MESSAGE_TEXT_MAX_LENGTH, QUOTED_MESSAGE_ID_DESCRIPTION, QUOTED_MESSAGE_ID_EXAMPLE } from './send-message.dto';
 
 /**
  * Validated DTOs for the message action endpoints. These replaced inline
@@ -55,6 +55,12 @@ export class SendLocationDto {
   @IsString()
   @MaxLength(LOCATION_TEXT_MAX_LENGTH)
   address?: string;
+
+  @ApiPropertyOptional({ description: QUOTED_MESSAGE_ID_DESCRIPTION, example: QUOTED_MESSAGE_ID_EXAMPLE })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  quotedMessageId?: string;
 }
 
 export class SendContactDto {
@@ -74,6 +80,12 @@ export class SendContactDto {
   @IsNotEmpty()
   @MaxLength(CONTACT_NUMBER_MAX_LENGTH)
   contactNumber!: string;
+
+  @ApiPropertyOptional({ description: QUOTED_MESSAGE_ID_DESCRIPTION, example: QUOTED_MESSAGE_ID_EXAMPLE })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  quotedMessageId?: string;
 }
 
 export class SendPollDto {
@@ -111,6 +123,12 @@ export class SendPollDto {
   @IsOptional()
   @IsBoolean()
   allowMultipleAnswers?: boolean;
+
+  @ApiPropertyOptional({ description: QUOTED_MESSAGE_ID_DESCRIPTION, example: QUOTED_MESSAGE_ID_EXAMPLE })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  quotedMessageId?: string;
 }
 
 export class ReplyMessageDto {

--- a/src/modules/message/dto/send-message.dto.spec.ts
+++ b/src/modules/message/dto/send-message.dto.spec.ts
@@ -10,7 +10,11 @@ import {
   SEND_AUDIO_BODY_EXAMPLES,
   SEND_DOCUMENT_BODY_EXAMPLES,
   SEND_STICKER_BODY_EXAMPLES,
+  SEND_LOCATION_BODY_EXAMPLES,
+  SEND_CONTACT_BODY_EXAMPLES,
+  SEND_POLL_BODY_EXAMPLES,
 } from './send-message.dto';
+import { SendLocationDto, SendContactDto, SendPollDto } from './message-actions.dto';
 
 // Mirror the global ValidationPipe (main.ts): whitelist + forbidNonWhitelisted strip/reject unknown props.
 const validateDto = (cls: new () => object, obj: unknown) =>
@@ -123,6 +127,39 @@ describe('media route body examples', () => {
     for (const [name, example] of Object.entries(examples)) {
       const v = example.value as { url?: string; base64?: string };
       expect({ name, sources: [v.url, v.base64].filter(Boolean).length }).toEqual({ name, sources: 1 });
+    }
+  });
+});
+
+// send-location, send-contact and send-poll were sampler-driven until quotedMessageId gave them an
+// optional property whose sampled value the send path REFUSES (an unresolvable quote fails rather
+// than delivering unquoted), which would have made every unedited Execute an error. Same trap as
+// #1068, so the same contract: each example must validate, and must not carry a quotedMessageId.
+describe('location / contact / poll body examples', () => {
+  const suites: Array<[string, new () => object, Record<string, { value: unknown }>]> = [
+    ['send-location', SendLocationDto, SEND_LOCATION_BODY_EXAMPLES],
+    ['send-contact', SendContactDto, SEND_CONTACT_BODY_EXAMPLES],
+    ['send-poll', SendPollDto, SEND_POLL_BODY_EXAMPLES],
+  ];
+
+  it.each(suites)('%s declares at least one example', (_route, _cls, examples) => {
+    expect(Object.keys(examples).length).toBeGreaterThan(0);
+  });
+
+  it.each(suites)('%s examples all pass DTO validation', async (_route, cls, examples) => {
+    for (const [name, example] of Object.entries(examples)) {
+      const errors = await validateDto(cls, example.value);
+      expect({ name, errors: errors.map(e => e.property) }).toEqual({ name, errors: [] });
+    }
+  });
+
+  // The whole reason these examples exist: a pre-filled quoted id points at no real message.
+  it.each(suites)('%s examples carry no quotedMessageId', (_route, _cls, examples) => {
+    for (const [name, example] of Object.entries(examples)) {
+      expect({ name, quoted: (example.value as { quotedMessageId?: string }).quotedMessageId }).toEqual({
+        name,
+        quoted: undefined,
+      });
     }
   });
 });

--- a/src/modules/message/dto/send-message.dto.ts
+++ b/src/modules/message/dto/send-message.dto.ts
@@ -23,6 +23,18 @@ const MENTIONS_DESCRIPTION =
 // (src/core/agent-tools/tools/message.tools.ts) so MCP and REST enforce the same limit.
 export const MESSAGE_TEXT_MAX_LENGTH = 4096;
 
+/**
+ * Shared wording for the quoted-send field (issue #1271). One constant rather than five copies so
+ * the two engine caveats — different id dialects, and Baileys' store requirement — cannot drift
+ * apart between the endpoints that all accept the same field.
+ */
+export const QUOTED_MESSAGE_ID_DESCRIPTION =
+  'Quote an earlier message, turning this send into a reply. The id is engine-specific: ' +
+  'whatsapp-web.js matches the serialized message id, Baileys matches the raw message key id and ' +
+  'can only quote a message it has already stored. An id that cannot be resolved fails the send ' +
+  'rather than delivering it unquoted.';
+export const QUOTED_MESSAGE_ID_EXAMPLE = 'true_628123456789@c.us_3EB0ABCD';
+
 export class CustomLinkPreviewDto {
   @ApiProperty({
     description: 'The URL as it appears in the message text — WhatsApp anchors the preview to it.',
@@ -105,6 +117,15 @@ export class SendTextMessageDto {
   @ValidateNested()
   @Type(() => CustomLinkPreviewDto)
   customLinkPreview?: CustomLinkPreviewDto;
+
+  @ApiPropertyOptional({
+    description: QUOTED_MESSAGE_ID_DESCRIPTION,
+    example: QUOTED_MESSAGE_ID_EXAMPLE,
+  })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  quotedMessageId?: string;
 }
 
 /**
@@ -196,6 +217,15 @@ export class SendMediaMessageDto {
   @MaxLength(64, { each: true })
   @Validate(IsMentionWidConstraint, { each: true })
   mentions?: string[];
+
+  @ApiPropertyOptional({
+    description: QUOTED_MESSAGE_ID_DESCRIPTION,
+    example: QUOTED_MESSAGE_ID_EXAMPLE,
+  })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  quotedMessageId?: string;
 }
 
 /**
@@ -228,6 +258,35 @@ export const SEND_DOCUMENT_BODY_EXAMPLES = mediaBodyExample('https://example.com
   filename: 'report.pdf',
 });
 export const SEND_STICKER_BODY_EXAMPLES = mediaBodyExample('https://example.com/sticker.webp');
+
+/**
+ * Request-body examples for the location, contact and poll routes.
+ *
+ * These three had no `@ApiBody` and were left to the schema sampler, which was harmless while every
+ * optional property was self-contained. `quotedMessageId` is not: the sampler emits EVERY property,
+ * so a Try-it body would carry a made-up message id, and the send path refuses an id it cannot
+ * resolve rather than delivering the message unquoted — turning every unedited Execute on these
+ * three routes into an error. Same failure #1068 fixed for the text and media routes, arriving by a
+ * different door, so the same remedy applies: pin an example that is submittable as-is.
+ */
+export const SEND_LOCATION_BODY_EXAMPLES = {
+  minimal: {
+    summary: 'Share a location',
+    value: { chatId: '628123456789@c.us', latitude: -6.2088, longitude: 106.8456, description: 'Jakarta' },
+  },
+};
+export const SEND_CONTACT_BODY_EXAMPLES = {
+  minimal: {
+    summary: 'Share a contact card',
+    value: { chatId: '628123456789@c.us', contactName: 'Alice', contactNumber: '628999888777' },
+  },
+};
+export const SEND_POLL_BODY_EXAMPLES = {
+  minimal: {
+    summary: 'Ask a single-choice poll',
+    value: { chatId: '120363000000000000@g.us', name: 'Where should we meet?', options: ['Park', 'Beach'] },
+  },
+};
 
 export class SendAudioMessageDto extends SendMediaMessageDto {
   @ApiPropertyOptional({

--- a/src/modules/message/message.controller.ts
+++ b/src/modules/message/message.controller.ts
@@ -14,6 +14,9 @@ import {
   SEND_AUDIO_BODY_EXAMPLES,
   SEND_DOCUMENT_BODY_EXAMPLES,
   SEND_STICKER_BODY_EXAMPLES,
+  SEND_LOCATION_BODY_EXAMPLES,
+  SEND_CONTACT_BODY_EXAMPLES,
+  SEND_POLL_BODY_EXAMPLES,
 } from './dto';
 import { SendTemplateMessageDto } from './dto/send-template.dto';
 import { SendBulkMessageDto, BulkMessageResponseDto } from './dto/bulk-message.dto';
@@ -226,6 +229,7 @@ export class MessageController {
   @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Send a location message' })
   @ApiParam({ name: 'sessionId', description: 'Session ID' })
+  @ApiBody({ type: SendLocationDto, examples: SEND_LOCATION_BODY_EXAMPLES })
   @ApiResponse({
     status: 201,
     description: 'Location sent',
@@ -241,6 +245,7 @@ export class MessageController {
   @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Send a contact card message' })
   @ApiParam({ name: 'sessionId', description: 'Session ID' })
+  @ApiBody({ type: SendContactDto, examples: SEND_CONTACT_BODY_EXAMPLES })
   @ApiResponse({
     status: 201,
     description: 'Contact sent',
@@ -276,6 +281,7 @@ export class MessageController {
   @RequireRole(ApiKeyRole.OPERATOR)
   @ApiOperation({ summary: 'Send a native WhatsApp poll' })
   @ApiParam({ name: 'sessionId', description: 'Session ID' })
+  @ApiBody({ type: SendPollDto, examples: SEND_POLL_BODY_EXAMPLES })
   @ApiResponse({
     status: 201,
     description: 'Poll sent',

--- a/src/modules/message/message.service.spec.ts
+++ b/src/modules/message/message.service.spec.ts
@@ -1148,6 +1148,92 @@ describe('MessageService', () => {
     });
   });
 
+  // ── quoted sends (issue #1271) ────────────────────────────────────
+
+  describe('quotedMessageId on the send endpoints', () => {
+    // One case per sender rather than the media funnel alone: location, contact and poll each build
+    // their own engine payload, so a thread that covered only buildMediaInput would leave three
+    // endpoints accepting the field and silently discarding it.
+    it('sendImage forwards quotedMessageId in the media payload', async () => {
+      await service.sendImage('sess-1', {
+        chatId: 'test@c.us',
+        url: 'https://example.com/a.png',
+        quotedMessageId: 'wa-quoted-9',
+      } as never);
+
+      expect(mockEngine.sendImageMessage).toHaveBeenCalledWith(
+        'test@c.us',
+        expect.objectContaining({ quotedMessageId: 'wa-quoted-9' }),
+      );
+    });
+
+    it('sendLocation forwards quotedMessageId', async () => {
+      await service.sendLocation('sess-1', {
+        chatId: 'test@c.us',
+        latitude: 1,
+        longitude: 2,
+        quotedMessageId: 'wa-quoted-9',
+      } as never);
+
+      expect(mockEngine.sendLocationMessage).toHaveBeenCalledWith(
+        'test@c.us',
+        expect.objectContaining({ quotedMessageId: 'wa-quoted-9' }),
+      );
+    });
+
+    it('sendContact forwards quotedMessageId', async () => {
+      await service.sendContact('sess-1', {
+        chatId: 'test@c.us',
+        contactName: 'Alice',
+        contactNumber: '628999',
+        quotedMessageId: 'wa-quoted-9',
+      } as never);
+
+      expect(mockEngine.sendContactMessage).toHaveBeenCalledWith(
+        'test@c.us',
+        expect.objectContaining({ quotedMessageId: 'wa-quoted-9' }),
+      );
+    });
+
+    it('sendPoll forwards quotedMessageId', async () => {
+      await service.sendPoll('sess-1', {
+        chatId: 'test@c.us',
+        name: 'Q',
+        options: ['a', 'b'],
+        quotedMessageId: 'wa-quoted-9',
+      } as never);
+
+      expect(mockEngine.sendPollMessage).toHaveBeenCalledWith(
+        'test@c.us',
+        expect.objectContaining({ quotedMessageId: 'wa-quoted-9' }),
+      );
+    });
+
+    it('sendText forwards quotedMessageId through the options bag', async () => {
+      await service.sendText('sess-1', {
+        chatId: 'test@c.us',
+        text: 'hi',
+        quotedMessageId: 'wa-quoted-9',
+      } as never);
+
+      expect(mockEngine.sendTextMessage).toHaveBeenCalledWith(
+        'test@c.us',
+        'hi',
+        undefined,
+        expect.objectContaining({ quotedMessageId: 'wa-quoted-9' }),
+      );
+    });
+
+    // Known-negative control: a plain text send must keep its narrow call shape. Without this an
+    // implementation that always passed an options object would satisfy the assertion above while
+    // rewriting every existing send.
+    it('leaves an unquoted text send on its existing two-argument call shape', async () => {
+      await service.sendText('sess-1', { chatId: 'test@c.us', text: 'hi' } as never);
+
+      expect(mockEngine.sendTextMessage).toHaveBeenCalledWith('test@c.us', 'hi');
+    });
+  });
+
   // ── reply / forward ───────────────────────────────────────────────
 
   describe('reply', () => {

--- a/src/modules/message/message.service.spec.ts
+++ b/src/modules/message/message.service.spec.ts
@@ -1159,7 +1159,7 @@ describe('MessageService', () => {
         chatId: 'test@c.us',
         url: 'https://example.com/a.png',
         quotedMessageId: 'wa-quoted-9',
-      } as never);
+      });
 
       expect(mockEngine.sendImageMessage).toHaveBeenCalledWith(
         'test@c.us',
@@ -1173,7 +1173,7 @@ describe('MessageService', () => {
         latitude: 1,
         longitude: 2,
         quotedMessageId: 'wa-quoted-9',
-      } as never);
+      });
 
       expect(mockEngine.sendLocationMessage).toHaveBeenCalledWith(
         'test@c.us',
@@ -1187,7 +1187,7 @@ describe('MessageService', () => {
         contactName: 'Alice',
         contactNumber: '628999',
         quotedMessageId: 'wa-quoted-9',
-      } as never);
+      });
 
       expect(mockEngine.sendContactMessage).toHaveBeenCalledWith(
         'test@c.us',
@@ -1201,7 +1201,7 @@ describe('MessageService', () => {
         name: 'Q',
         options: ['a', 'b'],
         quotedMessageId: 'wa-quoted-9',
-      } as never);
+      });
 
       expect(mockEngine.sendPollMessage).toHaveBeenCalledWith(
         'test@c.us',
@@ -1214,7 +1214,7 @@ describe('MessageService', () => {
         chatId: 'test@c.us',
         text: 'hi',
         quotedMessageId: 'wa-quoted-9',
-      } as never);
+      });
 
       expect(mockEngine.sendTextMessage).toHaveBeenCalledWith(
         'test@c.us',
@@ -1228,7 +1228,7 @@ describe('MessageService', () => {
     // implementation that always passed an options object would satisfy the assertion above while
     // rewriting every existing send.
     it('leaves an unquoted text send on its existing two-argument call shape', async () => {
-      await service.sendText('sess-1', { chatId: 'test@c.us', text: 'hi' } as never);
+      await service.sendText('sess-1', { chatId: 'test@c.us', text: 'hi' });
 
       expect(mockEngine.sendTextMessage).toHaveBeenCalledWith('test@c.us', 'hi');
     });

--- a/src/modules/message/message.service.ts
+++ b/src/modules/message/message.service.ts
@@ -118,6 +118,7 @@ export class MessageService {
       chatId: finalDto.chatId,
       body: finalDto.text,
       type: 'text',
+      quotedMessageId: finalDto.quotedMessageId,
     });
 
     // Opt-in humanising "typing…" pause before the actual send (anti-automation signal).
@@ -129,11 +130,12 @@ export class MessageService {
       // nor a preview choice keeps its two-argument shape, and one with mentions alone keeps its
       // three — trailing `undefined`s would be harmless to the engines but would rewrite the call
       // shape of every existing send for no behavioural gain.
-      const { linkPreview, customLinkPreview } = finalDto;
-      if (linkPreview !== undefined || customLinkPreview) {
+      const { linkPreview, customLinkPreview, quotedMessageId } = finalDto;
+      if (linkPreview !== undefined || customLinkPreview || quotedMessageId) {
         result = await engine.sendTextMessage(finalDto.chatId, finalDto.text, finalDto.mentions, {
           ...(linkPreview === undefined ? {} : { linkPreview }),
           ...(customLinkPreview ? { customPreview: customLinkPreview } : {}),
+          ...(quotedMessageId ? { quotedMessageId } : {}),
         });
       } else if (finalDto.mentions?.length) {
         result = await engine.sendTextMessage(finalDto.chatId, finalDto.text, finalDto.mentions);
@@ -261,6 +263,7 @@ export class MessageService {
       chatId: finalDto.chatId,
       body: finalDto.caption || '',
       type: 'image',
+      quotedMessageId: finalDto.quotedMessageId,
       metadata: {
         media: { mimetype: finalDto.mimetype, filename: finalDto.filename, data: media.data },
       },
@@ -285,6 +288,7 @@ export class MessageService {
       chatId: finalDto.chatId,
       body: finalDto.caption || '',
       type: 'video',
+      quotedMessageId: finalDto.quotedMessageId,
       metadata: {
         media: { mimetype: finalDto.mimetype, filename: finalDto.filename, data: media.data },
       },
@@ -321,6 +325,7 @@ export class MessageService {
       metadata: {
         media: { mimetype: audioDto.mimetype, filename: finalDto.filename, data: media.data },
       },
+      quotedMessageId: finalDto.quotedMessageId,
     });
 
     let result: MessageResult;
@@ -342,6 +347,7 @@ export class MessageService {
       chatId: finalDto.chatId,
       body: finalDto.caption || finalDto.filename || '',
       type: 'document',
+      quotedMessageId: finalDto.quotedMessageId,
       metadata: {
         media: { mimetype: finalDto.mimetype, filename: finalDto.filename, data: media.data },
       },
@@ -445,7 +451,14 @@ export class MessageService {
 
   async sendLocation(
     sessionId: string,
-    dto: { chatId: string; latitude: number; longitude: number; description?: string; address?: string },
+    dto: {
+      chatId: string;
+      latitude: number;
+      longitude: number;
+      description?: string;
+      address?: string;
+      quotedMessageId?: string;
+    },
   ): Promise<MessageResponseDto> {
     const finalDto = await this.applySendingGate(sessionId, 'location', dto);
     const engine = this.getEngine(sessionId);
@@ -455,6 +468,7 @@ export class MessageService {
       chatId: finalDto.chatId,
       body: `📍 ${finalDto.description || 'Location'}`,
       type: 'location',
+      quotedMessageId: finalDto.quotedMessageId,
     });
 
     let result: MessageResult;
@@ -464,6 +478,7 @@ export class MessageService {
         longitude: finalDto.longitude,
         description: finalDto.description,
         address: finalDto.address,
+        quotedMessageId: finalDto.quotedMessageId,
       });
     } catch (error) {
       return this.failSend(sessionId, 'location', message, finalDto, error);
@@ -473,7 +488,7 @@ export class MessageService {
 
   async sendContact(
     sessionId: string,
-    dto: { chatId: string; contactName: string; contactNumber: string },
+    dto: { chatId: string; contactName: string; contactNumber: string; quotedMessageId?: string },
   ): Promise<MessageResponseDto> {
     const finalDto = await this.applySendingGate(sessionId, 'contact', dto);
     const engine = this.getEngine(sessionId);
@@ -483,6 +498,7 @@ export class MessageService {
       chatId: finalDto.chatId,
       body: `📇 ${finalDto.contactName}`,
       type: 'contact',
+      quotedMessageId: finalDto.quotedMessageId,
     });
 
     let result: MessageResult;
@@ -490,6 +506,7 @@ export class MessageService {
       result = await engine.sendContactMessage(finalDto.chatId, {
         name: finalDto.contactName,
         number: finalDto.contactNumber,
+        quotedMessageId: finalDto.quotedMessageId,
       });
     } catch (error) {
       return this.failSend(sessionId, 'contact', message, finalDto, error);
@@ -499,7 +516,7 @@ export class MessageService {
 
   async sendPoll(
     sessionId: string,
-    dto: { chatId: string; name: string; options: string[]; allowMultipleAnswers?: boolean },
+    dto: { chatId: string; name: string; options: string[]; allowMultipleAnswers?: boolean; quotedMessageId?: string },
   ): Promise<MessageResponseDto> {
     const finalDto = await this.applySendingGate(sessionId, 'poll', dto);
     const engine = this.getEngine(sessionId);
@@ -510,6 +527,7 @@ export class MessageService {
       chatId: finalDto.chatId,
       body: `📊 ${finalDto.name}`,
       type: 'poll',
+      quotedMessageId: finalDto.quotedMessageId,
     });
 
     let result: MessageResult;
@@ -518,6 +536,7 @@ export class MessageService {
         name: finalDto.name,
         options: finalDto.options,
         allowMultipleAnswers: finalDto.allowMultipleAnswers === true,
+        quotedMessageId: finalDto.quotedMessageId,
       });
     } catch (error) {
       return this.failSend(sessionId, 'poll', message, finalDto, error);
@@ -534,6 +553,7 @@ export class MessageService {
     const message = await this.saveOutgoingMessage(sessionId, {
       chatId: finalDto.chatId,
       type: 'sticker',
+      quotedMessageId: finalDto.quotedMessageId,
       metadata: {
         media: { mimetype: finalDto.mimetype, filename: finalDto.filename, data: media.data },
       },
@@ -643,6 +663,14 @@ export class MessageService {
       timestamp?: number;
       status?: MessageStatus;
       metadata?: Record<string, unknown>;
+      /**
+       * Quoted id for a send that is a reply. Folded into `metadata.quotedMessage` here rather than
+       * by each sender so the nine send paths and `reply()` persist one shape — a row that quoted a
+       * message but records nothing is simply wrong history, and the dashboard reads this key to
+       * render the reply preview. The body is left empty: unlike `reply()`, the send paths do not
+       * look the quoted message up, and '' is already reply()'s own value when that lookup fails.
+       */
+      quotedMessageId?: string;
     },
   ): Promise<Message> {
     const session = await this.sessionService.findOne(sessionId);
@@ -663,7 +691,9 @@ export class MessageService {
       direction: MessageDirection.OUTGOING,
       timestamp: data.timestamp,
       status: data.status ?? MessageStatus.PENDING,
-      metadata: data.metadata,
+      metadata: data.quotedMessageId
+        ? { ...data.metadata, quotedMessage: { id: data.quotedMessageId, body: '' } }
+        : data.metadata,
     });
     const saved = await this.messageRepository.save(message).catch(async (err: unknown) => {
       const waMessageId = message.waMessageId;
@@ -1046,6 +1076,7 @@ export class MessageService {
       filename: dto.filename,
       caption: dto.caption,
       mentions: dto.mentions,
+      quotedMessageId: dto.quotedMessageId,
     };
   }
 }


### PR DESCRIPTION
Closes #1271.

`POST .../messages/reply` carries a `text` field and nothing else, so a reply could only ever be text. The reporter asked to reply with a contact card, and proposed replacing `text` with a `contentType` + `content` pair.

This takes the alternative they offered instead: an optional `quotedMessageId` on the `send-*` endpoints. Quoting is an option on the send in both engines rather than a message type, so the capability was already reachable — only the API shape was narrow.

```json
POST /api/sessions/{sessionId}/messages/send-contact
{
  "chatId": "628123456789@c.us",
  "contactName": "Alice",
  "contactNumber": "628999888777",
  "quotedMessageId": "true_628123456789@c.us_3EB0ABCD"
}
```

The same optional field lands on `send-text`, `send-image`, `send-video`, `send-audio`, `send-document`, `send-sticker`, `send-location`, `send-contact` and `send-poll`, and on the eight matching MCP tools. `POST .../messages/reply` is untouched and remains the text shorthand.

## Why not `contentType` + `content`

Replacing `text` breaks five surfaces at once: the REST field is required today, and the same signature is part of the plugin capability API (`PluginMessagingCapability.reply`), its sandbox RPC where the arguments are positional across a worker boundary, the conversation facade, and all five SDK clients.

It also would not buy type safety. Request bodies are validated against concrete typed classes under `whitelist` / `forbidNonWhitelisted`; a free-form `content` object gives the validator no metadata, so mismatched fields inside it pass through unchecked and `contentType` ends up decorative. `BulkMessageItemDto` already shows that shape's limits — its `type` discriminator does not constrain its `content` either.

The optional field is additive, so it stays PATCH-level under the pre-1.0 policy in `docs/15`.

## Implementation

`quotedMessageId` is a property on the payload interfaces (`MediaInput`, `ContactCard`, `LocationInput`, `PollInput`) and on `sendTextMessage`'s existing options bag, via a shared `Quotable`. No `IWhatsAppEngine` method signature changes, so the 112-row capability matrix and the parity gate are untouched — the gate matches call-shaped members only, which a mutation test confirmed by adding a call-shaped member and watching it turn red.

- **Baileys** quotes by full stored message, so `quoteOption` resolves the id through the same store handle `reply` already used. `sendTextMessage` builds its own options object and is merged into rather than overwritten, keeping the safe `getUrlInfo` generator in place on quoted sends.
- **whatsapp-web.js** takes the id as a plain send option. `ignoreQuoteErrors` is forced to `false`: the library default is `true`, which sends the message unquoted and reports success when the id cannot be resolved. A caller who asked for a reply and got a loose message with a `201` has no way to detect that.

The persisted row records the quote at the `saveOutgoingMessage` chokepoint, so the nine send paths and `reply()` write one metadata shape.

## Swagger examples for three routes

`send-location`, `send-contact` and `send-poll` had no `@ApiBody` and were left to the schema sampler, which emits every property. With the send path refusing an unresolvable quote, an unedited "Try it out" on those three would have submitted a made-up message id and failed — the same trap #1068 fixed for the text and media routes, arriving by a different door. Each now pins an example that is submittable as-is, and a spec asserts no example carries a `quotedMessageId`.

## Verification

Full suite, lint, typecheck, format, build, and every contract gate pass. `openapi.json` is additive: 64 insertions, no deletions, and `ReplyMessageDto` is unchanged.

`openapi:check` compares the snapshot to a fresh generate, so it cannot catch a field that never reached the contract — both sides would be wrong together. A separate assertion confirms `quotedMessageId` is present in all nine published schemas.

Verified against a running instance: the field is accepted on `send-contact`, `send-image` and `send-poll`; an empty value is rejected by name; and a control request with an unknown field is still rejected, which is what proves the whitelist was active and would have rejected this field before the change.

Not yet verified: whether WhatsApp's client renders a reply bubble for every content type. Both engines serialize the quote for all of them, but that is not proof of rendering, and the docs say so rather than implying uniform support.

## Follow-ups (not in this PR)

- The dashboard composer takes the media branch when an attachment is present, which never carries the quoted id, and clears the reply banner regardless — so replying with an attachment drops the quote with no visible sign.
- `replyToMessage` on whatsapp-web.js scans only the last 100 messages of a chat, so replying to anything older returns 404; `forwardMessage` repeats that window.
- One upstream gap stays: if a quoted message resolves but the page decides it is not replyable, whatsapp-web.js sends unquoted and still succeeds.
