### PR TITLE
ci(sdk): type-check the Python client, and make the gate able to fail

### DIFF
--- a/.github/workflows/sdk-ci.yml
+++ b/.github/workflows/sdk-ci.yml
@@ -69,6 +69,11 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - run: pip install -e '.[dev]'
+      # Before pytest: this package ships py.typed, so its annotations are a published contract,
+      # and pytest cannot see a mistake in them — TypedDict keys are not enforced at runtime, so a
+      # request type missing a field passes every test here while a typed caller is told the field
+      # does not exist.
+      - run: mypy
       - run: pytest
 
   php:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - The dashboard bundled all thirteen locales into one 476 KB chunk the page preloaded, so every visitor downloaded twelve languages to read one; each is now fetched on demand.
+- Fifteen return and parameter annotations in the Python SDK named `list[...]` inside classes that define a `list` method, so each resolved to the method rather than the builtin. That package ships `py.typed`, so the wrong types were what a consumer's own type checker read. Its CI now runs mypy, which nothing did before.
 - A locale chunk that failed to load left the dashboard right-to-left around English copy, because text direction followed the requested language rather than the catalogue that answered; it now follows what actually rendered.
 - `check:sdk-routes` scanned the JavaScript client for backtick-delimited paths only, while its PHP and Python rules already accepted every quote style, so the nine routes that client writes as single-quoted strings were never compared to the contract — `/api/health/ready` among them, which is also the container healthcheck and Kubernetes readiness path. Renaming one of those server-side passed every gate and the JS suite, and the published client would have 404'd with CI green.
 - The JavaScript, Python, Go and Java SDKs omitted `contact`, `call` and `ephemeralDuration` from their chat-history message type, so a typed client had to cast to read three fields the endpoint returns; all four now mirror the engine payload.

--- a/sdk/python/openwa/resources/channels.py
+++ b/sdk/python/openwa/resources/channels.py
@@ -6,7 +6,7 @@ Backed by ``src/modules/channel/channel.controller.ts``
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
 from .._http import quote_segment
 from ..types import (
@@ -37,7 +37,7 @@ class ChannelsResource:
 
     def messages(
         self, session_id: str, channel_id: str, query: ChannelMessageQuery | None = None
-    ) -> list[ChannelMessageRecord]:
+    ) -> List[ChannelMessageRecord]:
         return self._http.request(
             "GET", f"/api/sessions/{quote_segment(session_id)}/channels/{quote_segment(channel_id)}/messages", query=query
         )

--- a/sdk/python/openwa/resources/contacts.py
+++ b/sdk/python/openwa/resources/contacts.py
@@ -5,7 +5,7 @@ Backed by ``src/modules/contact/contact.controller.ts``.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypedDict
+from typing import List, TYPE_CHECKING, TypedDict
 
 from .._http import quote_segment
 from ..types import (
@@ -31,7 +31,7 @@ class ContactsResource:
     def __init__(self, http: "HttpExecutor") -> None:
         self._http = http
 
-    def list(self, session_id: str, query: ListContactsQuery | None = None) -> list[ContactRecord]:
+    def list(self, session_id: str, query: ListContactsQuery | None = None) -> List[ContactRecord]:
         return self._http.request("GET", f"/api/sessions/{quote_segment(session_id)}/contacts", query=query)
 
     def get(self, session_id: str, contact_id: str) -> ContactRecord:
@@ -45,7 +45,7 @@ class ContactsResource:
             "GET", f"/api/sessions/{quote_segment(session_id)}/contacts/{quote_segment(contact_id)}/profile-picture"
         )
 
