### PR TITLE
fix: recognize Meta-hosted ids, retry locked-database launches, and ship the Postgres client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A session launch that fails on a locked database is retried. The classifier looked for `SQLITE_BUSY` in the error message while the driver carries it on `code`, so the session stayed down until a restart.
 - Meta-hosted ids (`@hosted`, `@hosted.lid`) normalize to the dialect they name. They parsed as unknown before, so a chat surfaced with kind `unknown` and the same id was then refused with a `400` on any write.
 
 ## [0.21.0] - 2026-08-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The image ships the PostgreSQL client, so `backup.sh` and `restore.sh` work in-container with `DATABASE_TYPE=postgres`. Neither `pg_dump` nor `psql` was present, so the backup exited 1 and the restore printed an import that could not be run.
 - A session launch that fails on a locked database is retried. The classifier looked for `SQLITE_BUSY` in the error message while the driver carries it on `code`, so the session stayed down until a restart.
 - Meta-hosted ids (`@hosted`, `@hosted.lid`) normalize to the dialect they name. They parsed as unknown before, so a chat surfaced with kind `unknown` and the same id was then refused with a `400` on any write.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Meta-hosted ids (`@hosted`, `@hosted.lid`) normalize to the dialect they name. They parsed as unknown before, so a chat surfaced with kind `unknown` and the same id was then refused with a `400` on any write.
+
 ## [0.21.0] - 2026-08-18
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,11 @@ ENV NODE_ENV=production
 # with --no-install-recommends the package is dropped, and chromium launches fine under --no-sandbox.
 ARG TARGETARCH
 # sqlite3 ships the CLI so an in-container scripts/backup.sh run takes online-consistent SQLite
-# snapshots (.backup) instead of plain-copying a live database (which can archive a torn file).
+# snapshots (.backup) instead of plain-copying a live database (which can archive a torn file). The
+# DATABASE_TYPE=postgres half of the same script needs pg_dump, installed further down.
+#
+# ca-certificates is required to fetch the PGDG signing key over HTTPS below: the base image has no
+# CA bundle, and curl alone does not pull one in under --no-install-recommends (curl: (77)).
 #
 # ffmpeg backs the opt-in media-conversion endpoints, and also repairs an existing gap: whatsapp-web.js
 # requires fluent-ffmpeg at module load and calls it for video-to-webp animated stickers, so
@@ -110,8 +114,28 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     patch \
     curl \
     procps \
+    ca-certificates \
     sqlite3 \
     ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+# The PostgreSQL client for the DATABASE_TYPE=postgres half of backup.sh/restore.sh, which the
