### PR TITLE
fix(engine): answer 404, not an opaque 500, when a wwjs group write gets a non-group id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Nine whatsapp-web.js group routes answer `404` (`GroupNotFoundError`) when the id is not a group or is unknown, like the guarded settings writes; they previously threw a bare error that surfaced as an opaque `500`.
 - docs/06 repair pass over the Errors lines: the ingress `401` is the signature failure (not an API-key error), label writes have no `404`, the catalog product lookup answers `200` empty (not `404`), search's `501` names the no-provider case, multi-line Errors blocks were re-joined (no severed sentences, duplicate codes, or `· ·` separators), and the gate now reads wrapped blocks.
 - docs/14 corrects four hazard-table release labels (instance-config is 0.18.0, the reload `409` is 0.15.0, the group-summary retypes are 0.14.6, Baileys 5xx is 0.14.5), docs/03 drops a duplicated `health/`, and docs/10's scaling note matches docs/13's "still deploy replicas: 1" stance.
 - docs/06's audit section scopes the always-null columns correctly (`userAgent`/`statusCode` always null; `method`/`path` populated on auth-failure, key-lifecycle and queue-board rows), the Chats quote box renders identically under system-dark and explicit dark, and the Logs empty state gives server-filter guidance when only the severity filter is active (13 locales).

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -5591,6 +5591,24 @@ describe('WhatsAppWebJsAdapter group join + settings + own profile', () => {
       );
     });
 
