### PR TITLE
test(message): hold the media response body, not only its headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Turkish (`tr`) dashboard translation. Thanks @codedByCan.
 - `AUDIT_RETENTION_DAYS` is checked at boot, so a typo fails startup with a named error instead of silently reverting to the 90-day default. It is validated as an integer of any sign rather than a positive one, because both `0` and any negative value are documented switches that disable audit-log pruning entirely.
 - `message.controller.spec.ts` holds the two headers the stored-media download sends, `X-Content-Type-Options: nosniff` and `Content-Disposition: attachment`; deleting either had passed every suite in the repo.
+- That same spec now also holds the passthrough declaration and the returned bytes, so a media response carrying both security headers and no body at all no longer passes it.
 - Optional `quotedMessageId` on every `send-*` message endpoint and its MCP tool, so a reply can carry media, a location, a contact card or a poll instead of only text. An id the engine cannot resolve now fails the send rather than delivering the message unquoted. Thanks @nirizr for the report.
 
 ### Fixed

--- a/src/modules/message/message.controller.spec.ts
+++ b/src/modules/message/message.controller.spec.ts
@@ -1,3 +1,5 @@
+import { StreamableFile } from '@nestjs/common';
+import { RESPONSE_PASSTHROUGH_METADATA } from '@nestjs/common/constants';
 import { MessageController } from './message.controller';
 import type { MessageService } from './message.service';
 import type { BulkMessageService } from './bulk-message.service';
@@ -34,5 +36,30 @@ describe('MessageController — stored media download', () => {
 
   it('sends the media as an attachment, so it is never rendered on the API origin', async () => {
     expect((await mediaResponseHeaders())['Content-Disposition']).toBe('attachment');
+  });
+
+  /**
+   * The headers above are set on the response object directly, so they survive a handler that sends
+   * no body at all — a `404` with a perfect `Content-Disposition` would satisfy both. What actually
+   * carries the bytes is the returned `StreamableFile`, and Nest only sends that when the response
+   * parameter is declared passthrough: without it Nest treats the handler as having taken the
+   * response over and discards the return value entirely. Both halves are asserted here so the pair
+   * above cannot end up describing a response that is never sent.
+   *
+   * Nest records the flag under its own metadata key rather than in the route arguments, and only
+   * when it is truthy — so reading it back is what distinguishes `@Res({ passthrough: true })` from
+   * a bare `@Res()`.
+   */
+  it('declares the response passthrough, so Nest sends the returned file rather than discarding it', () => {
+    expect(Reflect.getMetadata(RESPONSE_PASSTHROUGH_METADATA, MessageController, 'getChatMedia')).toBe(true);
+  });
+
+  it('returns the stored bytes as the response body', async () => {
+    const res = { set: () => undefined } as unknown as Response;
+
+    const body = await controller.getChatMedia('session-1', '628123@c.us', 'msg-1', res);
+
+    expect(body).toBeInstanceOf(StreamableFile);
+    expect(body.getStream().read()).toEqual(Buffer.from('GIF89a'));
   });
 });


### PR DESCRIPTION
Follow-up to #1282. That spec asserts the two security headers on the stored-media download, and it holds them — but it holds nothing else, and the two are set on the response object directly. A handler that sets both and sends no body at all satisfied it completely.

## The gap

`getChatMedia` returns a `StreamableFile`, and Nest only sends that when the response parameter is declared passthrough. Without it Nest treats the handler as having taken the response over and discards the return value entirely.

Removing `passthrough: true` therefore breaks the download completely — headers set, no body ever sent — while the spec stays green:

```
@Res({ passthrough: true }) res: Response,   →   @Res() res: Response,
npx jest modules/message/message.controller.spec.ts   →   Tests: 2 passed, 2 total
```

The mutation run that accompanied #1282 mutated the two headers the claim named. It did not mutate the mechanism that delivers them, so it could not have found this.

## What is asserted now

- **The passthrough declaration.** Nest records the flag under `RESPONSE_PASSTHROUGH_METADATA` on the controller keyed by method, and only when truthy — so reading it back is what separates `@Res({ passthrough: true })` from a bare `@Res()`. Verified against the real controller: `getChatMedia` reads `true`, a sibling handler without it reads `undefined`.
- **The bytes.** The handler must return a `StreamableFile` carrying what the service produced, so a correct-looking empty response fails.

## Mutation results

Four axes, each removed separately, each failing exactly one test — so the assertions discriminate between the mechanisms rather than reacting to any change.

| Mutation | Result |
| --- | --- |
| baseline, controller untouched | GREEN — 4 passed |
| delete `'X-Content-Type-Options': 'nosniff',` | RED — 1 failed, 3 passed |
| delete `'Content-Disposition': 'attachment',` | RED — 1 failed, 3 passed |
| `@Res({ passthrough: true })` → `@Res()` | RED — 1 failed, 3 passed |
| return `StreamableFile(Buffer.alloc(0))` with every header intact | RED — 1 failed, 3 passed |

The controller was confirmed byte-identical to its original after the run.

## Gates

`lint`, `tsc --noEmit`, `format:check` and `build` all clean. Full suite: 5,579 passed, 5 skipped, 0 failed.

One note for whoever reads a red CI run here: on the first of four full-suite runs, `chat-media-archive.service.spec.ts › drains a backlog spanning many batches` timed out at 5,000 ms. It passed on the next three full runs and on five consecutive isolated runs, and this change touches only `message.controller.spec.ts` and the changelog, so it is a pre-existing timing flake under parallel load rather than anything from here.

## Scope

Test-only. No production code is touched.