### PR TITLE
fix(security): require an integrity pin for production plugin installs and document the plugin trust model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -666,6 +666,9 @@ PLUGINS_DIR=./data/plugins          # Plugin directory (default: ./data/plugins)
 # Cap on a plugin .zip downloaded by install-from-URL (matches the 5 MB upload limit). A non-positive
 # or non-numeric value falls back to the default.
 # PLUGIN_DOWNLOAD_MAX_BYTES=5242880   # default 5 MiB
+# Require a #sha256=<hex> integrity pin on EVERY plugin install from a URL (production default;
+# https alone authenticates the channel, not the bytes-as-reviewed). false lifts the requirement.
+# PLUGIN_INSTALL_REQUIRE_PIN=true
 # Host-side budget for one sandboxed plugin capability call; a wedged call is failed and its in-flight
 # slot freed (the late-settling work is only logged, not cancelled). A non-positive or non-numeric
 # value falls back to the default.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -57,6 +57,27 @@ withholds, and `/api/docs` is served outside the API-key guard. Comment the line
 set it to `false` to restore the production default. Docker Compose and the Helm chart
 are unaffected — neither forwards `ENABLE_SWAGGER` and the container never reads `.env`.
 
+### Plugins are full host trust — by design
+
+Installing or enabling a plugin is executing third-party code on the host that runs OpenWA.
+This is inherent to what a plugin IS here: the sandbox (a `worker_threads` isolate with a
+capped heap, an allowlisted environment, a deny-by-default network manifest, and a
+capability router with per-call timeouts) contains a buggy or runaway plugin — it is NOT a
+security boundary against a malicious one. A worker shares the process's filesystem and
+OS privileges with the API.
+
+The compensating gates on the install path:
+
+- every lifecycle route requires an **unscoped ADMIN** key;
+- install URLs are fetched behind the SSRF guard, with redirects re-validated per hop;
+- plain-`http` URLs require a `#sha256=` content pin, and in production **every** URL
+  install does (`PLUGIN_INSTALL_REQUIRE_PIN`, opt-out documented in `.env.example`);
+- the package manifest is strictly validated and symlink traps are detected at unpack.
+
+If you operate a fleet of plugins you do not fully trust, do not install them into the
+OpenWA process — run them in a separate container/VM with an OS-level sandbox and reach
+OpenWA over the API like any other client.
+
 ### Docker socket proxy — scope and residual risk
 
 The application container never mounts `/var/run/docker.sock`; it reaches the daemon

