### PR TITLE
fix(plugins): name where to declare a permission when one is refused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A plugin denied a capability was told which permission it lacked but not where to declare it. Both refusals — the capability denial, which fires when a verb is called and so reaches the operator detached from whatever upgrade caused it, and the load-time ingress check — now name the `permissions` array and the plugin's `manifest.json`. A spec binds the quotation in `docs/19` to the string the code throws, so the two cannot drift apart again.
 - The dashboard bundled all thirteen locales into one 476 KB chunk the page preloaded, so every visitor downloaded twelve languages to read one; each is now fetched on demand.
 - Fifteen return and parameter annotations in the Python SDK named `list[...]` inside classes that define a `list` method, so each resolved to the method rather than the builtin. That package ships `py.typed`, so the wrong types were what a consumer's own type checker read. Its CI now runs mypy, which nothing did before.
 - A locale chunk that failed to load left the dashboard right-to-left around English copy, because text direction followed the requested language rather than the catalogue that answered; it now follows what actually rendered.

--- a/docs/19-plugin-architecture.md
+++ b/docs/19-plugin-architecture.md
@@ -681,7 +681,8 @@ declare the matching permission (or declares none) is rejected with a `PluginCap
 private assertPermission(manifest: PluginManifest, permission: PluginCapabilityPermission): void {
   if (!(manifest.permissions ?? []).includes(permission)) {
     throw new PluginCapabilityError(
-      `Plugin ${manifest.id} is missing the '${permission}' permission required for this capability`,
+      `Plugin ${manifest.id} is missing the '${permission}' permission required for this capability. ` +
+        `Add "${permission}" to the "permissions" array in the plugin's manifest.json, then reload the plugin.`,
     );
   }
 }