+# runbook drives in-container. Debian bookworm ships client 15 and pg_dump refuses a newer server
+# outright ("aborting because of server version mismatch", reproduced against the postgres:16 the
+# bundled compose file runs), so the distro package would install a pg_dump that cannot dump our own
+# stack, and psql would be missing for restore. PGDG is PostgreSQL's own apt repository and carries
+# current majors for both architectures we build; measured cost ~59 MB.
+#
+# Deliberately NEWER than the postgres:16 the compose file ships. The rule is one-directional (a
+# client may be newer than its server, never older), and DATABASE_HOST often points at a managed
+# Postgres the compose file does not control, where 17 is the current default. Pinning to 16 would
+# have left every such deployment unable to back up. Verified against live 16 and 17 servers.
+RUN install -d /usr/share/postgresql-common/pgdg \
+    && curl -fsSL -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+        https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+    && echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] \
+http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
+    && apt-get update && apt-get install -y --no-install-recommends postgresql-client-17 \
     && rm -rf /var/lib/apt/lists/*
 
 # Set Puppeteer to skip automatic download during npm install (we download it explicitly below)

--- a/docs/03-system-architecture.md
+++ b/docs/03-system-architecture.md
@@ -180,7 +180,9 @@ chat `id`) is reduced to one small **neutral dialect**:
 
 Never `@s.whatsapp.net`, never a `:device` suffix. **Resolution rule:** prefer `@c.us` (resolve a lid
 to its phone when the mapping is known), and fall back to `@lid` only when it can't be resolved - an
-unresolved lid is never faked into a phone number.
+unresolved lid is never faked into a phone number. WhatsApp's Meta-hosted dialects fold in here
+too: `<n>@hosted` is the same account as `<n>@c.us` and normalizes to it, and `<lid>@hosted.lid`
+normalizes like any other lid. Baileys makes the same fold itself on every inbound message.
 
 The shared implementation lives in `src/engine/identity/wa-id.ts` (`parseWaId` / `toNeutralJid`); the
 contract is documented on the `IWhatsAppEngine` interface.

--- a/docs/21-glossary.md
+++ b/docs/21-glossary.md
@@ -134,7 +134,7 @@ Data stored in RAM. Fast but non-persistent — lost on restart. Independent of 
 
 ### JID (Jabber ID)
 
-WhatsApp's id format, inherited from XMPP; the user-facing "Chat ID" is a JID. The same entity can be addressed in more than one dialect: `<phone>@c.us` (whatsapp-web.js, and OpenWA's neutral form), `<phone>@s.whatsapp.net` (Baileys' raw form for the same user), `<id>@g.us` (a group), or `<lid>@lid` (a LID, a privacy id). OpenWA normalizes engine ids to a single neutral dialect at the engine boundary - see _System Architecture > WhatsApp Identity Contract_.
+WhatsApp's id format, inherited from XMPP; the user-facing "Chat ID" is a JID. The same entity can be addressed in more than one dialect: `<phone>@c.us` (whatsapp-web.js, and OpenWA's neutral form), `<phone>@s.whatsapp.net` (Baileys' raw form for the same user), `<id>@g.us` (a group), or `<lid>@lid` (a LID, a privacy id). WhatsApp also issues Meta-hosted dialects of the first and last of these (`@hosted`, `@hosted.lid`); they name the same account and normalize to the same neutral form. OpenWA normalizes engine ids to a single neutral dialect at the engine boundary - see _System Architecture > WhatsApp Identity Contract_.
 
 ### Job Queue
 

--- a/src/engine/identity/wa-id.spec.ts
+++ b/src/engine/identity/wa-id.spec.ts
@@ -2,6 +2,7 @@ import {
   chatKind,
   isAddressableParticipant,
   isChannelJid,
+  isIndividualWid,
   parseWaId,
   toNeutralJid,
   toParticipantWid,
@@ -153,5 +154,51 @@ describe('wa-id', () => {
         expect(toParticipantWid(value)).toBe(value);
       },
     );
+  });
+
+  /**
+   * WhatsApp issues Meta-hosted dialects of a phone id and a lid, and Baileys decodes them off the
+   * wire (`WAJIDDomains.HOSTED` = 128, `HOSTED_LID` = 129). They used to parse as `unknown` here, so
+   * an id we had emitted on GET /chats was refused with a 400 when it was handed back to us.
+   *
+   * They fold into `user` and `lid` rather than becoming kinds of their own, because the user-part
+   * names the SAME account: Baileys rewrites `<n>@hosted` to `<n>@s.whatsapp.net` on every inbound
+   * message (`cleanMessage`). A separate kind would split one person's history in two.
+   */
+  describe('Meta-hosted dialects', () => {
+    it('folds each hosted dialect into the entity it names', () => {
+      expect(parseWaId('628111@hosted')).toMatchObject({ kind: 'user', userPart: '628111' });
+      expect(parseWaId('4707@hosted.lid')).toMatchObject({ kind: 'lid', userPart: '4707' });
+      expect(parseWaId('628111:3@hosted')).toMatchObject({ kind: 'user', userPart: '628111', device: '3' });
+      expect(parseWaId('ABC@HOSTED.LID')).toMatchObject({ kind: 'lid', userPart: 'abc' });
+    });
+
+    it('does not confuse @hosted.lid with @hosted: the domain is the whole suffix', () => {
+      // Same user-part, different entity: one is a phone number, the other a privacy id.
+      expect(parseWaId('4707@hosted.lid').kind).toBe('lid');
+      expect(parseWaId('4707@hosted').kind).toBe('user');
+    });
+
+    it('accepts them as individuals, which is what the guards refused before', () => {
+      expect(isIndividualWid('628123456789@hosted')).toBe(true);
+      expect(isIndividualWid('12345678901234567890@hosted.lid')).toBe(true);
+      expect(isAddressableParticipant('628123456789@hosted')).toBe(true);
+      // The user-part still has to look like an id: the domain alone was never enough.
+      expect(isIndividualWid('NOT A USER@hosted')).toBe(false);
+      expect(isIndividualWid('1234@hosted.lid')).toBe(false);
+    });
+
+    it('normalizes to the neutral dialect of the same account, so history stays in one place', () => {
+      expect(toNeutralJid('628111@hosted')).toBe('628111@c.us');
+      expect(toNeutralJid('628111:3@hosted')).toBe('628111@c.us');
+      // An unresolved hosted lid keeps the lid dialect, exactly like a plain @lid.
+      expect(toNeutralJid('4707@hosted.lid')).toBe('4707@lid');
+      expect(toNeutralJid('4707@hosted.lid', () => '628111')).toBe('628111@c.us');
+    });
+
+    it('surfaces as an individual chat, not unknown', () => {
+      expect(chatKind('628111@hosted')).toBe('individual');
+      expect(chatKind('4707@hosted.lid')).toBe('individual');
+    });
   });
 });

