### PR TITLE
test(engine): make the parity throw registry total and literal-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The engine parity gate reads any single-quoted throw literal (a parenthesized site like sendText(customPreview) escaped the identifier-only regex), rejects construction sites it cannot see (template literals, variable arguments, literals naming no method), and pins conditional refusals in an explicit list; docs/29 states the refinements.
 - The Baileys adapter builds one shared host object for its nine delegates instead of nine overlapping closure bags; a new cross-cutting member is added once. No behavior change.
 - A transient whatsapp-web.js lid-to-phone lookup failure (dead page, rate limit) no longer overwrites a valid stored mapping with a definitive null; the engine method rejects on failure and the HTTP boundary keeps its null-on-failure contract.
 - Nine whatsapp-web.js group routes answer `404` (`GroupNotFoundError`) when the id is not a group or is unknown, like the guarded settings writes; they previously threw a bare error that surfaced as an opaque `500`.

--- a/docs/29-engine-capability-matrix.md
+++ b/docs/29-engine-capability-matrix.md
@@ -73,7 +73,12 @@ Key adapter facts:
   covers both shapes: besides the `Class.prototype.method.toString()` throw-scan it derives a
   throw registry from the `EngineNotSupportedError('method')` / `this.unsupported('method')`
   literals in every adapter and delegate source file (`engine-parity.spec.ts`), so a throw in a
-  delegate is machine-checked exactly like an inline one.
+  delegate is machine-checked exactly like an inline one. Two refinements: the literal must be a
+  plain single-quoted string naming the refused method (a template-literal or variable-argument
+  construction fails the gate, as does a literal that names no interface method), and a refusal
+  that fires only under a runtime condition - `sendText` with `customPreview` on whatsapp-web.js -
+  is pinned in the gate's conditional list instead of flipping the cell, because 'supported with a
+  refused option' is not 'not-available'.
 - **Inbound events** flow the other way: each adapter normalizes library events into the neutral
   `EngineEventCallbacks` (`onMessage`, `onMessageAck`, `onGroupEvent`, `onCall`, …), which the
   session module turns into OpenWA webhook events. Which library events are consumed — and which

