### PR TITLE
ci(security): correct the mistyped setup-node pin in the scheduled scan

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47331fe5020 # v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'


### PR DESCRIPTION
The first dispatch of the newly merged `security-scan.yml` failed to resolve `actions/setup-node` — the SHA was mistyped by one character when the workflow was written (`efc47331…` instead of `efc47a31…`). Neither actionlint nor the PR path could catch it: actionlint cannot validate remote SHAs, and the workflow has no push/PR trigger. The dispatch test exists precisely to close that gap, and it did — both image-scan jobs were green; only the audit job died on action resolution.

This corrects the pin, and all four action pins in the file are now verified byte-for-byte against the workflows they were copied from (`ci.yml`, `release.yml`). Post-merge the workflow will be dispatched again to confirm a fully green run.