### PR TITLE
test(plugins): bind both halves of the denial message to docs/19

### DIFF
--- a/src/core/plugins/plugin-capability.spec.ts
+++ b/src/core/plugins/plugin-capability.spec.ts
@@ -167,15 +167,29 @@ describe('PluginLoaderService capability facade — ctx.messages', () => {
   it('docs/19 quotes the same message the code throws', () => {
     // §19.9 reproduces assertPermission verbatim. A quoted string in prose is an UNGATED COPY of a
     // code string: it rots in silence, which is exactly the failure this repo has paid for more than
-    // once. The fragment is derived from the source rather than restated here, so the two cannot
-    // drift — restating it would just add a third copy to keep in step.
+    // once. The fragments are derived from the source rather than restated here, so the two cannot
+    // drift — restating them would just add a third copy to keep in step.
+    //
+    // EVERY literal in the throw, not just the one naming the fix. Binding the second half alone
+    // left the first — the sentence that names the FAULT, and the one an operator greps for — free
+    // to be reworded with docs/19 still asserting the old text, which is the exact rot this test
+    // exists to prevent. Deriving them from the function body catches a third sentence too, via the
+    // count assertion below.
     const norm = (s: string): string => s.replace(/\s+/g, ' ').trim();
     const source = readFileSync(join(__dirname, 'plugin-capability-context.ts'), 'utf8');
     const docs = readFileSync(join(__dirname, '..', '..', '..', 'docs', '19-plugin-architecture.md'), 'utf8');
 
-    const fragment = norm(source.match(/`Add "\$\{permission\}"[^`]*`/)?.[0] ?? '');
-    expect(fragment).not.toBe(''); // non-vacuous: a rename would otherwise make this pass on nothing
-    expect(norm(docs)).toContain(fragment);
+    // Start at the signature: the method's own docblock also backticks `permissions` and
+    // manifest.json, and must not be mistaken for part of the thrown string.
+    const body = source.match(/private assertPermission\([\s\S]*?\n {2}\}/)?.[0] ?? '';
+    expect(body).not.toBe(''); // non-vacuous: a rename would otherwise make this pass on nothing
+
+    const fragments = [...body.matchAll(/`[^`]*`/g)].map(m => norm(m[0]));
+    // Pins the count: a literal added to the throw has to be documented too, not silently skipped.
+    expect(fragments).toHaveLength(2);
+    for (const fragment of fragments) {
+      expect(norm(docs)).toContain(fragment);
+    }
   });
 
   it('denies reply when the plugin does not declare the messages:send permission', async () => {


### PR DESCRIPTION
## What

The spec that keeps `docs/19` §19.9 in step with the permission-denial message now derives **every** literal in the throw, not just one of them.

## Why

The gate extracted only the sentence that names the fix ("Add ... to the permissions array ..."). The sentence that names the **fault** — `Plugin <id> is missing the '<permission>' permission required for this capability.` — is quoted in `docs/19` too, with nothing holding it there. Rewording it in the code left the document asserting the old text and the suite still green, which is precisely the rot this test was added to prevent.

That first sentence is also the one an operator greps for when a plugin stops working, so it is the half least affordable to let drift.

## How

Both literals are read out of the `assertPermission` body and each is required to appear in `docs/19`. The count is pinned at two, so a third sentence added to the throw has to be documented rather than silently skipped.

The match starts at the method signature deliberately: the method's own docblock also backticks `permissions` and `manifest.json`, and must not be mistaken for part of the thrown string.

## Not vacuous

Two guards make a silent no-match impossible. If the method is renamed or reformatted so the body no longer matches, the extracted body is empty and `expect(body).not.toBe('')` fails loudly; if the literal count changes, the length assertion fails.

## Mutation-checked, each half separately

- Reword the **first** sentence → fails. Before this change it passed.
- Reword the **second** sentence → fails, as it already did.
- Add a **third** literal to the throw → fails on the count.
- Unmutated → green.

No production code changes.