### PR TITLE
refactor(config): export the validation options so a spec can run the real pipe

### DIFF
--- a/src/config/app-validation.ts
+++ b/src/config/app-validation.ts
@@ -1,15 +1,31 @@
-import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { INestApplication, ValidationPipe, ValidationPipeOptions } from '@nestjs/common';
 import { isValidationErrorDetailEnabled } from './bootstrap-security';
+
+/**
+ * The DTO validation contract itself, without the one option that depends on the environment.
+ *
+ * Exported so a spec can construct the real pipe from the same object production uses instead of
+ * restating the options as literals. A restated copy is a mirror, and a mirror can drift: loosening
+ * `whitelist` here would leave every spec that hardcoded `whitelist: true` still asserting the old
+ * contract, green, while the running app no longer honours it. Reading one object makes production
+ * and the specs unable to disagree — and turns those specs into a gate over this file.
+ *
+ * `disableErrorMessages` is deliberately NOT here: it is resolved from the environment at call time,
+ * so it is not part of the contract a spec should reproduce.
+ */
+export const GLOBAL_VALIDATION_OPTIONS: ValidationPipeOptions = {
+  whitelist: true,
+  forbidNonWhitelisted: true,
+  transform: true,
+  transformOptions: { enableImplicitConversion: true },
+};
 
 /** Apply the HTTP prefix and DTO validation contract shared by production and e2e applications. */
 export function applyGlobalValidation(app: INestApplication): void {
   app.setGlobalPrefix('api');
   app.useGlobalPipes(
     new ValidationPipe({
-      whitelist: true,
-      forbidNonWhitelisted: true,
-      transform: true,
-      transformOptions: { enableImplicitConversion: true },
+      ...GLOBAL_VALIDATION_OPTIONS,
       disableErrorMessages: !isValidationErrorDetailEnabled(process.env.VALIDATION_ERROR_DETAIL, process.env.NODE_ENV),
     }),
   );

--- a/src/modules/infra/dto/import-data.dto.spec.ts
+++ b/src/modules/infra/dto/import-data.dto.spec.ts
@@ -1,21 +1,31 @@
 import 'reflect-metadata';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { plainToInstance } from 'class-transformer';
-import { validate } from 'class-validator';
+import { BadRequestException, ValidationPipe } from '@nestjs/common';
+import { GLOBAL_VALIDATION_OPTIONS } from '../../../config/app-validation';
 import { ImportDataDto } from './import-data.dto';
 import { TABLE_IMPORTERS } from '../table-importers';
 
-// Mirrors the real pipe from src/config/app-validation.ts: whitelist + forbidNonWhitelisted, and the
-// enableImplicitConversion transform option. Both halves matter here — the whitelist is the reason
-// this DTO exists, and the implicit conversion is what makes a plain `boolean` property unsafe.
-const PIPE_TRANSFORM_OPTS = { enableImplicitConversion: true };
-const PIPE_VALIDATOR_OPTS = { whitelist: true, forbidNonWhitelisted: true };
+// The REAL pipe, built from the SAME options object production uses — not a restatement of them.
+// This spec exists because a regression reached main through a layer nothing exercised: the
+// round-trip specs call the handler directly and never touch validation at all. Reproducing the
+// pipe's options by hand would have repeated that mistake one level up, asserting against a mirror
+// that can drift from what the app actually installs.
+//
+// Two behaviours only the pipe has: `toEmptyIfNil` turns a null/undefined body into `{}` before
+// validation, and refusals arrive as a BadRequestException whose `message` is the string array a
+// client actually receives. Neither is visible through plainToInstance + validate.
+const pipe = new ValidationPipe(GLOBAL_VALIDATION_OPTIONS);
+const BODY = { type: 'body' as const, metatype: ImportDataDto };
 
-async function run(payload: unknown) {
-  const instance = plainToInstance(ImportDataDto, payload as object, PIPE_TRANSFORM_OPTS);
-  const errors = await validate(instance, PIPE_VALIDATOR_OPTS);
-  return { instance, errors };
+/** Push a payload through the pipe. `errors` holds the messages a client would receive. */
+async function run(payload: unknown): Promise<{ instance: ImportDataDto; errors: string[] }> {
+  try {
+    return { instance: (await pipe.transform(payload, BODY)) as ImportDataDto, errors: [] };
+  } catch (error) {
+    const body = (error as BadRequestException).getResponse() as { message?: string | string[] };
+    return { instance: {} as ImportDataDto, errors: [body.message ?? []].flat() };
+  }
 }
 
 /** A minimal but complete payload: every table the importer registry knows, each empty. */
@@ -48,12 +58,15 @@ describe('ImportDataDto', () => {
     const { errors } = await run({ force: true });
     // Before this DTO the inline `@Body()` type erased, so this body reached the restore and threw
     // from inside it — a 500 on the replace-all route, with nothing pointing at the missing field.
-    expect(errors.map(e => e.property)).toEqual(['tables']);
+    // Asserted on the field name the client is handed, not the sentence around it.
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('tables');
   });
 
   it('rejects an unknown key', async () => {
     const { errors } = await run({ tables: fullTables(), stopOrphan: true });
-    expect(errors.map(e => e.property)).toEqual(['stopOrphan']);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('stopOrphan');
   });
 
   it('accepts the export file posted back verbatim', async () => {
@@ -109,7 +122,20 @@ describe('ImportDataDto', () => {
 
   it.each(['force', 'stopOrphans'] as const)('rejects an ambiguous spelling on %s', async flag => {
     const { errors } = await run({ tables: fullTables(), [flag]: 'yes' });
-    expect(errors.map(e => e.property)).toEqual([flag]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain(flag);
+  });
+
+  it('turns a null body into a refusal rather than a crash', async () => {
+    // Only the pipe does this: `toEmptyIfNil` replaces a null/undefined body with `{}` before
+    // validation, so the route answers 400 on the missing `tables` instead of dereferencing null
+    // somewhere downstream. A spec that mirrored the options instead of running the pipe could not
+    // see this path at all.
+    for (const body of [null, undefined]) {
+      const { errors } = await run(body);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain('tables');
+    }
   });
 
   it('leaves an omitted flag absent, so the default orphan refusal still applies', async () => {


### PR DESCRIPTION
`import-data.dto.spec.ts` restated the global `ValidationPipe`'s options as literals:

```ts
const PIPE_TRANSFORM_OPTS = { enableImplicitConversion: true };
const PIPE_VALIDATOR_OPTS = { whitelist: true, forbidNonWhitelisted: true };
```

A restatement is a mirror, and a mirror drifts. Loosening `whitelist` in `app-validation.ts` would leave that spec asserting the old contract — green — while the running app no longer honours it. The spec was written to protect the most destructive route in the product from exactly that class of gap, so it should not itself depend on someone remembering to update two places.

The options are now one exported object, and the spec builds the real pipe from it. Production and the spec cannot disagree, and the spec becomes a **gate over `app-validation.ts`** rather than a copy of it.

`disableErrorMessages` deliberately stays out of the exported object: it is resolved from the environment at call time, so it is not part of the contract a spec should reproduce.

## Running the pipe reaches what mirroring could not

Two behaviours belong to the pipe, not to `class-validator`, and were invisible before:

- `toEmptyIfNil` replaces a `null`/`undefined` body with `{}` before validation, so the route answers 400 on the missing `tables` rather than dereferencing null downstream. There is now a test for it.
- Refusals arrive as a `BadRequestException` whose `message` is the string array a client actually receives. The assertions moved to that array, and check the **field name carried in each message** rather than the sentence — a punctuation edit should not redden them.

## Verification

The point of the change is the binding, so that is what was mutated — in the **production source**, not the spec:

```
app-validation.ts  forbidNonWhitelisted: true → false
  ● ImportDataDto › rejects an unknown key
  Tests: 1 failed, 10 passed
```

Reverting restores green. Before this change, that mutation reddened nothing in this spec.

Honest limit, measured: mutating `enableImplicitConversion → false` reddens **nothing** here. That is correct rather than a gap — `@ToStrictBoolean` reads the raw value, so this DTO behaves identically with implicit conversion on or off. The spec that would catch that particular loosening is `dto-strict-coercion.spec.ts`, which still mirrors; of the five specs left restating these options, it is the one with the highest marginal value to convert next.

## Scope

Five other specs still restate these options — all five say so in a comment ("Mirrors the real pipe … from `src/config/app-validation.ts`"). They are **left alone deliberately**, not overlooked: the parked scope was this spec, and widening it is being decided separately. Leaving them is a visible remainder, and this PR does not pretend otherwise.

No CHANGELOG entry: nothing user-visible changes.

## Gate

lint, `tsc --noEmit`, `format:check`, 5580 tests, build, `openapi:check`, and the four SDK contract gates — all green.