### PR TITLE
feat(sdk): expose quotedMessageId on the send request types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `AUDIT_RETENTION_DAYS` is checked at boot, so a typo fails startup with a named error instead of silently reverting to the 90-day default. It is validated as an integer of any sign rather than a positive one, because both `0` and any negative value are documented switches that disable audit-log pruning entirely.
 - `message.controller.spec.ts` holds the two headers the stored-media download sends, `X-Content-Type-Options: nosniff` and `Content-Disposition: attachment`; deleting either had passed every suite in the repo.
 - Optional `quotedMessageId` on every `send-*` message endpoint and its MCP tool, so a reply can carry media, a location, a contact card or a poll instead of only text. An id the engine cannot resolve now fails the send rather than delivering the message unquoted. Thanks @nirizr for the report.
+- All five SDK clients expose `quotedMessageId` on their send request types, so a typed caller can reply with media, a location, a contact card or a poll without hand-building the body.
 
 ### Fixed
 

--- a/sdk/go/quoted_send_test.go
+++ b/sdk/go/quoted_send_test.go
@@ -1,0 +1,70 @@
+package openwa
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// The body is what matters here, not the path. A dropped key is the failure mode this guards: Go's
+// `omitempty` and Java's Gson both omit an unset value, so a request type that forgot the field
+// still compiles, still routes correctly, and simply sends nothing — a 400 on one client while the
+// others work.
+func TestQuotedMessageIDReachesTheBody(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name string
+		call func(*Client)
+	}{
+		{"send-text", func(c *Client) {
+			c.Messages.SendText(ctx, "s1", SendTextRequest{ChatID: "a@c.us", Text: "hi", QuotedMessageID: "q1"})
+		}},
+		{"send-image", func(c *Client) {
+			c.Messages.SendImage(ctx, "s1", SendMediaRequest{ChatID: "a@c.us", URL: "http://u", QuotedMessageID: "q1"})
+		}},
+		{"send-audio", func(c *Client) {
+			c.Messages.SendAudio(ctx, "s1", SendAudioRequest{ChatID: "a@c.us", URL: "http://u", QuotedMessageID: "q1"})
+		}},
+		{"send-location", func(c *Client) {
+			c.Messages.SendLocation(ctx, "s1", SendLocationRequest{ChatID: "a@c.us", Latitude: 1, Longitude: 2, QuotedMessageID: "q1"})
+		}},
+		{"send-contact", func(c *Client) {
+			c.Messages.SendContact(ctx, "s1", SendContactRequest{ChatID: "a@c.us", ContactName: "A", ContactNumber: "628", QuotedMessageID: "q1"})
+		}},
+		{"send-poll", func(c *Client) {
+			c.Messages.SendPoll(ctx, "s1", SendPollRequest{ChatID: "a@c.us", Name: "Q", Options: []string{"a", "b"}, QuotedMessageID: "q1"})
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := &recordTransport{status: 200, body: `{}`}
+			tc.call(newTestClient(t, rt))
+
+			var body map[string]any
+			if err := json.Unmarshal(rt.lastRaw, &body); err != nil {
+				t.Fatalf("request body was not JSON: %v (%s)", err, rt.lastRaw)
+			}
+			if body["quotedMessageId"] != "q1" {
+				t.Fatalf("quotedMessageId missing from body: %s", rt.lastRaw)
+			}
+		})
+	}
+}
+
+// Known-negative control. `omitempty` is the whole reason the field is a plain string rather than a
+// pointer, and without this an implementation that emitted `"quotedMessageId": ""` on every send
+// would satisfy nothing above yet ship a wrong body on the ordinary path.
+func TestOrdinarySendOmitsTheQuoteKey(t *testing.T) {
+	rt := &recordTransport{status: 200, body: `{}`}
+	c := newTestClient(t, rt)
+	c.Messages.SendImage(context.Background(), "s1", SendMediaRequest{ChatID: "a@c.us", URL: "http://u"})
+
+	var body map[string]any
+	if err := json.Unmarshal(rt.lastRaw, &body); err != nil {
+		t.Fatalf("request body was not JSON: %v", err)
+	}
+	if _, present := body["quotedMessageId"]; present {
+		t.Fatalf("ordinary send carried a quote key: %s", rt.lastRaw)
+	}
+}

