### PR TITLE
fix(engine): answer 404 for an unresolvable quoted id on whatsapp-web.js

### DIFF
--- a/src/engine/adapters/wwebjs-messaging.ts
+++ b/src/engine/adapters/wwebjs-messaging.ts
@@ -101,6 +101,16 @@ export function isNoLidForUserError(err: unknown): boolean {
 }
 
 /**
+ * True when a send error is the page's "I could not resolve the quoted id" failure, raised only
+ * because {@link WwebjsMessaging.quoteOptions} opts out of `ignoreQuoteErrors` (Injected/Utils.js:
+ * 197-198). Matched on the text like {@link isNoLidForUserError} — there is no structured code, and
+ * puppeteer prefixes its own `Evaluation failed:`, so this is a substring test rather than equality.
+ */
+export function isQuoteUnresolvedError(err: unknown): boolean {
+  return err instanceof Error && err.message.includes('Could not get the quoted message');
+}
+
+/**
  * Build a MessageMedia from a MediaInput (URL → fetched, base64/Buffer → wrapped).
  *
  * `trustDeclaredType: false` keeps the fetched response's content-type for a remote URL. Use it
@@ -238,17 +248,6 @@ export class WwebjsMessaging {
   }
 
   /**
-   * Resolve `chatId` and run `send` against the resolved id. If the send fails with `No LID for user`
-   * — the signature of a contact whose cached/resolved id is stale (typically a `@c.us` for a contact
-   * that has since migrated to `@lid`) — drop the mapping, re-resolve once, and retry only if the
-   * fresh id differs, so a genuinely unreachable recipient surfaces its error instead of looping.
-   *
-   * When re-resolution cannot help, the recipient is unreachable rather than stale, and the raw
-   * `No LID for user` is replaced with {@link RecipientUnreachableError} (400). The bare page-side
-   * Error carries no status and no recipient, so letting it through produced an opaque 500 for what
-   * is really a caller-visible fact the gateway already established: `getNumberId` returned null.
-   */
-  /**
    * The send options that attach a quote, or nothing at all when the caller asked for none.
    *
    * `ignoreQuoteErrors` defaults to TRUE in the library (documented at Client.js:1383, applied at
@@ -264,7 +263,31 @@ export class WwebjsMessaging {
     return quotedMessageId ? { quotedMessageId, ignoreQuoteErrors: false } : {};
   }
 
-  private async sendResolved<T>(chatId: string, send: (to: string) => Promise<T>): Promise<T> {
+  /**
+   * Resolve `chatId` and run `send` against the resolved id. If the send fails with `No LID for user`
+   * — the signature of a contact whose cached/resolved id is stale (typically a `@c.us` for a contact
+   * that has since migrated to `@lid`) — drop the mapping, re-resolve once, and retry only if the
+   * fresh id differs, so a genuinely unreachable recipient surfaces its error instead of looping.
+   *
+   * When re-resolution cannot help, the recipient is unreachable rather than stale, and the raw
+   * `No LID for user` is replaced with {@link RecipientUnreachableError} (400). The bare page-side
+   * Error carries no status and no recipient, so letting it through produced an opaque 500 for what
+   * is really a caller-visible fact the gateway already established: `getNumberId` returned null.
+   *
+   * `quotedMessageId` gets the same treatment for the same reason. Opting out of `ignoreQuoteErrors`
+   * makes an id the page cannot resolve throw, but it throws a bare Error, and two things follow from
+   * that: the caller receives a 500 for an id THEY supplied, where the Baileys adapter answers 404
+   * (`requireStored`) for the identical request; and `countsTowardSendBreaker` classifies anything
+   * that is not an HttpException as an account-standing failure, so a caller retrying a stale id
+   * would trip the send breaker on a fault that is purely their own. Mapping it to
+   * {@link MessageNotFoundError} (404) settles both — the status matches Baileys and the published
+   * `docs/06` table, and the breaker exempts it as a 4xx.
+   */
+  private async sendResolved<T>(
+    chatId: string,
+    send: (to: string) => Promise<T>,
+    quotedMessageId?: string,
+  ): Promise<T> {
     const to = await this.resolveSendId(chatId);
     try {
       return await send(to);
@@ -272,6 +295,11 @@ export class WwebjsMessaging {
       // A transport-level failure means the page/browser is gone — report it as a death signal.
       // No-op for ordinary send errors; the retry/throw behavior below is unchanged.
       this.host.reportIfPageTransportError(err, 'sendMessage');
+      // Before the LID branch: an unresolvable quote is neither stale-id nor transport, and
+      // re-resolving the recipient would not make the quoted message appear.
+      if (quotedMessageId && isQuoteUnresolvedError(err)) {
+        throw new MessageNotFoundError(quotedMessageId);
+      }
       if (!chatId.endsWith('@c.us') || !isNoLidForUserError(err)) {
         throw err;
       }
@@ -290,6 +318,13 @@ export class WwebjsMessaging {
       try {
         return await send(fresh);
       } catch (retryErr) {
+        // Same remap as the first attempt. Re-resolving the RECIPIENT says nothing about the quoted
+        // message, so a send that reaches the page on the fresh id and only then fails on the quote
+        // is the same caller fault — without this it would be a 500 on the retry where the identical
+        // failure on the first attempt was a 404.
+        if (quotedMessageId && isQuoteUnresolvedError(retryErr)) {
+          throw new MessageNotFoundError(quotedMessageId);
+        }
         // The re-resolved id is no better than the stale one — same unreachable recipient, and the
         // raw error would 500 exactly as the first one did.
         if (isNoLidForUserError(retryErr)) {
@@ -329,10 +364,13 @@ export class WwebjsMessaging {
     if (mentions?.length) sendOptions.mentions = mentions;
     if (options?.linkPreview === false) sendOptions.linkPreview = false;
 
-    const msg = await this.sendResolved(chatId, to =>
-      Object.keys(sendOptions).length
-        ? this.client().sendMessage(to, text, sendOptions)
-        : this.client().sendMessage(to, text),
+    const msg = await this.sendResolved(
+      chatId,
+      to =>
+        Object.keys(sendOptions).length
+          ? this.client().sendMessage(to, text, sendOptions)
+          : this.client().sendMessage(to, text),
+      options?.quotedMessageId,
     );
     return toMessageResult(msg);
   }
@@ -382,15 +420,18 @@ export class WwebjsMessaging {
     if (extraOptions?.sendMediaAsDocument && !messageMedia.filename) {
       messageMedia.filename = 'file';
     }
-    const msg = await this.sendResolved(chatId, to =>
-      this.client().sendMessage(to, messageMedia, {
-        caption: media.caption,
-        ...(media.mentions?.length ? { mentions: media.mentions } : {}),
-        // sendAudioAsVoice only for audio, sendMediaAsDocument only for documents;
-        // {...undefined} contributes no keys.
-        ...extraOptions,
-        ...this.quoteOptions(media.quotedMessageId),
-      }),
+    const msg = await this.sendResolved(
+      chatId,
+      to =>
+        this.client().sendMessage(to, messageMedia, {
+          caption: media.caption,
+          ...(media.mentions?.length ? { mentions: media.mentions } : {}),
+          // sendAudioAsVoice only for audio, sendMediaAsDocument only for documents;
+          // {...undefined} contributes no keys.
+          ...extraOptions,
+          ...this.quoteOptions(media.quotedMessageId),
+        }),
+      media.quotedMessageId,
     );
 
     return toMessageResult(msg);
@@ -406,8 +447,10 @@ export class WwebjsMessaging {
       name: location.description || '',
       address: location.address || '',
     });
-    const msg = await this.sendResolved(chatId, to =>
-      this.client().sendMessage(to, loc, this.quoteOptions(location.quotedMessageId)),
+    const msg = await this.sendResolved(
+      chatId,
+      to => this.client().sendMessage(to, loc, this.quoteOptions(location.quotedMessageId)),
+      location.quotedMessageId,
     );
     return toMessageResult(msg);
   }
@@ -418,11 +461,14 @@ export class WwebjsMessaging {
     // can't inject extra vCard fields — the previous inline build interpolated raw values.
     const vcard = buildVCard(contact);
 
-    const msg = await this.sendResolved(chatId, to =>
-      this.client().sendMessage(to, vcard, {
-        parseVCards: true,
-        ...this.quoteOptions(contact.quotedMessageId),
-      }),
+    const msg = await this.sendResolved(
+      chatId,
+      to =>
+        this.client().sendMessage(to, vcard, {
+          parseVCards: true,
+          ...this.quoteOptions(contact.quotedMessageId),
+        }),
+      contact.quotedMessageId,
     );
     return toMessageResult(msg);
   }
@@ -437,11 +483,14 @@ export class WwebjsMessaging {
     // whatsapp-web.js returns the media unconverted once it reads as webp (Util.formatImageToWebpSticker).
     const messageMedia = await toMessageMedia(media, { trustDeclaredType: false });
 
-    const msg = await this.sendResolved(chatId, to =>
-      this.client().sendMessage(to, messageMedia, {
-        sendMediaAsSticker: true,
-        ...this.quoteOptions(media.quotedMessageId),
-      }),
+    const msg = await this.sendResolved(
+      chatId,
+      to =>
+        this.client().sendMessage(to, messageMedia, {
+          sendMediaAsSticker: true,
+          ...this.quoteOptions(media.quotedMessageId),
+        }),
+      media.quotedMessageId,
     );
     return toMessageResult(msg);
   }
@@ -459,12 +508,15 @@ export class WwebjsMessaging {
     // allowMultipleAnswers.
     type PollSendOptions = ConstructorParameters<typeof Poll>[2];
     const pollOptions = { allowMultipleAnswers: poll.allowMultipleAnswers === true } as PollSendOptions;
-    const msg = await this.sendResolved(chatId, to =>
-      this.client().sendMessage(
-        to,
-        new Poll(poll.name, poll.options, pollOptions),
-        this.quoteOptions(poll.quotedMessageId),
-      ),
+    const msg = await this.sendResolved(
+      chatId,
+      to =>
+        this.client().sendMessage(
+          to,
+          new Poll(poll.name, poll.options, pollOptions),
+          this.quoteOptions(poll.quotedMessageId),
+        ),
+      poll.quotedMessageId,
     );
     return toMessageResult(msg);
   }

--- a/src/engine/adapters/wwebjs-quoted-send.spec.ts
+++ b/src/engine/adapters/wwebjs-quoted-send.spec.ts
@@ -1,6 +1,7 @@
 import type { Client } from 'whatsapp-web.js';
 import { WwebjsMessaging } from './wwebjs-messaging';
 import { createLogger } from '../../common/services/logger.service';
+import { MessageNotFoundError } from '../../common/errors/message-not-found.error';
 import { type WwebjsEngineHost } from './wwebjs-host';
 
 /**
@@ -117,5 +118,95 @@ describe('WwebjsMessaging — a quote rides along with every content kind', () =
 
     expect(optionsOf(client).sendMediaAsDocument).toBe(true);
     expect(optionsOf(client).quotedMessageId).toBe(QUOTED);
+  });
+
+  /**
+   * Opting out of `ignoreQuoteErrors` only gets the caller an error; it does not decide WHICH error.
+   * The page throws a bare `Error`, and two things ride on that being remapped: the caller sees the
+   * same 404 the Baileys adapter returns for the identical request (and that `docs/06` publishes for
+   * both engines), and `countsTowardSendBreaker` treats anything that is not an HttpException as an
+   * account-standing failure — so an unmapped error let a caller's own stale id trip the send breaker.
+   */
+  describe('an id the page cannot resolve', () => {
+    const pageError = (): Error => new Error('Evaluation failed: Error: Could not get the quoted message.');
+
+    it.each([
+      ['image', (m: WwebjsMessaging) => m.sendImageMessage(CHAT, { ...IMAGE, quotedMessageId: QUOTED })],
+      ['sticker', (m: WwebjsMessaging) => m.sendStickerMessage(CHAT, { ...IMAGE, quotedMessageId: QUOTED })],
+      [
+        'location',
+        (m: WwebjsMessaging) => m.sendLocationMessage(CHAT, { latitude: 1, longitude: 2, quotedMessageId: QUOTED }),
+      ],
+      [
+        'contact',
+        (m: WwebjsMessaging) =>
+          m.sendContactMessage(CHAT, { name: 'Alice', number: '628999', quotedMessageId: QUOTED }),
+      ],
+      [
+        'poll',
+        (m: WwebjsMessaging) => m.sendPollMessage(CHAT, { name: 'Q', options: ['a', 'b'], quotedMessageId: QUOTED }),
+      ],
+      ['text', (m: WwebjsMessaging) => m.sendTextMessage(CHAT, 'hi', undefined, { quotedMessageId: QUOTED })],
+    ])('is a 404 naming the id, not a bare 500, on a %s send', async (_kind, send) => {
+      const { messaging, client } = makeMessaging();
+      client.sendMessage.mockRejectedValue(pageError());
+
+      // getStatus() rather than a `status` property: that is what NestJS exposes, and what
+      // message-not-found.error.spec.ts already pins the 404 mapping on.
+      await expect(send(messaging)).rejects.toBeInstanceOf(MessageNotFoundError);
+      const err = (await send(messaging).catch((e: unknown) => e)) as MessageNotFoundError;
+      expect(err.getStatus()).toBe(404);
+      expect(err.message).toContain(QUOTED);
+    });
+
+    // Known-negative control: the remap keys off the id the caller supplied, so a send that asked
+    // for no quote must still surface the page's own error rather than a fabricated not-found.
+    it('leaves the error of an unquoted send untouched', async () => {
+      const { messaging, client } = makeMessaging();
+      client.sendMessage.mockRejectedValue(pageError());
+
+      const err = (await messaging.sendImageMessage(CHAT, IMAGE).catch((e: unknown) => e)) as Error;
+      expect(err).not.toBeInstanceOf(MessageNotFoundError);
+      expect(err.message).toContain('Could not get the quoted message');
+    });
+
+    /**
+     * The LID retry runs the send a SECOND time against a freshly resolved recipient, through its own
+     * catch — which the first attempt's remap does not cover. Re-resolving the RECIPIENT says nothing
+     * about the quoted message, so a send that gets past the stale id and only then fails on the quote
+     * is the same caller fault. Without the second remap, one request answers 404 or 500 depending on
+     * whether the recipient happened to need re-resolving.
+     */
+    it('is still a 404 when the quote fails on the LID retry rather than the first attempt', async () => {
+      const { messaging, client } = makeMessaging();
+      const host = (messaging as unknown as { host: { getNumberId: jest.Mock } }).host;
+      // First resolve yields nothing (the send goes to the raw @c.us); after the LID failure the
+      // re-resolve returns a DIFFERENT id, which is what makes sendResolved retry at all.
+      host.getNumberId.mockResolvedValueOnce(undefined).mockResolvedValueOnce('999@lid');
+      client.sendMessage
+        .mockRejectedValueOnce(new Error('Evaluation failed: Error: No LID for user'))
+        .mockRejectedValueOnce(pageError());
+
+      const err = (await messaging
+        .sendImageMessage(CHAT, { ...IMAGE, quotedMessageId: QUOTED })
+        .catch((e: unknown) => e)) as MessageNotFoundError;
+
+      expect(client.sendMessage).toHaveBeenCalledTimes(2); // the retry really ran
+      expect(err).toBeInstanceOf(MessageNotFoundError);
+      expect(err.getStatus()).toBe(404);
+      expect(err.message).toContain(QUOTED);
+    });
+
+    // Second control: an unrelated failure on a QUOTED send must not be relabelled not-found.
+    it('does not relabel an unrelated send failure as a missing quote', async () => {
+      const { messaging, client } = makeMessaging();
+      client.sendMessage.mockRejectedValue(new Error('Evaluation failed: Error: something else broke'));
+
+      const err = (await messaging
+        .sendImageMessage(CHAT, { ...IMAGE, quotedMessageId: QUOTED })
+        .catch((e: unknown) => e)) as Error;
+      expect(err).not.toBeInstanceOf(MessageNotFoundError);
+      expect(err.message).toContain('something else broke');
+    });
   });
 });


### PR DESCRIPTION
## What

An unresolvable `quotedMessageId` now answers 404 on whatsapp-web.js, matching what the Baileys adapter already answers for the identical request and what `docs/06` publishes for both engines.

## Why

Opting out of `ignoreQuoteErrors` made the page throw instead of silently sending unquoted, which was the right call. But it throws a bare `Error`, and two things followed from that:

- The caller received a **500** for an id they supplied. The same request on Baileys is a 404 through `requireStored`. The `docs/06` "Quoted sends" table promises 404 for both engines, so the published contract was wrong for one of them.
- `countsTowardSendBreaker` classifies anything that is not an `HttpException` as an account-standing failure, so a caller retrying a stale id fed the **send breaker** on a fault entirely their own. That function's own documentation names "a message id that is not in the local store" as an input that must not count.

Mapping the page error to `MessageNotFoundError` settles both at once: the status matches Baileys, and the breaker already exempts a 4xx.

## How

The quoted id is passed to `sendResolved`, which already owns the sibling remap for `No LID for user`, so the mapping lives at the one choke point every quoted send passes through rather than being repeated at six call sites.

The remap is applied in **both** catches. The LID retry runs the send a second time against a freshly resolved recipient, through its own catch; re-resolving the recipient says nothing about the quoted message, so without the second remap one request would answer 404 or 500 depending on whether the recipient happened to need re-resolving.

Also restores `sendResolved`'s docblock, which the quote-options helper had been inserted in front of.

## Tests

Nine cases added. Every content kind is covered for the first-attempt path, plus the retry path, plus two known-negative controls: an **unquoted** send must still surface the page's own error, and an unrelated failure on a quoted send must not be relabelled not-found.

Each assertion was mutation-checked. Removing the first-attempt remap fails six; removing only the retry remap fails exactly one — the retry test — and nothing else.

## Verification

Full backend suite, e2e, scripts, dashboard, Java SDK and mypy all green; all ten Lint-job steps pass.

## Scope

No behaviour change for a send that carries no quote: the remap is gated on the caller having supplied an id.