-    def profile_pictures(self, session_id: str, ids: list[str]) -> ProfilePicturesResponse:
+    def profile_pictures(self, session_id: str, ids: List[str]) -> ProfilePicturesResponse:
         """Batch-resolve profile picture URLs for up to 50 contacts in one request.
         Returns a map of contact id → URL (None when a lookup fails)."""
         return self._http.request(
@@ -73,7 +73,7 @@ class ContactsResource:
     def unblock(self, session_id: str, contact_id: str) -> SuccessResult:
         return self._http.request("DELETE", f"/api/sessions/{quote_segment(session_id)}/contacts/{quote_segment(contact_id)}/block")
 
-    def list_blocked(self, session_id: str) -> list[str]:
+    def list_blocked(self, session_id: str) -> List[str]:
         """List the JIDs this account has blocked.
 
         Session-wide, so it takes no contact id — unlike ``block`` and ``unblock``, which act on one

--- a/sdk/python/openwa/resources/groups.py
+++ b/sdk/python/openwa/resources/groups.py
@@ -5,7 +5,7 @@ Backed by ``src/modules/group/group.controller.ts``.
 
 from __future__ import annotations
 
-from typing import Any, TYPE_CHECKING, TypedDict
+from typing import Any, List, TYPE_CHECKING, TypedDict
 
 from .._http import quote_segment
 from ..types import (
@@ -36,7 +36,7 @@ class GroupsResource:
     def __init__(self, http: "HttpExecutor") -> None:
         self._http = http
 
-    def list(self, session_id: str, query: ListGroupsQuery | None = None) -> list[GroupSummary]:
+    def list(self, session_id: str, query: ListGroupsQuery | None = None) -> List[GroupSummary]:
         return self._http.request("GET", f"/api/sessions/{quote_segment(session_id)}/groups", query=query)
 
     def get(self, session_id: str, group_id: str) -> GroupInfo:
@@ -50,25 +50,25 @@ class GroupsResource:
         """
         return self._http.request("POST", f"/api/sessions/{quote_segment(session_id)}/groups", body=body)
 
-    def add_participants(self, session_id: str, group_id: str, participants: list[str]) -> ParticipantsResult:
+    def add_participants(self, session_id: str, group_id: str, participants: List[str]) -> ParticipantsResult:
         return self._http.request(
             "POST", f"/api/sessions/{quote_segment(session_id)}/groups/{quote_segment(group_id)}/participants",
             body={"participants": participants},
         )
 
-    def remove_participants(self, session_id: str, group_id: str, participants: list[str]) -> ParticipantsResult:
+    def remove_participants(self, session_id: str, group_id: str, participants: List[str]) -> ParticipantsResult:
         return self._http.request(
             "DELETE", f"/api/sessions/{quote_segment(session_id)}/groups/{quote_segment(group_id)}/participants",
             body={"participants": participants},
         )
 
-    def promote_participants(self, session_id: str, group_id: str, participants: list[str]) -> ParticipantsResult:
+    def promote_participants(self, session_id: str, group_id: str, participants: List[str]) -> ParticipantsResult:
         return self._http.request(
             "POST", f"/api/sessions/{quote_segment(session_id)}/groups/{quote_segment(group_id)}/participants/promote",
             body={"participants": participants},
         )
 
-    def demote_participants(self, session_id: str, group_id: str, participants: list[str]) -> ParticipantsResult:
+    def demote_participants(self, session_id: str, group_id: str, participants: List[str]) -> ParticipantsResult:
         return self._http.request(
             "POST", f"/api/sessions/{quote_segment(session_id)}/groups/{quote_segment(group_id)}/participants/demote",
             body={"participants": participants},
@@ -146,7 +146,7 @@ class GroupsResource:
             "PUT", f"/api/sessions/{quote_segment(session_id)}/groups/{quote_segment(group_id)}/settings", body=body
         )
 
-    def get_membership_requests(self, session_id: str, group_id: str) -> list[GroupMembershipRequest]:
+    def get_membership_requests(self, session_id: str, group_id: str) -> List[GroupMembershipRequest]:
         """List a group's pending join requests. Requires the account to be a group admin.
 
         Only ``participantId`` is guaranteed on each entry — the rest is reported by the engine when
@@ -158,7 +158,7 @@ class GroupsResource:
         )
 
     def approve_membership_requests(
-        self, session_id: str, group_id: str, participants: list[str] | None = None
+        self, session_id: str, group_id: str, participants: List[str] | None = None
     ) -> ParticipantsResult:
         """Approve pending join requests. Omit ``participants`` to approve every pending request.
 
@@ -174,7 +174,7 @@ class GroupsResource:
         )
 
     def reject_membership_requests(
-        self, session_id: str, group_id: str, participants: list[str] | None = None
+        self, session_id: str, group_id: str, participants: List[str] | None = None
     ) -> ParticipantsResult:
         """Reject pending join requests. Omit ``participants`` to reject every pending request."""
         body: dict[str, object] = {} if participants is None else {"participants": participants}

--- a/sdk/python/openwa/resources/labels.py
+++ b/sdk/python/openwa/resources/labels.py
@@ -7,7 +7,7 @@ feature; the session must be a business account.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import List, TYPE_CHECKING
 
 from .._http import quote_segment
 from ..types import AddLabelRequest, ChatSummary, LabelRecord, SuccessResult, UpsertLabelRequest
@@ -20,13 +20,13 @@ class LabelsResource:
     def __init__(self, http: "HttpExecutor") -> None:
         self._http = http
 
