### PR TITLE
fix(dashboard): follow-ups from the accessibility review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Follow-ups from the accessibility review: the plugin ConfigField derives a per-field id (a hardcoded id collided on any schema with two booleans, making the second label toggle the first checkbox), the 10 codemod-touched files are Prettier-clean (9 failed the dashboard format gate), and six more multi-line labels in MessageTester are wired.
 - Dashboard accessibility: 55 form labels are associated with their controls (`htmlFor`/`id`, no duplicates or orphans), the muted-text token meets AA on both themes (4.76:1 light, 5.71:1 dark), and the primary button uses dark text on the green (9.0:1, from 1.98:1).
 - Follow-ups from the batch review: the chain-boot e2e sets MAIN_DATABASE_SYNCHRONIZE=false explicitly (the env's absence defaults to synchronize=true, so the main chain was never exercised), the drift gate classifies statements against the two known shape families (column-type rebuild, index-name drift) instead of blanket-filtering every index/DROP statement, the shared delivery recorder strips the raw error before the persistence spread, and the ignore-pattern list deduplicates.
 - The direct and queued webhook delivery paths share one POST-and-classify core (`postWebhookPayload`) and one terminal-failure recorder, instead of two line-for-line copies that an outbox would have tripled.

--- a/dashboard/src/components/PluginInstances.tsx
+++ b/dashboard/src/components/PluginInstances.tsx
@@ -236,7 +236,8 @@ export function PluginInstances({ pluginId }: { pluginId: string }) {
           }
         >
           <label htmlFor="pi-1">{t('plugins.instances.form.instanceId')}</label>
-          <input id="pi-1"
+          <input
+            id="pi-1"
             type="text"
             value={form.instanceId}
             placeholder={t('plugins.instances.form.instanceIdPlaceholder')}
@@ -244,21 +245,24 @@ export function PluginInstances({ pluginId }: { pluginId: string }) {
           />
           <p className="pi-hint">{t('plugins.instances.form.instanceIdHint')}</p>
           <label htmlFor="pi-2">{t('plugins.instances.form.sessionScope')}</label>
-          <input id="pi-2"
+          <input
+            id="pi-2"
             type="text"
             value={form.sessionScope}
             placeholder={t('plugins.instances.form.sessionScopePlaceholder')}
             onChange={e => setForm({ ...form, sessionScope: e.target.value })}
           />
           <label htmlFor="pi-3">{t('plugins.instances.form.verifyToken')}</label>
-          <input id="pi-3"
+          <input
+            id="pi-3"
             type="text"
             value={form.verifyToken}
             placeholder={t('plugins.instances.form.verifyTokenPlaceholder')}
             onChange={e => setForm({ ...form, verifyToken: e.target.value })}
           />
           <label htmlFor="pi-4">{t('plugins.instances.form.secret')}</label>
-          <input id="pi-4"
+          <input
+            id="pi-4"
             type="text"
             value={form.secret}
             placeholder={t('plugins.instances.form.secretPlaceholder')}
@@ -266,7 +270,8 @@ export function PluginInstances({ pluginId }: { pluginId: string }) {
           />
           <p className="pi-hint">{t('plugins.instances.form.secretHint')}</p>
           <label htmlFor="pi-5">{t('plugins.instances.form.config')}</label>
-          <textarea id="pi-5"
+          <textarea
+            id="pi-5"
             value={form.config}
             placeholder={t('plugins.instances.form.configPlaceholder')}
             onChange={e => setForm({ ...form, config: e.target.value })}
@@ -335,14 +340,16 @@ export function PluginInstances({ pluginId }: { pluginId: string }) {
           }
         >
           <label htmlFor="pi-6">{t('plugins.instances.form.sessionScope')}</label>
-          <input id="pi-6"
+          <input
+            id="pi-6"
             type="text"
             value={editForm.sessionScope}
             placeholder={t('plugins.instances.form.sessionScopePlaceholder')}
             onChange={e => setEditForm({ ...editForm, sessionScope: e.target.value })}
           />
           <label htmlFor="pi-7">{t('plugins.instances.form.config')}</label>
-          <textarea id="pi-7"
+          <textarea
+            id="pi-7"
             value={editForm.config}
             placeholder={t('plugins.instances.form.configPlaceholder')}
             onChange={e => setEditForm({ ...editForm, config: e.target.value })}

--- a/dashboard/src/components/chats/ChatSidebar.tsx
+++ b/dashboard/src/components/chats/ChatSidebar.tsx
@@ -119,8 +119,11 @@ function ChatSidebar({
       <div className="sidebar-header-box">
         {/* Session selector */}
         <div className="session-select-group">
-          <label className="form-label" htmlFor="csb-1">{t('chats.sessionLabel')}</label>
-          <select id="csb-1"
+          <label className="form-label" htmlFor="csb-1">
+            {t('chats.sessionLabel')}
+          </label>
+          <select
+            id="csb-1"
             value={selectedSessionId}
             onChange={e => onSelectSession(e.target.value)}
             className="session-selector"

--- a/dashboard/src/components/chats/StatusComposeModal.tsx
+++ b/dashboard/src/components/chats/StatusComposeModal.tsx
@@ -186,7 +186,8 @@ function StatusComposeModal({ sessionId, onClose, onPosted }: Props) {
         <>
           <div className="compose-field">
             <label htmlFor="scm-1">{t('chats.status.composeText')}</label>
-            <textarea id="scm-1"
+            <textarea
+              id="scm-1"
               value={composeText}
               onChange={e => setComposeText(e.target.value)}
               maxLength={4096}
@@ -196,7 +197,8 @@ function StatusComposeModal({ sessionId, onClose, onPosted }: Props) {
           <div className="compose-row">
             <div className="compose-field">
               <label htmlFor="scm-2">{t('chats.status.backgroundColor')}</label>
-              <input id="scm-2"
+              <input
+                id="scm-2"
                 type="color"
                 value={composeBgColor || '#000000'}
                 onChange={e => setComposeBgColor(e.target.value)}
@@ -221,7 +223,8 @@ function StatusComposeModal({ sessionId, onClose, onPosted }: Props) {
         <>
           <div className="compose-field">
             <label htmlFor="scm-4">{t('chats.status.composeImage')}</label>
-            <input id="scm-4"
+            <input
+              id="scm-4"
               type="url"
               placeholder="https://example.com/image.jpg"
               value={composeImageUrl}
@@ -234,7 +237,8 @@ function StatusComposeModal({ sessionId, onClose, onPosted }: Props) {
           </div>
           <div className="compose-field">
             <label htmlFor="scm-5">{t('chats.status.caption')}</label>
-            <input id="scm-5"
+            <input
+              id="scm-5"
               type="text"
               placeholder={t('chats.captionPlaceholder')}
               value={composeCaption}
@@ -248,7 +252,8 @@ function StatusComposeModal({ sessionId, onClose, onPosted }: Props) {
       {isBaileysEngine && (
         <div className="compose-field">
           <label htmlFor="scm-6">{t('chats.status.recipients')}</label>
-          <input id="scm-6"
+          <input
+            id="scm-6"
             type="text"
             placeholder={t('common.search')}
             value={composeRecipientSearch}

--- a/dashboard/src/pages/ApiKeys.tsx
+++ b/dashboard/src/pages/ApiKeys.tsx
@@ -302,7 +302,8 @@ export function ApiKeys() {
           ) : (
             <>
               <label htmlFor="ak-1">{t('common.name')}</label>
-              <input id="ak-1"
+              <input
+                id="ak-1"
                 type="text"
                 placeholder={t('apiKeys.namePlaceholder')}
                 value={newKey.name}

--- a/dashboard/src/pages/Infrastructure.tsx
+++ b/dashboard/src/pages/Infrastructure.tsx
@@ -215,7 +215,8 @@ export function Infrastructure() {
                   <div className="form-row">
                     <div className="form-group">
                       <label htmlFor="infra-1">{t('common.host')}</label>
-                      <input id="infra-1"
+                      <input
+                        id="infra-1"
                         type="text"
                         value={configForm.dbConfig.host}
                         onChange={e => configForm.updateDbConfig('host', e.target.value)}
@@ -223,7 +224,8 @@ export function Infrastructure() {
                     </div>
                     <div className="form-group small">
                       <label htmlFor="infra-2">{t('common.port')}</label>
-                      <input id="infra-2"
+                      <input
+                        id="infra-2"
                         type="text"
                         value={configForm.dbConfig.port}
                         onChange={e => configForm.updateDbConfig('port', e.target.value)}
@@ -233,7 +235,8 @@ export function Infrastructure() {
                   <div className="form-row">
                     <div className="form-group">
                       <label htmlFor="infra-3">{t('common.username')}</label>
-                      <input id="infra-3"
+                      <input
+                        id="infra-3"
                         type="text"
                         value={configForm.dbConfig.username}
                         onChange={e => configForm.updateDbConfig('username', e.target.value)}
@@ -241,7 +244,8 @@ export function Infrastructure() {
                     </div>
                     <div className="form-group">
                       <label htmlFor="infra-4">{t('common.password')}</label>
-                      <input id="infra-4"
+                      <input
+                        id="infra-4"
                         type="password"
                         value={configForm.dbConfig.password}
                         onChange={e => configForm.updateDbConfig('password', e.target.value)}
@@ -251,7 +255,8 @@ export function Infrastructure() {
                   <div className="form-row">
                     <div className="form-group">
                       <label htmlFor="infra-5">{t('infrastructure.database.dbName')}</label>
-                      <input id="infra-5"
+                      <input
+                        id="infra-5"
                         type="text"
                         value={configForm.dbConfig.database}
                         onChange={e => configForm.updateDbConfig('database', e.target.value)}
@@ -259,7 +264,8 @@ export function Infrastructure() {
                     </div>
                     <div className="form-group small">
                       <label htmlFor="infra-6">{t('infrastructure.database.poolSize')}</label>
-                      <input id="infra-6"
+                      <input
+                        id="infra-6"
                         type="number"
                         min="1"
                         max="50"
@@ -271,7 +277,8 @@ export function Infrastructure() {
                   <div className="form-row">
                     <div className="form-group">
                       <label htmlFor="infra-7">{t('infrastructure.database.schema')}</label>
-                      <input id="infra-7"
+                      <input
+                        id="infra-7"
                         type="text"
                         value={configForm.dbConfig.schema}
                         onChange={e => configForm.updateDbConfig('schema', e.target.value)}
@@ -427,7 +434,8 @@ export function Infrastructure() {
               </div>
               <div className="form-group">
                 <label htmlFor="infra-8">{t('infrastructure.engine.sessionDataPath')}</label>
-                <input id="infra-8"
+                <input
+                  id="infra-8"
                   type="text"
                   value={configForm.engineConfig.sessionDataPath}
                   onChange={e => configForm.updateEngineConfig('sessionDataPath', e.target.value)}
@@ -435,7 +443,8 @@ export function Infrastructure() {
               </div>
               <div className="form-group">
                 <label htmlFor="infra-9">{t('infrastructure.engine.browserArgs')}</label>
-                <input id="infra-9"
+                <input
+                  id="infra-9"
                   type="text"
                   value={configForm.engineConfig.browserArgs}
                   onChange={e => configForm.updateEngineConfig('browserArgs', e.target.value)}
@@ -516,7 +525,8 @@ export function Infrastructure() {
                   <div className="form-row">
                     <div className="form-group">
                       <label htmlFor="infra-10">{t('common.host')}</label>
-                      <input id="infra-10"
+                      <input
+                        id="infra-10"
                         type="text"
                         value={configForm.redisConfig.host}
                         onChange={e => configForm.updateRedisConfig('host', e.target.value)}
@@ -524,7 +534,8 @@ export function Infrastructure() {
                     </div>
                     <div className="form-group small">
                       <label htmlFor="infra-11">{t('common.port')}</label>
-                      <input id="infra-11"
+                      <input
+                        id="infra-11"
                         type="text"
                         value={configForm.redisConfig.port}
                         onChange={e => configForm.updateRedisConfig('port', e.target.value)}
@@ -532,7 +543,8 @@ export function Infrastructure() {
                     </div>
                     <div className="form-group">
                       <label htmlFor="infra-12">{t('common.password')}</label>
-                      <input id="infra-12"
+                      <input
+                        id="infra-12"
                         type="password"
                         value={configForm.redisConfig.password}
                         onChange={e => configForm.updateRedisConfig('password', e.target.value)}
@@ -672,7 +684,8 @@ export function Infrastructure() {
             {configForm.storageConfig.type === 'local' && (
               <div className="form-group">
                 <label htmlFor="infra-13">{t('infrastructure.storage.storagePath')}</label>
-                <input id="infra-13"
+                <input
+                  id="infra-13"
                   type="text"
                   value={configForm.storageConfig.localPath}
                   onChange={e => configForm.updateStorageConfig('localPath', e.target.value)}
@@ -702,7 +715,8 @@ export function Infrastructure() {
                     <div className="form-row">
                       <div className="form-group">
                         <label htmlFor="infra-14">{t('infrastructure.storage.bucket')}</label>
-                        <input id="infra-14"
+                        <input
+                          id="infra-14"
                           type="text"
                           value={configForm.storageConfig.s3Bucket}
                           onChange={e => configForm.updateStorageConfig('s3Bucket', e.target.value)}
@@ -710,7 +724,8 @@ export function Infrastructure() {
                       </div>
                       <div className="form-group">
                         <label htmlFor="infra-15">{t('infrastructure.storage.region')}</label>
-                        <input id="infra-15"
+                        <input
+                          id="infra-15"
                           type="text"
                           value={configForm.storageConfig.s3Region}
                           onChange={e => configForm.updateStorageConfig('s3Region', e.target.value)}
@@ -720,7 +735,8 @@ export function Infrastructure() {
                     <div className="form-row">
                       <div className="form-group">
                         <label htmlFor="infra-16">{t('infrastructure.storage.accessKey')}</label>
-                        <input id="infra-16"
+                        <input
+                          id="infra-16"
                           type="text"
                           value={configForm.storageConfig.s3AccessKey}
                           onChange={e => configForm.updateStorageConfig('s3AccessKey', e.target.value)}
@@ -728,7 +744,8 @@ export function Infrastructure() {
                       </div>
                       <div className="form-group">
                         <label htmlFor="infra-17">{t('infrastructure.storage.secretKey')}</label>
-                        <input id="infra-17"
+                        <input
+                          id="infra-17"
                           type="password"
                           value={configForm.storageConfig.s3SecretKey}
                           onChange={e => configForm.updateStorageConfig('s3SecretKey', e.target.value)}
@@ -737,7 +754,8 @@ export function Infrastructure() {
                     </div>
                     <div className="form-group">
                       <label htmlFor="infra-18">{t('infrastructure.storage.endpoint')}</label>
-                      <input id="infra-18"
+                      <input
+                        id="infra-18"
                         type="text"
                         value={configForm.storageConfig.s3Endpoint}
                         onChange={e => configForm.updateStorageConfig('s3Endpoint', e.target.value)}

--- a/dashboard/src/pages/MessageTester.tsx
+++ b/dashboard/src/pages/MessageTester.tsx
@@ -478,12 +478,13 @@ export function MessageTester() {
               </div>
 
               <div className="form-group">
-                <label>
+                <label htmlFor="mt-13">
                   {recipientType === 'group' ? t('messageTester.selectGroup') : t('messageTester.recipientPhone')}
                 </label>
                 {recipientType === 'group' ? (
                   <>
                     <select
+                      id="mt-13"
                       value={selectedGroup}
                       onChange={e => setSelectedGroup(e.target.value)}
                       disabled={loadingGroups || groups.length === 0}
@@ -538,7 +539,8 @@ export function MessageTester() {
           {messageType === 'text' && (
             <div className="form-group">
               <label htmlFor="mt-2">{t('messageTester.messageContent')}</label>
-              <textarea id="mt-2"
+              <textarea
+                id="mt-2"
                 value={content}
                 onChange={e => setContent(e.target.value)}
                 placeholder={t('messageTester.messagePlaceholder')}
@@ -551,7 +553,8 @@ export function MessageTester() {
             <>
               <div className="form-group">
                 <label htmlFor="mt-3">{t('messageTester.mediaUrl')}</label>
-                <input id="mt-3"
+                <input
+                  id="mt-3"
                   type="text"
                   value={mediaUrl}
                   onChange={e => {
@@ -591,11 +594,12 @@ export function MessageTester() {
               </div>
               {messageType !== 'audio' && messageType !== 'sticker' && (
                 <div className="form-group">
-                  <label>
+                  <label htmlFor="mt-14">
                     {messageType === 'document' ? t('messageTester.filename') : t('messageTester.caption')} (
                     {t('common.optional')})
                   </label>
                   <input
+                    id="mt-14"
                     type="text"
                     value={content}
                     onChange={e => setContent(e.target.value)}
@@ -615,7 +619,8 @@ export function MessageTester() {
               <div className="form-row">
                 <div className="form-group">
                   <label htmlFor="mt-4">{t('messageTester.locationLatitude')}</label>
-                  <input id="mt-4"
+                  <input
+                    id="mt-4"
                     type="number"
                     step="any"
                     min={-90}
@@ -627,7 +632,8 @@ export function MessageTester() {
                 </div>
                 <div className="form-group">
                   <label htmlFor="mt-5">{t('messageTester.locationLongitude')}</label>
-                  <input id="mt-5"
+                  <input
+                    id="mt-5"
                     type="number"
                     step="any"
                     min={-180}
@@ -639,16 +645,26 @@ export function MessageTester() {
                 </div>
               </div>
               <div className="form-group">
-                <label>
+                <label htmlFor="mt-15">
                   {t('messageTester.locationDescription')} ({t('common.optional')})
                 </label>
-                <input type="text" value={locationDescription} onChange={e => setLocationDescription(e.target.value)} />
+                <input
+                  id="mt-15"
+                  type="text"
+                  value={locationDescription}
+                  onChange={e => setLocationDescription(e.target.value)}
+                />
               </div>
               <div className="form-group">
-                <label>
+                <label htmlFor="mt-16">
                   {t('messageTester.locationAddress')} ({t('common.optional')})
                 </label>
-                <input type="text" value={locationAddress} onChange={e => setLocationAddress(e.target.value)} />
+                <input
+                  id="mt-16"
+                  type="text"
+                  value={locationAddress}
+                  onChange={e => setLocationAddress(e.target.value)}
+                />
               </div>
             </>
           )}
@@ -657,7 +673,8 @@ export function MessageTester() {
             <>
               <div className="form-group">
                 <label htmlFor="mt-6">{t('messageTester.contactName')}</label>
-                <input id="mt-6"
+                <input
+                  id="mt-6"
                   type="text"
                   value={contactName}
                   onChange={e => setContactName(e.target.value)}
@@ -666,7 +683,8 @@ export function MessageTester() {
               </div>
               <div className="form-group">
                 <label htmlFor="mt-7">{t('messageTester.contactNumber')}</label>
-                <input id="mt-7"
+                <input
+                  id="mt-7"
                   type="text"
                   value={contactNumber}
                   onChange={e => setContactNumber(e.target.value)}
@@ -680,7 +698,8 @@ export function MessageTester() {
             <>
               <div className="form-group">
                 <label htmlFor="mt-8">{t('messageTester.pollQuestion')}</label>
-                <input id="mt-8"
+                <input
+                  id="mt-8"
                   type="text"
                   value={pollQuestion}
                   onChange={e => setPollQuestion(e.target.value)}
@@ -734,10 +753,11 @@ export function MessageTester() {
           {messageType === 'forward' && (
             <>
               <div className="form-group">
-                <label>
+                <label htmlFor="mt-17">
                   {t('messageTester.forwardFromChatId')} ({t('common.optional')})
                 </label>
                 <input
+                  id="mt-17"
                   type="text"
                   value={forwardFrom}
                   onChange={e => setForwardFrom(e.target.value)}
@@ -749,7 +769,8 @@ export function MessageTester() {
               </div>
               <div className="form-group">
                 <label htmlFor="mt-9">{t('messageTester.forwardToChatId')}</label>
-                <input id="mt-9"
+                <input
+                  id="mt-9"
                   type="text"
                   value={forwardTo}
                   onChange={e => setForwardTo(e.target.value)}
@@ -758,7 +779,12 @@ export function MessageTester() {
               </div>
               <div className="form-group">
                 <label htmlFor="mt-10">{t('messageTester.forwardMessageId')}</label>
-                <input id="mt-10" type="text" value={forwardMessageId} onChange={e => setForwardMessageId(e.target.value)} />
+                <input
+                  id="mt-10"
+                  type="text"
+                  value={forwardMessageId}
+                  onChange={e => setForwardMessageId(e.target.value)}
+                />
                 <span className="hint">{t('messageTester.forwardMessageIdHint')}</span>
               </div>
             </>
@@ -768,7 +794,8 @@ export function MessageTester() {
             <>
               <div className="form-group">
                 <label htmlFor="mt-11">{t('messageTester.bulkRecipients')}</label>
-                <textarea id="mt-11"
+                <textarea
+                  id="mt-11"
                   value={bulkRecipients}
                   onChange={e => setBulkRecipients(e.target.value)}
                   placeholder={t('messageTester.bulkRecipientsPlaceholder')}
@@ -781,7 +808,8 @@ export function MessageTester() {
               </div>
               <div className="form-group">
                 <label htmlFor="mt-12">{t('messageTester.messageContent')}</label>
-                <textarea id="mt-12"
+                <textarea
+                  id="mt-12"
                   value={content}
                   onChange={e => setContent(e.target.value)}
                   placeholder={t('messageTester.messagePlaceholder')}
@@ -789,10 +817,11 @@ export function MessageTester() {
                 />
               </div>
               <div className="form-group">
-                <label>
+                <label htmlFor="mt-18">
                   {t('messageTester.bulkDelay')} ({t('common.optional')})
                 </label>
                 <input
+                  id="mt-18"
                   type="number"
                   min={1000}
                   max={60000}

--- a/dashboard/src/pages/Plugins.tsx
+++ b/dashboard/src/pages/Plugins.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo } from 'react';
+import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { localizePlugin } from '../utils/localizePlugin';
 import { configUiSafeConfig, missingRequiredConfig, sparseSessionOverride } from '../utils/pluginConfigRules';
@@ -65,6 +65,10 @@ function ConfigField({
   onChange: (next: unknown) => void;
 }) {
   const { t } = useTranslation();
+  // Per-instance id: ConfigField renders once per schema property (and recurses), so a hardcoded
+  // id would collide on any schema with two boolean fields - the second label would toggle the
+  // first checkbox. useId is stable across re-renders and unique per instance.
+  const fieldId = React.useId();
   const desc = field.description ? <small>{field.description}</small> : null;
   const labelEl = (
     <label>
@@ -77,11 +81,11 @@ function ConfigField({
     return (
       <div className="form-group toggle-group">
         <div className="toggle-info">
-          <label htmlFor="plg-1">{label}</label>
+          <label htmlFor={fieldId}>{label}</label>
           {desc}
         </div>
         <label className="toggle-switch">
-          <input id="plg-1" type="checkbox" checked={Boolean(value)} onChange={e => onChange(e.target.checked)} />
+          <input id={fieldId} type="checkbox" checked={Boolean(value)} onChange={e => onChange(e.target.checked)} />
           <span className="toggle-slider"></span>
         </label>
       </div>

--- a/dashboard/src/pages/Sessions.tsx
+++ b/dashboard/src/pages/Sessions.tsx
@@ -467,7 +467,8 @@ export function Sessions() {
           }
         >
           <label htmlFor="sess-1">{t('sessions.create.label')}</label>
-          <input id="sess-1"
+          <input
+            id="sess-1"
             type="text"
             placeholder={t('sessions.create.placeholder')}
             value={newSessionName}

--- a/dashboard/src/pages/Templates.tsx
+++ b/dashboard/src/pages/Templates.tsx
@@ -305,7 +305,8 @@ export function Templates() {
             <div className="template-form">
               <div className="form-group">
                 <label htmlFor="tpl-1">{t('common.name')}</label>
-                <input id="tpl-1"
+                <input
+                  id="tpl-1"
                   value={form.name}
                   onChange={event => setForm({ ...form, name: event.target.value })}
                   placeholder={t('templates.namePlaceholder')}
@@ -316,7 +317,8 @@ export function Templates() {
               <div className="template-message-fields">
                 <div className="form-group">
                   <label htmlFor="tpl-2">{t('templates.header')}</label>
-                  <input id="tpl-2"
+                  <input
+                    id="tpl-2"
                     value={form.header}
                     onChange={event => setForm({ ...form, header: event.target.value })}
                     placeholder={t('templates.headerPlaceholder')}
@@ -326,7 +328,8 @@ export function Templates() {
 
                 <div className="form-group body-field">
                   <label htmlFor="tpl-3">{t('templates.body')}</label>
-                  <textarea id="tpl-3"
+                  <textarea
+                    id="tpl-3"
                     value={form.body}
                     onChange={event => setForm({ ...form, body: event.target.value })}
                     placeholder={t('templates.bodyPlaceholder')}
@@ -337,7 +340,8 @@ export function Templates() {
 
                 <div className="form-group">
                   <label htmlFor="tpl-4">{t('templates.footer')}</label>
-                  <input id="tpl-4"
+                  <input
+                    id="tpl-4"
                     value={form.footer}
                     onChange={event => setForm({ ...form, footer: event.target.value })}
                     placeholder={t('templates.footerPlaceholder')}

--- a/dashboard/src/pages/Webhooks.tsx
+++ b/dashboard/src/pages/Webhooks.tsx
@@ -310,7 +310,8 @@ export function Webhooks() {
           }
         >
           <label htmlFor="wh-1">{t('webhooks.session')}</label>
-          <select id="wh-1"
+          <select
+            id="wh-1"
             value={newWebhook.sessionId}
             onChange={e => setNewWebhook({ ...newWebhook, sessionId: e.target.value })}
           >
@@ -322,7 +323,8 @@ export function Webhooks() {
             ))}
           </select>
           <label htmlFor="wh-2">{t('common.url')}</label>
-          <input id="wh-2"
+          <input
+            id="wh-2"
             type="url"
             placeholder="https://..."
             value={newWebhook.url}
@@ -373,7 +375,8 @@ export function Webhooks() {
           }
         >
           <label htmlFor="wh-3">{t('common.url')}</label>
-          <input id="wh-3"
+          <input
+            id="wh-3"
             type="url"
             value={editWebhook.url}
             onChange={e => setEditWebhook({ ...editWebhook, url: e.target.value })}


### PR DESCRIPTION
## Problem

Review of the accessibility batch (#1383) found one real functional regression, one CI-gating defect, and a coverage gap.

## What Changed

- **ConfigField duplicate id** (functional): the plugin config renderer hardcoded `id="plg-1"` on its boolean branch, but the component renders once per schema property and recurses - any schema with two boolean fields produced a duplicate id, and the second field's label toggled the FIRST checkbox. The id is now derived per instance via `React.useId()`.
- **Prettier violations** (CI): the codemod's inline `id` attribute style failed `format:check` on 9 of the 10 touched files. All reformatted; verified zero warnings across the dashboard src.
- **Coverage gap**: six more multi-line labels in MessageTester (caption/filename, location description, location address, forwardFrom, bulkDelay) are wired with htmlFor/id, bringing that file to 18 pairs. The four remaining bare labels (recipientType, messageType, uploadFile, pollOptions) sit above toggle groups, file inputs, or dynamic lists, not a single adjacent native control: skipped deliberately.

## Verification

All dashboard gates green: tsc, ESLint, production build, unit suite (325 tests). `prettier --check src/` passes with zero warnings. MessageTester: 18 wired labels, zero orphans, zero duplicates.
