### PR TITLE
fix(security): key the ingress route's rate bound on the instance alone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The ingress route's rate bound is the per-instance limit alone: the global per-IP medium tier (100/min, below the instance default of 120/min) used to 429 every tenant of a shared-egress-IP provider before the instance bound ever fired.
 - The in-flight body budget gives each client IP its own share (half the aggregate by default, keyed through TRUSTED_PROXIES): four trickle connections from one source now exhaust only that source's share instead of 503ing every body-bearing request for everyone.
 - The lifecycle fences (teardown chaining, fail-closed 409, identity-checked initial-status waits, force-destroy eviction) and the status broadcaster (persist-then-mirror, transition de-dup, clear-on-delete) carry their own unit specs instead of being reachable only through the session-service suite's white-box pokes.
 - Follow-ups: the transient-launch classifier rejects every HttpException up front (the 504 no-retry no longer rests on message wording) and recognizes ECONNRESET; the sendTemplate 404 description names only the template; import-status normalization comments and the parity-fence failure messages state their exact scope.

--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -6543,7 +6543,7 @@ plugin processing. `200` means the `GET` verification-challenge echo, or a dupli
 already persisted (idempotent re-delivery). A route may shape the synchronous status/body/headers
 the provider sees via its declarative `ack` config (doc 25); the plugin itself always runs async.
 
-**Errors:** `401` signature verification failed (missing, stale, or wrong secret) · `403` `GET` verification challenge failed (`verifyToken` mismatch) · `404` unknown pluginId/instanceId, or no such claimed route · `413` body over the route's `maxBodyBytes` · `429` per-instance rate limit (`INGRESS_INSTANCE_LIMIT` per `INGRESS_INSTANCE_TTL`, on top of the global per-IP throttle)
+**Errors:** `401` signature verification failed (missing, stale, or wrong secret) · `403` `GET` verification challenge failed (`verifyToken` mismatch) · `404` unknown pluginId/instanceId, or no such claimed route · `413` body over the route's `maxBodyBytes` · `429` per-instance rate limit (`INGRESS_INSTANCE_LIMIT` per `INGRESS_INSTANCE_TTL`; the per-instance bound is this route's only rate limit - the global per-IP tiers skip it)
 
 ## 6.5 Real-time API (WebSocket)
 

--- a/src/modules/integration/ingress.controller.ts
+++ b/src/modules/integration/ingress.controller.ts
@@ -1,17 +1,23 @@
 import { All, Controller, Param, Query, Req, Res, UseGuards } from '@nestjs/common';
+import { SkipThrottle } from '@nestjs/throttler';
 import { ApiTags, ApiOkResponse, ApiParam, ApiResponse } from '@nestjs/swagger';
 import type { Request, Response } from 'express';
 import { Public } from '../auth/decorators/auth.decorators';
 import { IngressService } from './ingress.service';
 import { InstanceThrottlerGuard } from './instance-throttler.guard';
 
-// @Public so the global ApiKeyGuard early-returns (providers can't present an API key), but NOT
-// @SkipThrottle — the global IP throttle stays as a coarse guard (per-instance fairness is P1).
+// @Public so the global ApiKeyGuard early-returns (providers can't present an API key). The
+// controller-level @SkipThrottle below exempts the GLOBAL per-IP guard (see its comment).
 // The provider body is read as RAW bytes from req.rawBody (stashed by the json() verify callback in
 // main.ts) — it is intentionally NOT DTO-bound, so the global ValidationPipe never 400s on the
 // provider's unknown keys, and the exact signed bytes reach the HMAC verifier.
 @ApiTags('integration')
 @Public()