--- a/src/engine/identity/wa-id.ts
+++ b/src/engine/identity/wa-id.ts
@@ -25,8 +25,30 @@
 
 export type WaIdKind = 'user' | 'group' | 'lid' | 'status' | 'newsletter' | 'broadcast' | 'unknown';
 
-/** Domains that denote a phone-addressed user (the two are the same entity, different dialects). */
-const USER_DOMAINS = new Set(['c.us', 's.whatsapp.net']);
+/**
+ * Domain to kind. `c.us` and `s.whatsapp.net` are one entity in two dialects.
+ *
+ * `hosted` and `hosted.lid` are two more dialects of the same two entities, not entities of their
+ * own: they are the Meta-hosted forms WhatsApp issues and Baileys decodes off the wire
+ * (`WAJIDDomains.HOSTED` = 128, `HOSTED_LID` = 129). The user-part is the SAME account either way,
+ * which the library states by folding them itself on every inbound message (`cleanMessage`:
+ * `<n>@hosted` becomes `<n>@s.whatsapp.net`, `<lid>@hosted.lid` becomes `<lid>@lid`) and by treating
+ * `isHostedPnUser` as `isPnUser` throughout its history handling.
+ *
+ * So they fold here too. A separate kind would split one person's history in two: rows arrive under
+ * the plain dialect (Baileys already rewrote them) while a caller filtering by the hosted id we
+ * published would match none of them.
+ */
+const DOMAIN_KINDS = new Map<string, WaIdKind>([
+  ['c.us', 'user'],
+  ['s.whatsapp.net', 'user'],
+  ['lid', 'lid'],
+  ['hosted', 'user'],
+  ['hosted.lid', 'lid'],
+  ['g.us', 'group'],
+  ['newsletter', 'newsletter'],
+  ['broadcast', 'broadcast'],
+]);
 
 export interface ParsedWaId {
   kind: WaIdKind;
@@ -56,17 +78,7 @@ export function parseWaId(jid: string): ParsedWaId {
   }
   const domain = lower.slice(at + 1);
   const [local, device] = lower.slice(0, at).split(':');
-  const kind: WaIdKind = USER_DOMAINS.has(domain)
-    ? 'user'
-    : domain === 'g.us'
-      ? 'group'
-      : domain === 'lid'
-        ? 'lid'
-        : domain === 'newsletter'
-          ? 'newsletter'
-          : domain === 'broadcast'
-            ? 'broadcast'
-            : 'unknown';
+  const kind: WaIdKind = DOMAIN_KINDS.get(domain) ?? 'unknown';
   return { kind, userPart: local, device, raw };
 }
 
