### PR TITLE
fix(contact): keep the phone route's documented errors out of the null boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- GET /contacts/:id/phone keeps its documented 400/409 answers (not-started, not-ready) and nulls only genuine lookup failures, logging them at debug; the boundary swallow had absorbed the deliberate errors too.
 - A transient session-launch failure (dead page at initialize, a database hiccup) gets one bounded retry that keeps the claim held; adopt and boot auto-start used to release the claim and leave the session down until a restart.
 - The twelve hand-rolled "Session is not started" guards in the session service route through the engine registry's `require()` (wire contract unchanged), and three routes drop an OpenAPI 404 declaration no code path can produce.
 - import-data restores an active session status from the backup as `disconnected` (scoped to claimable rows; a notice counts them), so migrated sessions are startable without a process restart.

--- a/src/modules/contact/contact.service.spec.ts
+++ b/src/modules/contact/contact.service.spec.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
 import { ContactService } from './contact.service';
 import { EngineRegistry } from '../../engine/engine-registry.service';
 import { IWhatsAppEngine } from '../../engine/interfaces/whatsapp-engine.interface';
@@ -205,6 +205,27 @@ describe('ContactService', () => {
       const upsertContact = jest.fn();
       await makeService({ upsertContact }).upsertContact('s1', id, 'Ada');
       expect(upsertContact).toHaveBeenCalled();
+    });
+  });
+
+  describe('resolveContactPhone error contract', () => {
+    it('propagates the 400 when the session is not started (getEngine is outside the swallow)', async () => {
+      const svc = makeService(undefined);
+      await expect(svc.resolveContactPhone('s1', '123@lid')).rejects.toThrow('Session is not started');
+    });
+
+    it('propagates an HttpException from the engine (409 not-ready keeps its retry guidance)', async () => {
+      const svc = makeService({
+        resolveContactPhone: jest.fn().mockRejectedValue(new ConflictException('Session is not connected')),
+      });
+      await expect(svc.resolveContactPhone('s1', '123@lid')).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('returns null for a non-HTTP lookup failure (dead page), preserving the route contract', async () => {
+      const svc = makeService({
+        resolveContactPhone: jest.fn().mockRejectedValue(new Error('Protocol error: Target closed')),
+      });
+      await expect(svc.resolveContactPhone('s1', '123@lid')).resolves.toBeNull();
     });
   });
 

--- a/src/modules/contact/contact.service.ts
+++ b/src/modules/contact/contact.service.ts
@@ -1,5 +1,6 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { HttpException, BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { EngineRegistry } from '../../engine/engine-registry.service';
+import { createLogger } from '../../common/services/logger.service';
 import { IWhatsAppEngine } from '../../engine/interfaces/whatsapp-engine.interface';
 import { paginate, ListOptions } from '../../common/utils/paginate';
 import { isIndividualWid, parseWaId } from '../../engine/identity/wa-id';
@@ -10,6 +11,8 @@ import { isIndividualWid, parseWaId } from '../../engine/identity/wa-id';
  */
 @Injectable()
 export class ContactService {
+  private readonly logger = createLogger('ContactService');
+
   constructor(private readonly engines: EngineRegistry) {}
 
   private getEngine(sessionId: string): IWhatsAppEngine {
@@ -47,15 +50,23 @@ export class ContactService {
   }
 
   /**
-   * The HTTP route promises null when the engine cannot map the id (docs/06 and the ApiResponse
-   * text), and that includes "the lookup itself failed": a dead page, an evaluation error or a
-   * rate limit answers 200 null, not a 5xx. The ENGINE method rejects on those (the lid resolver
-   * needs the distinction), so swallow here at the boundary.
+   * The HTTP route promises null when the LOOKUP cannot produce an answer (docs/06 and the
+   * ApiResponse text): a dead page, an evaluation error or a rate limit answers 200 null, not a
+   * 5xx. The ENGINE method rejects on those (the lid resolver needs the distinction), so genuine
+   * lookup failures are swallowed here at the boundary - logged at debug, since the old adapter
+   * catch was the only place these were visible. Deliberate HTTP answers (400 not-started, 409
+   * not-ready) propagate: nulling them would tell a retrying caller "no mapping" for a session
+   * that simply is not running.
    */
   async resolveContactPhone(sessionId: string, contactId: string): Promise<string | null> {
+    const engine = this.getEngine(sessionId);
     try {
-      return await this.getEngine(sessionId).resolveContactPhone(contactId);
-    } catch {
+      return await engine.resolveContactPhone(contactId);
+    } catch (error) {
+      if (error instanceof HttpException) throw error;
+      this.logger.debug(`resolveContactPhone lookup failed for ${contactId}`, {
+        error: error instanceof Error ? error.message : String(error),
+      });
       return null;
     }
   }


### PR DESCRIPTION
## Problem

The null-on-failure boundary added for the lid transient fix sat its `try` around the engine resolution too, so a not-started session answered `200 {phone: null}` instead of the documented 400, and an engine-not-ready 409 lost its retry guidance the same way. The MCP `ContactResolvePhone` tool inherited both (error became a null payload). The lookup-failure swallow also dropped the only logging those failures had.

## What changed

- The engine resolution (`getEngine`) moves above the `try`, so the 400 not-started propagates.
- The catch rethrows `HttpException`s, so the 409 not-ready (and any future deliberate answer) keeps its contract; only genuine lookup failures (dead page, evaluation error, rate limit) resolve to null.
- Those swallowed failures are logged at debug.

## Verification

Specs: not-started propagates the 400; a `ConflictException` from the engine propagates; a dead-page error resolves to null. Full unit suite green (5,735 tests); tsc, ESLint, Prettier clean.
