### PR TITLE
test(chat-media): give the backlog drain a timeout it can meet

### DIFF
--- a/src/modules/chat-media/chat-media-archive.service.spec.ts
+++ b/src/modules/chat-media/chat-media-archive.service.spec.ts
@@ -296,6 +296,11 @@ describe('ChatMediaArchiveService', () => {
       }
     }
 
+    // Explicit timeout: this is the one case in the file that seeds four figures of rows and drives
+    // them through real SQLite and a real temp filesystem, so it is genuinely slow rather than
+    // waiting on anything. Jest's 5s default left no headroom for that work once the rest of the
+    // suite was running beside it, and it timed out on every full-suite run while passing whenever
+    // the file was run alone — a failure that reported itself as a product bug and was not one.
     it('drains a backlog spanning many batches, and never exceeds the batch size in one statement', async () => {
       // The archive's default TTL is 0, so the first run after an operator sets a retention can
       // face an unbounded backlog. Unbatched, the single UPDATE ... WHERE id IN (...) blows past
@@ -314,7 +319,7 @@ describe('ChatMediaArchiveService', () => {
       // The message rows themselves survive retention — only the archived blob expires.
       expect(await repository.count()).toBe(1250);
       update.mockRestore();
-    });
+    }, 30_000);
 
     it('stops instead of spinning when every delete in a batch fails', async () => {
       await seedExpired(3);


### PR DESCRIPTION
## What

The `purgeExpired` backlog test gets an explicit 30s timeout.

## Why

It seeds 1250 rows and drives them through real SQLite and a real temp filesystem, so it is slow by construction rather than waiting on anything. Jest's 5s default left no headroom once the rest of the suite ran beside it.

The result was a test that **timed out on every full-suite run and passed whenever its file was run alone** — reporting itself as a product failure it never was, and costing time to re-diagnose each occurrence.

## Reproduction

- `npx jest` (whole suite): failed 3 out of 3, always the same test, always `Exceeded timeout of 5000 ms`.
- `npx jest <that file>`: passed 3 out of 3.
- After the change: 3 out of 3 green on the whole suite.

## Scope

Pre-existing — `src/modules/chat-media/` is untouched by the current release, and the spec last changed before the v0.16.0 tag. It did not fail under CI's own invocation (`npm test -- --coverage`), which is why CI stayed green; it reddened the bare-`jest` run a developer is most likely to use locally.

Only the timeout argument is added. The body and every assertion are unchanged — the test is rewrapped in the three-argument `it()` form, which is the only reason the diff touches indentation.

## Related observation, not fixed here

`whatsapp-web-js.adapter.spec.ts` shows the same timing sensitivity: three of its tests timed out once under heavy parallel load, and pass on a quiet machine. It never failed a full-suite run, so it is left alone rather than swept into this change — worth a look if it ever surfaces in CI.