### PR TITLE
docs: state the plugin sandbox memory-kind boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- docs/30 states the plugin sandbox's memory-kind boundary: the worker heap cap does not cover Buffer/native allocations, which grow host RSS up to the container limit.
 - `message.received` / `message.sent` WebSocket events shed inline media over `WEBHOOK_MEDIA_INLINE_MAX_BYTES` with the same omitted marker as webhooks; a large blob was broadcast in full to every subscribed socket (and across Redis pub/sub in multi-node).
 - The chat-media orphan sweep's `mediaPath IN (...)` lookup is served by a new partial index (`WHERE mediaPath IS NOT NULL`); it was a full messages-table scan per chunk.
 - `GET /api/health` audits a presented-but-invalid API key (`API_KEY_AUTH_FAILED`) like every other key-validation surface, rate-bounded per IP; probing through the unthrottled health route was invisible to the audit log.

--- a/docs/30-plugin-sandboxing.md
+++ b/docs/30-plugin-sandboxing.md
@@ -48,6 +48,11 @@ from disk is untrusted and sandboxed.
   runaway **hook** handler (e.g. an infinite synchronous loop) is skipped on the hook timeout so it can't
   stall the host's hook chain, but the worker keeps running it (pegging a core) until the plugin is
   reloaded or hits the heap cap — it is contained to its own thread, not instantly force-killed.
+- **Memory-kind boundary.** The heap cap bounds the V8 heap only. `Buffer`/`ArrayBuffer` allocations
+  are native memory outside `maxOldGenerationSizeMb`, and worker threads share the host's address
+  space, so a plugin that accumulates Buffers grows host RSS until the container's memory limit
+  (the bundled compose `mem_limit`, default 2g) kills the whole container, not just the worker.
+  Buffer-heavy plugin workloads need that outer limit sized deliberately.
 
 ## What the sandbox does NOT guarantee
 
@@ -108,10 +113,10 @@ Built-in plugins were unaffected and still run in-process.
 
 ## Configuration
 
-| Constant                                                   | Value   | Purpose                                                 |
-| ---------------------------------------------------------- | ------- | ------------------------------------------------------- |
-| `SANDBOX_MAX_OLD_GEN_MB` (worker `maxOldGenerationSizeMb`) | 256     | per-plugin heap cap; OOM kills the worker, not the host |
-| `SANDBOX_HOOK_TIMEOUT_MS`                                  | 5000 ms | budget before a sandboxed hook handler is skipped       |
+| Constant                                                   | Value   | Purpose                                                                                                                                    |
+| ---------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `SANDBOX_MAX_OLD_GEN_MB` (worker `maxOldGenerationSizeMb`) | 256     | per-plugin V8-heap cap; a heap OOM kills the worker, not the host (native/Buffer memory is outside it, see the memory-kind boundary above) |
+| `SANDBOX_HOOK_TIMEOUT_MS`                                  | 5000 ms | budget before a sandboxed hook handler is skipped                                                                                          |
 
 Both are hardcoded constants in the plugin loader — **neither is an environment variable**, so
 changing either requires a code change.


### PR DESCRIPTION
## What changed

docs/30's "What the sandbox guarantees" section claimed unqualified that "an OOM terminates the worker, not the host". That holds for the V8 heap only: `maxOldGenerationSizeMb` (256 MB) does not bound `Buffer`/`ArrayBuffer` allocations, which are native memory, and worker threads share the host's address space. A plugin that accumulates Buffers grows host RSS until the container's memory limit (the bundled compose `mem_limit`, default 2g) kills the whole container.

The section now carries an explicit memory-kind boundary bullet, and the constant table's row for the heap cap states the same scope instead of the unqualified claim.

Docs lane green; Prettier clean.