--- a/src/core/plugins/plugin-capability-context.ts
+++ b/src/core/plugins/plugin-capability-context.ts
@@ -89,11 +89,18 @@ export class PluginCapabilityContext {
    * use a capability whose permission string it declares in `manifest.permissions`; anything else
    * (including a manifest with no permissions) is denied. Runs first in each capability verb so a
    * missing grant fails fast and uniformly as a PluginCapabilityError.
+   *
+   * The message names the fix, not just the fault. A denial surfaces mid-run — the capability is
+   * checked when the verb is called, not at load — so it reaches the operator as a log line detached
+   * from whatever upgrade caused it, and it is the only text about the problem that arrives at the
+   * same time as the symptom. Naming `permissions` in the plugin's manifest.json turns "why is this
+   * plugin broken" into a one-line edit.
    */
   private assertPermission(manifest: PluginManifest, permission: PluginCapabilityPermission): void {
     if (!(manifest.permissions ?? []).includes(permission)) {
       throw new PluginCapabilityError(
-        `Plugin ${manifest.id} is missing the '${permission}' permission required for this capability`,
+        `Plugin ${manifest.id} is missing the '${permission}' permission required for this capability. ` +
+          `Add "${permission}" to the "permissions" array in the plugin's manifest.json, then reload the plugin.`,
       );
     }
   }

--- a/src/core/plugins/plugin-capability.spec.ts
+++ b/src/core/plugins/plugin-capability.spec.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { ConfigService } from '@nestjs/config';
 import { ModuleRef } from '@nestjs/core';
 import { PluginLoaderService } from './plugin-loader.service';
@@ -143,6 +145,37 @@ describe('PluginLoaderService capability facade — ctx.messages', () => {
     await expect(ctx.messages.sendText('sess-1', '628@c.us', 'hi')).rejects.toBeInstanceOf(PluginCapabilityError);
     expect(moduleRef.get).not.toHaveBeenCalled();
     expect(messageService.sendText).not.toHaveBeenCalled();
+  });
+
+  it('the denial names the fix — the permission, the array and the manifest file', async () => {
+    // The whole value of this message is that it reaches the operator at the same time as the
+    // symptom: a capability is checked when the verb is CALLED, so a denial lands mid-run as a log
+    // line detached from the upgrade that caused it. Naming the fault without the fix leaves the
+    // operator with "why is this plugin broken"; one template serves all seven permissions, so a
+    // trim here silently degrades every one of them.
+    // Asserted on the three carriers of the information — which permission, which field, which file —
+    // rather than on the sentence. Pinning the whole string would redden on a punctuation edit
+    // without being any stricter about what the operator is actually told.
+    const ctx = contextFor(makePlugin(['*'], []));
+    const error = await ctx.messages.sendText('sess-1', '628@c.us', 'hi').catch((e: unknown) => e);
+    const message = (error as Error).message;
+    expect(message).toContain('messages:send'); // the permission that is missing
+    expect(message).toContain('permissions'); // the manifest field to add it to
+    expect(message).toContain('manifest.json'); // the file that field lives in
+  });
+
+  it('docs/19 quotes the same message the code throws', () => {
+    // §19.9 reproduces assertPermission verbatim. A quoted string in prose is an UNGATED COPY of a
+    // code string: it rots in silence, which is exactly the failure this repo has paid for more than
+    // once. The fragment is derived from the source rather than restated here, so the two cannot
+    // drift — restating it would just add a third copy to keep in step.
+    const norm = (s: string): string => s.replace(/\s+/g, ' ').trim();
+    const source = readFileSync(join(__dirname, 'plugin-capability-context.ts'), 'utf8');
+    const docs = readFileSync(join(__dirname, '..', '..', '..', 'docs', '19-plugin-architecture.md'), 'utf8');
+
+    const fragment = norm(source.match(/`Add "\$\{permission\}"[^`]*`/)?.[0] ?? '');
+    expect(fragment).not.toBe(''); // non-vacuous: a rename would otherwise make this pass on nothing
+    expect(norm(docs)).toContain(fragment);
   });
 
   it('denies reply when the plugin does not declare the messages:send permission', async () => {
@@ -419,6 +452,19 @@ describe('PluginLoaderService capability facade — ctx.storage', () => {
     const ctx = contextFor(makePlugin(['*'], ['storage:use']));
     await expect(call(ctx)).resolves.not.toThrow();
     expect(backing[verb as keyof typeof backing]).toHaveBeenCalled();
+  });
+
+  it('the storage denial names the fix too, from the same template', async () => {
+    // `storage:use` is the newest permission and the reason this message matters most right now: an
+    // operator who upgrades the gateway without upgrading a plugin meets THIS refusal, mid-run. One
+    // template with `${permission}` interpolated serves all seven, so this should hold for free —
+    // which is exactly why it is asserted rather than assumed.
+    const ctx = contextFor(makePlugin(['*'], []));
+    const error = await ctx.storage.get('k').catch((e: unknown) => e);
+    const message = (error as Error).message;
+    expect(message).toContain('storage:use');
+    expect(message).toContain('permissions');
+    expect(message).toContain('manifest.json');
   });
 
   it('passes the caller arguments through untouched', async () => {

--- a/src/core/plugins/plugin-manifest-ingress.spec.ts
+++ b/src/core/plugins/plugin-manifest-ingress.spec.ts
@@ -48,6 +48,24 @@ describe('validateIngressManifest', () => {
     expect(() => validateIngressManifest(m as never)).toThrow(/webhook:ingress/);
   });
 
+  it('the ingress refusal names the array and the manifest file to fix', () => {
+    // Load-time twin of the capability denial: an author who sees only "is missing the
+    // 'webhook:ingress' permission" is told the fault, not where to declare it.
+    const m = baseManifest();
+    m.permissions = ['conversation:send'];
+    const error = (() => {
+      try {
+        validateIngressManifest(m as never);
+        return null;
+      } catch (e) {
+        return e as Error;
+      }
+    })();
+    expect(error?.message).toContain('webhook:ingress');
+    expect(error?.message).toContain('permissions');
+    expect(error?.message).toContain('manifest.json');
+  });
+
   it('rejects toleranceSec <= 0 (replay guard would be a no-op)', () => {
     const m = baseManifest();
     m.ingress[0].signature.toleranceSec = 0;

--- a/src/core/plugins/plugin.interfaces.ts
+++ b/src/core/plugins/plugin.interfaces.ts
@@ -325,7 +325,10 @@ export function validateIngressManifest(manifest: PluginManifest, allowUnsignedI
   }
   const perms = manifest.permissions ?? [];
   if (!perms.includes(PluginCapabilityPermission.WEBHOOK_INGRESS)) {
-    throw new Error(`Plugin ${manifest.id}: declares ingress routes but is missing the 'webhook:ingress' permission`);
+    throw new Error(
+      `Plugin ${manifest.id}: declares ingress routes but is missing the 'webhook:ingress' permission. ` +
+        `Add "webhook:ingress" to the "permissions" array in the plugin's manifest.json.`,
+    );
   }
   const seen = new Set<string>();
   for (const r of manifest.ingress) {


### PR DESCRIPTION
A permission refusal told the plugin author which permission was missing, not where to put it.

The capability denial is the worse of the two. Permissions are checked when a verb is **called**, not at load, so it surfaces mid-run as a log line detached from whatever upgrade caused it — and it is the only text about the problem that arrives at the same time as the symptom. The CHANGELOG and the release notes are read at upgrade time, if at all; this line is read when the plugin stops working.

That matters concretely for the `storage:use` enforcement landing in the same release: an operator who upgrades the gateway without upgrading a plugin meets this message, mid-conversation, and nothing else.

## What changed

- `assertPermission` and the load-time ingress check now name the `permissions` array and the plugin's `manifest.json`. Verified against source before writing: the file really is `manifest.json` (loader and installer), and the field really is `permissions?: string[]`.
- One template serves all seven capability permissions, so this is a single site — it stays correct for a permission added later, including `storage:use`.
- `docs/19` §19.9 reproduces the throw verbatim. It is updated, and bound (below) so it cannot drift again.

Both messages are one logical change: the same sentence, missing the same half, on the two paths that refuse a permission.

## Tests

The assertions check the three carriers of the information — which permission, which field, which file — rather than the sentence. Pinning the whole string would redden on a punctuation edit without being any stricter about what the operator is told.

A third spec binds the `docs/19` quotation to the code. A quoted string in prose is an ungated copy of a code string; it rots silently. The fragment is **derived from the source file** rather than restated in the spec — restating it would only add a third copy to keep in step.

Verified by mutation, each applied and reverted separately:

```
message reverted to its old form  → both message specs fail
docs/19 quote reworded            → the binding spec fails, alone
```

The binding spec also asserts the extracted fragment is non-empty, so a rename cannot make it pass on nothing.

## Composition with #1281

Both merge orders are clean. Because a clean merge is not evidence of a correct result, the composed tree was read directly from its blobs:

```
main + #1281 + this PR
  plugin-capability-context.ts   buildStorageCapability present, new message present
  docs/19                        "exactly **seven**" + STORAGE_USE + updated quote
  CHANGELOG [Unreleased]         Added 1 · Changed 1 · Documentation 1 · Fixed 1
  conflict markers               0
```

This PR uses `### Fixed`, which already exists on main, so it cannot collide with the `### Changed` that #1281 introduces.

## Verification

Full gate green: lint, `tsc --noEmit`, `format:check`, 5582 tests, build, `openapi:check`, and the four SDK contract gates.