--- a/src/engine/engine-parity.spec.ts
+++ b/src/engine/engine-parity.spec.ts
@@ -69,12 +69,27 @@ const ADAPTERS: ReadonlyArray<[AdapterKey, AdapterCtor]> = [
  * Bucketed by filename because that is what identifies the engine: `baileys*` is Baileys, the wwjs
  * adapter and its `wwebjs-*` delegates are wwjs.
  */
-const THROW_SITE_RE = /(?:new EngineNotSupportedError|this\.unsupported)\(\s*'([a-zA-Z][a-zA-Z0-9]*)'/;
+const THROW_SITE_RE = /(?:new EngineNotSupportedError|this\.unsupported)\(\s*'([^']+)'/;
+/** Every construction site, literal-arg or not - the fence denominator. */
+const ANY_THROW_SITE_RE = /(?:new EngineNotSupportedError|this\.unsupported)\(/;
+
+/**
+ * Throw sites whose literal names a CONDITION, not a whole method: the method is supported and the
+ * refusal fires only when the caller passes the named option. These must NOT flip the matrix cell
+ * ('supported with a refused option' is not 'not-available'), but they stay pinned here so deleting
+ * the throw without updating this list fails the fence below - the registry keys on the literal, so
+ * an unlisted conditional site would otherwise register as a pseudo-method nothing reads.
+ */
+const CONDITIONAL_THROW_SITES: Readonly<Record<string, string>> = {
+  'sendTextMessage(customPreview)':
+    'wwjs sendTextMessage is supported; it refuses only when customPreview is passed, because whatsapp-web.js takes a boolean linkPreview and cannot represent a custom card',
+};
 
 function readDelegateThrows(): Record<string, Set<string>> {
   const registry: Record<string, Set<string>> = { wwjs: new Set(), baileys: new Set() };
   for (const file of adapterFiles()) {
     for (const method of throwsIn(file)) {
+      if (method in CONDITIONAL_THROW_SITES) continue;
       for (const engine of enginesForFile(file)) registry[engine].add(method);
     }
   }
@@ -169,6 +184,44 @@ describe('engine capability matrix — drift invariants', () => {
   // fail here rather than pass vacuously. A NEW unprefixed adapter file appears on the left and names
   // itself — attribute it in UNPREFIXED_FILE_ENGINES or give it an engine prefix — and an entry left
   // behind by a rename or deletion is caught the same way from the other side.
+  // A construction site the literal registry cannot see (template literal, variable argument,
+  // anything but a plain single-quoted string) is invisible to BOTH invariants while still
+  // refusing at runtime. And a literal that names a CONDITION rather than a method registers as a
+  // pseudo-method no assertion reads. This fence counts every construction site in every adapter
+  // file and requires each to be exactly one of: a literal naming a real interface method, a
+  // conditional site listed above, or the single variable-argument site in the unsupported() helper.
+  it('every unsupported-throw construction site is literal-arg, a method name, and registered', () => {
+    const interfaceMethods = new Set(readInterfaceMethods());
+    const exemptHelperBody = /private unsupported\(method: string\)[\s\S]*?new EngineNotSupportedError\(method\)/;
+    for (const file of adapterFiles()) {
+      const src = readFileSync(join(__dirname, 'adapters', file), 'utf8');
+      const all = [...src.matchAll(new RegExp(ANY_THROW_SITE_RE.source, 'g'))];
+      const literal = [...src.matchAll(new RegExp(THROW_SITE_RE.source, 'g'))].map(m => m[1]);
+      for (const name of literal) {
+        if (name in CONDITIONAL_THROW_SITES) continue;
+        if (!interfaceMethods.has(name)) {
+          throw new Error(
+            `throw site '${name}' in ${file} names no interface method: it is a conditional refusal ` +
+              '(list it in CONDITIONAL_THROW_SITES) or a name typo (name the method it refuses)',
+          );
+        }
+      }
+      const nonLiteral = all.length - literal.length;
+      const hasHelper = exemptHelperBody.test(src);
+      expect(nonLiteral).toBe(hasHelper ? 1 : 0);
+    }
+    // Reverse direction: a conditional entry whose throw site no longer exists is stale.
+    const allLiterals = new Set(
+      adapterFiles().flatMap(file =>
+        [
+          ...readFileSync(join(__dirname, 'adapters', file), 'utf8').matchAll(new RegExp(THROW_SITE_RE.source, 'g')),
+        ].map(m => m[1]),
+      ),
+    );
+    const stale = Object.keys(CONDITIONAL_THROW_SITES).filter(name => !allLiterals.has(name));
+    expect(stale).toEqual([]);
+  });
+
   it('every adapter file is attributed to an engine', () => {
     expect([...UNPREFIXED_FILES].sort()).toEqual(Object.keys(UNPREFIXED_FILE_ENGINES).sort());
   });


### PR DESCRIPTION
## Problem

The engine parity gate derives its delegate throw registry from an identifier-only regex. A literal containing punctuation escapes it entirely: the live case is sendTextMessage(customPreview) in wwebjs-messaging.ts, whose refusal has been invisible to the gate since it landed. The matrix cell stayed supported - which is correct, since the method works without the option - but by accident rather than by decision. Template-literal and variable-argument constructions would likewise register nothing while still refusing at runtime.

## What changed

- The registry regex accepts any single-quoted literal, so the parenthesized site is captured.
- A new fence makes the registry total: every EngineNotSupportedError / unsupported() construction site in every adapter file must be a plain single-quoted string naming a real interface method, a conditional-refusal site pinned in an explicit list, or the single variable-argument site inside the unsupported() helper body.
- The conditional list carries the semantics the biconditional cannot express: a method that is supported but refuses one option is not not-available. sendTextMessage(customPreview) is its first entry, with the reason recorded.
- docs/29 states both refinements in place of the flat "machine-checked exactly like an inline one" claim.

## Verification

Mutation-tested in all three directions: a template-literal construction fails the fence; emptying the conditional list while the throw remains fails with "names no interface method"; deleting the throw while the entry remains fails the stale check. Docs lane green (261 tests); full unit suite green (5,727 tests); tsc, ESLint, Prettier clean.