-    def list(self, session_id: str) -> list[LabelRecord]:
+    def list(self, session_id: str) -> List[LabelRecord]:
         return self._http.request("GET", f"/api/sessions/{quote_segment(session_id)}/labels")
 
     def get(self, session_id: str, label_id: str) -> LabelRecord:
         return self._http.request("GET", f"/api/sessions/{quote_segment(session_id)}/labels/{quote_segment(label_id)}")
 
-    def chats(self, session_id: str, label_id: str) -> list[ChatSummary]:
+    def chats(self, session_id: str, label_id: str) -> List[ChatSummary]:
         """Every chat carrying a label.
 
         whatsapp-web.js only -- Baileys has label writes but no label query of any kind, and
@@ -54,7 +54,7 @@ class LabelsResource:
             "DELETE", f"/api/sessions/{quote_segment(session_id)}/labels/{quote_segment(label_id)}"
         )
 
-    def for_chat(self, session_id: str, chat_id: str) -> list[LabelRecord]:
+    def for_chat(self, session_id: str, chat_id: str) -> List[LabelRecord]:
         return self._http.request("GET", f"/api/sessions/{quote_segment(session_id)}/labels/chat/{quote_segment(chat_id)}")
 
     def add_to_chat(self, session_id: str, chat_id: str, body: AddLabelRequest) -> SuccessResult:

--- a/sdk/python/openwa/resources/messages.py
+++ b/sdk/python/openwa/resources/messages.py
@@ -6,7 +6,7 @@ NOTE: the real paths use the ``/send-`` prefix, e.g. ``/messages/send-text``.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import List, TYPE_CHECKING
 
 from .._http import quote_segment
 from ..types import (
@@ -102,12 +102,12 @@ class MessagesResource:
 
     def history(
         self, session_id: str, chat_id: str, query: MessageHistoryQuery | None = None
-    ) -> list[ChatHistoryMessage]:
+    ) -> List[ChatHistoryMessage]:
         return self._http.request(
             "GET", f"/api/sessions/{quote_segment(session_id)}/messages/{quote_segment(chat_id)}/history", query=query
         )
 
-    def reactions(self, session_id: str, chat_id: str, message_id: str) -> list[ReactionRecord]:
+    def reactions(self, session_id: str, chat_id: str, message_id: str) -> List[ReactionRecord]:
         return self._http.request(
             "GET", f"/api/sessions/{quote_segment(session_id)}/messages/{quote_segment(chat_id)}/{quote_segment(message_id)}/reactions"
         )

--- a/sdk/python/openwa/resources/status.py
+++ b/sdk/python/openwa/resources/status.py
@@ -6,7 +6,7 @@ NOTE: this is WhatsApp "Status/Stories", distinct from session lifecycle status.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import List, TYPE_CHECKING
 
 from .._http import quote_segment
 from ..types import (
@@ -27,10 +27,10 @@ class StatusResource:
     def __init__(self, http: "HttpExecutor") -> None:
         self._http = http
 
-    def list(self, session_id: str) -> dict[str, list[StatusRecord]]:
+    def list(self, session_id: str) -> dict[str, List[StatusRecord]]:
         return self._http.request("GET", f"/api/sessions/{quote_segment(session_id)}/status")
 
-    def from_contact(self, session_id: str, contact_id: str) -> dict[str, list[StatusRecord]]:
+    def from_contact(self, session_id: str, contact_id: str) -> dict[str, List[StatusRecord]]:
         return self._http.request("GET", f"/api/sessions/{quote_segment(session_id)}/status/{quote_segment(contact_id)}")
 
     def media(self, session_id: str, status_id: str) -> StatusMedia:

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
 dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.23",
+    "mypy>=1.8",
 ]
 
 [project.urls]
@@ -38,3 +39,32 @@ openwa = ["py.typed"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+# This package ships py.typed (see package-data above), so its annotations are a published
+# contract — a consumer's own type checker reads them. pytest cannot see a mistake in one:
+# TypedDict keys are not enforced at runtime, so a request type missing a field still passes every
+# test in this suite while a typed caller is told the field does not exist.
+#
+# BOTH settings below were arrived at by mutation, not by taste. Deleting a key from a TypedDict
+# and confirming the gate goes red is the only way to know it watches anything — and the first two
+# configurations that looked correct were green with the key gone:
+#
+#   files = ["openwa"] only     → exit 0. The resources forward request bodies untouched, so a
+#                                 missing key is invisible from inside the package. The typed
+#                                 CALLERS live in tests/, so that is where the failure surfaces.
+#   check_untyped_defs unset    → exit 0. The test methods carry no annotations, and mypy skips
+#                                 the body of any unannotated function, so every typed call in
+#                                 the suite went unread.
+#
+# A third blind spot lived outside this file: `make_client()` in tests/conftest.py had no return
+# annotation, so it yielded Any and every `make_client(...).messages.send_*(...)` was unchecked.
+# Do not remove that annotation.
+[tool.mypy]
+files = ["openwa", "tests"]
+check_untyped_defs = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+no_implicit_optional = true
+# No python_version pin on purpose: the CI matrix runs this job on 3.9 and 3.12, so mypy checks
+# against whichever interpreter it is installed under and both floors get covered. Pinning one
+# here would check that version twice and mask the other.

--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -8,6 +8,14 @@ to test an httpx-based client.
 from __future__ import annotations
 
 import json
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # Import-time cost is why the runtime import stays inside make_client; the annotation still
+    # needs the name so mypy can follow a call chain through this helper. Without a return type
+    # the helper yields Any, and every `make_client(...).messages.send_*(...)` in the suite goes
+    # unchecked — which is exactly how a TypedDict key can go missing with the gate still green.
+    from openwa import OpenWAClient
 from dataclasses import dataclass, field
 from typing import Any, Callable
 
@@ -75,7 +83,9 @@ class MockBackend:
         return self.calls[-1]
 
 
-def make_client(backend: MockBackend, base_url: str = "http://localhost:2785", api_key: str = "owa_k1_test"):
+def make_client(
+    backend: MockBackend, base_url: str = "http://localhost:2785", api_key: str = "owa_k1_test"
+) -> "OpenWAClient":
     from openwa import OpenWAClient
 
     return OpenWAClient(base_url=base_url, api_key=api_key, transport=backend.as_transport())

--- a/sdk/python/tests/test_sdk.py
+++ b/sdk/python/tests/test_sdk.py
@@ -6,7 +6,9 @@ import httpx
 import pytest
 
 from openwa import OpenWAClient, OpenWAApiError, OpenWANotFoundError
+from openwa._http import build_url
 from openwa.errors import OpenWAServiceUnavailableError
+from openwa.types import WebhookFilters
 
 from conftest import MockBackend, make_client
 
@@ -99,9 +101,24 @@ class TestClientCore:
         assert "chatId=a%40c.us" in url
         assert "limit=10" in url
 
+    def test_build_url_omits_none_valued_params(self):
+        # The behaviour a caller depends on: a None never reaches the wire as the literal "None".
+        # Tested here because build_url is what implements it — the typed resource signatures
+        # forbid None, so proving it through one of them would mean lying about a type.
+        url = build_url("http://x", "/api/search", {"q": "x", "sessionId": None, "limit": 5})
+
+        assert "q=x" in url
+        assert "limit=5" in url
+        assert "sessionId" not in url
+        assert "None" not in url
+
     def test_204_is_none(self):
+        # `delete` is declared `-> None`, so asserting on its result is a type error and proves
+        # nothing the signature does not already guarantee. What is worth asserting is that a 204
+        # completes without trying to parse an empty body as JSON.
         backend = MockBackend().on("DELETE", "/api/sessions", status=204)
-        assert make_client(backend).sessions.delete("x") is None
+        make_client(backend).sessions.delete("x")
+        assert backend.last_call.method == "DELETE"
 
     def test_404_maps_to_not_found_error(self):
         backend = MockBackend().on("GET", "/api/sessions/missing", status=404, body={
@@ -563,7 +580,10 @@ class TestWebhooks:
 
     def test_create_forwards_polymorphic_filter_values_verbatim(self):
         backend = MockBackend().on("POST", "/webhooks", body={"id": "w1"})
-        filters = {
+        # Annotated, not inferred: an unannotated literal widens to dict[str, list[object]] and the
+        # call below then proves nothing about the declared filter shape — which is the whole point
+        # of a test named "forwards polymorphic filter values verbatim".
+        filters: WebhookFilters = {
             "conditions": [
                 {"field": "sender", "operator": "is", "value": ["123@c.us"]},
                 {"field": "body", "operator": "contains", "value": "invoice", "caseSensitive": True},
@@ -882,11 +902,16 @@ class TestSearch:
         assert res["hits"][0]["direction"] == "incoming"
 
     def test_search_none_values_skipped_in_query(self):
-        # None-typed optional filters must be omitted, never sent as the literal "None".
+        # Asserted against build_url, which is where the omission actually happens, rather than by
+        # routing `sessionId: None` through the typed resource. The contract has sessionId optional
+        # but NOT nullable (openapi.json: required false, type string, no nullable), so the
+        # TypedDict is right to demand a str and the old call was sending a payload the gateway
+        # would reject. Testing the mechanism at its owner keeps the regression covered without
+        # anything having to lie about the type.
         backend = MockBackend().on("GET", "/api/search", body={
             "hits": [], "total": 0, "tookMs": 0, "provider": "builtin-fts",
         })
-        make_client(backend).search.search({"q": "x", "sessionId": None, "limit": 5})
+        make_client(backend).search.search({"q": "x", "limit": 5})
         url = backend.last_call.url
         assert "q=x" in url
         assert "limit=5" in url


### PR DESCRIPTION
The Python client ships `py.typed` for `openwa` and `openwa.resources`, so its annotations are a published contract under PEP 561 — a consumer running mypy reads them, and our mistakes surface as errors in *their* code. Nothing verified them: the SDK workflow ran `pip install` then `pytest`, with no type-check step anywhere.

pytest cannot cover this. `TypedDict` keys are not enforced at runtime, so a request type missing a field passes every test in the suite while a typed caller is told the field does not exist.

## The gate was green while blind — twice

This is the part worth reading, because the working configuration looks unremarkable and the broken ones looked correct.

The test for a type gate is not "does mypy pass". It is "does mypy **fail** when I break the thing it exists to catch". Deleting a key from a `SendTextRequest` and re-running is the whole method. Two configurations passed that mutation with the key gone:

| configuration | mutation result | why |
| --- | --- | --- |
| `files = ["openwa"]` | **exit 0** | Resources forward request bodies untouched, so a missing key is invisible from inside the package. The typed callers live in `tests/`. |
| `+ files = [..., "tests"]` | **exit 0** | mypy skips the body of any unannotated function, and the test methods carry no annotations — every typed call went unread. |
| `+ check_untyped_defs` | **exit 0** | `make_client()` in `conftest.py` had no return annotation, so it yielded `Any` and every `make_client(...).messages.send_*(...)` was unchecked. |

Only after all three does the gate see anything. The third is the one to worry about: a single missing return annotation in a test helper blinded the checker to the entire surface it was installed to guard, and nothing in the mypy config would ever have shown it.

Had this shipped at step one, we would have had a permanently green job that could not catch a single bug it was created for — and no one would have found out, because a gate that never goes red is never questioned.

## Verified reach

Two axes, each with a cold cache (`.mypy_cache` served a stale result mid-session and briefly reported a reverted file as still mutated — worth knowing if you re-run these by hand):

```
baseline, clean              exit 0
axis 1  key deleted          exit 1   Extra key "text" for TypedDict "SendTextRequest"
restore                      exit 0
axis 2  field str -> int     exit 1   Incompatible types ... item "text" has type "int"
restore                      exit 0
```

Two axes rather than one because a configuration loose enough to miss a wrong type can still catch a missing key; one mutation proves one axis.

## What it found immediately

**15 wrong annotations in shipped types.** Every resource class defines a `list` method, so `list[str]` inside that class resolves to the method, not the builtin — mypy reports all fifteen as `Function ... is not valid as a type`. Fixed in its own commit, `typing.List` at each site.

**3 real defects in the test suite**, which had to be fixed for the gate to install cleanly:

- an assertion on the result of a method declared `-> None`
- a filter literal that widened to `dict[str, list[object]]`, so a test named "forwards polymorphic filter values verbatim" was not checking the filter shape at all
- `search({"sessionId": None})` — the contract has `sessionId` optional but **not** nullable (`openapi.json`: `required: false`, `type: string`, no `nullable`), so the TypedDict demanding a `str` is correct and the call was sending a payload the gateway rejects

That last test was covering something real — that a `None` is omitted rather than serialized as the literal `"None"`. It now asserts that against `build_url`, which is the function that implements it, so the regression stays covered without anything having to lie about a type. `build_url` had no direct test before.

No `# type: ignore` anywhere. A new gate arriving with built-in exceptions teaches the next person that exceptions are normal here.

## Tooling choice

mypy, not pyright: the job already runs `pip install -e '.[dev]'`, so this is one entry in `dev` extras and no new toolchain. Pyright would need Node, which that job does not set up.

No `python_version` pin — the matrix already runs 3.9 and 3.12, so mypy checks against whichever interpreter it is installed under and both floors are covered. Pinning one would check it twice and mask the other.

## Verification

mypy clean on 24 files, pytest 80 passing (up from 79 — `build_url` gained one), `check:sdk-docs`, `check:sdk-routes` and repo `format:check` all pass.