--- a/sdk/go/types_message.go
+++ b/sdk/go/types_message.go
@@ -26,6 +26,10 @@ type SendTextRequest struct {
 	// fetched, so it works even for a URL the gateway cannot reach. Baileys only — whatsapp-web.js
 	// takes a boolean and answers 501. Cannot be combined with LinkPreview=false.
 	CustomLinkPreview *CustomLinkPreview `json:"customLinkPreview,omitempty"`
+	// QuotedMessageID quotes an earlier message, turning this send into a reply. Engine-specific:
+	// whatsapp-web.js matches the serialized message id, Baileys the raw key id of a message it has
+	// already stored. Omitted when empty, so an ordinary send carries no quote key.
+	QuotedMessageID string `json:"quotedMessageId,omitempty"`
 }
 
 // SendMediaRequest sends image/video/document/sticker media. Provide exactly
@@ -37,6 +41,10 @@ type SendMediaRequest struct {
 	Mimetype string `json:"mimetype,omitempty"`
 	Filename string `json:"filename,omitempty"`
 	Caption  string `json:"caption,omitempty"`
+	// QuotedMessageID quotes an earlier message, turning this send into a reply. Engine-specific:
+	// whatsapp-web.js matches the serialized message id, Baileys the raw key id of a message it has
+	// already stored. Omitted when empty, so an ordinary send carries no quote key.
+	QuotedMessageID string `json:"quotedMessageId,omitempty"`
 }
 
 // SendAudioRequest sends audio. PTT sends as a voice note. Server only accepts
@@ -49,6 +57,10 @@ type SendAudioRequest struct {
 	Filename string `json:"filename,omitempty"`
 	Caption  string `json:"caption,omitempty"`
 	PTT      *bool  `json:"ptt,omitempty"`
+	// QuotedMessageID quotes an earlier message, turning this send into a reply. Engine-specific:
+	// whatsapp-web.js matches the serialized message id, Baileys the raw key id of a message it has
+	// already stored. Omitted when empty, so an ordinary send carries no quote key.
+	QuotedMessageID string `json:"quotedMessageId,omitempty"`
 }
 
 // SendLocationRequest sends a location pin. ChatID/Latitude/Longitude required.
@@ -58,6 +70,10 @@ type SendLocationRequest struct {
 	Longitude   float64 `json:"longitude"`
 	Description string  `json:"description,omitempty"`
 	Address     string  `json:"address,omitempty"`
+	// QuotedMessageID quotes an earlier message, turning this send into a reply. Engine-specific:
+	// whatsapp-web.js matches the serialized message id, Baileys the raw key id of a message it has
+	// already stored. Omitted when empty, so an ordinary send carries no quote key.
+	QuotedMessageID string `json:"quotedMessageId,omitempty"`
 }
 
 // SendContactRequest sends a contact card.
@@ -65,6 +81,10 @@ type SendContactRequest struct {
 	ChatID        string `json:"chatId"`
 	ContactName   string `json:"contactName"`
 	ContactNumber string `json:"contactNumber"`
+	// QuotedMessageID quotes an earlier message, turning this send into a reply. Engine-specific:
+	// whatsapp-web.js matches the serialized message id, Baileys the raw key id of a message it has
+	// already stored. Omitted when empty, so an ordinary send carries no quote key.
+	QuotedMessageID string `json:"quotedMessageId,omitempty"`
 }
 
 // SendTemplateRequest sends a stored template. Provide exactly one of
@@ -85,6 +105,10 @@ type SendPollRequest struct {
 	Options []string `json:"options"`
 	// AllowMultipleAnswers lets voters pick several options (default single choice).
 	AllowMultipleAnswers *bool `json:"allowMultipleAnswers,omitempty"`
+	// QuotedMessageID quotes an earlier message, turning this send into a reply. Engine-specific:
+	// whatsapp-web.js matches the serialized message id, Baileys the raw key id of a message it has
+	// already stored. Omitted when empty, so an ordinary send carries no quote key.
+	QuotedMessageID string `json:"quotedMessageId,omitempty"`
 }
 
 // ReplyMessageRequest replies to a quoted message.

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/model/SendContactRequest.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/model/SendContactRequest.java
@@ -1,7 +1,8 @@
 package com.rmyndharis.openwa.model;
 
 /** Request body for sending a contact card. */
