### PR TITLE
fix(security): enforce the webhook secret floor on update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- `PUT /sessions/{sessionId}/webhooks/{id}` now enforces the same 16-character webhook-secret floor as create; an empty string still clears signing.
+
 ## [0.20.0] - 2026-08-16
 
 ### Fixed

--- a/src/modules/webhook/dto/webhook-secret-entropy.spec.ts
+++ b/src/modules/webhook/dto/webhook-secret-entropy.spec.ts
@@ -1,5 +1,5 @@
 import { validate } from 'class-validator';
-import { CreateWebhookDto } from './webhook.dto';
+import { CreateWebhookDto, UpdateWebhookDto } from './webhook.dto';
 
 /**
  * The HMAC secret signs every delivery this webhook fires. A short secret is recoverable
@@ -33,5 +33,38 @@ describe('CreateWebhookDto secret entropy', () => {
     function errorsOf(errs: { property: string }[]): number {
       return errs.filter(e => e.property === 'secret').length;
     }
+  });
+});
+
+describe('UpdateWebhookDto secret entropy', () => {
+  const dtoWithSecret = (secret: unknown) => {
+    const dto = new UpdateWebhookDto();
+    dto.secret = secret as string | undefined;
+    return dto;
+  };
+
+  it('rejects rotating to a secret shorter than 16 characters', async () => {
+    const errors = await validate(dtoWithSecret('short'));
+    expect(errors.some(e => e.property === 'secret')).toBe(true);
+  });
+
+  it('accepts rotating to a 16+ character secret', async () => {
+    const errors = await validate(dtoWithSecret('a-fully-entropic-secret'));
+    expect(errors.some(e => e.property === 'secret')).toBe(false);
+  });
+
+  it('still accepts an empty string, which this route treats as clearing the secret', async () => {
+    const errors = await validate(dtoWithSecret(''));
+    expect(errors.some(e => e.property === 'secret')).toBe(false);
+  });
+
+  it('still allows leaving the secret out of the patch entirely', async () => {
+    const errors = await validate(new UpdateWebhookDto());
+    expect(errors.some(e => e.property === 'secret')).toBe(false);
+  });
+
+  it('still rejects a non-string value', async () => {
+    const errors = await validate(dtoWithSecret(42));
+    expect(errors.some(e => e.property === 'secret')).toBe(true);
   });
 });

--- a/src/modules/webhook/dto/webhook.dto.ts
+++ b/src/modules/webhook/dto/webhook.dto.ts
@@ -12,6 +12,7 @@ import {
   MaxLength,
   Min,
   MinLength,
+  ValidateIf,
 } from 'class-validator';
 import { Expose, plainToInstance } from 'class-transformer';
 import { Webhook } from '../entities/webhook.entity';
@@ -192,6 +193,11 @@ export class UpdateWebhookDto {
   @ApiPropertyOptional({ description: 'Secret key for HMAC signature' })
   @IsOptional()
   @IsString()
+  // Same floor as create: a short secret is brute-forcible from one observed signature. The
+  // floor is skipped only for the empty string, which this route treats as "clear the secret"
+  // (the service stores null for it); a non-string value is still rejected by @IsString.
+  @ValidateIf((o: UpdateWebhookDto) => o.secret !== '')
+  @MinLength(16)
   @MaxLength(255)
   secret?: string;
 


### PR DESCRIPTION
## What

`CreateWebhookDto` rejects a secret shorter than 16 characters; `UpdateWebhookDto` capped it at 255 but accepted anything below, so a webhook created under the floor could be rotated to a brute-forcible key through `PUT /sessions/{sessionId}/webhooks/{id}`.

Update now runs the same `@MinLength(16)`, skipped only for the empty string, which this route defines as clearing the secret (the service stores null for it). Everything else behaves exactly as before:

- absent and null stay valid via `@IsOptional`
- a non-string value is still rejected by `@IsString` (the `@ValidateIf` condition is `o.secret !== ''`, not a length test, precisely so type validation is not bypassed)
- the OpenAPI schema is untouched, matching create, which declares the floor only as runtime validation

Webhooks already holding a short secret are unaffected: validation only sees fields present in the request, responses never return the secret, and the delivery path does not re-validate the stored key.

## Tests

`webhook-secret-entropy.spec.ts` now covers the update DTO directly: a short rotation is rejected, 16+ is accepted, the empty string still clears, an absent field stays valid, and a non-string value is still rejected. The webhooks e2e suite passes end to end (21 tests), including both PUT flows.
