### PR TITLE
fix(sdk): restore dropped contract-gate mappings and floor the mapping size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Weekly scheduled security scan (`.github/workflows/security-scan.yml`): the merge-time audit gates re-run against the current dependency trees, and the release image scan re-runs against the published `latest` image on both architectures — a newly published advisory surfaces within days instead of at the next push or release. Also dispatchable on demand.
-- Client wire-shape contract gate (`check:contract-shapes`, in the CI lint job): the JavaScript SDK's and the dashboard's hand-written wire types are now checked field-by-field against the OpenAPI schemas — presence, required-vs-optional, and type drift for simple fields — closing the gap where every existing gate verified which routes exist but none verified the body shapes they carry. 33 pairs conform today; the 7 remaining exclusions are recorded inline with reasons — one is deliberate (the dashboard's tri-state `engineLoaded` client model), the rest are a field-by-field adjudication backlog.
+- Client wire-shape contract gate (`check:contract-shapes`, in the CI lint job): the JavaScript SDK's and the dashboard's hand-written wire types are now checked field-by-field against the OpenAPI schemas — presence, required-vs-optional, and type drift for simple fields — closing the gap where every existing gate verified which routes exist but none verified the body shapes they carry. 37 pairs conform today; the 7 remaining exclusions are recorded inline with reasons — one is deliberate (the dashboard's tri-state `engineLoaded` client model), the rest are a field-by-field adjudication backlog.
 
 ## [0.19.0] - 2026-08-15
 

--- a/scripts/check-contract-shapes.mjs
+++ b/scripts/check-contract-shapes.mjs
@@ -34,6 +34,7 @@ import { readFileSync } from 'node:fs';
 const MAPPINGS = {
   'sdk/javascript/src/types.ts': {
     AccountRestriction: 'AccountRestrictionDto',
+    BatchMessageResult: 'BatchMessageResultDto',
     BatchProgress: 'BatchProgressDto',
     BatchStatusResponse: 'BatchStatusResponseDto',
     BulkMessageContent: 'BulkMessageContentDto',
@@ -60,10 +61,13 @@ const MAPPINGS = {
   'dashboard/src/services/api.ts': {
     AccountRestriction: 'AccountRestrictionDto',
     AuditLog: 'AuditLogDto',
+    BatchMessageResult: 'BatchMessageResultDto',
     BatchProgress: 'BatchProgressDto',
     BatchStatusResponse: 'BatchStatusResponseDto',
+    BulkMessageItem: 'BulkMessageItemDto',
     Channel: 'ChannelDto',
     ChannelMessage: 'ChannelMessageDto',
+    Chat: 'ChatSummaryDto',
     ChatPresence: 'ChatPresenceResponseDto',
     Contact: 'ContactDto',
     CreatedApiKey: 'ApiKeyCreatedResponseDto',
@@ -72,9 +76,21 @@ const MAPPINGS = {
     ParticipantPresence: 'ParticipantPresenceDto',
     ProfilePictureResponse: 'ProfilePictureResponseDto',
     SearchHit: 'SearchHitDto',
+    Session: 'SessionResponseDto',
     SessionConfig: 'SessionConfigResponseDto',
     Webhook: 'WebhookResponseDto',
   },
+};
+
+/**
+ * Floor on the mapping SIZE per client. The per-file compared-pairs guard above cannot see a
+ * rewrite that silently DROPS entries (protection shrinks while everything stays green — observed
+ * in review: a from-memory rewrite lost four conforming pairs and the run still passed). Raising
+ * these floors as pairs are added makes the shrink loud.
+ */
+const MINIMUM_MAPPED = {
+  'sdk/javascript/src/types.ts': 24,
+  'dashboard/src/services/api.ts': 20,
 };
 
 /** Known drift, deliberately not gated yet — each line is a to-adjudicate follow-up. */
@@ -327,6 +343,12 @@ if (isDirectRun) {
       }
     }
 
+    if (Object.keys(mapping).length < MINIMUM_MAPPED[file]) {
+      fileResults.push(
+        `  only ${Object.keys(mapping).length} mapped pairs for ${file} (floor ${MINIMUM_MAPPED[file]}) — entries were dropped`,
+      );
+      failures++;
+    }
     if (fileCompared < 8) {
       fileResults.push(`  only ${fileCompared} pairs compared for ${file} — vacuous-pass guard`);
       failures++;


### PR DESCRIPTION
## Summary

Post-merge review of the backlog triage (#1319) found the from-memory `MAPPINGS` rewrite had silently dropped entries:

- The **dashboard** lost `BatchMessageResult`, `Chat`, and `BulkMessageItem` (all conforming pairs — protection shrank while the run stayed green) and `Session` — making its by-design `engineLoaded` exclusion unreachable dead weight.
- The **SDK's `BatchMessageResult`** was never mapped at all, so the triage's "tightened and gated" claim for it carried no ongoing protection on the SDK side.

All four conforming pairs are restored — **37 pairs now gated** (the number #1319's changelog entry quoted as 33; corrected here). Every restored pair conforms on first adjudication.

To keep the failure mode from recurring, the gate gains a **mapping-size floor per client** (24 SDK / 20 dashboard, to be raised as pairs are added): the compared-pairs guard could not see a rewrite that DROPS entries. The floor was tamper-tested — removing one entry fails the run naming the drop.

## Tests

- `check:contract-shapes` green at 37; comparator spec 9/9; `test:scripts` 100/100; prettier clean.