### PR TITLE
refactor(engine): build one shared host for the Baileys delegates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The Baileys adapter builds one shared host object for its nine delegates instead of nine overlapping closure bags; a new cross-cutting member is added once. No behavior change.
 - A transient whatsapp-web.js lid-to-phone lookup failure (dead page, rate limit) no longer overwrites a valid stored mapping with a definitive null; the engine method rejects on failure and the HTTP boundary keeps its null-on-failure contract.
 - Nine whatsapp-web.js group routes answer `404` (`GroupNotFoundError`) when the id is not a group or is unknown, like the guarded settings writes; they previously threw a bare error that surfaced as an opaque `500`.
 - The cold-reachout budget is charged only after the group engine call resolves; a createGroup that 501s (whatsapp-web.js, always) or an add the engine refuses no longer burns the day's allowance for participants never contacted.

--- a/src/engine/adapters/baileys-host.ts
+++ b/src/engine/adapters/baileys-host.ts
@@ -1,0 +1,27 @@
+import { type BaileysEventsHost } from './baileys-events';
+import { type BaileysGroupsHost } from './baileys-groups';
+import { type BaileysMessagingHost } from './baileys-messaging';
+import { type BaileysContactsHost } from './baileys-contacts';
+import { type BaileysStatusHost } from './baileys-status';
+import { type BaileysChannelsHost } from './baileys-channels';
+import { type BaileysCatalogHost } from './baileys-catalog';
+import { type BaileysHistoryHost } from './baileys-history';
+import { type BaileysLifecycleHost } from './baileys-lifecycle';
+
+/**
+ * The single host surface handed to every Baileys delegate, mirroring the wwebjs-host pattern:
+ * the adapter builds ONE object literal of these closures and gives it to each delegate, so a new
+ * cross-cutting member (a jid helper, a callback getter) is added once instead of to up to eight
+ * per-delegate literals. Each delegate still declares its own narrow Host interface - the literal
+ * satisfies them all structurally, and the narrow interfaces keep documenting what a delegate may
+ * touch (least privilege: a delegate cannot accidentally grow dependencies on the full surface).
+ */
+export type BaileysEngineHost = BaileysEventsHost &
+  BaileysGroupsHost &
+  BaileysMessagingHost &
+  BaileysContactsHost &
+  BaileysStatusHost &
+  BaileysChannelsHost &
+  BaileysCatalogHost &
+  BaileysHistoryHost &
+  BaileysLifecycleHost;

--- a/src/engine/adapters/baileys.adapter.ts
+++ b/src/engine/adapters/baileys.adapter.ts
@@ -7,6 +7,7 @@ import { BaileysContacts } from './baileys-contacts';
 import { BaileysEvents } from './baileys-events';
 import { BaileysGroups } from './baileys-groups';
 import { BaileysHistory, toUnixSeconds } from './baileys-history';
+import { type BaileysEngineHost } from './baileys-host';
 import { BaileysLifecycle } from './baileys-lifecycle';
 import { BaileysMessaging } from './baileys-messaging';
 import { BaileysStatus } from './baileys-status';
