### PR TITLE
fix(config): accept a negative AUDIT_RETENTION_DAYS again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Turkish (`tr`) dashboard translation. Thanks @codedByCan.
-- `AUDIT_RETENTION_DAYS` is checked at boot, so a typo fails startup with a named error instead of silently reverting to the 90-day default. It is validated as non-negative rather than positive, because `0` is the documented switch that disables audit-log pruning entirely.
+- `AUDIT_RETENTION_DAYS` is checked at boot, so a typo fails startup with a named error instead of silently reverting to the 90-day default. It is validated as an integer of any sign rather than a positive one, because both `0` and any negative value are documented switches that disable audit-log pruning entirely.
 - `message.controller.spec.ts` holds the two headers the stored-media download sends, `X-Content-Type-Options: nosniff` and `Content-Disposition: attachment`; deleting either had passed every suite in the repo.
 - Optional `quotedMessageId` on every `send-*` message endpoint and its MCP tool, so a reply can carry media, a location, a contact card or a poll instead of only text. An id the engine cannot resolve now fails the send rather than delivering the message unquoted. Thanks @nirizr for the report.
 

--- a/src/config/env.validation.spec.ts
+++ b/src/config/env.validation.spec.ts
@@ -107,11 +107,14 @@ describe('validateEnv', () => {
     expect(() => validateEnv({ WEBHOOK_MAX_PER_SESSION: '0', WEBHOOK_MEDIA_INLINE_MAX_BYTES: '0' })).not.toThrow();
   });
 