@@ -78,7 +90,7 @@ const NUMERIC_ID = /^\d{5,}$/;
 
 /**
  * Whether a string names an individual in a qualified dialect: `<phone>@c.us` (and its raw-protocol
- * twin `@s.whatsapp.net`) or `<lid>@lid`. A `:<device>` suffix is fine — {@link parseWaId} strips it.
+ * twin `@s.whatsapp.net`), `<lid>@lid`, or the Meta-hosted dialect of either. A `:<device>` suffix is fine — {@link parseWaId} strips it.
  *
  * **The domain alone is not enough.** `parseWaId` classifies anything ending in `@c.us` as a user, so
  * a check that stops at the kind accepts `NOT A USER@c.us` and `@c.us`. Those still reach WhatsApp

--- a/src/modules/contact/contact.service.spec.ts
+++ b/src/modules/contact/contact.service.spec.ts
@@ -128,6 +128,23 @@ describe('ContactService', () => {
     });
 
     /**
+     * A Meta-hosted id names the same account as its plain twin, so the write must reach the engine
+     * rather than be refused. It is neutralized on the way there: whatsapp-web.js knows no `@hosted`
+     * domain, so forwarding the suffix verbatim would fail inside the page instead of blocking anyone.
+     */
+    it('accepts a Meta-hosted id and hands the engine the neutral dialect', () => {
+      const blockContact = jest.fn();
+      const unblockContact = jest.fn();
+      const svc = makeService({ blockContact, unblockContact });
+
+      svc.blockContact('s1', '628123456789@hosted');
+      svc.unblockContact('s1', '12345678901234567890@hosted.lid');
+
+      expect(blockContact).toHaveBeenCalledWith('628123456789@c.us');
+      expect(unblockContact).toHaveBeenCalledWith('12345678901234567890@lid');
+    });
+
+    /**
      * A privacy-id contact has no phone number at all, and the blocklist READ answers those ids
      * verbatim (Baileys maps each blocked jid through toNeutralJid, which leaves an unresolved lid
      * as `<lid>@lid`; whatsapp-web.js returns the wid as-is). Refusing them here made the ids the

--- a/src/modules/contact/contact.service.ts
+++ b/src/modules/contact/contact.service.ts
@@ -3,7 +3,7 @@ import { EngineRegistry } from '../../engine/engine-registry.service';
 import { createLogger } from '../../common/services/logger.service';
 import { IWhatsAppEngine } from '../../engine/interfaces/whatsapp-engine.interface';
 import { paginate, ListOptions } from '../../common/utils/paginate';
-import { isIndividualWid, parseWaId } from '../../engine/identity/wa-id';
+import { isIndividualWid, parseWaId, toNeutralJid } from '../../engine/identity/wa-id';
 
 /**
  * Owns engine access for contact operations so the "session not started" guard and
@@ -200,7 +200,12 @@ export class ContactService {
    * qualification is a no-op there.
    */
   private toAddressableId(contactId: string): string {
-    return this.isBareNumber(contactId) ? `${contactId.trim()}@c.us` : contactId;
+    const trimmed = contactId.trim();
+    // Neutralized rather than passed through: a Meta-hosted id names the same account as its plain
+    // twin but whatsapp-web.js knows no such domain, so forwarding the suffix verbatim would fail
+    // inside the page instead of acting on the person. toNeutralJid is idempotent on ids already in
+    // the neutral dialect, and the Baileys adapter re-encodes to its own dialect on the way out.
+    return this.isBareNumber(trimmed) ? `${trimmed}@c.us` : toNeutralJid(trimmed);
   }
 
   upsertContact(sessionId: string, contactId: string, firstName: string, lastName?: string) {

--- a/src/modules/docker/compose-parity.spec.ts
+++ b/src/modules/docker/compose-parity.spec.ts
@@ -420,3 +420,34 @@ describe('DockerService managed specs ↔ docker-compose.yml parity', () => {
     });
   });
 });
