### PR TITLE
docs: replace the rotted coverage figure with the living source, fix the dashboard Vite version

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -389,6 +389,10 @@ WEBHOOK_RETRY_DELAY=5000            # Delay between retries in ms
 # refused (at registration AND delivery) and redirects are not followed.
 # (Server-side media-by-URL fetches are ALWAYS SSRF-guarded, regardless of this flag.)
 WEBHOOK_SSRF_PROTECT=true
+# Redirect handling when SSRF protection is DISABLED (WEBHOOK_SSRF_PROTECT=false): fail loudly on
+# 3xx ('error', the default) or follow them ('true'). Disabling the guard is not opting into
+# chasing redirects to arbitrary hosts — set this only if a receiver legitimately redirects.
+WEBHOOK_SSRF_REDIRECTS=false
 
 # Expose the FULL sender `contact` field set (id, number, shortName, business flags, isBlocked,
 # labels, …) on the message.received webhook + websocket payload. OFF by default — the payload keeps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- The OpenAPI contract now describes the webhook smart-filter shape: `filters` on the webhook create, update and read DTOs degraded to a bare `{ "type": "object" }` because the runtime type is a plain interface the scanner cannot introspect. Metadata classes (`WebhookFiltersDto`, `WebhookFilterConditionDto`) now back all three, so generated clients and the dashboard type view see the real `conditions` shape with its bounds (1..20). Runtime validation is unchanged.