-  it('rejects a non-integer audit retention (0 is the documented retention-off switch)', () => {
+  it('rejects a non-integer audit retention but accepts every value documented as "disable"', () => {
     expect(() => validateEnv({ AUDIT_RETENTION_DAYS: 'ninety' })).toThrow(/AUDIT_RETENTION_DAYS/);
     expect(() => validateEnv({ AUDIT_RETENTION_DAYS: '90.5' })).toThrow(/AUDIT_RETENTION_DAYS/);
-    // 0 disables pruning in audit.service.ts, so this knob must never become positive-only.
+    expect(() => validateEnv({ AUDIT_RETENTION_DAYS: '30d' })).toThrow(/AUDIT_RETENTION_DAYS/);
+    // audit.service.ts and docs/05 both document `<= 0` as the off switch, so BOTH spellings must
+    // boot. Requiring non-negative here would refuse to start on a configuration the docs advertise.
     expect(() => validateEnv({ AUDIT_RETENTION_DAYS: '0' })).not.toThrow();
+    expect(() => validateEnv({ AUDIT_RETENTION_DAYS: '-1' })).not.toThrow();
     expect(() => validateEnv({ AUDIT_RETENTION_DAYS: '90' })).not.toThrow();
   });
 

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -173,9 +173,31 @@ export function validateEnv(config: EnvConfig): EnvConfig {
     'AUTOMATION_MAX_PER_SESSION', // 0 = unlimited
     'WEBHOOK_MEDIA_INLINE_MAX_BYTES', // 0 = never inline media
     'EXPORT_INLINE_MEDIA_BUDGET_BYTES', // 0 = a data export carries no inline media at all
-    'AUDIT_RETENTION_DAYS', // 0 = retention disabled, so this cannot be positive-only
   ]) {
     checkNonNegativeInt(key);
+  }
+
+  // Retention knobs whose read site documents `<= 0` as the switch that disables pruning, so a
+  // negative value is a supported spelling of "off" rather than a typo — `audit.service.ts` clamps
+  // with Math.max(0, parsed) and `docs/05-database-design.md` advertises `≤ 0 disables`. The point of
+  // validating them is to reject `30d` / `ninety`, which parse to NaN and silently become the
+  // default; rejecting `-1` would instead refuse to boot a configuration this repo documents.
+  const SIGNED_DECIMAL_INTEGER = /^-?\d+$/;
+  const checkInt = (key: string): void => {
+    const raw = str(key);
+    if (raw === undefined) return;
+    const n = SIGNED_DECIMAL_INTEGER.test(raw) ? Number(raw) : NaN;
+    if (!Number.isInteger(n)) {
+      errors.push(`${key} must be an integer (got "${raw}")`);
+    }
+  };
+  // Keep this an ARRAY LITERAL even at one entry: docs-env-example.spec.ts derives the keys it
+  // requires `.env.example` to list by scanning `'KEY',` array elements in this file. Collapsing it
+  // into a bare checkInt('AUDIT_RETENTION_DAYS') call would silently drop the knob out of that gate.
+  for (const key of [
+    'AUDIT_RETENTION_DAYS', // <= 0 disables retention
+  ]) {
+    checkInt(key);
   }
 
   // Some knobs are nonsensical at 0 and contradict the "non-negative" intent: a rate-limit LIMIT of 0


### PR DESCRIPTION
Follow-up to #1277, found by a post-merge self-review of my own change. **This is a boot-failure regression that #1277 introduced and that is live on `main` now.**

## The defect

#1277 added `AUDIT_RETENTION_DAYS` to `checkNonNegativeInt`. That helper's guard is `/^\d+$/`, so it rejects every negative value. But `<= 0` — not just `0` — is the documented switch that disables pruning:

| Source | Text |
|---|---|
| `src/modules/audit/audit.service.ts:48` | *"default 90; set `<= 0` to disable"* |
| `src/modules/audit/audit.service.ts:55` | `if (retentionDays <= 0) { … return; }` |
| `docs/05-database-design.md:866` | *"`AUDIT_RETENTION_DAYS` (≤ 0 disables)"* |

`AUDIT_RETENTION_DAYS=-1` booted on 0.14.6, 0.15.0 and 0.16.0 and disabled retention exactly as advertised. After #1277 it aborts startup with `AUDIT_RETENTION_DAYS must be a non-negative integer (got "-1")`. An operator who followed `docs/05` cannot start the gateway after upgrading.

The irony is the point: #1277 existed to stop a typo silently becoming the default. It should not turn a *documented* value into a refusal to boot.

## The fix

A signed integer check. Measured truth table on the merged code, before and after:

| Value | before #1277 | on `main` today | this PR |
|---|---|---|---|
| `-1`, `-5` | boots, retention off | **ABORTS** | boots, retention off |
| `0` | boots, retention off | boots | boots |
| `90` | boots | boots | boots |
| `""` (unset/empty) | boots | boots | boots |
| `abc`, `30d`, `90.5`, `+90`, `1e2`, `0x10` | silently → 90 | ABORTS | ABORTS |

Typo protection is fully retained; only the documented "off" spellings come back.

**No document needs editing.** Fixing the check rather than the prose makes all three sources above accurate again — the alternative was editing `audit.service.ts` twice and `docs/05` once to retract a supported value.

## The one-entry array literal is deliberate

`docs-env-example.spec.ts` derives the keys it requires `.env.example` to list by scanning `'KEY',` **array elements** in this file — its header comment records that `MAIN_DATABASE_NAME` is invisible to it precisely because it is a call argument instead. Collapsing this into `checkInt('AUDIT_RETENTION_DAYS')` would silently drop the knob out of that gate, undoing the reach #1277 established. There is a comment saying so.

Verified by control, not assumed: with the key removed from `.env.example`, the gate still fails and names `+ "AUDIT_RETENTION_DAYS"`.

## Verification

Mutation-tested on both axes separately:

| Mutation | Expected | Result |
|---|---|---|
| baseline | pass | `exit=0` |
| regex back to `/^\d+$/` (the bug) | `-1` assertion red | `exit=1` |
| key removed from the `checkInt` list | reject assertions red | `exit=1` |

`env.validation.ts` restored from a saved copy and diffed byte-for-byte afterwards.

```
npm run lint                        EXIT=0
npx tsc --noEmit -p tsconfig.json   EXIT=0
npm run format:check                EXIT=0
npm run check:versions              EXIT=0
npm test                            EXIT=0  330 passed, 5577 tests
npm run build                        EXIT=0
```

The `[Unreleased]` CHANGELOG bullet from #1277 is amended in place rather than given a second entry, since it has not shipped: it claimed the knob is "validated as non-negative", which is exactly the part being corrected.