### PR TITLE
docs: session-lifecycle invariant catalog

### DIFF
--- a/docs/31-session-lifecycle-design.md
+++ b/docs/31-session-lifecycle-design.md
@@ -1,0 +1,149 @@
+# 31 — Session Lifecycle: Invariant Catalog
+
+> **Status:** living design note. This document maps the race windows the session lifecycle
+> defends against to the code that defends them and the spec that pins each one. It is the
+> companion to `docs/03` §_Engine Lifecycle State Machine_, which describes the WHAT; this
+> describes the WHY-NOT-THE-OBVIOUS-THING. Anchors reference **spec files by name** (stable) —
+> not line numbers (they rot).
+
+The lifecycle is split across three files with one rule each:
+
+| File                                                                                | Owns                                                                   |
+| ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `session-engine-lifecycle.service.ts` (~1,100 lines)                                | Engine creation/initialization, status transitions, teardown           |
+| `session-engine-controls.ts` (~660 lines)                                           | The seven control verbs (start/stop/logout/forceKill/delete/reconnect) |
+| `session-ownership.service.ts` + `src/modules/takeover/session-takeover.service.ts` | Cross-node leases, adoption, orphan reaping                            |
+
+---
+
+## 31.1 The invariant catalog
+
+Each entry: the interleaving that would break a naive implementation → where it is defended →
+which spec pins it. **If you change one of these files, re-read the rows that cite it.**
+
+### INV-1 — Double-start cannot orphan the first engine
+
+**Interleaving:** two `POST /start` for the same session race; both pass the "not already
+starting" read; two engines come up; one is leaked forever (registry holds the second).
+**Defense:** `initializingSessions` is reserved SYNCHRONOUSLY (before any `await`) in
+`session-engine-controls.ts` — the second request observes the reservation and fails fast.
+**Pinned by:** `session.service.spec.ts` (the maxConcurrent/double-start cases, incl. the concurrent-start
+claim-holding verbs at `')() keeps the claim when a concurrent start still holds the session
+here'`).
+**The naive fix that is wrong:** checking session.status instead — status is written to the DB
+and read back with an await in between; the reservation map is the only synchronous view.
+
+### INV-2 — INITIALIZING is persisted before `initialize()`, and retirement can await that write
+
+**Interleaving:** a stop/logout lands while `initialize()` is in flight; the control sees status
+`READY` (stale) and skips teardown of an engine that is actually mid-boot.
+**Defense:** the INITIALIZING row is written and its promise tracked
+(`session-engine-lifecycle.service.ts`, `initializeEngine`); a retiring control awaits the
+pending write before deciding what it is retiring.
+**Pinned by:** `session.service.spec.ts` (the stop/delete-during-start teardown cases).
+
+### INV-3 — Ownership is re-validated by object identity, not by session id
+
+**Interleaving:** control A starts engine #1; engine #1 fails and is destroyed; control B (a
+retry) starts engine #2; a stale callback from #1 arrives and mutates registry state owned by #2.
+**Defense:** `EngineRegistry` keys by session id but validates liveness by object identity
+(`isLive` / `deleteIfLive`) — a superseded engine's late callback cannot act.
+**Pinned by:** `engine-registry.service.spec.ts` (isLive / deleteIfLive cases); the registry
+is the single most repeated invariant in the module.
+
+### INV-4 — Init timeout evicts and 504s; init rejection propagates as FAILED
+
+**Interleaving:** whatsapp-web.js calls `page.goto(..., {timeout: 0})` — a hung browser never
+rejects, so a plain `await` hangs the start forever.
+**Defense:** `Promise.race` deadline in `initializeEngine`; on timeout the engine is evicted +
+force-destroyed + status DISCONNECTED + 504 to the caller. A REAL rejection is NOT treated as a
+timeout: it propagates so `start()` records FAILED with the reason.
+**Pinned by:** `session.service.spec.ts` (start failure-path cases; the timeout/rejection
+split lives in `session.service.spec.ts`'s init-timeout describes).
+**Do not "simplify" the two paths into one** — the distinction is why a bad proxy config returns
+FAILED + reason while a wedged browser returns 504 + eviction.
+
+### INV-5 — Delete racing a start re-purges auth directories after init resolves
+
+**Interleaving:** delete runs (purges dirs, tombstones the row); the in-flight start's
+`initialize()` resolves and re-creates the auth dir; a phantom session lingers on disk.
+**Defense:** post-init resurrection guards re-check the tombstone and re-purge
+(`session-engine-controls.ts` start path, after the awaited init).
+**Pinned by:** `session.service.spec.ts` ('tears down the just-initialized engine if a
+stop/delete lands during start() — no resurrection to READY').
+
+### INV-6 — Lease loss tears down local engines only; it never writes session rows
+
+**Interleaving:** node A holds session X's lease; node B adopts it after A's lease lapses; a
+stale in-flight write from A would clobber B's status.
+**Defense:** on lease loss, `stopOrphanEngines` destroys local engines; the session row is the
+owning node's alone (`session.service.ts` boot path).
+**Pinned by:** `src/modules/takeover/session-takeover.service.spec.ts` +
+`session-ownership.service.spec.ts` + `session-ownership-status-fence.spec.ts`.
+
+### INV-7 — FAILED sessions are deliberately NOT adopted by takeover
+
+**Interleaving:** a session that failed on node A (real engine error) would be adopted by node B
+and quietly retried, hiding the failure from the operator.
+**Defense:** the adoption sweep skips FAILED rows — a human decides.
+**Pinned by:** `src/modules/takeover/session-takeover.service.spec.ts` ('skips sessions not
+worth resuming: unauthenticated, mid-pairing, or operator-flagged failed').
+
+### INV-8 — Logout teardown races nothing: the browser must be gone before dir removal
+
+**Interleaving:** `client.logout()` chains `authStrategy.logout()` → `fs.rm(userDataDir)` while
+the Chromium process still holds file handles → rm fails or races a browser re-write.
+**Defense:** the logout path force-destroys the browser first, waits, then removes the dir; the
+475-line spec enumerates the interleavings.
+**Pinned by:** `logout-teardown-race.spec.ts` — the module's most complete race corpus. Read it
+before touching anything in the logout/forceKill path.
+
+### INV-9 — The reconnect loop bounds itself: backoff with jitter, clamp ≤ 1h and ≤ setTimeout's 32-bit range, alert every 5 consecutive attempts
+
+**Defense:** `reconnect-policy.ts` — a pure decision function (5-minute stability reset, loop
+alerts) consumed by the lifecycle; the clamps exist because a naive `delay * 2^attempt` reaches
+values `setTimeout` silently truncates.
+**Pinned by:** `reconnect-policy.spec.ts`.
+
+### INV-10 — Boot auto-start is sequential, staggered (2s per Chromium), and detached from bootstrap
+
+**Why:** ten Chromium instances launching simultaneously on boot would hold the HTTP port closed
+for minutes; detaching from bootstrap means the API answers while engines warm.
+**Pinned by:** `session.service.spec.ts` (boot auto-start ordering/staggering cases).
+
+---
+
+## 31.2 Status-transition ownership
+
+Exactly one writer per transition — when debugging a status surprise, find the writer before
+anything else:
+
+| Transition                      | Sole writer                                                                                |
+| ------------------------------- | ------------------------------------------------------------------------------------------ |
+| → `INITIALIZING`                | `initializeEngine` (persisted before `initialize()`)                                       |
+| → `QR_READY` / `AUTHENTICATING` | engine callbacks (wired in the lifecycle delegate), via the registry's liveness check      |
+| → `READY`                       | `handleEngineReady` (also drops a recorded failure reason — see INV-7's rationale comment) |
+| → `DISCONNECTED`                | init-timeout eviction, graceful stop, puppeteer-death detection                            |
+| → `FAILED`                      | `start()`'s rejection path — and nothing else; reconnect loops NEVER write FAILED          |
+
+The last row is load-bearing: a reconnect loop that wrote FAILED would convert every transient
+network blip into an operator-visible terminal state, defeating INV-7's signal.
+
+## 31.3 Comments that exist because the obvious fix is wrong
+
+Collected here so they survive refactors of the code around them:
+
+- `session-engine-lifecycle.service.ts` (init deadline region): the do-not-reorder note — the
+  ownership re-validation window between the status write and `initialize()` is _narrowed, not
+  closed_; moving the re-validation after init reopens INV-2.
+- `session-engine-controls.ts` (start): `session.config` is clamped to trusted keys because the
+  row is client-writable; an unclamped spread would let a caller smuggle engine options.
+- `EngineRegistry`: identity-based `deleteIfLive` rather than `delete(id)` — see INV-3; every
+  site that bypassed this in review's history created the same phantom-callback bug.
+
+## 31.4 What this document is NOT
+
+- Not a state machine diagram (docs/03 has it).
+- Not exhaustive per-file documentation — the source comments carry the local detail; this maps
+  the SYSTEM of invariants and where each lives.
+- Not a spec: where this document and a spec disagree, the spec is right — fix this document.

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,38 +30,39 @@
 
 **Full Index (by number)**
 
-| No  | Document                                                         | Description                                         |
-| --- | ---------------------------------------------------------------- | --------------------------------------------------- |
-| 01  | [Project Overview](./01-project-overview.md)                     | Vision, goals, scope, current status                |
-| 02  | [Requirements Specification](./02-requirements-specification.md) | Functional and non-functional requirements          |
-| 03  | [System Architecture](./03-system-architecture.md)               | Architecture, modules, and runtime flows            |
-| 04  | [Security Design](./04-security-design.md)                       | Auth, rate limiting, and security controls          |
-| 05  | [Database Design](./05-database-design.md)                       | Entities and storage considerations                 |
-| 06  | [API Specification](./06-api-specification.md)                   | REST API and WebSocket protocol                     |
-| 07  | [API Collection](./07-api-collection.md)                         | Example requests and Postman import tips            |
-| 08  | [Development Guidelines](./08-development-guidelines.md)         | Coding standards and workflow                       |
-| 09  | [Testing Strategy](./09-testing-strategy.md)                     | Test types and tooling                              |
-| 10  | [DevOps & Infrastructure](./10-devops-infrastructure.md)         | Docker, deployment, and environment configuration   |
-| 11  | [Operational Runbooks](./11-operational-runbooks.md)             | Incident, maintenance, and backup runbooks          |
-| 12  | [Troubleshooting FAQ](./12-troubleshooting-faq.md)               | Common issues and fixes                             |
-| 13  | [Horizontal Scaling](./13-horizontal-scaling.md)                 | Multi-node deployment guidance                      |
-| 14  | [Migration Guide](./14-migration-guide.md)                       | Upgrade and data migration guidance                 |
-| 15  | [Project Roadmap](./15-project-roadmap.md)                       | Near-term and long-term roadmap                     |
-| 16  | [Risk Management](./16-risk-management.md)                       | Risks and mitigations                               |
-| 17  | [Dashboard Design](./17-dashboard-design.md)                     | Dashboard UX overview                               |
-| 18  | [SDK Design](./18-sdk-design.md)                                 | SDK plans and conventions                           |
-| 19  | [Plugin Architecture](./19-plugin-architecture.md)               | Extensibility concepts                              |
-| 20  | [Community Guidelines](./20-community-guidelines.md)             | Contribution and governance                         |
-| 21  | [Glossary](./21-glossary.md)                                     | Terms and definitions                               |
-| 22  | [n8n Integration](./22-n8n-integration.md)                       | n8n community nodes for OpenWA                      |
-| 23  | [Community Integrations](./23-community-integrations.md)         | Third-party adapters built on the OpenWA API        |
-| 24  | [MCP Integration](./24-mcp-integration.md)                       | Model Context Protocol tools and auth model         |
-| 25  | [Integration Fabric](./25-integration-fabric.md)                 | Inbound webhook substrate for plugin integrations   |
-| 26  | [Global Search](./26-global-search.md)                           | Cross-session message search and the provider model |
-| 27  | [Plugin Search Providers](./27-plugin-search-providers.md)       | Writing a search-provider plugin                    |
-| 28  | [Multitenancy](./28-multitenancy.md)                             | Multi-tenant target design (draft proposal)         |
-| 29  | [Engine Capability Matrix](./29-engine-capability-matrix.md)     | Per-engine capability support, gaps, and roadmap    |
-| 30  | [Plugin Sandboxing](./30-plugin-sandboxing.md)                   | Worker isolation, capabilities, and plugin limits   |
+| No  | Document                                                                 | Description                                                                        |
+| --- | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
+| 01  | [Project Overview](./01-project-overview.md)                             | Vision, goals, scope, current status                                               |
+| 02  | [Requirements Specification](./02-requirements-specification.md)         | Functional and non-functional requirements                                         |
+| 03  | [System Architecture](./03-system-architecture.md)                       | Architecture, modules, and runtime flows                                           |
+| 04  | [Security Design](./04-security-design.md)                               | Auth, rate limiting, and security controls                                         |
+| 05  | [Database Design](./05-database-design.md)                               | Entities and storage considerations                                                |
+| 06  | [API Specification](./06-api-specification.md)                           | REST API and WebSocket protocol                                                    |
+| 07  | [API Collection](./07-api-collection.md)                                 | Example requests and Postman import tips                                           |
+| 08  | [Development Guidelines](./08-development-guidelines.md)                 | Coding standards and workflow                                                      |
+| 09  | [Testing Strategy](./09-testing-strategy.md)                             | Test types and tooling                                                             |
+| 10  | [DevOps & Infrastructure](./10-devops-infrastructure.md)                 | Docker, deployment, and environment configuration                                  |
+| 11  | [Operational Runbooks](./11-operational-runbooks.md)                     | Incident, maintenance, and backup runbooks                                         |
+| 12  | [Troubleshooting FAQ](./12-troubleshooting-faq.md)                       | Common issues and fixes                                                            |
+| 13  | [Horizontal Scaling](./13-horizontal-scaling.md)                         | Multi-node deployment guidance                                                     |
+| 14  | [Migration Guide](./14-migration-guide.md)                               | Upgrade and data migration guidance                                                |
+| 15  | [Project Roadmap](./15-project-roadmap.md)                               | Near-term and long-term roadmap                                                    |
+| 16  | [Risk Management](./16-risk-management.md)                               | Risks and mitigations                                                              |
+| 17  | [Dashboard Design](./17-dashboard-design.md)                             | Dashboard UX overview                                                              |
+| 18  | [SDK Design](./18-sdk-design.md)                                         | SDK plans and conventions                                                          |
+| 19  | [Plugin Architecture](./19-plugin-architecture.md)                       | Extensibility concepts                                                             |
+| 20  | [Community Guidelines](./20-community-guidelines.md)                     | Contribution and governance                                                        |
+| 21  | [Glossary](./21-glossary.md)                                             | Terms and definitions                                                              |
+| 22  | [n8n Integration](./22-n8n-integration.md)                               | n8n community nodes for OpenWA                                                     |
+| 23  | [Community Integrations](./23-community-integrations.md)                 | Third-party adapters built on the OpenWA API                                       |
+| 24  | [MCP Integration](./24-mcp-integration.md)                               | Model Context Protocol tools and auth model                                        |
+| 25  | [Integration Fabric](./25-integration-fabric.md)                         | Inbound webhook substrate for plugin integrations                                  |
+| 26  | [Global Search](./26-global-search.md)                                   | Cross-session message search and the provider model                                |
+| 27  | [Plugin Search Providers](./27-plugin-search-providers.md)               | Writing a search-provider plugin                                                   |
+| 28  | [Multitenancy](./28-multitenancy.md)                                     | Multi-tenant target design (draft proposal)                                        |
+| 29  | [Engine Capability Matrix](./29-engine-capability-matrix.md)             | Per-engine capability support, gaps, and roadmap                                   |
+| 30  | [Plugin Sandboxing](./30-plugin-sandboxing.md)                           | Worker isolation, capabilities, and plugin limits                                  |
+| 31  | [Session Lifecycle: Invariant Catalog](./31-session-lifecycle-design.md) | The race windows the lifecycle defends, where each is defended, which spec pins it |
 
 **Examples**
 


### PR DESCRIPTION
## Summary

`docs/31-session-lifecycle-invariant-catalog.md` maps the race windows the session lifecycle defends against to the code that defends them and the spec that pins each one — ten invariants (double-start reservation, init-write ordering, identity-based registry liveness, timeout-vs-rejection, delete-vs-start resurrection, lease-loss teardown scope, FAILED-not-adopted, logout teardown ordering, reconnect clamps, boot stagger), the status-transition ownership table (one writer per transition), and the collected "the obvious fix is wrong" notes.

Anchors cite spec files by name (stable), not line numbers. Every cited spec was verified to exist; where an invariant's pin lives in a different file than intuition suggests (takeover specs live under `src/modules/takeover/`, the controls invariants under `session.service.spec.ts`), the catalog names the real file. Where this document and a spec disagree, the spec wins — stated in the doc.

This is the bus-factor investment: the ~2,700 lines of interleaved race reasoning currently live in scattered comments and one head.