### PR TITLE
fix(sdk): expose quotedMessageId on the Java send-audio request

### DIFF
--- a/sdk/java/src/main/java/com/rmyndharis/openwa/model/SendAudioRequest.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/model/SendAudioRequest.java
@@ -8,7 +8,8 @@ public record SendAudioRequest(
     String mimetype,
     String filename,
     String caption,
-    Boolean ptt) {
+    Boolean ptt,
+    String quotedMessageId) {
 
     public static Builder builder() {
         return new Builder();
@@ -22,6 +23,7 @@ public record SendAudioRequest(
         private String filename;
         private String caption;
         private Boolean ptt;
+        private String quotedMessageId;
 
         public Builder chatId(String v) { this.chatId = v; return this; }
         public Builder url(String v) { this.url = v; return this; }
@@ -31,8 +33,15 @@ public record SendAudioRequest(
         public Builder caption(String v) { this.caption = v; return this; }
         public Builder ptt(Boolean v) { this.ptt = v; return this; }
 
+        /**
+         * Quote an earlier message, turning this send into a reply. Engine-specific:
+         * whatsapp-web.js matches the serialized message id, Baileys the raw key id of a message
+         * it has already stored.
+         */
+        public Builder quotedMessageId(String v) { this.quotedMessageId = v; return this; }
+
         public SendAudioRequest build() {
-            return new SendAudioRequest(chatId, url, base64, mimetype, filename, caption, ptt);
+            return new SendAudioRequest(chatId, url, base64, mimetype, filename, caption, ptt, quotedMessageId);
         }
     }
 }

--- a/sdk/java/src/test/java/com/rmyndharis/openwa/resources/MessagesResourceTest.java
+++ b/sdk/java/src/test/java/com/rmyndharis/openwa/resources/MessagesResourceTest.java
@@ -186,6 +186,15 @@ class MessagesResourceTest {
             "s", SendMediaRequest.builder().chatId("628@c.us").url("http://u").quotedMessageId("q-media").build());
         assertTrue(tx.lastRequest().body().contains("q-media"));
 
+        // Audio takes its own record rather than SendMediaRequest, because `ptt` is accepted on this
+        // route alone — and a Java record cannot inherit, so the field has to be declared twice. That
+        // is precisely how send-audio was left as the one quotable route Java could not quote on
+        // while the other four clients could.
+        tx.respond(200, MSG);
+        client.messages.sendAudio(
+            "s", SendAudioRequest.builder().chatId("628@c.us").url("http://u").quotedMessageId("q-audio").build());
+        assertTrue(tx.lastRequest().body().contains("q-audio"));
+
         tx.respond(200, MSG);
         client.messages.sendLocation(
             "s",
@@ -220,11 +229,20 @@ class MessagesResourceTest {
         assertTrue(tx.lastRequest().body().contains("q-poll"));
     }
 
-    // Known-negative control: an ordinary send must not carry the key at all.
+    // Known-negative control: an ordinary send must not carry the key at all. The server declares
+    // quotedMessageId @IsNotEmpty, so a client that emitted "" or null would 400 every plain send.
+    // Audio is covered separately from the shared media record: it is the one send with its own
+    // record, it is the one that already drifted out of step, and bodySerializer() picks the
+    // serializer per REQUEST TYPE — so routing SendAudioRequest to the null-emitting Gson would
+    // break only audio, and the sendImage case alone would not notice.
     @Test
     void ordinarySendOmitsTheQuoteKey() {
         tx.respond(200, MSG);
         client.messages.sendImage("s", SendMediaRequest.builder().chatId("628@c.us").url("http://u").build());
+        assertTrue(!tx.lastRequest().body().contains("quotedMessageId"));
+
+        tx.respond(200, MSG);
+        client.messages.sendAudio("s", SendAudioRequest.builder().chatId("628@c.us").url("http://u").build());
         assertTrue(!tx.lastRequest().body().contains("quotedMessageId"));
     }
 


### PR DESCRIPTION
## What

`SendAudioRequest` in the Java SDK gains `quotedMessageId`, so `send-audio` can be quoted from Java as it already can from every other client.

## Why

`send-audio` was the one quotable route a Java caller had no typed way to quote on. The server accepts the field there — `SendAudioMessageDto extends SendMediaMessageDto`, and `openapi.json` publishes it — and the JavaScript, Python, Go and PHP clients all carry it. This was a one-client gap against a contract the other four already met.

Audio is the only send whose Java model is a separate record rather than `SendMediaRequest`, because `ptt` is accepted on this route alone and a Java record cannot inherit. The field therefore has to be declared twice, and the second declaration was missed.

## Why nothing caught it

The every-send test covered five routes and stopped short of audio. `check:sdk-coverage` documents its own scope as asserting a route is *reachable* from each client, not that its body matches — so no gate was ever going to see this.

Audio now sits in that test alongside the others, and the known-negative control that locks "an ordinary send emits no quote key" now exercises the audio record too. That control matters specifically here: `bodySerializer()` picks the serializer per request type, so routing `SendAudioRequest` to the null-emitting Gson would break only audio — and the server declares `quotedMessageId` `@IsNotEmpty`, so an emitted `null` would 400 every plain audio send. Verified by making that exact change and confirming the control fails.

## Compatibility

Appending a record component changes the canonical constructor from 7 to 8 arguments. Nothing in this repository constructs `SendAudioRequest` positionally — the builder is the only path — but a consumer calling the 7-arg constructor directly against the published 0.3.0 jar would need to recompile.

This is the same shape of change already merged in this release cycle, which took `SendMediaRequest` 6→7 and `SendTextRequest`, `SendContactRequest`, `SendLocationRequest` and `SendPollRequest` likewise, and `sdk/java/pom.xml` was not bumped for those either — the SDK version moves at SDK release time. Flagging it so the version decision is made deliberately rather than by omission.

## Verification

`mvn test` green (186 tests). Mutation-checked: dropping the field from `build()` fails one test.