### PR TITLE
fix(dashboard): associate form labels, meet AA contrast on muted text and the primary button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Dashboard accessibility: 55 form labels are associated with their controls (`htmlFor`/`id`, no duplicates or orphans), the muted-text token meets AA on both themes (4.76:1 light, 5.71:1 dark), and the primary button uses dark text on the green (9.0:1, from 1.98:1).
 - Follow-ups from the batch review: the chain-boot e2e sets MAIN_DATABASE_SYNCHRONIZE=false explicitly (the env's absence defaults to synchronize=true, so the main chain was never exercised), the drift gate classifies statements against the two known shape families (column-type rebuild, index-name drift) instead of blanket-filtering every index/DROP statement, the shared delivery recorder strips the raw error before the persistence spread, and the ignore-pattern list deduplicates.
 - The direct and queued webhook delivery paths share one POST-and-classify core (`postWebhookPayload`) and one terminal-failure recorder, instead of two line-for-line copies that an outbox would have tripled.
 - Test and DB infrastructure: the 23 file-reading specs are excluded from the unit coverage denominators (spec files were counted as 0%-covered source, ~994 lines inflating every floor), an e2e boots the production SQLite schema from scratch through both full migration chains (the path the other suites' synchronize=true never touches), and a drift gate derives the chain-vs-entity diff so a missing index, column, or constraint fails while the known column-type rebuild is pinned as a visible baseline.

--- a/dashboard/src/App.css
+++ b/dashboard/src/App.css
@@ -9,7 +9,7 @@
   --bg-card: #ffffff;
   --text-primary: #0f172a; /* Slate 900 */
   --text-secondary: #475569; /* Slate 600 */
-  --text-muted: #94a3b8; /* Slate 400 */
+  --text-muted: #64748b; /* Slate 500; 4.76:1 on white (AA) */
   --border: #e2e8f0; /* Slate 200 */
   --error: #ef4444;
   --success: #22c55e;
@@ -32,7 +32,7 @@
   --bg-card: #1e293b;
   --text-primary: #f1f5f9; /* Slate 100 */
   --text-secondary: #cbd5e1; /* Slate 300 */
-  --text-muted: #64748b; /* Slate 500 */
+  --text-muted: #94a3b8; /* Slate 400; 5.71:1 on Slate 800 (AA) */
   --border: #334155; /* Slate 700 */
   --info: #60a5fa; /* Blue 400 — lighter so it reads over the dark translucent-blue tints */
   --primary-soft: color-mix(in srgb, var(--primary) 18%, transparent);
@@ -58,7 +58,7 @@
     --bg-card: #1e293b;
     --text-primary: #f1f5f9;
     --text-secondary: #cbd5e1;
-    --text-muted: #64748b;
+    --text-muted: #94a3b8;
     --border: #334155;
     --info: #60a5fa;
     --primary-soft: color-mix(in srgb, var(--primary) 18%, transparent);

--- a/dashboard/src/components/PluginInstances.tsx
+++ b/dashboard/src/components/PluginInstances.tsx
@@ -235,38 +235,38 @@ export function PluginInstances({ pluginId }: { pluginId: string }) {
             </>
           }
         >
-          <label>{t('plugins.instances.form.instanceId')}</label>
-          <input
+          <label htmlFor="pi-1">{t('plugins.instances.form.instanceId')}</label>
+          <input id="pi-1"
             type="text"
             value={form.instanceId}
             placeholder={t('plugins.instances.form.instanceIdPlaceholder')}
             onChange={e => setForm({ ...form, instanceId: e.target.value })}
           />
           <p className="pi-hint">{t('plugins.instances.form.instanceIdHint')}</p>
-          <label>{t('plugins.instances.form.sessionScope')}</label>
-          <input
+          <label htmlFor="pi-2">{t('plugins.instances.form.sessionScope')}</label>
+          <input id="pi-2"
             type="text"
             value={form.sessionScope}
             placeholder={t('plugins.instances.form.sessionScopePlaceholder')}
             onChange={e => setForm({ ...form, sessionScope: e.target.value })}
           />
-          <label>{t('plugins.instances.form.verifyToken')}</label>
-          <input
+          <label htmlFor="pi-3">{t('plugins.instances.form.verifyToken')}</label>
+          <input id="pi-3"
             type="text"
             value={form.verifyToken}
             placeholder={t('plugins.instances.form.verifyTokenPlaceholder')}
             onChange={e => setForm({ ...form, verifyToken: e.target.value })}
           />
-          <label>{t('plugins.instances.form.secret')}</label>
-          <input
+          <label htmlFor="pi-4">{t('plugins.instances.form.secret')}</label>
+          <input id="pi-4"
             type="text"
             value={form.secret}
             placeholder={t('plugins.instances.form.secretPlaceholder')}
             onChange={e => setForm({ ...form, secret: e.target.value })}
           />
           <p className="pi-hint">{t('plugins.instances.form.secretHint')}</p>
-          <label>{t('plugins.instances.form.config')}</label>
-          <textarea
+          <label htmlFor="pi-5">{t('plugins.instances.form.config')}</label>
+          <textarea id="pi-5"
             value={form.config}
             placeholder={t('plugins.instances.form.configPlaceholder')}
             onChange={e => setForm({ ...form, config: e.target.value })}
@@ -334,15 +334,15 @@ export function PluginInstances({ pluginId }: { pluginId: string }) {
             </>
           }
         >
-          <label>{t('plugins.instances.form.sessionScope')}</label>
-          <input
+          <label htmlFor="pi-6">{t('plugins.instances.form.sessionScope')}</label>
+          <input id="pi-6"
             type="text"
             value={editForm.sessionScope}
             placeholder={t('plugins.instances.form.sessionScopePlaceholder')}
             onChange={e => setEditForm({ ...editForm, sessionScope: e.target.value })}
           />
-          <label>{t('plugins.instances.form.config')}</label>
-          <textarea
+          <label htmlFor="pi-7">{t('plugins.instances.form.config')}</label>
+          <textarea id="pi-7"
             value={editForm.config}
             placeholder={t('plugins.instances.form.configPlaceholder')}
             onChange={e => setEditForm({ ...editForm, config: e.target.value })}

--- a/dashboard/src/components/chats/ChatSidebar.tsx
+++ b/dashboard/src/components/chats/ChatSidebar.tsx
@@ -119,8 +119,8 @@ function ChatSidebar({
       <div className="sidebar-header-box">
         {/* Session selector */}
         <div className="session-select-group">
-          <label className="form-label">{t('chats.sessionLabel')}</label>
-          <select
+          <label className="form-label" htmlFor="csb-1">{t('chats.sessionLabel')}</label>
+          <select id="csb-1"
             value={selectedSessionId}
             onChange={e => onSelectSession(e.target.value)}
             className="session-selector"

--- a/dashboard/src/components/chats/StatusComposeModal.tsx
+++ b/dashboard/src/components/chats/StatusComposeModal.tsx
@@ -185,8 +185,8 @@ function StatusComposeModal({ sessionId, onClose, onPosted }: Props) {
       {composeType === 'text' ? (
         <>
           <div className="compose-field">
-            <label>{t('chats.status.composeText')}</label>
-            <textarea
+            <label htmlFor="scm-1">{t('chats.status.composeText')}</label>
+            <textarea id="scm-1"
               value={composeText}
               onChange={e => setComposeText(e.target.value)}
               maxLength={4096}
@@ -195,16 +195,16 @@ function StatusComposeModal({ sessionId, onClose, onPosted }: Props) {
           </div>
           <div className="compose-row">
             <div className="compose-field">
-              <label>{t('chats.status.backgroundColor')}</label>
-              <input
+              <label htmlFor="scm-2">{t('chats.status.backgroundColor')}</label>
+              <input id="scm-2"
                 type="color"
                 value={composeBgColor || '#000000'}
                 onChange={e => setComposeBgColor(e.target.value)}
               />
             </div>
             <div className="compose-field">
-              <label>{t('chats.status.font')}</label>
-              <select value={composeFont} onChange={e => setComposeFont(e.target.value)}>
+              <label htmlFor="scm-3">{t('chats.status.font')}</label>
+              <select id="scm-3" value={composeFont} onChange={e => setComposeFont(e.target.value)}>
                 <option value="">{t('chats.status.fontDefault')}</option>
                 {/* The WhatsApp status font enum: 6 is the bold system face; 3–5 don't exist on
                     the wire and the backend rejects them. */}
@@ -220,8 +220,8 @@ function StatusComposeModal({ sessionId, onClose, onPosted }: Props) {
       ) : (
         <>
           <div className="compose-field">
-            <label>{t('chats.status.composeImage')}</label>
-            <input
+            <label htmlFor="scm-4">{t('chats.status.composeImage')}</label>
+            <input id="scm-4"
               type="url"
               placeholder="https://example.com/image.jpg"
               value={composeImageUrl}
@@ -233,8 +233,8 @@ function StatusComposeModal({ sessionId, onClose, onPosted }: Props) {
             <input type="file" accept="image/*" ref={composeFileInputRef} onChange={handleComposeImageFile} />
           </div>
           <div className="compose-field">
-            <label>{t('chats.status.caption')}</label>
-            <input
+            <label htmlFor="scm-5">{t('chats.status.caption')}</label>
+            <input id="scm-5"
               type="text"
               placeholder={t('chats.captionPlaceholder')}
               value={composeCaption}
@@ -247,8 +247,8 @@ function StatusComposeModal({ sessionId, onClose, onPosted }: Props) {
 
       {isBaileysEngine && (
         <div className="compose-field">
-          <label>{t('chats.status.recipients')}</label>
-          <input
+          <label htmlFor="scm-6">{t('chats.status.recipients')}</label>
+          <input id="scm-6"
             type="text"
             placeholder={t('common.search')}
             value={composeRecipientSearch}

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -347,7 +347,9 @@ select:disabled {
   gap: 0.5rem;
   padding: 0.75rem 1.25rem;
   background: var(--primary, #25d366);
-  color: #fff;
+  /* Dark text on the WhatsApp green: 9.0:1 (AAA). White was 1.98:1, failing even the AA
+     large-text floor - the single worst contrast pair in the dashboard. */
+  color: #0f172a;
   border: none;
   border-radius: 8px;
   font-size: 0.9375rem;

--- a/dashboard/src/pages/ApiKeys.tsx
+++ b/dashboard/src/pages/ApiKeys.tsx
@@ -301,15 +301,15 @@ export function ApiKeys() {
             </div>
           ) : (
             <>
-              <label>{t('common.name')}</label>
-              <input
+              <label htmlFor="ak-1">{t('common.name')}</label>
+              <input id="ak-1"
                 type="text"
                 placeholder={t('apiKeys.namePlaceholder')}
                 value={newKey.name}
                 onChange={e => setNewKey({ ...newKey, name: e.target.value })}
               />
-              <label>{t('common.role')}</label>
-              <select value={newKey.role} onChange={e => setNewKey({ ...newKey, role: e.target.value })}>
+              <label htmlFor="ak-2">{t('common.role')}</label>
+              <select id="ak-2" value={newKey.role} onChange={e => setNewKey({ ...newKey, role: e.target.value })}>
                 {roleNames.map(r => (
                   <option key={r} value={r}>
                     {t(`apiKeys.roles.${r}`)}

--- a/dashboard/src/pages/Infrastructure.tsx
+++ b/dashboard/src/pages/Infrastructure.tsx
@@ -214,16 +214,16 @@ export function Infrastructure() {
                 <div className="config-form">
                   <div className="form-row">
                     <div className="form-group">
-                      <label>{t('common.host')}</label>
-                      <input
+                      <label htmlFor="infra-1">{t('common.host')}</label>
+                      <input id="infra-1"
                         type="text"
                         value={configForm.dbConfig.host}
                         onChange={e => configForm.updateDbConfig('host', e.target.value)}
                       />
                     </div>
                     <div className="form-group small">
-                      <label>{t('common.port')}</label>
-                      <input
+                      <label htmlFor="infra-2">{t('common.port')}</label>
+                      <input id="infra-2"
                         type="text"
                         value={configForm.dbConfig.port}
                         onChange={e => configForm.updateDbConfig('port', e.target.value)}
@@ -232,16 +232,16 @@ export function Infrastructure() {
                   </div>
                   <div className="form-row">
                     <div className="form-group">
-                      <label>{t('common.username')}</label>
-                      <input
+                      <label htmlFor="infra-3">{t('common.username')}</label>
+                      <input id="infra-3"
                         type="text"
                         value={configForm.dbConfig.username}
                         onChange={e => configForm.updateDbConfig('username', e.target.value)}
                       />
                     </div>
                     <div className="form-group">
-                      <label>{t('common.password')}</label>
-                      <input
+                      <label htmlFor="infra-4">{t('common.password')}</label>
+                      <input id="infra-4"
                         type="password"
                         value={configForm.dbConfig.password}
                         onChange={e => configForm.updateDbConfig('password', e.target.value)}
@@ -250,16 +250,16 @@ export function Infrastructure() {
                   </div>
                   <div className="form-row">
                     <div className="form-group">
-                      <label>{t('infrastructure.database.dbName')}</label>
-                      <input
+                      <label htmlFor="infra-5">{t('infrastructure.database.dbName')}</label>
+                      <input id="infra-5"
                         type="text"
                         value={configForm.dbConfig.database}
                         onChange={e => configForm.updateDbConfig('database', e.target.value)}
                       />
                     </div>
                     <div className="form-group small">
-                      <label>{t('infrastructure.database.poolSize')}</label>
-                      <input
+                      <label htmlFor="infra-6">{t('infrastructure.database.poolSize')}</label>
+                      <input id="infra-6"
                         type="number"
                         min="1"
                         max="50"
@@ -270,8 +270,8 @@ export function Infrastructure() {
                   </div>
                   <div className="form-row">
                     <div className="form-group">
-                      <label>{t('infrastructure.database.schema')}</label>
-                      <input
+                      <label htmlFor="infra-7">{t('infrastructure.database.schema')}</label>
+                      <input id="infra-7"
                         type="text"
                         value={configForm.dbConfig.schema}
                         onChange={e => configForm.updateDbConfig('schema', e.target.value)}
@@ -426,16 +426,16 @@ export function Infrastructure() {
                 </label>
               </div>
               <div className="form-group">
-                <label>{t('infrastructure.engine.sessionDataPath')}</label>
-                <input
+                <label htmlFor="infra-8">{t('infrastructure.engine.sessionDataPath')}</label>
+                <input id="infra-8"
                   type="text"
                   value={configForm.engineConfig.sessionDataPath}
                   onChange={e => configForm.updateEngineConfig('sessionDataPath', e.target.value)}
                 />
               </div>
               <div className="form-group">
-                <label>{t('infrastructure.engine.browserArgs')}</label>
-                <input
+                <label htmlFor="infra-9">{t('infrastructure.engine.browserArgs')}</label>
+                <input id="infra-9"
                   type="text"
                   value={configForm.engineConfig.browserArgs}
                   onChange={e => configForm.updateEngineConfig('browserArgs', e.target.value)}
@@ -515,24 +515,24 @@ export function Infrastructure() {
                 <div className="config-form">
                   <div className="form-row">
                     <div className="form-group">
-                      <label>{t('common.host')}</label>
-                      <input
+                      <label htmlFor="infra-10">{t('common.host')}</label>
+                      <input id="infra-10"
                         type="text"
                         value={configForm.redisConfig.host}
                         onChange={e => configForm.updateRedisConfig('host', e.target.value)}
                       />
                     </div>
                     <div className="form-group small">
-                      <label>{t('common.port')}</label>
-                      <input
+                      <label htmlFor="infra-11">{t('common.port')}</label>
+                      <input id="infra-11"
                         type="text"
                         value={configForm.redisConfig.port}
                         onChange={e => configForm.updateRedisConfig('port', e.target.value)}
                       />
                     </div>
                     <div className="form-group">
-                      <label>{t('common.password')}</label>
-                      <input
+                      <label htmlFor="infra-12">{t('common.password')}</label>
+                      <input id="infra-12"
                         type="password"
                         value={configForm.redisConfig.password}
                         onChange={e => configForm.updateRedisConfig('password', e.target.value)}
@@ -671,8 +671,8 @@ export function Infrastructure() {
           <div className="config-form">
             {configForm.storageConfig.type === 'local' && (
               <div className="form-group">
-                <label>{t('infrastructure.storage.storagePath')}</label>
-                <input
+                <label htmlFor="infra-13">{t('infrastructure.storage.storagePath')}</label>
+                <input id="infra-13"
                   type="text"
                   value={configForm.storageConfig.localPath}
                   onChange={e => configForm.updateStorageConfig('localPath', e.target.value)}
@@ -701,16 +701,16 @@ export function Infrastructure() {
                   <>
                     <div className="form-row">
                       <div className="form-group">
-                        <label>{t('infrastructure.storage.bucket')}</label>
-                        <input
+                        <label htmlFor="infra-14">{t('infrastructure.storage.bucket')}</label>
+                        <input id="infra-14"
                           type="text"
                           value={configForm.storageConfig.s3Bucket}
                           onChange={e => configForm.updateStorageConfig('s3Bucket', e.target.value)}
                         />
                       </div>
                       <div className="form-group">
-                        <label>{t('infrastructure.storage.region')}</label>
-                        <input
+                        <label htmlFor="infra-15">{t('infrastructure.storage.region')}</label>
+                        <input id="infra-15"
                           type="text"
                           value={configForm.storageConfig.s3Region}
                           onChange={e => configForm.updateStorageConfig('s3Region', e.target.value)}
@@ -719,16 +719,16 @@ export function Infrastructure() {
                     </div>
                     <div className="form-row">
                       <div className="form-group">
-                        <label>{t('infrastructure.storage.accessKey')}</label>
-                        <input
+                        <label htmlFor="infra-16">{t('infrastructure.storage.accessKey')}</label>
+                        <input id="infra-16"
                           type="text"
                           value={configForm.storageConfig.s3AccessKey}
                           onChange={e => configForm.updateStorageConfig('s3AccessKey', e.target.value)}
                         />
                       </div>
                       <div className="form-group">
-                        <label>{t('infrastructure.storage.secretKey')}</label>
-                        <input
+                        <label htmlFor="infra-17">{t('infrastructure.storage.secretKey')}</label>
+                        <input id="infra-17"
                           type="password"
                           value={configForm.storageConfig.s3SecretKey}
                           onChange={e => configForm.updateStorageConfig('s3SecretKey', e.target.value)}
@@ -736,8 +736,8 @@ export function Infrastructure() {
                       </div>
                     </div>
                     <div className="form-group">
-                      <label>{t('infrastructure.storage.endpoint')}</label>
-                      <input
+                      <label htmlFor="infra-18">{t('infrastructure.storage.endpoint')}</label>
+                      <input id="infra-18"
                         type="text"
                         value={configForm.storageConfig.s3Endpoint}
                         onChange={e => configForm.updateStorageConfig('s3Endpoint', e.target.value)}

--- a/dashboard/src/pages/MessageTester.tsx
+++ b/dashboard/src/pages/MessageTester.tsx
@@ -445,8 +445,8 @@ export function MessageTester() {
           <h2 className="eyebrow">{t('messageTester.compose')}</h2>
 
           <div className="form-group">
-            <label>{t('messageTester.session')}</label>
-            <select value={session} onChange={e => setSession(e.target.value)}>
+            <label htmlFor="mt-1">{t('messageTester.session')}</label>
+            <select id="mt-1" value={session} onChange={e => setSession(e.target.value)}>
               {sessions.length === 0 && <option value="">{t('messageTester.noReadySessions')}</option>}
               {sessions.map(s => (
                 <option key={s.id} value={s.id}>
@@ -537,8 +537,8 @@ export function MessageTester() {
 
           {messageType === 'text' && (
             <div className="form-group">
-              <label>{t('messageTester.messageContent')}</label>
-              <textarea
+              <label htmlFor="mt-2">{t('messageTester.messageContent')}</label>
+              <textarea id="mt-2"
                 value={content}
                 onChange={e => setContent(e.target.value)}
                 placeholder={t('messageTester.messagePlaceholder')}
@@ -550,8 +550,8 @@ export function MessageTester() {
           {isMediaMessageType && (
             <>
               <div className="form-group">
-                <label>{t('messageTester.mediaUrl')}</label>
-                <input
+                <label htmlFor="mt-3">{t('messageTester.mediaUrl')}</label>
+                <input id="mt-3"
                   type="text"
                   value={mediaUrl}
                   onChange={e => {
@@ -614,8 +614,8 @@ export function MessageTester() {
             <>
               <div className="form-row">
                 <div className="form-group">
-                  <label>{t('messageTester.locationLatitude')}</label>
-                  <input
+                  <label htmlFor="mt-4">{t('messageTester.locationLatitude')}</label>
+                  <input id="mt-4"
                     type="number"
                     step="any"
                     min={-90}
@@ -626,8 +626,8 @@ export function MessageTester() {
                   />
                 </div>
                 <div className="form-group">
-                  <label>{t('messageTester.locationLongitude')}</label>
-                  <input
+                  <label htmlFor="mt-5">{t('messageTester.locationLongitude')}</label>
+                  <input id="mt-5"
                     type="number"
                     step="any"
                     min={-180}
@@ -656,8 +656,8 @@ export function MessageTester() {
           {messageType === 'contact' && (
             <>
               <div className="form-group">
-                <label>{t('messageTester.contactName')}</label>
-                <input
+                <label htmlFor="mt-6">{t('messageTester.contactName')}</label>
+                <input id="mt-6"
                   type="text"
                   value={contactName}
                   onChange={e => setContactName(e.target.value)}
@@ -665,8 +665,8 @@ export function MessageTester() {
                 />
               </div>
               <div className="form-group">
-                <label>{t('messageTester.contactNumber')}</label>
-                <input
+                <label htmlFor="mt-7">{t('messageTester.contactNumber')}</label>
+                <input id="mt-7"
                   type="text"
                   value={contactNumber}
                   onChange={e => setContactNumber(e.target.value)}
@@ -679,8 +679,8 @@ export function MessageTester() {
           {messageType === 'poll' && (
             <>
               <div className="form-group">
-                <label>{t('messageTester.pollQuestion')}</label>
-                <input
+                <label htmlFor="mt-8">{t('messageTester.pollQuestion')}</label>
+                <input id="mt-8"
                   type="text"
                   value={pollQuestion}
                   onChange={e => setPollQuestion(e.target.value)}
@@ -748,8 +748,8 @@ export function MessageTester() {
                 <span className="hint">{t('messageTester.forwardFromHint')}</span>
               </div>
               <div className="form-group">
-                <label>{t('messageTester.forwardToChatId')}</label>
-                <input
+                <label htmlFor="mt-9">{t('messageTester.forwardToChatId')}</label>
+                <input id="mt-9"
                   type="text"
                   value={forwardTo}
                   onChange={e => setForwardTo(e.target.value)}
@@ -757,8 +757,8 @@ export function MessageTester() {
                 />
               </div>
               <div className="form-group">
-                <label>{t('messageTester.forwardMessageId')}</label>
-                <input type="text" value={forwardMessageId} onChange={e => setForwardMessageId(e.target.value)} />
+                <label htmlFor="mt-10">{t('messageTester.forwardMessageId')}</label>
+                <input id="mt-10" type="text" value={forwardMessageId} onChange={e => setForwardMessageId(e.target.value)} />
                 <span className="hint">{t('messageTester.forwardMessageIdHint')}</span>
               </div>
             </>
@@ -767,8 +767,8 @@ export function MessageTester() {
           {messageType === 'bulk' && (
             <>
               <div className="form-group">
-                <label>{t('messageTester.bulkRecipients')}</label>
-                <textarea
+                <label htmlFor="mt-11">{t('messageTester.bulkRecipients')}</label>
+                <textarea id="mt-11"
                   value={bulkRecipients}
                   onChange={e => setBulkRecipients(e.target.value)}
                   placeholder={t('messageTester.bulkRecipientsPlaceholder')}
@@ -780,8 +780,8 @@ export function MessageTester() {
                 </span>
               </div>
               <div className="form-group">
-                <label>{t('messageTester.messageContent')}</label>
-                <textarea
+                <label htmlFor="mt-12">{t('messageTester.messageContent')}</label>
+                <textarea id="mt-12"
                   value={content}
                   onChange={e => setContent(e.target.value)}
                   placeholder={t('messageTester.messagePlaceholder')}

--- a/dashboard/src/pages/Plugins.tsx
+++ b/dashboard/src/pages/Plugins.tsx
@@ -77,11 +77,11 @@ function ConfigField({
     return (
       <div className="form-group toggle-group">
         <div className="toggle-info">
-          <label>{label}</label>
+          <label htmlFor="plg-1">{label}</label>
           {desc}
         </div>
         <label className="toggle-switch">
-          <input type="checkbox" checked={Boolean(value)} onChange={e => onChange(e.target.checked)} />
+          <input id="plg-1" type="checkbox" checked={Boolean(value)} onChange={e => onChange(e.target.checked)} />
           <span className="toggle-slider"></span>
         </label>
       </div>

--- a/dashboard/src/pages/Sessions.tsx
+++ b/dashboard/src/pages/Sessions.tsx
@@ -466,8 +466,8 @@ export function Sessions() {
             </>
           }
         >
-          <label>{t('sessions.create.label')}</label>
-          <input
+          <label htmlFor="sess-1">{t('sessions.create.label')}</label>
+          <input id="sess-1"
             type="text"
             placeholder={t('sessions.create.placeholder')}
             value={newSessionName}

--- a/dashboard/src/pages/Templates.tsx
+++ b/dashboard/src/pages/Templates.tsx
@@ -304,8 +304,8 @@ export function Templates() {
 
             <div className="template-form">
               <div className="form-group">
-                <label>{t('common.name')}</label>
-                <input
+                <label htmlFor="tpl-1">{t('common.name')}</label>
+                <input id="tpl-1"
                   value={form.name}
                   onChange={event => setForm({ ...form, name: event.target.value })}
                   placeholder={t('templates.namePlaceholder')}
@@ -315,8 +315,8 @@ export function Templates() {
 
               <div className="template-message-fields">
                 <div className="form-group">
-                  <label>{t('templates.header')}</label>
-                  <input
+                  <label htmlFor="tpl-2">{t('templates.header')}</label>
+                  <input id="tpl-2"
                     value={form.header}
                     onChange={event => setForm({ ...form, header: event.target.value })}
                     placeholder={t('templates.headerPlaceholder')}
@@ -325,8 +325,8 @@ export function Templates() {
                 </div>
 
                 <div className="form-group body-field">
-                  <label>{t('templates.body')}</label>
-                  <textarea
+                  <label htmlFor="tpl-3">{t('templates.body')}</label>
+                  <textarea id="tpl-3"
                     value={form.body}
                     onChange={event => setForm({ ...form, body: event.target.value })}
                     placeholder={t('templates.bodyPlaceholder')}
@@ -336,8 +336,8 @@ export function Templates() {
                 </div>
 
                 <div className="form-group">
-                  <label>{t('templates.footer')}</label>
-                  <input
+                  <label htmlFor="tpl-4">{t('templates.footer')}</label>
+                  <input id="tpl-4"
                     value={form.footer}
                     onChange={event => setForm({ ...form, footer: event.target.value })}
                     placeholder={t('templates.footerPlaceholder')}

--- a/dashboard/src/pages/Webhooks.tsx
+++ b/dashboard/src/pages/Webhooks.tsx
@@ -309,8 +309,8 @@ export function Webhooks() {
             </>
           }
         >
-          <label>{t('webhooks.session')}</label>
-          <select
+          <label htmlFor="wh-1">{t('webhooks.session')}</label>
+          <select id="wh-1"
             value={newWebhook.sessionId}
             onChange={e => setNewWebhook({ ...newWebhook, sessionId: e.target.value })}
           >
@@ -321,8 +321,8 @@ export function Webhooks() {
               </option>
             ))}
           </select>
-          <label>{t('common.url')}</label>
-          <input
+          <label htmlFor="wh-2">{t('common.url')}</label>
+          <input id="wh-2"
             type="url"
             placeholder="https://..."
             value={newWebhook.url}
@@ -372,8 +372,8 @@ export function Webhooks() {
             </>
           }
         >
-          <label>{t('common.url')}</label>
-          <input
+          <label htmlFor="wh-3">{t('common.url')}</label>
+          <input id="wh-3"
             type="url"
             value={editWebhook.url}
             onChange={e => setEditWebhook({ ...editWebhook, url: e.target.value })}


### PR DESCRIPTION
## Problem

The dashboard's design doc claims WCAG 2.1 AA compliance, but three measurements failed it: 71 of 99 labels had no htmlFor/id association (screen readers could not reach the controls), the muted-text token was 2.56:1 on light and 3.07:1 on dark (AA needs 4.5:1), and the primary button's white text on WhatsApp green was 1.98:1.

## What Changed

- **55 label-control pairs** across 10 files wired with `htmlFor`/`id`. Each id is file-prefixed and unique; verified programmatically (no duplicates within a file, no orphan `htmlFor` without a matching `id`). `CustomSelect` instances are skipped (not a native control; its internal accessibility differs).
- **Muted text token**: the two theme values were each right for the other theme's background, so they swap. Light `--text-muted` #94a3b8 -> #64748b (2.56:1 -> 4.76:1, AA); dark `--text-muted` #64748b -> #94a3b8 (3.07:1 -> 5.71:1, AA). The system-dark twin follows.
- **Primary button**: white on #25d366 (1.98:1) -> #0f172a on #25d366 (9.0:1, AAA). The page-level `.btn-primary` overrides in ApiKeys.css and Sessions.css are layout-only (width, justify-content), so the color change applies everywhere.

## Verification

All dashboard gates green: tsc, ESLint, production build, unit suite (325 tests), i18n parity. The id uniqueness and htmlFor-orphan checks ran clean after the codemod.