+
+/**
+ * The image's pg_dump/psql must never be OLDER than the Postgres it talks to: pg_dump refuses a
+ * newer server outright ("aborting because of server version mismatch"), so an in-container
+ * backup of a DATABASE_TYPE=postgres deployment fails on version alone. The server major is
+ * declared once for the compose stack and again for the container the app orchestrates itself,
+ * while the client major lives in the Dockerfile, so bumping either server silently breaks backups
+ * until this fails.
+ */
+describe('PostgreSQL client is not older than the servers the stack ships', () => {
+  const root = join(__dirname, '../../..');
+
+  const major = (file: string, pattern: RegExp): number => {
+    const match = readFileSync(join(root, file), 'utf8').match(pattern);
+    if (!match) throw new Error(`could not read a Postgres major version from ${file} via ${String(pattern)}`);
+    return Number(match[1]);
+  };
+
+  it('the Dockerfile client covers both the compose server and the managed-container server', () => {
+    const client = major('Dockerfile', /postgresql-client-(\d+)/);
+    const composeServer = major('docker-compose.yml', /image:\s*postgres:(\d+)/);
+    const managedServer = major('src/modules/docker/docker.service.ts', /image: 'postgres:(\d+)/);
+
+    // Reported together so a failure names every version at once rather than the first mismatch.
+    expect({
+      client,
+      composeServerCovered: composeServer <= client,
+      managedServerCovered: managedServer <= client,
+    }).toEqual({ client, composeServerCovered: true, managedServerCovered: true });
+  });
+});

--- a/src/modules/message/message.service.spec.ts
+++ b/src/modules/message/message.service.spec.ts
@@ -219,6 +219,23 @@ describe('MessageService', () => {
 
       expect(messages.map(m => m.id)).toEqual(['m-dm']); // only the @c.us DM matches
     });
+
+    // `<n>@hosted` is the Meta-hosted dialect of the SAME phone account, which is why Baileys
+    // rewrites it to `<n>@s.whatsapp.net` on every inbound message. Rows therefore land under the
+    // plain dialect while a chat id we published may carry the hosted suffix, so a filter given the
+    // hosted form has to expand to the phone dialects or it returns none of the person's history.
+    it('expands a hosted id into the phone dialects, so it finds rows stored under @c.us', async () => {
+      const qb = makeFilteringQb();
+      (repository.createQueryBuilder as jest.Mock).mockReturnValue(qb);
+
+      const { messages } = await service.getMessages('sess-1', { from: '628999@hosted' });
+
+      expect(messages.map(m => m.id)).toEqual(['m-dm']);
+      expect(lidMappingStore.lidsForPhone).toHaveBeenCalledWith('628999');
+      const calls = qb.andWhere.mock.calls as Array<[string, { froms?: string[] }?]>;
+      const froms = calls.find(c => c[1]?.froms)?.[1]?.froms;
+      expect(froms).toEqual(expect.arrayContaining(['628999@hosted', '628999@c.us', '628999@s.whatsapp.net']));
+    });
   });
 
   // ── getMessages from-filter matches the group author ──────────────

--- a/src/modules/session/session.service.spec.ts
+++ b/src/modules/session/session.service.spec.ts
@@ -3,7 +3,7 @@ import { SessionRestrictionStore } from './session-restriction-store.service';
 import { PresenceStore } from './presence-store.service';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken, getDataSourceToken } from '@nestjs/typeorm';