+// The global per-IP throttle SKIPS this route (its medium tier, 100/min by default, sits below the
+// per-instance limit's 120/min, so a provider delivering every tenant's webhooks from one shared
+// egress IP was 429'd at the IP tier before the instance bound ever fired). Fairness here is the
+// InstanceThrottlerGuard's job: keyed on (pluginId, instanceId), a noisy tenant sheds alone.
+@SkipThrottle()
 @Controller('ingress')
 export class IngressController {
   constructor(private readonly ingress: IngressService) {}
@@ -19,13 +25,15 @@ export class IngressController {
   // Express 5 (path-to-regexp v8) has no bare `*` — Nest's route converter rewrites it to the named
   // wildcard `*path`, so the trailing segments land in req.params.path (an array), not req.params[0].
   //
-  // InstanceThrottlerGuard runs IN ADDITION to the global per-IP ProxyAwareThrottlerGuard (an
-  // APP_GUARD, so it still applies here) — two independent buckets, keyed differently, both enforced.
+  // InstanceThrottlerGuard is the route's ONLY rate bound: the global per-IP guard skips this
+  // controller (@SkipThrottle above) because its medium tier (100/min) sits below this guard's
+  // per-instance default (120/min), which 429'd every tenant of a shared-egress-IP provider at
+  // the IP tier before the instance bound ever fired. This guard ignores the bare @SkipThrottle
+  // (see its shouldSkip) and keys on (pluginId, instanceId), so a noisy tenant sheds alone.
   // Its limit/ttl (INGRESS_INSTANCE_LIMIT / INGRESS_INSTANCE_TTL) are read directly by the guard
   // itself, NOT via @Throttle: @Throttle metadata is reflected on the route and read by every
-  // ThrottlerGuard subclass that walks a tier of that name, including the global per-IP guard — so a
-  // route-level override here would silently retarget the global guard's tolerance too. See
-  // InstanceThrottlerGuard's onModuleInit for how it keeps its tier fully independent.
+  // ThrottlerGuard subclass that walks a tier of that name. See InstanceThrottlerGuard's
+  // onModuleInit for how it keeps its tier fully independent.
   @UseGuards(InstanceThrottlerGuard)
   @All(':pluginId/:instanceId/*path')
   // The wildcard segment is part of the published path template, so it needs a parameter of its own —

--- a/src/modules/integration/instance-throttler.guard.ts
+++ b/src/modules/integration/instance-throttler.guard.ts
@@ -39,6 +39,18 @@ export class InstanceThrottlerGuard extends ProxyAwareThrottlerGuard {
     ];
   }
 
+  /**
+   * This guard does NOT honour a bare `@SkipThrottle()`. The ingress controller carries one so the
+   * GLOBAL per-IP guard skips the route: its medium tier (default 100/min) sits BELOW this guard's
+   * per-instance default (120/min), so a provider delivering every tenant's webhooks from one
+   * shared egress IP - the exact scenario this guard exists for - was 429'd at the IP tier before
+   * the instance bound ever fired, and sustained traffic hit the 1000/h long tier at ~16/min. The
+   * instance fairness bound is the better-keyed limit for this route and stays unconditional.
+   */
+  protected shouldSkip(): Promise<boolean> {
+    return Promise.resolve(false);
+  }
+
   protected async getTracker(req: Record<string, unknown>): Promise<string> {
     const params = (req.params ?? {}) as { pluginId?: string; instanceId?: string };
     if (params.pluginId && params.instanceId) {


### PR DESCRIPTION
## Problem

The global per-IP ProxyAwareThrottlerGuard ran on the ingress route alongside InstanceThrottlerGuard, and its medium tier (100/min by default) sits BELOW the per-instance limit (120/min by default): a provider delivering every tenant's webhooks from one shared egress IP - the exact scenario the instance guard's own doc names - was 429'd at the IP tier before the instance bound ever fired, and sustained traffic hit the 1000/h long tier at ~16/min. The fairness guard was unreachable at the default settings.

## What Changed

- The ingress controller carries `@SkipThrottle()`: the global guard honours the bare decorator and skips the route.
- `InstanceThrottlerGuard` overrides `shouldSkip` to ignore that decorator - the per-instance bound is the route's only rate limit and stays unconditional (keyed on `(pluginId, instanceId)`, a noisy tenant sheds alone).
- The `@Throttle`-metadata hazard the old comments warned about is unchanged: the guard still reads its limit from the env, never from route metadata.
- docs/06's ingress 429 line states the per-instance bound is the route's only rate limit.

## Verification

The ingress-instance-throttle e2e still passes (the 429 + neighbor-isolation contract), and the integration-fabric golden e2e (202/401 coverage) is green. Full unit suite green (5,758 tests); docs lane green; tsc, ESLint, Prettier clean.