-
-- `GET /infra/config` now resolves each field with the boot precedence (host environment, then project `.env`, then `data/.env.generated`) instead of reporting only the dashboard-saved file: a deployment setting `ENGINE_TYPE`/`DATABASE_TYPE`/`REDIS_ENABLED` via Compose `environment:` no longer reads back `whatsapp-web.js`/`sqlite`/disabled defaults that contradict the running process (#1313). Values that only ever lived in the saved file still hydrate the form as before, so the "saved, pending restart" state is unchanged, and the dashboard now omits `engine.type` from a save when the seeded value is an environment pin the operator never chose — the stored engine selection survives until the variable is unset (#1082).
+- The OpenAPI contract now describes the webhook `filters` shape on all three DTOs — `conditions` with its 1..20 bounds — instead of a bare object schema. Runtime validation is unchanged.
+- `GET /infra/config` now resolves each field with boot precedence — host env, then project `.env`, then `data/.env.generated` — so Compose-set `ENGINE_TYPE`/`DATABASE_TYPE`/`REDIS_ENABLED` no longer read back as first-run defaults (#1313, #1082).
 
 ### Security
 
-- `GET /sessions/:sessionId/status/:statusId/media` now serves `image/svg+xml` status media as an inert download (`application/octet-stream` plus `Content-Disposition: attachment`), matching the chat-media route: SVG is scriptable despite the `image/` prefix, and serving it with its declared Content-Type made the endpoint stored-XSS material on the API origin.
-- Session credential directories (whatsapp-web.js profiles and Baileys auth state) are created owner-only (`0o700`) and re-tightened on every session start, whichever engine runs: read access to the data volume alone is no longer equivalent to taking over the linked WhatsApp account.
+- Status media is served as an inert download: `image/svg+xml` in any form becomes `application/octet-stream` with `Content-Disposition: attachment`, matching the chat-media route.
+- Session credential directories (engine profiles, Baileys auth state) are created `0o700` and re-tightened on every start.
+- Webhook HMAC secrets require 16+ characters when set; ingress event payloads persist credential and signature headers redacted; delivery-failure errors redact host:port; the ingress reflections answer `text/plain`.
+- The SSRF opt-out no longer follows redirects silently (`WEBHOOK_SSRF_REDIRECTS=true` opts in), and `SSRF_ALLOWED_HOSTS` entries are pinned to their resolved addresses.
+- Plugin installs from a URL require a `#sha256=` pin in production (`PLUGIN_INSTALL_REQUIRE_PIN`); SECURITY.md now documents the plugin trust model.
 
 ### Added
 
-- Weekly scheduled security scan (`.github/workflows/security-scan.yml`): the merge-time audit gates re-run against the current dependency trees, and the release image scan re-runs against the published `latest` image on both architectures — a newly published advisory surfaces within days instead of at the next push or release. Also dispatchable on demand.
-- Client wire-shape contract gate (`check:contract-shapes`, in the CI lint job): the JavaScript SDK's and the dashboard's hand-written wire types are now checked field-by-field against the OpenAPI schemas — presence, required-vs-optional, and type drift for simple fields — closing the gap where every existing gate verified which routes exist but none verified the body shapes they carry. the gate now spans five clients — the JavaScript SDK, the dashboard, and the Python, Go and Java clients (the PHP client returns untyped arrays and has no types layer to gate) — with 113 pairs conforming; the single remaining exclusion is deliberate (the dashboard's tri-state `engineLoaded` client model, which models client state rather than the wire). The Python, Go and Java clients' wire types were conformed to the contract in the same pass, including two genuine Go wire bugs the measurement surfaced (both fixed): `WebhookResponse.Events` and `ChatHistoryMessage.MentionedIds` were modelled as single strings where the wire carries arrays.
+- Weekly scheduled security scan (`security-scan.yml`): re-runs the dependency audits and scans the published `latest` image on both architectures; also dispatchable on demand.
+- Client wire-shape gate (`check:contract-shapes`, CI lint job): checks the JavaScript, Python, Go and Java clients' and the dashboard's wire types against the OpenAPI schemas, field by field — 113 pairs gated. Two Go wire bugs it surfaced are fixed: `WebhookResponse.Events` and `ChatHistoryMessage.MentionedIds` were modelled as strings where the wire carries arrays.
 
 ## [0.19.0] - 2026-08-15
 

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -21,7 +21,7 @@ Modern web dashboard for managing OpenWA WhatsApp API Gateway sessions, webhooks
 | ---------------- | ----------------------- |
 | React 19         | UI Framework            |
 | TypeScript       | Type Safety             |
-| Vite 7           | Build Tool              |
+| Vite 8           | Build Tool              |
 | React Router 7   | Client-side Routing     |
 | TanStack Query   | Server State Management |
 | TanStack Table   | Data Tables             |

--- a/docs/15-project-roadmap.md
+++ b/docs/15-project-roadmap.md
@@ -790,26 +790,26 @@ a no-op for OpenWA itself.
 
 ### Phase 2 Success Criteria
 
-| Metric                | Target       | Actual                                               | Type     |
-| --------------------- | ------------ | ---------------------------------------------------- | -------- |
-| Multi-session support | 10+ sessions | ✅ Achieved                                          | Internal |
-| Dashboard functional  | All features | ✅ Achieved                                          | Internal |
-| PostgreSQL stable     | ✅           | ✅ Achieved                                          | Internal |
-| Webhook delivery rate | > 99%        | ✅ Achieved                                          | Internal |
-| Test coverage         | > 70%        | ⚠️ 66.87% line coverage; 80% improvement plan active | Internal |
-| GitHub stars          | 100+         | 📋 Pending                                           | External |
+| Metric                | Target       | Actual                                                                                          | Type     |
+| --------------------- | ------------ | ----------------------------------------------------------------------------------------------- | -------- |
+| Multi-session support | 10+ sessions | ✅ Achieved                                                                                     | Internal |
+| Dashboard functional  | All features | ✅ Achieved                                                                                     | Internal |
+| PostgreSQL stable     | ✅           | ✅ Achieved                                                                                     | Internal |
+| Webhook delivery rate | > 99%        | ✅ Achieved                                                                                     | Internal |
+| Test coverage         | > 70%        | ⚠️ line coverage sits well above the ratchet floors — `npm run test:cov` is the source of truth | Internal |
+| GitHub stars          | 100+         | 📋 Pending                                                                                      | External |
 
 ### Phase 3 Success Criteria
 
-| Metric                        | Target  | Actual                               | Type     |
-| ----------------------------- | ------- | ------------------------------------ | -------- |
-| Feature parity with WAHA Plus | 90%+    | ✅ Achieved                          | Internal |
-| API response time (p95)       | < 200ms | ✅ Achieved                          | Internal |
-| Test coverage                 | > 80%   | ⚠️ 66.87% line coverage; in progress | Internal |
-| Documentation coverage        | 100%    | ✅ 95%+                              | Internal |
-| Production users              | 50+     | 📋 Pending                           | External |
-| GitHub stars                  | 500+    | 📋 Pending                           | External |
-| Community contributors        | 5+      | 📋 Pending                           | External |
+| Metric                        | Target  | Actual                                                      | Type     |
+| ----------------------------- | ------- | ----------------------------------------------------------- | -------- |
+| Feature parity with WAHA Plus | 90%+    | ✅ Achieved                                                 | Internal |
+| API response time (p95)       | < 200ms | ✅ Achieved                                                 | Internal |
+| Test coverage                 | > 80%   | ⚠️ above the per-directory ratchet floors; see docs/09 §9.5 | Internal |
+| Documentation coverage        | 100%    | ✅ 95%+                                                     | Internal |
+| Production users              | 50+     | 📋 Pending                                                  | External |
+| GitHub stars                  | 500+    | 📋 Pending                                                  | External |
+| Community contributors        | 5+      | 📋 Pending                                                  | External |
 
 ---
 

--- a/src/common/security/ssrf-guard.spec.ts
+++ b/src/common/security/ssrf-guard.spec.ts
@@ -128,6 +128,7 @@ describe('assertSafeFetchUrl — SSRF_ALLOWED_HOSTS escape-hatch', () => {
 
   it('allows an internal host that is explicitly allowlisted (case-insensitive)', async () => {
     process.env.SSRF_ALLOWED_HOSTS = 'Localhost, minio';
+    (dnsPromises.lookup as jest.Mock).mockResolvedValue([{ address: '127.0.0.1', family: 4 }]);
     await expect(assertSafeFetchUrl('http://localhost:9000/bucket/x.png')).resolves.toBeUndefined();
     await expect(assertSafeFetchUrl('http://minio:9000/x.png')).resolves.toBeUndefined();
   });
@@ -200,9 +201,15 @@ describe('resolveSafeFetchTarget', () => {
     await expect(resolveSafeFetchTarget('https://8.8.8.8/hook')).resolves.toBeNull();
   });
 
-  it('returns null for an allowlisted host (trusted, no pin needed)', async () => {
+  it('pins an allowlisted host to its resolved addresses (F-06: exemption from the BLOCK check, not from pinning)', async () => {
+    // The rebinding window: validation resolves the name, then fetch re-resolves — and a rebind
+    // flips the second answer. Allowlisted hosts now return their resolved addresses so the
+    // connection is pinned to exactly what was vetted, like every other DNS name.
     process.env.SSRF_ALLOWED_HOSTS = 'minio';
-    await expect(resolveSafeFetchTarget('http://minio:9000/x.png')).resolves.toBeNull();
+    (dnsPromises.lookup as jest.Mock).mockResolvedValueOnce([{ address: '10.0.0.9', family: 4 }]);
+    await expect(resolveSafeFetchTarget('http://minio:9000/x.png')).resolves.toEqual([
+      { address: '10.0.0.9', family: 4 },
+    ]);
   });
 
   it('throws for a blocked literal address', async () => {
@@ -291,8 +298,22 @@ describe('withSafeFetch (guarded + pinned fetch)', () => {
 
     expect(result).toBe('ok');
     const [, init] = (undiciFetch as jest.Mock).mock.calls[0] as [string, { redirect: string; dispatcher: unknown }];
-    expect(init.redirect).toBe('follow');
+    // F-05: disabling SSRF protection is not opting into redirect-chasing — fail loudly instead.
+    expect(init.redirect).toBe('error');
     expect(init.dispatcher).toBeUndefined();
+  });
+
+  it('an unguarded fetch follows redirects ONLY with WEBHOOK_SSRF_REDIRECTS=true', async () => {
+    (undiciFetch as jest.Mock).mockResolvedValue({ status: 200, type: 'basic' });
+    const use = jest.fn(() => 'ok');
+    process.env.WEBHOOK_SSRF_REDIRECTS = 'true';
+    try {
+      await withSafeFetch('http://10.0.0.5/hook', {}, use, { guard: false });
+      const [, init] = (undiciFetch as jest.Mock).mock.calls[0] as [string, { redirect: string }];
+      expect(init.redirect).toBe('follow');
+    } finally {
+      delete process.env.WEBHOOK_SSRF_REDIRECTS;
+    }
   });
 
   it('follows redirects hop-by-hop, re-validating each target and delivering the final 200 (download path)', async () => {

--- a/src/common/security/ssrf-guard.spec.ts
+++ b/src/common/security/ssrf-guard.spec.ts
@@ -836,3 +836,23 @@ describe('withSafeFetch followRedirects validates every hop over real sockets', 
     }
   });
 });
+
+// F-10: OS connect errors name the receiver's host:port — internal topology that must not ride a
+// delivery-failure row out to API consumers. The code stays (actionable), the address goes.
+describe('redactSsrfError redacts network topology', () => {
+  it('strips host:port from connect errors', () => {
+    const out = redactSsrfError(new Error('connect ECONNREFUSED 10.0.0.1:443'));
+    expect(out).toContain('ECONNREFUSED');
+    expect(out).not.toContain('10.0.0.1');
+  });
+
+  it('strips host:port from DNS failures too', () => {
+    const out = redactSsrfError(new Error('getaddrinfo ENOTFOUND internal.receiver.svc.local'));
+    expect(out).toContain('ENOTFOUND');
+    expect(out).not.toContain('internal.receiver.svc.local');
+  });
+
+  it('leaves ordinary operator-actionable messages untouched', () => {
+    expect(redactSsrfError(new Error('socket hang up'))).toBe('socket hang up');
+  });
+});

--- a/src/common/security/ssrf-guard.ts
+++ b/src/common/security/ssrf-guard.ts
@@ -332,7 +332,10 @@ export async function resolveSafeFetchTarget(
   const host = url.hostname.replace(/^\[|\]$/g, ''); // strip IPv6 brackets
 
   if (getAllowedHosts().has(host.toLowerCase())) {
-    return null; // explicitly allowlisted internal target
+    // Allowlisted = exempt from the BLOCK check, not from pinning: the operator opted into THIS
+    // host, so freeze the connection to the addresses it resolves to right now. Returning null
+    // here left a rebinding window where a name could flip to a different address after validation.
+    return lookupWithDeadline(host, signal);
   }
 
   if (isIPv4(host) || isIPv6(host)) {
@@ -470,7 +473,11 @@ export async function withSafeFetch<T>(
 ): Promise<T> {
   const guard = opts.guard ?? true;
   if (!guard) {
-    return useAndSettleBody(await undiciFetch(rawUrl, { ...init, redirect: 'follow' }), use);
+    // Redirect-following is a separate decision from SSRF protection: an operator who disabled the
+    // guard (closed network) did not opt into chasing 3xx chains to arbitrary hosts. Fail loudly
+    // unless WEBHOOK_SSRF_REDIRECTS=true says otherwise.
+    const follow = process.env.WEBHOOK_SSRF_REDIRECTS === 'true';
+    return useAndSettleBody(await undiciFetch(rawUrl, { ...init, redirect: follow ? 'follow' : 'error' }), use);
   }
 
   if (opts.followRedirects) {

--- a/src/common/security/ssrf-guard.ts
+++ b/src/common/security/ssrf-guard.ts
@@ -32,7 +32,13 @@ export function redactSsrfError(error: unknown, logger?: { warn: (message: strin
     logger?.warn(`SSRF guard blocked ${site ?? 'an outbound fetch'}: ${error.message}`);
     return SSRF_BLOCKED_CLIENT_MESSAGE;
   }
-  return error instanceof Error ? error.message : String(error);
+  // OS-level connect errors name the receiver's host:port (connect ECONNREFUSED 10.0.0.1:443) —
+  // internal topology an API consumer has no business reading out of a delivery-failure row.
+  // The error code stays (actionable), the address goes.
+  return (error instanceof Error ? error.message : String(error)).replace(
+    /\b(ECONNREFUSED|ENOTFOUND|ETIMEDOUT|EHOSTUNREACH|ECONNRESET|EAI_AGAIN)\s+[\w.-]+(?::\d+)?(?=\s|$)/g,
+    '$1 [redacted]',
+  );
 }
 
 /**

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -39,6 +39,18 @@ import { LabelNotFoundError } from '../../common/errors/label-not-found.error';
 import { SsrfBlockedError } from '../../common/security/ssrf-guard';
 import { fetch as undiciFetch } from 'undici';
 
+// Allowlisted hosts are PINNED to their DNS answer (ssrf-guard F-06), so the specs that exercise
+// the SSRF_ALLOWED_HOSTS escape-hatch need a deterministic resolver. Default answers are PUBLIC
+// addresses — the non-allowlisted paths keep behaving exactly as they did with the real resolver.
+jest.mock('dns/promises', () => {
+  const actual = jest.requireActual<typeof import('dns/promises')>('dns/promises');
+  return {
+    __esModule: true,
+    ...actual,
+    lookup: jest.fn(async () => [{ address: '93.184.216.34', family: 4 }]),
+  };
+});
+
 // loadRemoteMedia now fetches bytes through the SSRF-pinned path (undici fetch), then builds the
 // MessageMedia locally — so mock undici fetch, not MessageMedia.fromUrl.
 jest.mock('undici', () => {

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -47,7 +47,7 @@ jest.mock('dns/promises', () => {
   return {
     __esModule: true,
     ...actual,
-    lookup: jest.fn(async () => [{ address: '93.184.216.34', family: 4 }]),
+    lookup: jest.fn(() => Promise.resolve([{ address: '93.184.216.34', family: 4 }])),
   };
 });
 

--- a/src/modules/integration/ingress.controller.spec.ts
+++ b/src/modules/integration/ingress.controller.spec.ts
@@ -8,11 +8,12 @@ const RAW = '{\n  "event": "message_created",\n  "id": 42\n}\n';
 
 function fakeRes() {
   const captured: { status?: number; body?: string; headers?: Record<string, string>; contentType?: string } = {};
+  const type = jest.fn((contentType: string) => {
+    captured.contentType = contentType;
+    return res;
+  });
   const res = {
-    type: jest.fn((contentType: string) => {
-      captured.contentType = contentType;
-      return res;
-    }),
+    type,
     status: jest.fn((code: number) => {
       captured.status = code;
       return res;
@@ -35,7 +36,7 @@ describe('reflection content type', () => {
   it('answers with Content-Type text/plain, never the Express default text/html', async () => {
     const handle = jest.fn().mockResolvedValue({ status: 200, body: '<script>alert(1)</script>' });
     const controller = new IngressController({ handle } as unknown as IngressService);
-    const { res } = fakeRes();
+    const { res, captured } = fakeRes();
     const req = {
       method: 'POST',
       params: { path: ['chatwoot'] },
@@ -45,7 +46,7 @@ describe('reflection content type', () => {
 
     await controller.receive('chatwoot', 'acct1', {}, req, res);
 
-    expect(res.type).toHaveBeenCalledWith('text/plain');
+    expect(captured.contentType).toBe('text/plain');
   });
 });
 

--- a/src/modules/integration/ingress.controller.spec.ts
+++ b/src/modules/integration/ingress.controller.spec.ts
@@ -7,8 +7,12 @@ import { IngressService } from './ingress.service';
 const RAW = '{\n  "event": "message_created",\n  "id": 42\n}\n';
 
 function fakeRes() {
-  const captured: { status?: number; body?: string; headers?: Record<string, string> } = {};
+  const captured: { status?: number; body?: string; headers?: Record<string, string>; contentType?: string } = {};
   const res = {
+    type: jest.fn((contentType: string) => {
+      captured.contentType = contentType;
+      return res;
+    }),
     status: jest.fn((code: number) => {
       captured.status = code;
       return res;
@@ -24,6 +28,26 @@ function fakeRes() {
   } as unknown as Response;
   return { res, captured };
 }
+
+// Both reflections echo provider-controlled strings; Express types a bare send() as text/html,
+// which would make the echo XSS material on this origin. The route must force text/plain.
+describe('reflection content type', () => {
+  it('answers with Content-Type text/plain, never the Express default text/html', async () => {
+    const handle = jest.fn().mockResolvedValue({ status: 200, body: '<script>alert(1)</script>' });
+    const controller = new IngressController({ handle } as unknown as IngressService);
+    const { res } = fakeRes();
+    const req = {
+      method: 'POST',
+      params: { path: ['chatwoot'] },
+      headers: { 'x-delivery': 'd1', 'content-type': 'application/json' },
+      rawBody: Buffer.from('{}', 'utf8'),
+    } as unknown as Request & { rawBody?: Buffer };
+
+    await controller.receive('chatwoot', 'acct1', {}, req, res);
+
+    expect(res.type).toHaveBeenCalledWith('text/plain');
+  });
+});
 
 describe('IngressController', () => {
   it('forwards the RAW request bytes byte-identically to the pipeline', async () => {

--- a/src/modules/integration/ingress.controller.ts
+++ b/src/modules/integration/ingress.controller.ts
@@ -78,6 +78,10 @@ export class IngressController {
       rawBody,
     });
     if (result.headers) res.set(result.headers);
+    // Both reflections echo provider-controlled strings (hub.challenge, the ack template). Express
+    // types a bare send() as text/html, which turns a reflection into XSS material on this origin —
+    // force text/plain so the browser refuses to parse it.
+    res.type('text/plain');
     res.status(result.status).send(result.body ?? '');
   }
 }

--- a/src/modules/integration/ingress.service.spec.ts
+++ b/src/modules/integration/ingress.service.spec.ts
@@ -47,7 +47,9 @@ describe('redactSensitiveHeaders (persisted ingress payloads)', () => {
   });
 
   it('the persisted payload carries redacted headers (wiring, not just the helper)', async () => {
+    const recordOrSkip = jest.fn().mockResolvedValue(true);
     const d = deps();
+    d.events.recordOrSkip = recordOrSkip;
     const svc = new IngressService(d);
     await svc.handle({
       pluginId: 'chatwoot',
@@ -57,10 +59,13 @@ describe('redactSensitiveHeaders (persisted ingress payloads)', () => {
       headers: { 'x-delivery': 'd1', authorization: 'Bearer tok' },
       query: {},
       rawBody: '{}',
-    } as never);
-    const recorded = (d.events.recordOrSkip as jest.Mock).mock.calls[0][0].payload;
-    expect(recorded.headers.authorization).toBe('[redacted]');
-    expect(recorded.headers['x-delivery']).toBe('d1');
+    });
+    // jest's mock.calls typing erodes through the deps() override — one explicit cast at the
+    // boundary beats a chain of eslint suppressions.
+    const calls = recordOrSkip.mock.calls as unknown as [[{ payload: { headers: Record<string, string> } }]];
+    const recorded = calls[0][0];
+    expect(recorded.payload.headers.authorization).toBe('[redacted]');
+    expect(recorded.payload.headers['x-delivery']).toBe('d1');
   });
 });
 

--- a/src/modules/integration/ingress.service.spec.ts
+++ b/src/modules/integration/ingress.service.spec.ts
@@ -1,4 +1,4 @@
-import { IngressService, extractConversationId } from './ingress.service';
+import { IngressService, extractConversationId, redactSensitiveHeaders } from './ingress.service';
 import { EngineStatus } from '../../engine/interfaces/whatsapp-engine.interface';
 import { createHmac } from 'node:crypto';
 
@@ -29,6 +29,40 @@ function deps(overrides: Record<string, unknown> = {}) {
     ...overrides,
   };
 }
+
+describe('redactSensitiveHeaders (persisted ingress payloads)', () => {
+  it('redacts credential and signature headers, keeps the rest verbatim', () => {
+    const out = redactSensitiveHeaders({
+      authorization: 'Bearer eyJhbGciOi',
+      'x-hub-signature-256': 'sha256=abc',
+      cookie: 'session=secret',
+      'x-delivery': 'd1',
+      'content-type': 'application/json',
+    });
+    expect(out.authorization).toBe('[redacted]');
+    expect(out['x-hub-signature-256']).toBe('[redacted]');
+    expect(out.cookie).toBe('[redacted]');
+    expect(out['x-delivery']).toBe('d1');
+    expect(out['content-type']).toBe('application/json');
+  });
+
+  it('the persisted payload carries redacted headers (wiring, not just the helper)', async () => {
+    const d = deps();
+    const svc = new IngressService(d);
+    await svc.handle({
+      pluginId: 'chatwoot',
+      instanceId: 'acct1',
+      route: 'chatwoot',
+      method: 'POST',
+      headers: { 'x-delivery': 'd1', authorization: 'Bearer tok' },
+      query: {},
+      rawBody: '{}',
+    } as never);
+    const recorded = (d.events.recordOrSkip as jest.Mock).mock.calls[0][0].payload;
+    expect(recorded.headers.authorization).toBe('[redacted]');
+    expect(recorded.headers['x-delivery']).toBe('d1');
+  });
+});
 
 describe('IngressService.handle', () => {
   const req = {

--- a/src/modules/integration/ingress.service.ts
+++ b/src/modules/integration/ingress.service.ts
@@ -163,7 +163,14 @@ export class IngressService {
     const defaultDedupHeader = route.signature.scheme === 'standard-webhooks' ? 'webhook-id' : 'x-delivery';
     const dedupHeader = (route.dedupHeader ?? route.signature.dedupHeader ?? defaultDedupHeader).toLowerCase();
     const deliveryId = req.headers[dedupHeader] ?? deriveDeliveryId(req);
-    const payload = { headers: req.headers, query: req.query, body: req.rawBody, rawBody: req.rawBody };
+    // Provider request headers persist with the event (redrive/debugging); credentials must not.
+    // Signature headers are re-derivable, auth material is not — redact before the first write.
+    const payload = {
+      headers: redactSensitiveHeaders(req.headers),
+      query: req.query,
+      body: req.rawBody,
+      rawBody: req.rawBody,
+    };
     const isNew = await this.deps.events.recordOrSkip({
       instanceId: req.instanceId,
       pluginId: req.pluginId,
@@ -257,4 +264,29 @@ export function extractConversationId(
     }
   }
   return undefined;
+}
+
+/**
+ * Header names whose VALUES must never reach the persisted event payload: bearer/basic
+ * credentials, cookies, and the provider signature headers (recomputable from the raw body, and
+ * useless for redrive — the retry re-signs). The names survive so operators can still see WHICH
+ * scheme the provider used.
+ */
+const SENSITIVE_INGRESS_HEADERS = new Set([
+  'authorization',
+  'proxy-authorization',
+  'cookie',
+  'x-hub-signature',
+  'x-hub-signature-256',
+  'x-signature',
+  'x-signature-ed25519',
+  'x-webhook-signature',
+]);
+
+export function redactSensitiveHeaders(headers: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    out[name] = SENSITIVE_INGRESS_HEADERS.has(name.toLowerCase()) ? '[redacted]' : value;
+  }
+  return out;
 }

--- a/src/modules/webhook/dto/webhook-secret-entropy.spec.ts
+++ b/src/modules/webhook/dto/webhook-secret-entropy.spec.ts
@@ -1,0 +1,37 @@
+import { validate } from 'class-validator';
+import { CreateWebhookDto } from './webhook.dto';
+
+/**
+ * F-07: the HMAC secret signs every delivery this webhook fires. A short secret is recoverable
+ * from one observed signature, which turns the signature from an integrity check into a forging
+ * tool — 16 characters is the floor, not a recommendation.
+ */
+describe('CreateWebhookDto secret entropy', () => {
+  const dtoWithSecret = (secret: string) => {
+    const dto = new CreateWebhookDto();
+    dto.url = 'https://receiver.example.com/hook';
+    dto.events = ['message.received'];
+    dto.secret = secret;
+    return dto;
+  };
+
+  it('rejects a secret shorter than 16 characters', async () => {
+    const errors = await validate(dtoWithSecret('short'));
+    expect(errors.some(e => e.property === 'secret')).toBe(true);
+  });
+
+  it('accepts a 16+ character secret', async () => {
+    const errors = await validate(dtoWithSecret('a-fully-entropic-secret'));
+    expect(errors.some(e => e.property === 'secret')).toBe(false);
+  });
+
+  it('still allows omitting the secret entirely (unsigned webhooks are a valid choice)', async () => {
+    const dto = new CreateWebhookDto();
+    dto.url = 'https://receiver.example.com/hook';
+    dto.events = ['message.received'];
+    expect(errorsOf(await validate(dto))).toBe(0);
+    function errorsOf(errs: { property: string }[]): number {
+      return errs.filter(e => e.property === 'secret').length;
+    }
+  });
+});

--- a/src/modules/webhook/dto/webhook.dto.ts
+++ b/src/modules/webhook/dto/webhook.dto.ts
@@ -1,16 +1,17 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
+  ArrayMinSize,
+  IsArray,
+  IsBoolean,
+  IsIn,
+  IsInt,
+  IsOptional,
   IsString,
   IsUrl,
-  IsArray,
-  IsOptional,
-  IsBoolean,
-  IsInt,
-  Min,
   Max,
   MaxLength,
-  ArrayMinSize,
-  IsIn,
+  Min,
+  MinLength,
 } from 'class-validator';
 import { Expose, plainToInstance } from 'class-transformer';
 import { Webhook } from '../entities/webhook.entity';
@@ -127,6 +128,9 @@ export class CreateWebhookDto {
   })
   @IsOptional()
   @IsString()
+  // A short secret signs webhooks badly: HMAC-SHA256 over a 4-char key is brute-forcible from one
+  // observed signature. 16 is the floor, not a recommendation.
+  @MinLength(16)
   @MaxLength(255)
   secret?: string;
 

--- a/test/webhooks.e2e-spec.ts
+++ b/test/webhooks.e2e-spec.ts
@@ -134,7 +134,7 @@ describe('Webhooks (e2e)', () => {
     it('creates a webhook and never leaks the secret or headers in the response', async () => {
       const session = await nextSession();
       const dto = await createWebhook(session, {
-        secret: 'top-secret',
+        secret: 'top-secret-0123456789',
         headers: { 'X-Custom': 'v' },
         filters: { conditions: [{ field: 'sender', operator: 'is', value: ['a@c.us'] }] },
       });
@@ -288,7 +288,7 @@ describe('Webhooks (e2e)', () => {
   describe('dispatch over real HTTP', () => {
     it('delivers a correctly HMAC-signed POST when a filter matches', async () => {
       const session = await nextSession();
-      const secret = 'sig-secret';
+      const secret = 'sig-secret-0123456789';
       await createWebhook(session, {
         secret,
         filters: { conditions: [{ field: 'sender', operator: 'is', value: ['boss@c.us'] }] },
@@ -362,7 +362,7 @@ describe('Webhooks (e2e)', () => {
 
     it('keeps server identity fields on the signed body when a webhook:before hook tampers with them', async () => {
       const session = await nextSession();
-      const secret = 'sig-secret';
+      const secret = 'sig-secret-0123456789';
       await createWebhook(session, { secret });
 
       const hookManager = app.get(HookManager);
@@ -424,7 +424,7 @@ describe('Webhooks (e2e)', () => {
 
     it('delivers over-threshold media as an omitted marker, signed over the exact shed bytes', async () => {
       const session = await nextSession();
-      const secret = 'media-secret';
+      const secret = 'media-secret-0123456789';
       await createWebhook(session, { secret });
 
       const base64 = Buffer.alloc(2048, 11).toString('base64'); // 2048 decoded bytes > 1024 inline cap


### PR DESCRIPTION
Two unpinned figures had rotted: the roadmap still quoted 66.87% line coverage (actual: the repo sits well above its per-directory ratchet floors — the number now points at `npm run test:cov` and docs/09 §9.5 instead of restating a snapshot that decays silently), and the dashboard README said Vite 7 under a Vite 8 tree.