### PR TITLE
docs: document the wildcard-instance config residue in the fabric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- docs/25 documents the known wildcard-instance config residue: per-instance isolation covers ingress dispatch only; wildcard/null siblings still merge into the plugin base config.
 - `message.received` / `message.sent` WebSocket events shed inline media over `WEBHOOK_MEDIA_INLINE_MAX_BYTES` with the same omitted marker as webhooks; a large blob was broadcast in full to every subscribed socket (and across Redis pub/sub in multi-node).
 - The chat-media orphan sweep's `mediaPath IN (...)` lookup is served by a new partial index (`WHERE mediaPath IS NOT NULL`); it was a full messages-table scan per chunk.
 - `GET /api/health` audits a presented-but-invalid API key (`API_KEY_AUTH_FAILED`) like every other key-validation surface, rate-bounded per IP; probing through the unthrottled health route was invisible to the audit log.

--- a/docs/25-integration-fabric.md
+++ b/docs/25-integration-fabric.md
@@ -111,6 +111,12 @@ Alongside this async pipeline, a route may additionally declare a `response` con
   many instances (for example, one external account per WhatsApp number). Each instance owns a host-minted
   ingress secret, a resolved session scope, and a config slice. It is a serializable field threaded
   through payloads and rows — **not** a separate worker; there is still one worker per plugin.
+  _Known residue:_ per-instance isolation covers the **ingress dispatch** path (concrete-scoped
+  instances resolve their own config slice). A `wildcard`/`null`-scoped sibling is still projected
+  into the plugin's **base** config with last-write-wins merging, so a sparse wildcard instance
+  inherits keys a sibling projected, and hook dispatch resolves config without per-instance
+  scoping. Run one enabled wildcard instance per plugin, or scope instances concretely, until the
+  projection is re-keyed per instance.
 - **`conversation.send` capability** — a normalized outbound send authored by the plugin and translated
   host-side to the message service, so persistence and the message hook chain are preserved. It is gated
   by a `conversation:send` permission and the instance's session scope.


### PR DESCRIPTION
## What changed

docs/25's plugin-instance bullet presents the per-instance config slice as a first-class property without qualification. Isolation currently covers the ingress dispatch path only: a `wildcard`/`null`-scoped sibling instance is projected into the plugin's base config with last-write-wins merging, so a sparse wildcard instance inherits keys another instance projected, and hook dispatch resolves config without per-instance scoping (the projection is not re-keyed per instance yet).

The bullet now carries a *known residue* note stating the boundary and the operator guidance (scope instances concretely, or run one enabled wildcard instance per plugin) until the re-keying lands.

Docs lane green; Prettier clean.