+    // The nine write routes that previously threw a bare Error('Chat is not a group') for a
+    // non-group id (surfacing as an opaque 500) now share this guard: unknown id, 1:1 id and
+    // status id are all GroupNotFoundError (404), like the guarded settings writes above.
+    it.each([
+      ['addParticipants', (a: WhatsAppWebJsAdapter) => a.addParticipants('628111@c.us', ['628222@c.us'])],
+      ['removeParticipants', (a: WhatsAppWebJsAdapter) => a.removeParticipants('628111@c.us', ['628222@c.us'])],
+      ['promoteParticipants', (a: WhatsAppWebJsAdapter) => a.promoteParticipants('628111@c.us', ['628222@c.us'])],
+      ['demoteParticipants', (a: WhatsAppWebJsAdapter) => a.demoteParticipants('628111@c.us', ['628222@c.us'])],
+      ['leaveGroup', (a: WhatsAppWebJsAdapter) => a.leaveGroup('628111@c.us')],
+      ['setGroupSubject', (a: WhatsAppWebJsAdapter) => a.setGroupSubject('628111@c.us', 'New subject')],
+      ['setGroupDescription', (a: WhatsAppWebJsAdapter) => a.setGroupDescription('628111@c.us', 'New description')],
+      ['getGroupInviteCode', (a: WhatsAppWebJsAdapter) => a.getGroupInviteCode('628111@c.us')],
+      ['revokeGroupInviteCode', (a: WhatsAppWebJsAdapter) => a.revokeGroupInviteCode('628111@c.us')],
+    ])('%s answers 404 (GroupNotFoundError) when the id is not a group', async (_name, call) => {
+      const getChatById = jest.fn().mockResolvedValue({ isGroup: false });
+      await expect(call(readyAdapter({ getChatById }))).rejects.toBeInstanceOf(GroupNotFoundError);
+    });
+
     it.each([
       ['setGroupMessagesAdminsOnly', 'setMessagesAdminsOnly'],
       ['setGroupInfoAdminsOnly', 'setInfoAdminsOnly'],

--- a/src/engine/adapters/wwebjs-groups.ts
+++ b/src/engine/adapters/wwebjs-groups.ts
@@ -185,13 +185,9 @@ export class WwebjsGroups {
   }
 
   async addParticipants(groupId: string, participants: string[]): Promise<ParticipantOperationResult[]> {
-    this.host.ensureReady();
-    const chat = await this.client().getChatById(groupId);
-    if (!chat.isGroup) {
-      throw new Error('Chat is not a group');
-    }
+    const chat = await this.requireGroupChat(groupId);
     const participantIds = participants.map(toParticipantWid);
-    const raw = await (chat as unknown as GroupChat).addParticipants(participantIds);
+    const raw = await chat.addParticipants(participantIds);
     // whatsapp-web.js reports a batch-level refusal (no admin rights, empty group) by RESOLVING a
     // plain reason string (GroupChat.js:106-107,128-130) instead of throwing — surface it as a
     // refusal, not a success.
@@ -248,13 +244,9 @@ export class WwebjsGroups {
     groupId: string,
     participants: string[],
   ): Promise<ParticipantOperationResult[]> {
-    this.host.ensureReady();
-    const chat = await this.client().getChatById(groupId);
-    if (!chat.isGroup) {
-      throw new Error('Chat is not a group');
-    }
+    const chat = await this.requireGroupChat(groupId);
     const participantIds = participants.map(toParticipantWid);
-    const res = await this.runParticipantBatch(op, groupId, chat as unknown as GroupChat, participantIds);
+    const res = await this.runParticipantBatch(op, groupId, chat, participantIds);
     if (res?.status !== 200) {
       throw new EngineRefusedError(`${op} refused for group ${groupId} (status ${res?.status ?? 'unknown'})`);
     }
@@ -319,51 +311,35 @@ export class WwebjsGroups {
   }
 
   async leaveGroup(groupId: string): Promise<void> {
-    this.host.ensureReady();
-    const chat = await this.client().getChatById(groupId);
-    if (!chat.isGroup) {
-      throw new Error('Chat is not a group');
-    }
-    await (chat as unknown as GroupChat).leave();
+    const chat = await this.requireGroupChat(groupId);
+    await chat.leave();
   }
 
   async setGroupSubject(groupId: string, subject: string): Promise<void> {
-    this.host.ensureReady();
-    const chat = await this.client().getChatById(groupId);
-    if (!chat.isGroup) {
-      throw new Error('Chat is not a group');
-    }
+    const chat = await this.requireGroupChat(groupId);
     // GroupChat.setSubject resolves false when WA Web rejects the change (e.g. the account lacks
     // admin rights; index.d.ts:1982) instead of throwing — surface the refusal, not a false success.
-    const ok = await (chat as unknown as GroupChat).setSubject(subject);
+    const ok = await chat.setSubject(subject);
     if (!ok) {
       throw new EngineRefusedError(`Failed to set the subject for group ${groupId} — admin rights required`);
     }
   }
 
   async setGroupDescription(groupId: string, description: string): Promise<void> {
-    this.host.ensureReady();
-    const chat = await this.client().getChatById(groupId);
-    if (!chat.isGroup) {
-      throw new Error('Chat is not a group');
-    }
+    const chat = await this.requireGroupChat(groupId);
     // Same discarded-boolean contract as setSubject (index.d.ts:1984).
-    const ok = await (chat as unknown as GroupChat).setDescription(description);
+    const ok = await chat.setDescription(description);
     if (!ok) {
       throw new EngineRefusedError(`Failed to set the description for group ${groupId} — admin rights required`);
     }
   }
 
   async getGroupInviteCode(groupId: string): Promise<string> {
-    this.host.ensureReady();
-    const chat = await this.client().getChatById(groupId);
-    if (!chat.isGroup) {
-      throw new Error(`${groupId} is not a group`);
-    }
+    const chat = await this.requireGroupChat(groupId);
     // Typed Promise<string>, but WA Web yields nothing when the account is not an admin of the
     // group — and String(undefined) is the literal 'undefined', which the caller renders as the
     // link "https://chat.whatsapp.com/undefined". Same refusal contract as setDescription.
-    const inviteCode = await (chat as unknown as GroupChat).getInviteCode();
+    const inviteCode = await chat.getInviteCode();
     if (!inviteCode) {
       throw new EngineRefusedError(`Failed to get the invite code for group ${groupId} — admin rights required`);
     }
@@ -372,12 +348,8 @@ export class WwebjsGroups {
   }
 
   async revokeGroupInviteCode(groupId: string): Promise<string> {
-    this.host.ensureReady();
-    const chat = await this.client().getChatById(groupId);
-    if (!chat.isGroup) {
-      throw new Error(`${groupId} is not a group`);
-    }
-    const newCode = await (chat as unknown as GroupChat).revokeInvite();
+    const chat = await this.requireGroupChat(groupId);
+    const newCode = await chat.revokeInvite();
     if (!newCode) {
       throw new EngineRefusedError(`Failed to revoke the invite code for group ${groupId} — admin rights required`);
     }


### PR DESCRIPTION
## What changed

Seven call sites in `wwebjs-groups.ts` resolved the chat with a bare `getChatById` + `throw new Error('Chat is not a group')`. whatsapp-web.js **resolves `undefined`** for an unknown id (it does not throw), so `chat.isGroup` was a TypeError for unknown ids and a bare error for 1:1 ids - and with no global exception filter, nine controller routes (`addParticipants`, `removeParticipants`, `promoteParticipants`, `demoteParticipants`, `leaveGroup`, `setGroupSubject`, `setGroupDescription`, `getGroupInviteCode`, `revokeGroupInviteCode`) answered an opaque `500` while their sibling settings writes answered the documented `404`.

All seven sites now route through the existing `requireGroupChat` guard (`GroupNotFoundError` extends `NotFoundException` -> 404), which collapses unknown-id, 1:1-id and status-id into the same client-facing outcome and removes the now-redundant `chat as unknown as GroupChat` casts.

## Verification

Nine new spec cases pin the `GroupNotFoundError` for every affected route with a non-group id (matching the existing guarded-write specs' shape). Full unit suite green (5,706 tests); `tsc --noEmit`, ESLint, Prettier clean.