### PR TITLE
fix(dashboard): apply the Chats dark palette to the system theme too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The Chats page honours the system dark theme: four dark-palette rules (outgoing bubble, document media, quote box, action menus) only matched an explicit data-theme and left the default 'system' theme rendering light popups inside a dark thread.
 - docs/06 documents every route-specific status code the contract declares (409/413/415/422/429/501/502/503; 153 missing code mentions across ~90 sections), corrects the catalog routes to Baileys-implements, the profile refusals to 403, scope violations to 401, and the phantom channel 422; a spec now derives the required codes from openapi.json.
 - docs/06 scopes the audit log honestly: message/webhook actions are never emitted (their tables own that data), the request-actor columns are documented as null, and the OpenAPI example uses a real snake_case action.
 - docs/30 states the plugin sandbox's memory-kind boundary: the worker heap cap does not cover Buffer/native allocations, which grow host RSS up to the container limit.

--- a/dashboard/src/pages/Chats.css
+++ b/dashboard/src/pages/Chats.css
@@ -541,6 +541,16 @@
   color: #e9edef;
 }
 
+/* System-dark twin: the default 'system' theme removes data-theme entirely, so the explicit rule
+   above never matches on a dark OS. :not([data-theme='light']) keeps an explicit light choice in
+   control (same pattern as Webhooks.css). */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) .chats-page .message-bubble.outgoing {
+    background: #005c4b;
+    color: #e9edef;
+  }
+}
+
 .chats-page .message-text {
   word-break: break-word;
   white-space: pre-wrap;
@@ -959,6 +969,13 @@
   border-color: #2f3b43;
 }
 
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) .chats-page .chat-document-media {
+    background: #202c33;
+    border-color: #2f3b43;
+  }
+}
+
 .chats-page .message-bubble.media-type {
   padding: 0.5rem;
 }
@@ -1127,6 +1144,12 @@
   background: rgba(255, 255, 255, 0.08);
 }
 
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) .chats-page .message-quote-box {
+    background: rgba(255, 255, 255, 0.08);
+  }
+}
+
 .chats-page .quote-body {
   white-space: nowrap;
   overflow: hidden;
@@ -1198,6 +1221,15 @@
 [data-theme='dark'] .chats-page .message-reactions-badge {
   background: #202c33;
   border-color: #2f3b43;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) .chats-page .message-actions-menu,
+  :root:not([data-theme='light']) .chats-page .reaction-quick-popover,
+  :root:not([data-theme='light']) .chats-page .message-reactions-badge {
+    background: #202c33;
+    border-color: #2f3b43;
+  }
 }
 
 /* Inline code inside a message body. */


### PR DESCRIPTION
## What changed

Four dark-palette rules in `Chats.css` matched only `[data-theme='dark']`:

- the outgoing message bubble (`#005c4b` WhatsApp dark green),
- the document-media chip,
- the message quote box,
- the message-actions menu / reaction popover / reactions badge (`#202c33`).

The default **system** theme removes `data-theme` entirely (`useTheme` clears the attribute), so on a dark OS the global tokens go dark (App.css carries `@media (prefers-color-scheme: dark)` twins) while these four surfaces stayed light: a light-green outgoing bubble inside a dark thread, light popups over dark messages.

Each rule now carries a system-dark twin using the repo's established `:root:not([data-theme='light'])` pattern (Webhooks.css): a dark OS applies the palette unless the user explicitly chose light.

## Verification

Dashboard build green; Prettier clean; no light-mode rule touched (each twin lives inside its own `prefers-color-scheme: dark` block).