### PR TITLE
fix(engine): refuse non-person ids on block/unblock instead of a false 200 or opaque 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- block/unblock refuse ids that do not name a person (400, both engines): whatsapp-web.js silently returned false for a group id (answered 200 "blocked" with nothing blocked) and Baileys surfaced an opaque 500 for an unresolvable jid.
 - docs/06 repair pass over the Errors lines: the ingress `401` is the signature failure (not an API-key error), label writes have no `404`, the catalog product lookup answers `200` empty (not `404`), search's `501` names the no-provider case, multi-line Errors blocks were re-joined (no severed sentences, duplicate codes, or `· ·` separators), and the gate now reads wrapped blocks.
 - docs/14 corrects four hazard-table release labels (instance-config is 0.18.0, the reload `409` is 0.15.0, the group-summary retypes are 0.14.6, Baileys 5xx is 0.14.5), docs/03 drops a duplicated `health/`, and docs/10's scaling note matches docs/13's "still deploy replicas: 1" stance.
 - docs/06's audit section scopes the always-null columns correctly (`userAgent`/`statusCode` always null; `method`/`path` populated on auth-failure, key-lifecycle and queue-board rows), the Chats quote box renders identically under system-dark and explicit dark, and the Logs empty state gives server-filter guidance when only the severity filter is active (13 locales).

--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -2442,7 +2442,7 @@ This route is annotated `@HttpCode(200)`, so it returns `200` rather than the PO
 { "success": true, "message": "Contact blocked" }
 ```
 
-**Errors:** `400` session is not started · `401` missing/invalid API key · `403` key role below OPERATOR · `409` conflict or engine not ready (retryable) · `503` session not ready or dependency unavailable (retryable)
+**Errors:** `400` session is not started, or the id is not a phone-based contact id (group/newsletter/lid/free text are refused on both engines) · `401` missing/invalid API key · `403` key role below OPERATOR · `409` conflict or engine not ready (retryable) · `503` session not ready or dependency unavailable (retryable)
 
 #### DELETE /api/sessions/:sessionId/contacts/:contactId/block
 
@@ -2467,7 +2467,7 @@ No `@HttpCode` override is present, so this DELETE returns the NestJS default `2
 { "success": true, "message": "Contact unblocked" }
 ```
 
-**Errors:** `400` session is not started · `401` missing/invalid API key · `403` key role below OPERATOR · `409` conflict or engine not ready (retryable) · `503` session not ready or dependency unavailable (retryable)
+**Errors:** `400` session is not started, or the id is not a phone-based contact id (group/newsletter/lid/free text are refused on both engines) · `401` missing/invalid API key · `403` key role below OPERATOR · `409` conflict or engine not ready (retryable) · `503` session not ready or dependency unavailable (retryable)
 
 ### 6.4.4 Groups
 

--- a/src/modules/contact/contact.service.spec.ts
+++ b/src/modules/contact/contact.service.spec.ts
@@ -107,6 +107,37 @@ describe('ContactService', () => {
     expect(Date.now() - started).toBeLessThan(12_000);
   }, 15_000);
 
+  describe('block/unblock reject ids that do not name a person', () => {
+    // whatsapp-web.js's Contact.block()/unblock() return false for a group id (nothing blocked,
+    // answered 200 "blocked"); Baileys hands the id to updateBlockStatus whose Boom for an
+    // unresolvable jid surfaces as an opaque 500. Both engines share this 400 guard.
+    it.each([
+      ['blockContact', (svc: ContactService) => svc.blockContact('s1', '120363000000000000@g.us')],
+      ['unblockContact', (svc: ContactService) => svc.unblockContact('s1', '120363000000000000@g.us')],
+      ['blockContact (lid)', (svc: ContactService) => svc.blockContact('s1', '159442138038327@lid')],
+      ['blockContact (free text)', (svc: ContactService) => svc.blockContact('s1', 'hello@c.us')],
+    ])('%s refuses the id with a 400 before the engine is called', (_name, call) => {
+      const blockContact = jest.fn();
+      const unblockContact = jest.fn();
+      const svc = makeService({ blockContact, unblockContact });
+      expect(() => call(svc)).toThrow(BadRequestException);
+      expect(blockContact).not.toHaveBeenCalled();
+      expect(unblockContact).not.toHaveBeenCalled();
+    });
+
+    it('qualifies a bare number and forwards it to the engine as a @c.us id', async () => {
+      const blockContact = jest.fn().mockResolvedValue(undefined);
+      await makeService({ blockContact }).blockContact('s1', '628123');
+      expect(blockContact).toHaveBeenCalledWith('628123@c.us');
+    });
+
+    it('still allows a normal phone-based contact id through to the engine', async () => {
+      const unblockContact = jest.fn().mockResolvedValue(undefined);
+      await makeService({ unblockContact }).unblockContact('s1', '628123@c.us');
+      expect(unblockContact).toHaveBeenCalledWith('628123@c.us');
+    });
+  });
+
   describe('addressbook writes reject a privacy id', () => {
     // The lid's digits are NOT a phone number (see the note on
     // MessageService.resolveJidCandidates). whatsapp-web.js takes a bare NUMBER for the

--- a/src/modules/contact/contact.service.ts
+++ b/src/modules/contact/contact.service.ts
@@ -103,8 +103,16 @@ export class ContactService {
     return pictures;
   }
 
+  /**
+   * Guarded like the addressbook writes: whatsapp-web.js's Contact.block()/unblock() silently
+   * return false for a group id (nothing blocked, reported as success), and Baileys passes the id
+   * to updateBlockStatus, whose Boom for an unresolvable jid has no HttpException mapping (opaque
+   * 500). A group/newsletter/lid id does not name a person, so refuse it here on both engines
+   * with the same 400 the addressbook surfaces use.
+   */
   blockContact(sessionId: string, contactId: string) {
-    return this.getEngine(sessionId).blockContact(contactId);
+    this.assertAddressable(contactId);
+    return this.getEngine(sessionId).blockContact(this.toAddressableId(contactId));
   }
 
   /**
@@ -166,6 +174,7 @@ export class ContactService {
   }
 
   unblockContact(sessionId: string, contactId: string) {
-    return this.getEngine(sessionId).unblockContact(contactId);
+    this.assertAddressable(contactId);
+    return this.getEngine(sessionId).unblockContact(this.toAddressableId(contactId));
   }
 }


### PR DESCRIPTION
## What changed

Two engines, two wrong answers for the same mistake:

- **whatsapp-web.js**: `Contact.block()`/`unblock()` return `false` for a group id without doing anything (`Contact.js: if (this.isGroup) return false;`), so `POST .../contacts/{groupId}/block` answered `200 { success: true, message: "Contact blocked" }` while nothing was blocked.
- **Baileys**: the id goes straight to `updateBlockStatus`, whose Boom for an invalid or unresolvable jid is not an `HttpException`, surfacing as an opaque `500`.

Both writes now run through the same `assertAddressable` guard the addressbook routes (`upsert`/`delete`) already use: a group/newsletter/broadcast/status/lid/free-text id does not name a person and is refused with a `400` that names the fix - on both engines, before the engine is touched. Bare numbers are qualified to `@c.us` exactly like the addressbook writes (they previously reached wwjs unqualified, which resolved them as a number-shaped contact).

docs/06 states the new 400 on both routes.

## Verification

New spec cases: group/lid/free-text ids are refused with a 400 before the engine is called (block and unblock); a bare number is qualified and forwarded; a normal phone-based id passes through. Full unit suite green (5,703 tests); docs lane green; `tsc --noEmit`, ESLint, Prettier clean.