### PR TITLE
docs,fix: follow-ups from the engine and session review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Follow-ups: the transient-launch classifier rejects every HttpException up front (the 504 no-retry no longer rests on message wording) and recognizes ECONNRESET; the sendTemplate 404 description names only the template; import-status normalization comments and the parity-fence failure messages state their exact scope.
 - GET /contacts/:id/phone keeps its documented 400/409 answers (not-started, not-ready) and nulls only genuine lookup failures, logging them at debug; the boundary swallow had absorbed the deliberate errors too.
 - A transient session-launch failure (dead page at initialize, a database hiccup) gets one bounded retry that keeps the claim held; adopt and boot auto-start used to release the claim and leave the session down until a restart.
 - The twelve hand-rolled "Session is not started" guards in the session service route through the engine registry's `require()` (wire contract unchanged), and three routes drop an OpenAPI 404 declaration no code path can produce.

--- a/docs/29-engine-capability-matrix.md
+++ b/docs/29-engine-capability-matrix.md
@@ -75,8 +75,9 @@ Key adapter facts:
   literals in every adapter and delegate source file (`engine-parity.spec.ts`), so a throw in a
   delegate is machine-checked exactly like an inline one. Two refinements: the literal must be a
   plain single-quoted string naming the refused method (a template-literal or variable-argument
-  construction fails the gate, as does a literal that names no interface method), and a refusal
-  that fires only under a runtime condition - `sendText` with `customPreview` on whatsapp-web.js -
+  construction fails the gate outside the one `unsupported()` helper body, as does a literal that
+  names no interface method), and a refusal
+  that fires only under a runtime condition - `sendTextMessage` with `customPreview` on whatsapp-web.js -
   is pinned in the gate's conditional list instead of flipping the cell, because 'supported with a
   refused option' is not 'not-available'.
 - **Inbound events** flow the other way: each adapter normalizes library events into the neutral

