### PR TITLE
fix(dashboard): re-register the WS message handler after a manual reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The dashboard's manual WebSocket retry re-registers the message handler on the fresh socket; the handler effect only re-ran on events changes, so a reconnect left the new socket silent while reporting connected.
 - docs/06 documents every route-specific status code the contract declares (409/413/415/422/429/501/502/503; 153 missing code mentions across ~90 sections), corrects the catalog routes to Baileys-implements, the profile refusals to 403, scope violations to 401, and the phantom channel 422; a spec now derives the required codes from openapi.json.
 - docs/06 scopes the audit log honestly: message/webhook actions are never emitted (their tables own that data), the request-actor columns are documented as null, and the OpenAPI example uses a real snake_case action.
 - docs/30 states the plugin sandbox's memory-kind boundary: the worker heap cap does not cover Buffer/native allocations, which grow host RSS up to the container limit.

--- a/dashboard/src/hooks/useWebSocket.ts
+++ b/dashboard/src/hooks/useWebSocket.ts
@@ -152,6 +152,11 @@ export function useWebSocket(events: WebSocketEvents = {}) {
   // `reconnect_failed` never fires). Lets the UI show a "connection lost" indicator + a manual
   // retry instead of silently going stale.
   const [connectionFailed, setConnectionFailed] = useState(false);
+  // Bumped every time connect() creates a NEW socket instance. The envelope-handler effect below
+  // captures socketRef.current when it runs; without this epoch in its deps, a manual reconnect()
+  // (which swaps in a fresh socket) leaves the new socket with NO 'message' listener while
+  // isConnected still reports true - realtime events stop arriving with no signal anywhere.
+  const [socketEpoch, setSocketEpoch] = useState(0);
 
   const connect = useCallback(() => {
     if (socketRef.current?.connected) return;
@@ -164,6 +169,7 @@ export function useWebSocket(events: WebSocketEvents = {}) {
       return;
     }
 
+    setSocketEpoch(epoch => epoch + 1);
     socketRef.current = io(`${SOCKET_URL}/events`, {
       autoConnect: true,
       reconnection: true,
@@ -355,7 +361,9 @@ export function useWebSocket(events: WebSocketEvents = {}) {
     return () => {
       socket.off('message', handleIncomingMessage);
     };
-  }, [events]);
+    // socketEpoch re-runs this effect for the socket a manual reconnect() swapped in; the cleanup
+    // above detaches the handler from the dead instance first.
+  }, [events, socketEpoch]);
 
   return { isConnected, connectionFailed, reconnect, subscribe, unsubscribe };
 }


### PR DESCRIPTION
## What changed

`useWebSocket`'s envelope-handler effect captured `socketRef.current` once and listed only `[events]` as its dependency. `reconnect()` (the manual retry button after the socket permanently gave up) disconnects the dead socket, nulls the ref, and `connect()` creates a **fresh** Socket.IO instance: the effect never re-ran, so the new socket had no `message` listener while `isConnected` reported true. Realtime events silently stopped arriving after a manual retry.

The bug is masked today because `useChatMessages` returns a fresh events object every render (the `wsEvents` memo recomputes constantly, contradicting its own comment), forcing the effect to re-run. Any consumer that honours the documented memoisation, or any new consumer with a stable events object, loses realtime updates on the first manual retry.

The fix tracks a `socketEpoch` bumped whenever `connect()` creates a new socket, included in the effect deps: the cleanup detaches the handler from the dead instance, the new one registers. Socket.IO's own auto-reconnect reuses the same Socket instance, so only the manual path was affected.

## Verification

Dashboard gates green: `tsc --noEmit`, ESLint, production build, unit suite (325 tests). The dashboard test harness is pure-function `node:test` (no React rendering), so the hook wiring is covered by the surgical-deps design and the type checker rather than a render test.