### PR TITLE
docs(config): correct two knob descriptions added in #1278

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,11 +100,14 @@ CORS_ORIGINS=*
 # TRUSTED_PROXIES=172.18.0.0/16
 
 # Docker daemon endpoint used to manage the built-in datastore containers (POSTGRES_BUILTIN,
-# REDIS_BUILTIN, MINIO_BUILTIN — each in its own section below). Only the tcp://host:port form is
-# parsed; anything else, including a unix:// path, falls back to /var/run/docker.sock. The bundled
-# compose sets this to its own socket-proxy and forwards no value from .env, so setting it here
-# affects a non-compose run only.
-# DOCKER_HOST=tcp://docker-proxy:2375 # set ONLY to reach a remote/proxied daemon; default is the socket
+# REDIS_BUILTIN, MINIO_BUILTIN — each in its own section below). Unset means /var/run/docker.sock.
+# OpenWA itself recognises only the exact tcp://host:port form; every other value is handed to the
+# Docker client, which parses DOCKER_HOST again on its own — unix:// and npipe:// land back on the
+# local socket, but any host-shaped value (https://host:2376, ssh://user@host, tcp://host:2375/path,
+# even an unparseable one) still connects to THAT host. So a typo here is a different daemon, not a
+# fallback. The bundled compose hard-codes its own socket-proxy and forwards no value from .env, so
+# setting this affects a non-compose run only.
+# DOCKER_HOST=tcp://127.0.0.1:2375    # example only — a compose deployment cannot override this
 
 # =============================================================================
 # ENGINE CONFIGURATION
@@ -660,7 +663,9 @@ PLUGINS_DIR=./data/plugins          # Plugin directory (default: ./data/plugins)
 # downgrade (though an http→https→http chain is still refused).
 # PLUGIN_DOWNLOAD_ALLOW_INSECURE_REDIRECTS=false
 # Catalog the plugin browser reads its list of installable packages from. Point it at your own
-# published catalog to install from a private index instead of the public one.
+# published catalog to install from a private index instead of the public one. The fetch goes through
+# the SSRF guard, so an internal host must also be named in SSRF_ALLOWED_HOSTS or the request is
+# refused — a private index on a non-public address does not work on this key alone.
 # PLUGIN_CATALOG_URL=https://raw.githubusercontent.com/rmyndharis/OpenWA-plugins/main/plugins.json
 
 # =============================================================================


### PR DESCRIPTION
Follow-up to #1278, from a post-merge review of my own change. Both errors are mine and both are live on `main`.

## 1. The `DOCKER_HOST` fallback claim is false

Shipped text: *"Only the tcp://host:port form is parsed; anything else, including a unix:// path, falls back to `/var/run/docker.sock`."*

`buildDockerOptions()` does return `{socketPath: '/var/run/docker.sock'}` when its regex misses — but that is only the argument. `dockerode`'s modem parses `DOCKER_HOST` again on its own and overrides it. Measured against the real `dockerode` in `node_modules`, feeding a verbatim copy of `buildDockerOptions()` and reading back `modem.host` / `socketPath`:

| `DOCKER_HOST` | Resolves to | Comment was |
|---|---|---|
| `tcp://docker-proxy:2375` | host `docker-proxy:2375` | correct |
| `unix:///run/user/1000/docker.sock` | local socket | correct |
| `npipe:////./pipe/docker_engine` | local socket | correct |
| `http://remote:2375` | **host `remote:2375`** | wrong |
| `https://remote:2376` | **host `remote:2376`, TLS** | wrong |
| `ssh://user@host` | **host `host`** | wrong |
| `tcp://host:2375/path` | **host `host:2375`** | wrong |
| `TCP://HOST:2375` | **host `HOST:2375`** | wrong |
| `garbage` | **host `garbage`** | wrong |

So a typo in this key silently targets a *different daemon* — the opposite of the safe reading the comment promised. That is the more dangerous direction to get wrong, which is why this is worth its own fix rather than a note.

## 2. The `DOCKER_HOST` example value is unusable in the only mode it applies to

It shipped as `# DOCKER_HOST=tcp://docker-proxy:2375`. `docker-proxy` is a compose service name (`docker-compose.yml:6`), resolvable only inside the compose network — while the four comment lines directly above it say the bundled compose hard-codes the value and forwards nothing from `.env`, "so setting it here affects a non-compose run only". The entry contradicted itself.

Now `tcp://127.0.0.1:2375`: reachable in the mode the key actually governs, and a form OpenWA's own `tcp://host:port` regex matches. Verified that uncommenting it parses to exactly `tcp://127.0.0.1:2375` with the inline comment stripped.

## 3. `PLUGIN_CATALOG_URL` recommended something that does not work

The entry says to point the knob at a private index. Its own read site records the constraint I left out — `src/config/configuration.ts:317`: *"Fetched through the SSRF guard — add its host to `SSRF_ALLOWED_HOSTS` if it is not publicly resolvable."* The catalog goes through `fetchSafeBuffer` with the guard always on, so a private index on an internal address is refused unless the host is allowlisted. `SSRF_ALLOWED_HOSTS` is already documented at `.env.example:396`; the entry now points at it.

## Scope

`.env.example` only — comment text and one example value. No key added or removed, no behaviour touched.

No CHANGELOG entry: #1278's bullet is still in `[Unreleased]` and already covers documenting these knobs. This makes that documentation correct before it ships, rather than adding a second entry retracting the first.

## Verification

```
npm run lint                        EXIT=0
npx tsc --noEmit -p tsconfig.json   EXIT=0
npm run format:check                EXIT=0
npm run check:versions              EXIT=0
npm test                            EXIT=0  330 passed, 5577 tests
npm run build                        EXIT=0
```

`dotenv` still parses the file to the same 27 keys, none malformed, and neither `DOCKER_HOST` nor `PLUGIN_CATALOG_URL` leaks in as a live key.