--- a/openapi.json
+++ b/openapi.json
@@ -2347,7 +2347,7 @@
             "description": "Session not active or invalid request"
           },
           "404": {
-            "description": "Session or template not found"
+            "description": "Template not found"
           },
           "409": {
             "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."

--- a/src/engine/engine-parity.spec.ts
+++ b/src/engine/engine-parity.spec.ts
@@ -147,7 +147,7 @@ const SHARED_FILES = Object.entries(UNPREFIXED_FILE_ENGINES)
 /** Method names an adapter file refuses by literal, in file order. */
 function throwsIn(file: string): string[] {
   const src = readFileSync(join(__dirname, 'adapters', file), 'utf8');
-  // A fresh regex per call: THROW_SITE_RE carries /g, and a shared /g regex keeps lastIndex between
+  // A fresh regex per call: matchAll requires the global flag, and a shared /g regex keeps lastIndex between
   // calls, so reusing the instance would silently skip matches on every other file.
   return [...src.matchAll(new RegExp(THROW_SITE_RE.source, 'g'))].map(m => m[1]);
 }
@@ -190,7 +190,7 @@ describe('engine capability matrix — drift invariants', () => {
   // pseudo-method no assertion reads. This fence counts every construction site in every adapter
   // file and requires each to be exactly one of: a literal naming a real interface method, a
   // conditional site listed above, or the single variable-argument site in the unsupported() helper.
-  it('every unsupported-throw construction site is literal-arg, a method name, and registered', () => {
+  it('every EngineNotSupportedError construction site is literal-arg, a method name, and registered', () => {
     const interfaceMethods = new Set(readInterfaceMethods());
     const exemptHelperBody = /private unsupported\(method: string\)[\s\S]*?new EngineNotSupportedError\(method\)/;
     for (const file of adapterFiles()) {
@@ -208,7 +208,12 @@ describe('engine capability matrix — drift invariants', () => {
       }
       const nonLiteral = all.length - literal.length;
       const hasHelper = exemptHelperBody.test(src);
-      expect(nonLiteral).toBe(hasHelper ? 1 : 0);
+      if (nonLiteral !== (hasHelper ? 1 : 0)) {
+        throw new Error(
+          `${file}: ${nonLiteral} non-literal construction site(s) (expected ${hasHelper ? 1 : 0}) - ` +
+            'a template-literal or variable-argument EngineNotSupportedError escapes the registry',
+        );
+      }
     }
     // Reverse direction: a conditional entry whose throw site no longer exists is stale.
     const allLiterals = new Set(

--- a/src/modules/infra/infra-data.service.ts
+++ b/src/modules/infra/infra-data.service.ts
@@ -673,8 +673,10 @@ export class InfraDataService {
         // initializing, ...) in a backup describes the SOURCE host's engines, and restoring it
         // verbatim leaves rows reading ready with no engine anywhere - invisible to auto-start
         // (selects disconnected) and to the takeover sweep, until a process restart. Scoped to
-        // CLAIMABLE rows only, so a session whose ownership claim was just re-applied to this
-        // node or a peer (a live engine still backs it) keeps the backup's status.
+        // CLAIMABLE rows: a PEER's preserved claim (a live engine backs the row elsewhere) keeps
+        // the backup's status; this node's own claims normalize exactly like boot's reset does -
+        // for a live self-engine the row understates reality until the next engine status event,
+        // which is the same trade boot makes.
         const ACTIVE_STATUSES = [
           SessionStatus.READY,
           SessionStatus.INITIALIZING,

--- a/src/modules/message/message.controller.ts
+++ b/src/modules/message/message.controller.ts
@@ -131,7 +131,7 @@ export class MessageController {
     status: 400,
     description: 'Session not active or invalid request',
   })
-  @ApiResponse({ status: 404, description: 'Session or template not found' })
+  @ApiResponse({ status: 404, description: 'Template not found' })
   @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async sendTemplate(
     @Param('sessionId') sessionId: string,

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -1,4 +1,5 @@
 import {
+  HttpException,
   Injectable,
   NotFoundException,
   ConflictException,
@@ -43,12 +44,14 @@ function isTransientLaunchFailure(error: unknown): boolean {
   // EngineTransportError (503) is the one mapped HTTP shape that means infrastructure died
   // mid-launch (dead page/socket at initialize). Every OTHER HttpException is a deliberate
   // answer: the 409 not-ready family reflects session state, the 504 auth-timeout family
-  // reflects the account/proxy, and a 4xx is a refusal.
+  // reflects the account/proxy, and a 4xx is a refusal. The explicit early-exit (not a message
+  // regex relying on the 504 texts never containing 'connection') pins that intent.
   if (error instanceof EngineTransportError) return true;
+  if (error instanceof HttpException) return false;
   // TypeORM QueryFailedError and driver errors carry no HttpException shape.
   return (
     error instanceof Error &&
-    /connection|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN|SQLITE_BUSY|terminating connection/i.test(error.message)
+    /connection|ECONNREFUSED|ECONNRESET|ETIMEDOUT|EAI_AGAIN|SQLITE_BUSY|terminating connection/i.test(error.message)
   );
 }
 


### PR DESCRIPTION
## Problem

Review of the merged engine/session batch found one real regression (fixed separately in the phone-route PR) and a set of smaller accuracy and robustness gaps: the transient-launch classifier's 504 no-retry rested on message wording, the sendTemplate 404 description named an unreachable Session half, the import normalization comment claimed self-claims keep the backup status while the predicate normalizes them, and the parity fence's failure messages and docs wording over- or under-stated their scope.

## What changed

- The classifier gains an explicit `HttpException` early-exit (the intent the spec already pinned, now structural instead of wording-dependent), and ECONNRESET joins the driver-error family.
- sendTemplate's 404 description names only the template; the OpenAPI snapshot follows (one-line diff).
- The import normalization comment states the actual semantics: peer-held claims keep the backup status, this node's own claims normalize exactly like boot's reset.
- The parity fence test name scopes to EngineNotSupportedError, the non-literal count failure names the file, docs/29 says sendTextMessage and acknowledges the unsupported() helper exemption, and a stale comment about a /g flag is corrected.

## Verification

Full unit suite green (5,735 tests); docs lane green (261 tests); openapi:check clean; tsc, ESLint, Prettier clean.