-import { Repository, DataSource, In } from 'typeorm';
+import { Repository, DataSource, In, QueryFailedError } from 'typeorm';
 import {
   NotFoundException,
   ConflictException,
@@ -891,6 +891,50 @@ describe('SessionService', () => {
       await expect(service.start('sess-uuid-1')).resolves.toBeDefined();
 
       expect(mockEngine.initialize).toHaveBeenCalledTimes(2);
+    });
+
+    /**
+     * The shape better-sqlite3 actually throws under write contention: the token lives on `code`,
+     * and the message reads `database is locked`. TypeORM copies the driver's own properties onto
+     * QueryFailedError and rewrites the message to `SqliteError: database is locked`, so the token
+     * appears in neither message. A classifier matching `SQLITE_BUSY` as text cannot fire on either.
+     */
+    const sqliteBusy = (): QueryFailedError => {
+      const driverError = Object.assign(new Error('database is locked'), {
+        name: 'SqliteError',
+        code: 'SQLITE_BUSY',
+      });
+      return new QueryFailedError('UPDATE sessions SET status = ?', [], driverError);
+    };
+
+    it('retries a locked-database launch failure, which no message text reveals', async () => {
+      (repository.findOne as jest.Mock).mockResolvedValue(createMockSession());
+      (repository.update as jest.Mock).mockResolvedValue({ affected: 1 });
+      (engineFactory.create as jest.Mock).mockClear().mockReturnValue(mockEngine);
+      const busy = sqliteBusy();
+      // The premise of reading `code`: the token is absent from every message on this error.
+      expect(busy.message).not.toContain('SQLITE_BUSY');
+      expect(busy.driverError.message).not.toContain('SQLITE_BUSY');
+      expect((busy as unknown as { code: string }).code).toBe('SQLITE_BUSY');
+
+      mockEngine.initialize.mockRejectedValueOnce(busy).mockResolvedValueOnce(undefined);
+
+      await expect(service.start('sess-uuid-1')).resolves.toBeDefined();
+      expect(mockEngine.initialize).toHaveBeenCalledTimes(2);
+    });
+
+    it('does NOT retry a malformed query, which carries a different driver code', async () => {
+      (repository.findOne as jest.Mock).mockResolvedValue(createMockSession());
+      (repository.update as jest.Mock).mockResolvedValue({ affected: 1 });
+      (engineFactory.create as jest.Mock).mockClear().mockReturnValue(mockEngine);
+      const driverError = Object.assign(new Error('no such column: nope'), {
+        name: 'SqliteError',
+        code: 'SQLITE_ERROR',
+      });
+      mockEngine.initialize.mockRejectedValue(new QueryFailedError('SELECT nope', [], driverError));
+
+      await expect(service.start('sess-uuid-1')).rejects.toBeInstanceOf(QueryFailedError);
+      expect(mockEngine.initialize).toHaveBeenCalledTimes(1);
     });
 
     it('gives up after the single retry and surfaces the failure (no unbounded loop)', async () => {

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -35,6 +35,17 @@ import { HookManager } from '../../core/hooks';
 const SESSION_START_RETRY_DELAY_MS = 2_000;
 
 /**
+ * Driver codes meaning "locked, try again", not "your query is wrong".
+ *
+ * These are unreachable through the message regex below, which is why the code is read separately.
+ * better-sqlite3 reports lock contention as `code: 'SQLITE_BUSY'` with the message `database is
+ * locked`, and TypeORM's QueryFailedError copies the driver's own properties onto itself while
+ * rewriting the message to `SqliteError: database is locked`. So the code survives the wrap and the
+ * token never appears in any message: matching `SQLITE_BUSY` as text could not fire on either shape.
+ */
+const TRANSIENT_DB_CODES = new Set(['SQLITE_BUSY', 'SQLITE_LOCKED']);
+
+/**
  * A launch failure worth one retry: infrastructure said "not now" (a 5xx, a transport death, a
  * database error while persisting status), not the session or the caller being refused. HTTP 4xx
  * and the documented 409 not-ready are deliberate answers, and a lost-claim ConflictException is a
@@ -49,10 +60,10 @@ function isTransientLaunchFailure(error: unknown): boolean {
   if (error instanceof EngineTransportError) return true;
   if (error instanceof HttpException) return false;
   // TypeORM QueryFailedError and driver errors carry no HttpException shape.
-  return (
-    error instanceof Error &&
-    /connection|ECONNREFUSED|ECONNRESET|ETIMEDOUT|EAI_AGAIN|SQLITE_BUSY|terminating connection/i.test(error.message)
-  );
+  if (!(error instanceof Error)) return false;
+  const code: unknown = (error as { code?: unknown }).code;
+  if (typeof code === 'string' && TRANSIENT_DB_CODES.has(code)) return true;
+  return /connection|ECONNREFUSED|ECONNRESET|ETIMEDOUT|EAI_AGAIN|terminating connection/i.test(error.message);
 }
 
 /** Pause between sequential auto-start launches so a burst of Chromium boots does not spike the host. */


### PR DESCRIPTION
Three independent operator-facing defects, one commit each.

## Meta-hosted ids were refused

WhatsApp issues Meta-hosted dialects of a phone id and a lid, and Baileys decodes both off the wire (`WAJIDDomains.HOSTED` = 128, `HOSTED_LID` = 129). Neither matched a known domain here, so `<n>@hosted` and `<lid>@hosted.lid` parsed as `unknown`: such a chat surfaced on `GET /chats` with kind `unknown`, and handing that same id back on a write was refused with a `400`.

They fold into the dialects they name rather than becoming kinds of their own, because the user-part is the same account either way. The library says so itself: `cleanMessage` rewrites `<n>@hosted` to `<n>@s.whatsapp.net` and `<lid>@hosted.lid` to `<lid>@lid` on every inbound message, and its history handling treats `isHostedPnUser` exactly as `isPnUser`. A separate kind would split one person's history in two, since rows arrive under the plain dialect while a caller filtering by the hosted id we published would match none of them.

- `toNeutralJid` normalizes them to the neutral form of the same account, so history stays in one place and the message `chatId`/`from` filters keep matching.
- Ids reaching an engine are neutralized first: whatsapp-web.js knows no `@hosted` domain, so forwarding the suffix verbatim would fail inside the page rather than act on the person.
- `WaIdKind` and `ChatKind` are unchanged, so no response shape or SDK type moves.

## A locked database wedged a session until restart

The transient-launch classifier tested the error message for `SQLITE_BUSY`, a token no error carries. better-sqlite3 reports lock contention as `code: 'SQLITE_BUSY'` with the message `database is locked`, and TypeORM's `QueryFailedError` copies the driver's properties onto itself while rewriting the message to `SqliteError: database is locked`. The code survives the wrap; the token appears in neither message, so the match could not fire on either shape.

Under real write contention (a lock held past the 5s busy timeout by a backup or a second process, with boot auto-start firing) the launch was therefore classified permanent, and the session stayed down until a restart. The driver code is now read directly, with `SQLITE_LOCKED` alongside it as the same class of contention.

## Postgres deployments had no working in-container backup

The runbook drives `scripts/backup.sh` and `scripts/restore.sh` inside the container, and `sqlite3` is installed for exactly that, but neither `pg_dump` nor `psql` was in the image: `backup.sh` logged `pg_dump is not installed` and exited 1, and the `psql` import that `restore.sh` stages the dump for could not be run there either.

The distro package would not have fixed it. Debian bookworm ships client 15, and `pg_dump` aborts on a newer server (`server version mismatch`, reproduced against the `postgres:16` the bundled compose file runs), so apt's `postgresql-client` installs a `pg_dump` that cannot dump our own stack. The client comes from PostgreSQL's apt repository instead, measured at ~59 MB.

It is pinned deliberately newer than the server compose ships. The compatibility rule is one-directional, and `DATABASE_HOST` frequently points at a managed Postgres the compose file does not control, where 17 is the current default; pinning to 16 would have left those deployments unable to back up at all.

`ca-certificates` joins the runtime list because the base image carries no CA bundle and `curl` does not pull one in under `--no-install-recommends`, so fetching the signing key over HTTPS fails with curl error 77.

The server major is declared both in `docker-compose.yml` and in the container the app orchestrates itself, so either could drift past the client. A parity spec now fails when the client is older than either.

## Verification

- Each behavior is mutation-tested, including negative controls: a malformed query is still not retried, a client newer than its server is still allowed, and treating a hosted id as an entity of its own turns the message-filter spec red.
- `pg_dump` 17 was checked against live 16 and 17 servers. The release image builds clean on both architectures and ships `pg_dump`/`psql` 17.11; `backup.sh` run inside it against a live `postgres:16` exits 0 and produces an archive whose `database.sql` contains the seeded row.
- Full local gate: ESLint, `tsc --noEmit`, `format:check`, and the eight contract and SDK checks all pass. The suite was run three times with identical results (5780 passing, no flake).