-public record SendContactRequest(String chatId, String contactName, String contactNumber) {
+public record SendContactRequest(String chatId, String contactName, String contactNumber,
+    String quotedMessageId) {
     public static Builder builder() {
         return new Builder();
     }
@@ -10,6 +11,7 @@ public record SendContactRequest(String chatId, String contactName, String conta
         private String chatId;
         private String contactName;
         private String contactNumber;
+        private String quotedMessageId;
 
         public Builder chatId(String v) {
             this.chatId = v;
@@ -26,8 +28,18 @@ public record SendContactRequest(String chatId, String contactName, String conta
             return this;
         }
 
+        /**
+         * Quote an earlier message, turning this send into a reply. Engine-specific:
+         * whatsapp-web.js matches the serialized message id, Baileys the raw key id of a message
+         * it has already stored.
+         */
+        public Builder quotedMessageId(String v) {
+            this.quotedMessageId = v;
+            return this;
+        }
+
         public SendContactRequest build() {
-            return new SendContactRequest(chatId, contactName, contactNumber);
+            return new SendContactRequest(chatId, contactName, contactNumber, quotedMessageId);
         }
     }
 }

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/model/SendLocationRequest.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/model/SendLocationRequest.java
@@ -6,7 +6,8 @@ public record SendLocationRequest(
     double latitude,
     double longitude,
     String description,
-    String address) {
+    String address,
+    String quotedMessageId) {
 
     public static Builder builder() {
         return new Builder();
@@ -18,6 +19,7 @@ public record SendLocationRequest(
         private double longitude;
         private String description;
         private String address;
+        private String quotedMessageId;
 
         public Builder chatId(String v) {
             this.chatId = v;
@@ -44,8 +46,18 @@ public record SendLocationRequest(
             return this;
         }
 
+        /**
+         * Quote an earlier message, turning this send into a reply. Engine-specific:
+         * whatsapp-web.js matches the serialized message id, Baileys the raw key id of a message
+         * it has already stored.
+         */
+        public Builder quotedMessageId(String v) {
+            this.quotedMessageId = v;
+            return this;
+        }
+
         public SendLocationRequest build() {
-            return new SendLocationRequest(chatId, latitude, longitude, description, address);
+            return new SendLocationRequest(chatId, latitude, longitude, description, address, quotedMessageId);
         }
     }
 }

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/model/SendMediaRequest.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/model/SendMediaRequest.java
@@ -7,7 +7,8 @@ public record SendMediaRequest(
     String base64,
     String mimetype,
     String filename,
-    String caption) {
+    String caption,
+    String quotedMessageId) {
 
     public static Builder builder() {
         return new Builder();
@@ -20,6 +21,7 @@ public record SendMediaRequest(
         private String mimetype;
         private String filename;
         private String caption;
+        private String quotedMessageId;
 
         public Builder chatId(String v) {
             this.chatId = v;
@@ -55,8 +57,18 @@ public record SendMediaRequest(
             return this;
         }
 
+        /**
+         * Quote an earlier message, turning this send into a reply. Engine-specific:
+         * whatsapp-web.js matches the serialized message id, Baileys the raw key id of a message
+         * it has already stored.
+         */
+        public Builder quotedMessageId(String v) {
+            this.quotedMessageId = v;
+            return this;
+        }
+
         public SendMediaRequest build() {
-            return new SendMediaRequest(chatId, url, base64, mimetype, filename, caption);
+            return new SendMediaRequest(chatId, url, base64, mimetype, filename, caption, quotedMessageId);
         }
     }
 }

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/model/SendPollRequest.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/model/SendPollRequest.java
@@ -3,7 +3,8 @@ package com.rmyndharis.openwa.model;
 import java.util.List;
 
 /** Request body for sending a native WhatsApp poll (2–12 options). */
-public record SendPollRequest(String chatId, String name, List<String> options, Boolean allowMultipleAnswers) {
+public record SendPollRequest(String chatId, String name, List<String> options, Boolean allowMultipleAnswers,
+    String quotedMessageId) {
     public static Builder builder() {
         return new Builder();
     }
@@ -13,6 +14,7 @@ public record SendPollRequest(String chatId, String name, List<String> options, 
         private String name;
         private List<String> options;
         private Boolean allowMultipleAnswers;
+        private String quotedMessageId;
 
         public Builder chatId(String v) {
             this.chatId = v;
@@ -37,8 +39,18 @@ public record SendPollRequest(String chatId, String name, List<String> options, 
             return this;
         }
 
+        /**
+         * Quote an earlier message, turning this send into a reply. Engine-specific:
+         * whatsapp-web.js matches the serialized message id, Baileys the raw key id of a message
+         * it has already stored.
+         */
+        public Builder quotedMessageId(String v) {
+            this.quotedMessageId = v;
+            return this;
+        }
+
         public SendPollRequest build() {
-            return new SendPollRequest(chatId, name, options, allowMultipleAnswers);
+            return new SendPollRequest(chatId, name, options, allowMultipleAnswers, quotedMessageId);
         }
     }
 }

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/model/SendTextRequest.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/model/SendTextRequest.java
@@ -4,15 +4,16 @@ import java.util.List;
 
 /** Request body for sending a text message. */
 public record SendTextRequest(
-    String chatId, String text, List<String> mentions, Boolean linkPreview, CustomLinkPreview customLinkPreview) {
+    String chatId, String text, List<String> mentions, Boolean linkPreview, CustomLinkPreview customLinkPreview,
+    String quotedMessageId) {
     /** Back-compatible constructor without mentions. */
     public SendTextRequest(String chatId, String text) {
-        this(chatId, text, null, null, null);
+        this(chatId, text, null, null, null, null);
     }
 
     /** Back-compatible constructor without a link-preview choice. */
     public SendTextRequest(String chatId, String text, List<String> mentions) {
-        this(chatId, text, mentions, null, null);
+        this(chatId, text, mentions, null, null, null);
     }
 
     public static Builder builder() {
@@ -25,6 +26,7 @@ public record SendTextRequest(
         private List<String> mentions;
         private Boolean linkPreview;
         private CustomLinkPreview customLinkPreview;
+        private String quotedMessageId;
 
         public Builder chatId(String v) {
             this.chatId = v;
@@ -62,8 +64,18 @@ public record SendTextRequest(
             return this;
         }
 
+        /**
+         * Quote an earlier message, turning this send into a reply. Engine-specific:
+         * whatsapp-web.js matches the serialized message id, Baileys the raw key id of a message
+         * it has already stored.
+         */
+        public Builder quotedMessageId(String v) {
+            this.quotedMessageId = v;
+            return this;
+        }
+
         public SendTextRequest build() {
-            return new SendTextRequest(chatId, text, mentions, linkPreview, customLinkPreview);
+            return new SendTextRequest(chatId, text, mentions, linkPreview, customLinkPreview, quotedMessageId);
         }
     }
 }

--- a/sdk/java/src/test/java/com/rmyndharis/openwa/resources/MessagesResourceTest.java
+++ b/sdk/java/src/test/java/com/rmyndharis/openwa/resources/MessagesResourceTest.java
@@ -172,6 +172,62 @@ class MessagesResourceTest {
         assertTrue(tx.lastRequest().body().contains("welcome-tpl"));
     }
 
+    // Asserted on the body rather than the path: Gson omits a null component, so a record that
+    // forgot the field would still compile and still route correctly while sending nothing.
+    @Test
+    void quotedMessageIdReachesTheBodyOnEverySend() {
+        tx.respond(200, MSG);
+        client.messages.sendText(
+            "s", SendTextRequest.builder().chatId("628@c.us").text("hi").quotedMessageId("q-text").build());
+        assertTrue(tx.lastRequest().body().contains("q-text"));
+
+        tx.respond(200, MSG);
+        client.messages.sendImage(
+            "s", SendMediaRequest.builder().chatId("628@c.us").url("http://u").quotedMessageId("q-media").build());
+        assertTrue(tx.lastRequest().body().contains("q-media"));
+
+        tx.respond(200, MSG);
+        client.messages.sendLocation(
+            "s",
+            SendLocationRequest.builder()
+                .chatId("628@c.us")
+                .latitude(1.0)
+                .longitude(2.0)
+                .quotedMessageId("q-loc")
+                .build());
+        assertTrue(tx.lastRequest().body().contains("q-loc"));
+
+        tx.respond(200, MSG);
+        client.messages.sendContact(
+            "s",
+            SendContactRequest.builder()
+                .chatId("628@c.us")
+                .contactName("A")
+                .contactNumber("628")
+                .quotedMessageId("q-contact")
+                .build());
+        assertTrue(tx.lastRequest().body().contains("q-contact"));
+
+        tx.respond(200, MSG);
+        client.messages.sendPoll(
+            "s",
+            SendPollRequest.builder()
+                .chatId("628@c.us")
+                .name("Q")
+                .options(java.util.List.of("a", "b"))
+                .quotedMessageId("q-poll")
+                .build());
+        assertTrue(tx.lastRequest().body().contains("q-poll"));
+    }
+
+    // Known-negative control: an ordinary send must not carry the key at all.
+    @Test
+    void ordinarySendOmitsTheQuoteKey() {
+        tx.respond(200, MSG);
+        client.messages.sendImage("s", SendMediaRequest.builder().chatId("628@c.us").url("http://u").build());
+        assertTrue(!tx.lastRequest().body().contains("quotedMessageId"));
+    }
+
     @Test
     void replyHitsReplyPath() {
         tx.respond(200, MSG);

--- a/sdk/javascript/src/types.ts
+++ b/sdk/javascript/src/types.ts
@@ -240,6 +240,12 @@ export interface SendTextRequest {
    * boolean and answers 501. Cannot be combined with `linkPreview: false`.
    */
   customLinkPreview?: { url: string; title: string; description?: string };
+  /**
+   * Quote an earlier message, turning this send into a reply. Engine-specific: whatsapp-web.js
+   * matches the serialized message id, Baileys the raw message key id of a message it has already
+   * stored. An id the engine cannot resolve fails the send rather than delivering it unquoted.
+   */
+  quotedMessageId?: string;
 }
 
 export interface SendMediaRequest {
@@ -253,6 +259,12 @@ export interface SendMediaRequest {
   filename?: string;
   /** Max 1024 chars. */
   caption?: string;
+  /**
+   * Quote an earlier message, turning this send into a reply. Engine-specific: whatsapp-web.js
+   * matches the serialized message id, Baileys the raw message key id of a message it has already
+   * stored. An id the engine cannot resolve fails the send rather than delivering it unquoted.
+   */
+  quotedMessageId?: string;
 }
 
 export interface SendAudioRequest extends SendMediaRequest {
@@ -276,12 +288,24 @@ export interface SendLocationRequest {
   longitude: number;
   description?: string;
   address?: string;
+  /**
+   * Quote an earlier message, turning this send into a reply. Engine-specific: whatsapp-web.js
+   * matches the serialized message id, Baileys the raw message key id of a message it has already
+   * stored. An id the engine cannot resolve fails the send rather than delivering it unquoted.
+   */
+  quotedMessageId?: string;
 }
 
 export interface SendContactRequest {
   chatId: Jid;
   contactName: string;
   contactNumber: string;
+  /**
+   * Quote an earlier message, turning this send into a reply. Engine-specific: whatsapp-web.js
+   * matches the serialized message id, Baileys the raw message key id of a message it has already
+   * stored. An id the engine cannot resolve fails the send rather than delivering it unquoted.
+   */
+  quotedMessageId?: string;
 }
 
 export interface ReplyMessageRequest {
@@ -408,6 +432,12 @@ export interface SendPollRequest {
   options: string[];
   /** Allow voters to pick several options (default single choice). */
   allowMultipleAnswers?: boolean;
+  /**
+   * Quote an earlier message, turning this send into a reply. Engine-specific: whatsapp-web.js
+   * matches the serialized message id, Baileys the raw message key id of a message it has already
+   * stored. An id the engine cannot resolve fails the send rather than delivering it unquoted.
+   */
+  quotedMessageId?: string;
 }
 
 export interface ListMessagesQuery {

--- a/sdk/javascript/test/messages.test.ts
+++ b/sdk/javascript/test/messages.test.ts
@@ -84,7 +84,17 @@ describe('MessagesResource — exact paths', () => {
     const t = new MockTransport().on('GET', /\/messages$/, {
       body: {
         messages: [
-          { id: '1', sessionId: 's', chatId: 'a@c.us', from: 'a@c.us', to: 's', type: 'text', direction: 'incoming', status: 'delivered', createdAt: '' },
+          {
+            id: '1',
+            sessionId: 's',
+            chatId: 'a@c.us',
+            from: 'a@c.us',
+            to: 's',
+            type: 'text',
+            direction: 'incoming',
+            status: 'delivered',
+            createdAt: '',
+          },
         ],
         total: 1,
       },
@@ -92,6 +102,52 @@ describe('MessagesResource — exact paths', () => {
     const res = await client(t).messages.list('s', { chatId: 'a@c.us' });
     expect(res.total).toBe(1);
     expect(res.messages).toHaveLength(1);
+  });
+
+  // Asserted on the BODY, not the URL: the field is what this is about, and a URL assertion cannot
+  // see a dropped key. One case per request type, because each is a separate declaration — a type
+  // that forgot the field would still send it from JS but would not compile for a typed caller.
+  it.each([
+    [
+      'send-text',
+      (c: OpenWAClient) => c.messages.sendText('s1', { chatId: 'a@c.us', text: 'hi', quotedMessageId: 'q1' }),
+    ],
+    [
+      'send-image',
+      (c: OpenWAClient) => c.messages.sendImage('s1', { chatId: 'a@c.us', url: 'http://u', quotedMessageId: 'q1' }),
+    ],
+    [
+      'send-location',
+      (c: OpenWAClient) =>
+        c.messages.sendLocation('s1', { chatId: 'a@c.us', latitude: 1, longitude: 2, quotedMessageId: 'q1' }),
+    ],
+    [
+      'send-contact',
+      (c: OpenWAClient) =>
+        c.messages.sendContact('s1', {
+          chatId: 'a@c.us',
+          contactName: 'A',
+          contactNumber: '628',
+          quotedMessageId: 'q1',
+        }),
+    ],
+    [
+      'send-poll',
+      (c: OpenWAClient) =>
+        c.messages.sendPoll('s1', { chatId: 'a@c.us', name: 'Q', options: ['a', 'b'], quotedMessageId: 'q1' }),
+    ],
+  ])('%s forwards quotedMessageId in the body', async (route, call) => {
+    const t = new MockTransport().on('POST', new RegExp(`${route}$`), { body: { messageId: 'm', timestamp: 1 } });
+    await call(client(t));
+    expect(t.lastCall!.body).toMatchObject({ quotedMessageId: 'q1' });
+  });
+
+  // Known-negative control: an ordinary send must not carry the key at all, so an implementation
+  // that always emitted it (as `undefined`, which JSON.stringify drops but a proxy may not) fails.
+  it('omits quotedMessageId entirely on an ordinary send', async () => {
+    const t = new MockTransport().on('POST', /send-image$/, { body: { messageId: 'm', timestamp: 1 } });
+    await client(t).messages.sendImage('s1', { chatId: 'a@c.us', url: 'http://u' });
+    expect(t.lastCall!.body).not.toHaveProperty('quotedMessageId');
   });
 
   it('reply / forward / react / delete', async () => {
@@ -149,7 +205,11 @@ describe('MessagesResource — exact paths', () => {
         },
       })
       .on('POST', /\/batch\/b\/cancel$/, {
-        body: { batchId: 'b', status: 'cancelled', progress: { total: 1, sent: 0, failed: 0, pending: 0, cancelled: 1 } },
+        body: {
+          batchId: 'b',
+          status: 'cancelled',
+          progress: { total: 1, sent: 0, failed: 0, pending: 0, cancelled: 1 },
+        },
       });
     const c = client(t);
     await c.messages.sendBulk('s', { messages: [{ chatId: 'a@c.us', type: 'text', content: { text: 'x' } }] });

--- a/sdk/php/tests/MessagesTest.php
+++ b/sdk/php/tests/MessagesTest.php
@@ -109,6 +109,47 @@ class MessagesTest extends TestCase
         $this->assertStringContainsString('/messages/delete', $backend->calls()[3]['url']);
     }
 
+    /**
+     * This client takes an untyped array, so nothing here checks the shape at compile time — the
+     * body assertion is the only thing standing between a caller and a silently dropped key.
+     */
+    public function testQuotedMessageIdReachesTheBodyOnEverySend(): void
+    {
+        $backend = new MockBackend();
+        foreach (range(1, 5) as $ignored) {
+            $backend->on(201, ['messageId' => 'm', 'timestamp' => 1]);
+        }
+        $client = $backend->makeClient();
+
+        $client->messages->sendText('s', ['chatId' => 'a@c.us', 'text' => 'hi', 'quotedMessageId' => 'q1']);
+        $client->messages->sendImage('s', ['chatId' => 'a@c.us', 'url' => 'http://u', 'quotedMessageId' => 'q1']);
+        $client->messages->sendLocation(
+            's',
+            ['chatId' => 'a@c.us', 'latitude' => 1, 'longitude' => 2, 'quotedMessageId' => 'q1']
+        );
+        $client->messages->sendContact(
+            's',
+            ['chatId' => 'a@c.us', 'contactName' => 'A', 'contactNumber' => '628', 'quotedMessageId' => 'q1']
+        );
+        $client->messages->sendPoll(
+            's',
+            ['chatId' => 'a@c.us', 'name' => 'Q', 'options' => ['a', 'b'], 'quotedMessageId' => 'q1']
+        );
+
+        foreach ($backend->calls() as $call) {
+            $this->assertSame('q1', $call['body']['quotedMessageId'] ?? null, $call['url']);
+        }
+    }
+
+    public function testOrdinarySendCarriesNoQuoteKey(): void
+    {
+        $backend = new MockBackend();
+        $backend->on(201, ['messageId' => 'm', 'timestamp' => 1]);
+        $backend->makeClient()->messages->sendImage('s', ['chatId' => 'a@c.us', 'url' => 'http://u']);
+
+        $this->assertArrayNotHasKey('quotedMessageId', $backend->lastCall()['body']);
+    }
+
     public function testEditMessageUsesEditPath(): void
     {
         $backend = (new MockBackend())->on(200, ['messageId' => 'm1', 'timestamp' => 123]);

--- a/sdk/python/openwa/types.py
+++ b/sdk/python/openwa/types.py
@@ -297,6 +297,9 @@ class SendTextRequest(TypedDict, total=False):
     # so this works even for a URL the gateway cannot reach. Baileys only -- whatsapp-web.js takes a
     # boolean and answers 501. Cannot be combined with linkPreview=False.
     customLinkPreview: CustomLinkPreview
+    # Quote an earlier message, turning this send into a reply. Engine-specific: whatsapp-web.js
+    # matches the serialized message id, Baileys the raw key id of a message it has already stored.
+    quotedMessageId: str
 
 
 class SendMediaRequest(TypedDict, total=False):
@@ -306,6 +309,9 @@ class SendMediaRequest(TypedDict, total=False):
     mimetype: str
     filename: str
     caption: str
+    # Quote an earlier message, turning this send into a reply. Engine-specific: whatsapp-web.js
+    # matches the serialized message id, Baileys the raw key id of a message it has already stored.
+    quotedMessageId: str
 
 
 class SendAudioRequest(SendMediaRequest, total=False):
@@ -329,12 +335,23 @@ class SendLocationRequest(TypedDict, total=False):
     longitude: float
     description: str
     address: str
+    # Quote an earlier message, turning this send into a reply. Engine-specific: whatsapp-web.js
+    # matches the serialized message id, Baileys the raw key id of a message it has already stored.
+    quotedMessageId: str
 
 
-class SendContactRequest(TypedDict):
+class _SendContactRequired(TypedDict):
     chatId: Jid
     contactName: str
     contactNumber: str
+
+
+# Split so the optional key can be added without loosening the three required ones — the same
+# inheritance shape SendAudioRequest already uses.
+class SendContactRequest(_SendContactRequired, total=False):
+    # Quote an earlier message, turning this send into a reply. Engine-specific: whatsapp-web.js
+    # matches the serialized message id, Baileys the raw key id of a message it has already stored.
+    quotedMessageId: str
 
 
 class ReplyMessageRequest(TypedDict):
@@ -386,6 +403,9 @@ class SendPollRequest(TypedDict, total=False):
     # Options to vote on (WhatsApp allows between 2 and 12).
     options: list[str]
     allowMultipleAnswers: bool
+    # Quote an earlier message, turning this send into a reply. Engine-specific: whatsapp-web.js
+    # matches the serialized message id, Baileys the raw key id of a message it has already stored.
+    quotedMessageId: str
 
 
 # ``from`` is a Python keyword, so use the functional TypedDict form.

--- a/sdk/python/tests/test_sdk.py
+++ b/sdk/python/tests/test_sdk.py
@@ -192,6 +192,36 @@ class TestMessages:
         assert res["total"] == 1
         assert len(res["messages"]) == 1
 
+    def test_quoted_message_id_reaches_the_body_on_every_send(self):
+        # Asserted on the BODY, not the URL: a URL assertion cannot see a dropped key, and dropping
+        # one is exactly how a client ends up 400ing while its four siblings work.
+        backend = MockBackend()
+        for route in ("send-text", "send-image", "send-location", "send-contact", "send-poll"):
+            backend.on("POST", f"/{route}", body={"messageId": "m", "timestamp": 1})
+        client = make_client(backend)
+
+        client.messages.send_text("s", {"chatId": "a@c.us", "text": "hi", "quotedMessageId": "q1"})
+        client.messages.send_image("s", {"chatId": "a@c.us", "url": "http://u", "quotedMessageId": "q1"})
+        client.messages.send_location(
+            "s", {"chatId": "a@c.us", "latitude": 1, "longitude": 2, "quotedMessageId": "q1"}
+        )
+        client.messages.send_contact(
+            "s", {"chatId": "a@c.us", "contactName": "A", "contactNumber": "628", "quotedMessageId": "q1"}
+        )
+        client.messages.send_poll(
+            "s", {"chatId": "a@c.us", "name": "Q", "options": ["a", "b"], "quotedMessageId": "q1"}
+        )
+
+        for call in backend.calls[-5:]:
+            assert call.body["quotedMessageId"] == "q1", call.url
+
+    def test_ordinary_send_carries_no_quote_key(self):
+        # Known-negative control: without it an implementation that always emitted the key — as null,
+        # which some clients drop and others send — would satisfy the assertion above.
+        backend = MockBackend().on("POST", "/send-image", body={"messageId": "m", "timestamp": 1})
+        make_client(backend).messages.send_image("s", {"chatId": "a@c.us", "url": "http://u"})
+        assert "quotedMessageId" not in backend.calls[-1].body
+
     def test_reply_forwardReactDelete(self):
         backend = MockBackend()
         backend.on("POST", "/reply", body={"messageId": "m", "timestamp": 1})


### PR DESCRIPTION
Refs #1271. Follows #1284, which is on main — the API accepts `quotedMessageId` on `send-*`.

All five clients gain the optional field on their send request types, so a typed caller can reply with media, a location, a contact card or a poll without hand-building the body.

| client | types touched | shape |
| --- | --- | --- |
| JavaScript | 5 interfaces | `quotedMessageId?: string` |
| Python | 5 TypedDicts | `quotedMessageId: str` (optional) |
| Go | 6 structs | `QuotedMessageID string` + `omitempty` |
| Java | 5 records + builders | new component, `null` omitted by Gson |
| PHP | — | takes an untyped array; test-only |

Go has six because `SendAudioRequest` is a standalone struct there rather than inheriting from the media one.

## Two strict shapes needed care

**Java `SendTextRequest`** carries two back-compatible convenience constructors that delegate to the canonical one. Adding a component changed the canonical arity, so both had to be widened — the only mechanical churn in this change, and it is two lines. It stayed small because every test builds through `Builder`, not the constructor.

**Python `SendContactRequest`** was a strict `TypedDict` with all keys required, so an optional key could not simply be appended. It is now a required base plus a `total=False` subclass — the same inheritance shape `SendAudioRequest` already used. Verified: `__required_keys__` is still `chatId`, `contactName`, `contactNumber`, with `quotedMessageId` optional.

## Every assertion is on the body, never the URL

This is the failure mode worth guarding: Go's `omitempty` and Gson both omit an unset value, so a request type that forgot the field still compiles and still routes to the right path — it just sends nothing. That is how one client 400s while the other four work, and a URL assertion cannot see it.

Each client also carries a known-negative control asserting that an ordinary send emits **no** quote key at all. Without it, an implementation that always emitted the key (as `null`, or as `""`) would satisfy every positive assertion while shipping a wrong body on the common path.

## What actually gates each client

Worth stating, because it is uneven:

- **JavaScript** — `npm test` runs `tsc --noEmit` first, so a missing field fails the build.
- **Go** — a missing struct field is a compile error in the test.
- **Java** — same, at `mvn test`.
- **PHP** — bodies are untyped arrays; the test is the only guard, which is why one was added.
- **Python** — `pytest` only. There is no mypy or pyright step in the SDK workflow, so `TypedDict` keys are **not** gated by CI. The runtime test here passes with or without the type change, because TypedDict is not enforced at runtime; it proves the transport forwards the body, not that the type is right. Worth knowing before relying on that suite to catch a type regression.

## Verification

JavaScript 88 · Python 81 · Go all · Java 186 · PHP 80/253 assertions — all pass. `check:sdk-routes`, `check:sdk-coverage`, `check:sdk-docs` and `check:sdk-events` all pass, as does the repo-wide `format:check`.

No new route, so `check:sdk-coverage` was never at risk here — this change is invisible to it, which is precisely why the body assertions had to be written by hand.