@@ -113,19 +114,24 @@ export class BaileysAdapter implements IWhatsAppEngine {
     this.sessionStore = new BaileysSessionStore(config.lidMappingStore, config.sessionId);
     // Constructed before messaging: the messaging delegate's own-send echo maps through
     // events.mapMessage (and the lifecycle delegate clears that same live-call cache on teardown).
-    // An object-literal getter's `this` is the literal itself, so the live connectedAt read goes
-    // through an arrow closure that captures the adapter.
+    // One host literal for every delegate (the wwebjs-host pattern): a new cross-cutting member
+    // is added once here, not to nine per-delegate bags. Each delegate keeps its own narrow Host
+    // interface, which this literal satisfies structurally - least privilege stays enforceable.
+    const delegates: { events?: BaileysEvents } = {};
     const connectedAt = (): number => this.connectedAt;
-    this.events = new BaileysEvents({
+    const host: BaileysEngineHost = {
+      // An object-literal getter's `this` is the literal itself, so the live connectedAt read goes
+      // through the arrow closure above, which captures the adapter.
+      get connectedAt() {
+        return connectedAt();
+      },
       getSocket: () => this.sock!,
       getSocketOrNull: () => this.sock,
       logger: this.logger,
       toNeutralJid: jid => this.sessionStore.toNeutralJid(jid),
       normalizedSelfJid: () => this.normalizedSelfJid(),
       loadLib: () => this.loadLib(),
-      get connectedAt() {
-        return connectedAt();
-      },
+      toUnixSeconds,
       inboundLimiter: this.inboundLimiter,
       recordKeyLidMappings: key => this.sessionStore.recordKeyLidMappings(key),
       recordMessage: msg => this.sessionStore.recordMessage(msg),
@@ -141,86 +147,33 @@ export class BaileysAdapter implements IWhatsAppEngine {
       getOnCall: () => this.callbacks.onCall,
       getOnPresenceUpdate: () => this.callbacks.onPresenceUpdate,
       getOnCallOutcome: () => this.callbacks.onCallOutcome,
-    });
-    this.groups = new BaileysGroups({
       ensureReady: () => this.ensureReady(),
-      getSocket: () => this.sock!,
-      logger: this.logger,
-      toNeutralJid: jid => this.sessionStore.toNeutralJid(jid),
       toEngineJid: jid => this.sessionStore.toEngineJid(jid),
-      normalizedSelfJid: () => this.normalizedSelfJid(),
-    });
-    this.messaging = new BaileysMessaging({
-      ensureReady: () => this.ensureReady(),
-      getSocket: () => this.sock!,
-      logger: this.logger,
-      toNeutralJid: jid => this.sessionStore.toNeutralJid(jid),
-      toEngineJid: jid => this.sessionStore.toEngineJid(jid),
-      normalizedSelfJid: () => this.normalizedSelfJid(),
       getEphemeralExpiration: chatId => this.sessionStore.getEphemeralExpiration(chatId),
-      toUnixSeconds,
-      loadLib: () => this.loadLib(),
-      putStoredMessage: msg => this.config.messageStore?.put(this.config.dbSessionId, msg),
       getStoredMessage: messageId => this.config.messageStore?.getMessage(this.config.dbSessionId, messageId),
-      // Store the device-stripped lid: that is the key the lid->phone lookup reads.
       recordLidMapping: (lid, pn) =>
         this.sessionStore.addLidMappings([{ lid: `${lid.split('@')[0].split(':')[0]}@lid`, pn }]),
-      getOnMessageCreate: () => this.callbacks.onMessageCreate,
       mapMessage: (msg, contentType, opts) => this.events.mapMessage(msg, contentType, opts),
-    });
-    this.contacts = new BaileysContacts({
-      ensureReady: () => this.ensureReady(),
-      getSocket: () => this.sock!,
-      logger: this.logger,
-      normalizedSelfJid: () => this.normalizedSelfJid(),
       listContacts: () => this.sessionStore.listContacts(),
       findContact: contactId => this.sessionStore.findContact(contactId),
       resolvePhone: contactId => this.sessionStore.resolvePhone(contactId),
       listChats: () => this.sessionStore.listChats(),
       lastMessage: chatId => this.sessionStore.lastMessage(chatId),
-      toEngineJid: jid => this.sessionStore.toEngineJid(jid),
-      toNeutralJid: jid => this.sessionStore.toNeutralJid(jid),
-    });
-    this.statusOps = new BaileysStatus({
-      ensureReady: () => this.ensureReady(),
-      getSocket: () => this.sock!,
-      toEngineJid: jid => this.sessionStore.toEngineJid(jid),
-      normalizedSelfJid: () => this.normalizedSelfJid(),
-      toUnixSeconds,
-    });
-    this.channels = new BaileysChannels({
-      ensureReady: () => this.ensureReady(),
-      getSocket: () => this.sock!,
-      toEngineJid: jid => this.sessionStore.toEngineJid(jid),
-    });
-    this.catalog = new BaileysCatalog({
-      ensureReady: () => this.ensureReady(),
-      getSocket: () => this.sock!,
-      logger: this.logger,
-      normalizedSelfJid: () => this.normalizedSelfJid(),
-    });
-    this.history = new BaileysHistory({
-      getSocket: () => this.sock!,
-      logger: this.logger,
-      toNeutralJid: jid => this.sessionStore.toNeutralJid(jid),
-      normalizedSelfJid: () => this.normalizedSelfJid(),
-      loadLib: () => this.loadLib(),
-      recordMessage: msg => this.sessionStore.recordMessage(msg),
       upsertContacts: records => this.sessionStore.upsertContacts(records),
       upsertChats: records => this.sessionStore.upsertChats(records),
       extractEphemeralDuration: msg => this.sessionStore.extractEphemeralDuration(msg),
       getOnHistoryMessages: () => this.callbacks.onHistoryMessages,
-    });
-    // Constructed last: its host closes over the delegates above (event/history handlers), while the
-    // live-call map is captured eagerly — a stable readonly reference owned by BaileysEvents.
-    this.lifecycle = new BaileysLifecycle({
-      logger: this.logger,
       authPath: this.authPath,
       config: this.config,
-      liveCalls: this.events.liveCalls,
+      // A getter so the events delegate exists by first read: the literal is built before the
+      // delegates are constructed, and the OLD wiring captured this.events.liveCalls eagerly -
+      // a stable readonly reference owned by BaileysEvents. The indirection defers the capture.
+      get liveCalls() {
+        // Construction order guarantees the events delegate exists before lifecycle first reads
+        // this (lifecycle is constructed last and only USES the bag during socket events).
+        return delegates.events!.liveCalls;
+      },
       extractPhone: id => this.extractPhone(id),
-      upsertContacts: records => this.sessionStore.upsertContacts(records),
-      upsertChats: records => this.sessionStore.upsertChats(records),
       addLidMappings: mappings => this.sessionStore.addLidMappings(mappings),
       handleMessagesUpsert: event => this.events.handleMessagesUpsert(event),
       handleMessagesUpdate: updates => this.events.handleMessagesUpdate(updates),
@@ -239,7 +192,16 @@ export class BaileysAdapter implements IWhatsAppEngine {
       getOnStateChanged: () => this.callbacks.onStateChanged,
       getOnCredentialTeardownStarted: () => this.callbacks.onCredentialTeardownStarted,
       getOnAccountRestriction: () => this.callbacks.onAccountRestriction,
-    });
+    };
+    delegates.events = this.events = new BaileysEvents(host);
+    this.groups = new BaileysGroups(host);
+    this.messaging = new BaileysMessaging(host);
+    this.contacts = new BaileysContacts(host);
+    this.statusOps = new BaileysStatus(host);
+    this.channels = new BaileysChannels(host);
+    this.catalog = new BaileysCatalog(host);
+    this.history = new BaileysHistory(host);
+    this.lifecycle = new BaileysLifecycle(host);
   }
 
   // ----- Lifecycle -----


### PR DESCRIPTION
## Problem

The Baileys adapter constructed nine per-delegate host bags with heavily overlapping members: getSocket in 8 of 9, logger in 7, normalizedSelfJid in 7, ensureReady in 6, the jid helpers in 5 each, and two closures (putStoredMessage, getOnMessageCreate) duplicated verbatim across bags. Adding a cross-cutting member meant touching up to eight literals. The whatsapp-web.js side already consolidated to the one-literal wwebjs-host pattern for exactly this reason.

## What changed

- baileys-host.ts declares BaileysEngineHost as the intersection of the nine existing per-delegate Host interfaces.
- The adapter builds ONE object literal of the 59 closures and hands it to every delegate.
- The narrow per-delegate interfaces stay: the wide literal satisfies them structurally, least privilege remains enforceable, and all 22 delegate specs keep their "as unknown as BaileysXHost" typed casts unchanged (verified: zero spec edits needed).

Two construction-order subtleties are preserved deliberately: connectedAt stays an object-literal getter backed by an adapter-capturing arrow (a literal getter's this is the literal itself), and liveCalls - which the old wiring captured eagerly from the events delegate - becomes a getter that defers the capture until the lifecycle delegate first reads it.

Net: 30 insertions, 68 deletions in the adapter constructor.

## Verification

Full unit suite green (5,727 tests; the 52 engine suites include every Baileys delegate spec unchanged). tsc --noEmit, ESLint, Prettier clean.