### PR TITLE
docs: state the audit log's real scope and fix its wire example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- docs/06 scopes the audit log honestly: message/webhook actions are never emitted (their tables own that data), the request-actor columns are documented as null, and the OpenAPI example uses a real snake_case action.
 - docs/30 states the plugin sandbox's memory-kind boundary: the worker heap cap does not cover Buffer/native allocations, which grow host RSS up to the container limit.
 - docs/25 documents the known wildcard-instance config residue: per-instance isolation covers ingress dispatch only; wildcard/null siblings still merge into the plugin base config.
 - docs/14's Known Upgrade Hazards table covers every breaking change since 0.12.0 (15 missing rows across 0.14-0.20, including both v0.20.0 config opt-outs); the Redis switch steps now name the real queues.

--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -5041,20 +5041,20 @@ Notes: raw return of an in-memory `Settings` object built once in the controller
 
 #### GET /api/audit
 
-List audit-log entries, newest first. Every API-key lifecycle change, session/message/webhook event and ADMIN infra operation lands here.
+List audit-log entries, newest first. API-key lifecycle changes, session lifecycle events and ADMIN infra operations land here. **Message and webhook events deliberately do not**: message sends and webhook deliveries are tracked in their own tables (`messages`, `webhook_delivery_failures`), so filtering for `message_sent`, `message_failed`, `webhook_created`, `webhook_deleted`, `webhook_triggered` or `webhook_failed` returns zero rows by design.
 
 **Auth:** API key (ADMIN) · **Scope:** rows are confined to the calling key's `allowedSessions` — the `sessionId` query may only narrow within that list, never widen it
 
 **Query parameters**
 
-| Name        | Type                          | Required | Default | Description                                                                                                                   |
-| ----------- | ----------------------------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `action`    | string                        | No       | —       | Filter by `AuditAction` (e.g. `api_key_created`, `session_started`, `message_sent`, `webhook_failed`, `infra_data_imported`). |
-| `severity`  | `'info' \| 'warn' \| 'error'` | No       | —       | Filter by `AuditSeverity`.                                                                                                    |
-| `sessionId` | string                        | No       | —       | Narrow to one session. A value outside the key's `allowedSessions` returns `{ "data": [], "total": 0 }`.                      |
-| `apiKeyId`  | string                        | No       | —       | Filter by the acting key's id.                                                                                                |
-| `limit`     | integer                       | No       | `50`    | Page size, clamped to a maximum of `200`.                                                                                     |
-| `offset`    | integer                       | No       | `0`     | Rows to skip; a negative value resolves to `0`.                                                                               |
+| Name        | Type                          | Required | Default | Description                                                                                                                                        |
+| ----------- | ----------------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `action`    | string                        | No       | —       | Filter by `AuditAction` (e.g. `api_key_created`, `session_started`, `infra_data_imported`). Message/webhook actions are never emitted (see above). |
+| `severity`  | `'info' \| 'warn' \| 'error'` | No       | —       | Filter by `AuditSeverity`.                                                                                                                         |
+| `sessionId` | string                        | No       | —       | Narrow to one session. A value outside the key's `allowedSessions` returns `{ "data": [], "total": 0 }`.                                           |
+| `apiKeyId`  | string                        | No       | —       | Filter by the acting key's id.                                                                                                                     |
+| `limit`     | integer                       | No       | `50`    | Page size, clamped to a maximum of `200`.                                                                                                          |
+| `offset`    | integer                       | No       | `0`     | Rows to skip; a negative value resolves to `0`.                                                                                                    |
 
 **Response** `200`
 
@@ -5070,10 +5070,10 @@ List audit-log entries, newest first. Every API-key lifecycle change, session/me
       "sessionId": "9f1c…",
       "sessionName": "support-line",
       "ipAddress": "203.0.113.7",
-      "userAgent": "curl/8.4.0",
-      "method": "POST",
-      "path": "/api/sessions/9f1c…/start",
-      "statusCode": 200,
+      "userAgent": null,
+      "method": null,
+      "path": null,
+      "statusCode": null,
       "metadata": null,
       "errorMessage": null,
       "createdAt": "2026-06-25T11:42:07.000Z"
@@ -5083,7 +5083,7 @@ List audit-log entries, newest first. Every API-key lifecycle change, session/me
 }
 ```
 
-Unlike the other list routes this one is **not** a bare array: `data` is the page and `total` the unpaginated match count. Nullable columns (`apiKeyId`, `sessionId`, `metadata`, `errorMessage`, …) are `null` when the event has no such dimension.
+Unlike the other list routes this one is **not** a bare array: `data` is the page and `total` the unpaginated match count. Nullable columns (`apiKeyId`, `sessionId`, `metadata`, `errorMessage`, …) are `null` when the event has no such dimension. `userAgent`, `method`, `path` and `statusCode` are reserved columns: the request-actor context does not populate them today, so rows carry `null` (the sample above shows a `session_started` row as it is actually written).
 
 **Errors:** `401` missing/invalid API key · `403` key role below ADMIN
 

--- a/openapi.json
+++ b/openapi.json
@@ -9566,7 +9566,7 @@
           "action": {
             "type": "string",
             "description": "What happened.",
-            "example": "session.create"
+            "example": "session_started"
           },
           "severity": {
             "type": "string",

--- a/src/modules/audit/dto/audit-response.dto.ts
+++ b/src/modules/audit/dto/audit-response.dto.ts
@@ -9,7 +9,7 @@ import { ApiProperty } from '@nestjs/swagger';
 export class AuditLogDto {
   @ApiProperty({ example: '4f1c9b2a-8d3e-4c5b-9a17-2e6f0b4d8c31' }) id!: string;
 
-  @ApiProperty({ description: 'What happened.', example: 'session.create' })
+  @ApiProperty({ description: 'What happened.', example: 'session_started' })
   action!: string;
 
   @ApiProperty({ enum: ['info', 'warn', 'error'], example: 'info' })


### PR DESCRIPTION
## What changed

Three honesty fixes on the `GET /api/audit` surface, each verified against the emitters and `intentionally-unemitted-actions.ts`:

1. **Scope**: the route description promised "every session/message/webhook event" lands in the audit log. Six message/webhook actions (`message_sent`, `message_failed`, `webhook_created`, `webhook_deleted`, `webhook_triggered`, `webhook_failed`) are deliberately never emitted: message sends and webhook deliveries are tracked in their own tables. The prose now says so, and the filter examples no longer suggest actions that can never match.
2. **Sample row**: showed `userAgent`, `method`, `path`, `statusCode` populated for a `session_started` event, but the emitter writes only `sessionId`/`sessionName` and the request-actor context does not populate those columns. The sample now shows the row as it is actually written, with a prose note that the four columns are reserved.
3. **Wire example**: the OpenAPI `action` example was the dot-case `session.create`, which no emitter produces; it is now `session_started`, with `openapi.json` re-exported (single-line diff).

## Verification

`openapi:check` green against the re-exported snapshot; docs lane green (23 suites); audit module specs green; full unit suite green; `tsc --noEmit`, ESLint, Prettier clean.