--- a/src/modules/plugins/plugin-download.spec.ts
+++ b/src/modules/plugins/plugin-download.spec.ts
@@ -1,4 +1,4 @@
-import { expectedSha256FromUrl, assertDownloadSha256, assertPluginInstallUrl } from './plugin-download';
+import { assertDownloadSha256, assertPluginInstallUrl, expectedSha256FromUrl } from './plugin-download';
 import { createHash } from 'crypto';
 
 /**
@@ -82,5 +82,43 @@ describe('assertPluginInstallUrl', () => {
   it('leaves unparseable URLs and other schemes to the SSRF guard (no duplicate rejection here)', () => {
     expect(() => assertPluginInstallUrl('not a url')).not.toThrow();
     expect(() => assertPluginInstallUrl('ftp://h/pkg.zip')).not.toThrow();
+  });
+});
+
+// a URL install EXECUTES third-party code — https authenticates the channel, not the bytes.
+// In production (or wherever PLUGIN_INSTALL_REQUIRE_PIN says so) the pin is mandatory.
+describe('assertPluginInstallUrl — pin required in production', () => {
+  const env = { ...process.env };
+  afterEach(() => {
+    process.env = { ...env };
+  });
+
+  it('rejects an unpinned https URL when NODE_ENV=production', () => {
+    process.env.NODE_ENV = 'production';
+    delete process.env.PLUGIN_INSTALL_REQUIRE_PIN;
+    expect(() => assertPluginInstallUrl('https://release.example.com/pkg.zip')).toThrow(/integrity pin/);
+  });
+
+  it('accepts the same URL with a pin', () => {
+    process.env.NODE_ENV = 'production';
+    expect(() => assertPluginInstallUrl('https://release.example.com/pkg.zip#sha256=' + 'a'.repeat(64))).not.toThrow();
+  });
+
+  it('keeps the lighter default outside production', () => {
+    process.env.NODE_ENV = 'development';
+    delete process.env.PLUGIN_INSTALL_REQUIRE_PIN;
+    expect(() => assertPluginInstallUrl('https://release.example.com/pkg.zip')).not.toThrow();
+  });
+
+  it('PLUGIN_INSTALL_REQUIRE_PIN=true enforces the pin regardless of NODE_ENV', () => {
+    process.env.NODE_ENV = 'development';
+    process.env.PLUGIN_INSTALL_REQUIRE_PIN = 'true';
+    expect(() => assertPluginInstallUrl('https://release.example.com/pkg.zip')).toThrow(/integrity pin/);
+  });
+
+  it('PLUGIN_INSTALL_REQUIRE_PIN=false lifts the requirement even in production (operator opt-out)', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.PLUGIN_INSTALL_REQUIRE_PIN = 'false';
+    expect(() => assertPluginInstallUrl('https://release.example.com/pkg.zip')).not.toThrow();
   });
 });

--- a/src/modules/plugins/plugin-download.ts
+++ b/src/modules/plugins/plugin-download.ts
@@ -66,11 +66,30 @@ export function assertPluginInstallUrl(url: string): void {
   } catch {
     return; // not a parseable URL — resolveSafeFetchTarget rejects it with the clearer error
   }
-  if (parsed.protocol !== 'http:') return; // https unaffected; other schemes are the SSRF guard's call
-  // expectedSha256FromUrl throws on a malformed marker, so an explicit-but-unusable pin fails
-  // closed here rather than silently degrading to "no pin".
-  if (expectedSha256FromUrl(url) === null) {
+  // expectedSha256FromUrl throws on a malformed marker. On http that surfaces here (fail-closed
+  // at the transport gate); on https it is left for the post-download integrity check to report,
+  // preserving that error's wording — either way an explicit-but-unusable pin never degrades to
+  // "no pin".
+  let pinned = false;
+  try {
+    pinned = expectedSha256FromUrl(url) !== null;
+  } catch (error) {
+    if (parsed.protocol === 'http:') throw error;
+  }
+  if (parsed.protocol === 'http:' && !pinned) {
     throw new Error('plain http is only accepted with a content pin: append #sha256=<64 hex> to the URL, or use https');
+  }
+  // Installing a plugin is executing third-party code on the host. HTTPS authenticates the
+  // CHANNEL, not the bytes-as-reviewed — a compromised release host or a hijacked catalog still
+  // ships whatever it likes. In production (or wherever PLUGIN_INSTALL_REQUIRE_PIN says so) an
+  // install from a URL therefore requires the pin; dev keeps the lighter default.
+  const requirePin =
+    process.env.PLUGIN_INSTALL_REQUIRE_PIN === 'true' ||
+    (process.env.PLUGIN_INSTALL_REQUIRE_PIN !== 'false' && process.env.NODE_ENV === 'production');
+  if (requirePin && !pinned) {
+    throw new Error(
+      'installing from a URL requires an integrity pin in this deployment: append #sha256=<64 hex> to the URL (PLUGIN_INSTALL_REQUIRE_PIN=false disables this)',
+    );
   }
 }
 


### PR DESCRIPTION
> Stacked on #1327 — retarget to `main` when it lands.

## Summary

- **Integrity pin required for production URL installs.** Installing a plugin is executing third-party code; HTTPS authenticates the channel, not the bytes-as-reviewed. `PLUGIN_INSTALL_REQUIRE_PIN` (production default, explicit opt-out documented in `.env.example`) makes a `#sha256=<hex>` pin mandatory on every URL install — plain `http` already required one, now in production so does `https`.
- **Plugin trust model documented in SECURITY.md.** The sandbox (worker isolate, capped heap, allowlisted env, deny-by-default network manifest, capability router) contains a buggy or runaway plugin — it is not a boundary against a malicious one. The section enumerates the install-path gates and points operators running untrusted fleets at a separate container with an OS-level sandbox.

## Tests

Five new cases pin the gate: unpinned https rejected in production, pinned accepted, lighter default outside production, `=true` enforces anywhere, `=false` lifts even in production. Malformed-marker sequencing preserved (post-download check keeps its error wording). Full lane, tsc, ESLint, prettier green.