### PR TITLE
fix(baileys): read the WA web version from WhatsApp, not the Baileys repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The Baileys engine reads the WhatsApp Web protocol version from `web.whatsapp.com/sw.js` instead of the version pinned in the Baileys repository. The pinned value lags what WhatsApp's servers accept, and a stale version fails the handshake silently, so pairing links (and some ordinary connections) never completed and gave no reason.
 - The Go and Java SDKs can @mention on an audio send. `SendAudioRequest` was flattened off the shared media type and lost the field, so the typed path could not set it while every other client could.
 - Three routes declare the `409` they can answer: a duplicate template name on create or rename, and an integration instance id that already exists. Clients generated from the contract modelled those calls as unable to conflict.
 - `DOMAIN` is dropped from `.env.example`. Nothing read it, so an operator setting it to their real hostname changed nothing.

--- a/src/engine/adapters/baileys-lifecycle.ts
+++ b/src/engine/adapters/baileys-lifecycle.ts
@@ -180,7 +180,12 @@ export class BaileysLifecycle {
     }
     const b = await this.loadLib();
     const { state, saveCreds } = await b.useMultiFileAuthState(this.host.authPath);
-    const { version } = await b.fetchLatestBaileysVersion();
+    // fetchLatestBaileysVersion() scrapes a hardcoded version out of the Baileys GitHub repo, which
+    // lags what WhatsApp's own servers actually expect — the confirmed root cause of pairing links
+    // (and, per upstream reports, some ordinary connections) silently failing on a stale protocol
+    // version. fetchLatestWaWebVersion() reads the version directly out of web.whatsapp.com/sw.js,
+    // matching what WhatsApp's servers are actually serving.
+    const { version } = await b.fetchLatestWaWebVersion();
     // BaileysLogger matches ILogger exactly; cast needed because the module resolves the type
     // through a deep import path that TypeScript does not auto-unify here. Shared by the key
     // store wrapper below and the socket itself, rather than constructing two instances.
@@ -528,7 +533,7 @@ export class BaileysLifecycle {
         return; // stopped while waiting — abort
       }
       void this.connect().catch(err => {
-        // A failed attempt (e.g. fetchLatestBaileysVersion offline mid-outage) is NOT terminal —
+        // A failed attempt (e.g. fetchLatestWaWebVersion offline mid-outage) is NOT terminal —
         // the outage may outlast any fixed attempt budget, so schedule the following attempt.
         this.host.logger.warn('Baileys reconnect attempt failed; will retry', {
           attempt: this.reconnectAttempts,

--- a/src/engine/adapters/baileys.adapter.spec.ts
+++ b/src/engine/adapters/baileys.adapter.spec.ts
@@ -92,7 +92,7 @@ jest.mock('@whiskeysockets/baileys', () => ({
     return fakeSock;
   }),
   useMultiFileAuthState: jest.fn().mockResolvedValue({ state: { creds: {}, keys: {} }, saveCreds }),
-  fetchLatestBaileysVersion: jest.fn().mockResolvedValue({ version: [2, 3000, 0] }),
+  fetchLatestWaWebVersion: jest.fn().mockResolvedValue({ version: [2, 3000, 0] }),
   // Identity passthrough — the adapter wraps state.keys with this for session-store caching; tests
   // don't exercise the caching behavior itself, just need the real store object to flow through.
   makeCacheableSignalKeyStore: jest.fn((store: unknown) => store),
@@ -585,22 +585,22 @@ describe('BaileysAdapter lifecycle & status', () => {
   it('C2: disconnect() during in-flight connect does NOT assign a socket or reach READY', async () => {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     const baileys = jest.requireMock('@whiskeysockets/baileys') as {
-      fetchLatestBaileysVersion: jest.Mock;
+      fetchLatestWaWebVersion: jest.Mock;
       default: jest.Mock;
     };
 
-    // Make fetchLatestBaileysVersion block until we manually resolve it.
+    // Make fetchLatestWaWebVersion block until we manually resolve it.
     let resolveVersion!: (v: { version: number[] }) => void;
     const versionPromise = new Promise<{ version: number[] }>(res => {
       resolveVersion = res;
     });
-    baileys.fetchLatestBaileysVersion.mockReturnValueOnce(versionPromise);
+    baileys.fetchLatestWaWebVersion.mockReturnValueOnce(versionPromise);
     baileys.default.mockClear();
 
     const adapter = newAdapter();
     const initPromise = adapter.initialize(noopCallbacks({}));
 
-    // While connect() is blocked waiting for fetchLatestBaileysVersion, call disconnect().
+    // While connect() is blocked waiting for fetchLatestWaWebVersion, call disconnect().
     await adapter.disconnect();
 
     // Now resolve the version fetch.
@@ -616,9 +616,9 @@ describe('BaileysAdapter lifecycle & status', () => {
   it('I5: first connect failure → initialize() rejects, status FAILED, onError fired', async () => {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     const baileys = jest.requireMock('@whiskeysockets/baileys') as {
-      fetchLatestBaileysVersion: jest.Mock;
+      fetchLatestWaWebVersion: jest.Mock;
     };
-    baileys.fetchLatestBaileysVersion.mockRejectedValueOnce(new Error('network error'));
+    baileys.fetchLatestWaWebVersion.mockRejectedValueOnce(new Error('network error'));
 
     const onError = jest.fn();
     const adapter = newAdapter();
@@ -671,7 +671,7 @@ describe('BaileysAdapter lifecycle & status', () => {
 describe('BaileysAdapter reconnect policy — unlimited backoff (I4 hardening)', () => {
   const baileys = () =>
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-    jest.requireMock('@whiskeysockets/baileys') as { default: jest.Mock; fetchLatestBaileysVersion: jest.Mock };
+    jest.requireMock('@whiskeysockets/baileys') as { default: jest.Mock; fetchLatestWaWebVersion: jest.Mock };
 
   const fireRecoverableClose = (): void => {
     fakeSock.fire('connection.update', {
@@ -793,8 +793,8 @@ describe('BaileysAdapter reconnect policy — unlimited backoff (I4 hardening)',
     jest.useFakeTimers();
     jest.spyOn(Math, 'random').mockReturnValue(0);
 
-    // The first reconnect attempt fails inside connect() (e.g. fetchLatestBaileysVersion offline).
-    baileys().fetchLatestBaileysVersion.mockRejectedValueOnce(new Error('network down'));
+    // The first reconnect attempt fails inside connect() (e.g. fetchLatestWaWebVersion offline).
+    baileys().fetchLatestWaWebVersion.mockRejectedValueOnce(new Error('network down'));
 
     fireRecoverableClose(); // attempt 1 (1 s)
     await jest.advanceTimersByTimeAsync(1_000); // attempt 1 runs and FAILS → must schedule attempt 2 (2 s)

--- a/test/__mocks__/@whiskeysockets/baileys.ts
+++ b/test/__mocks__/@whiskeysockets/baileys.ts
@@ -11,7 +11,7 @@
  */
 export default jest.fn();
 export const useMultiFileAuthState = jest.fn();
-export const fetchLatestBaileysVersion = jest.fn();
+export const fetchLatestWaWebVersion = jest.fn();
 export const getContentType = jest.fn();
 export const DisconnectReason = { loggedOut: 401 };
 

--- a/test/baileys-engine.e2e-spec.ts
+++ b/test/baileys-engine.e2e-spec.ts
@@ -5,7 +5,7 @@ jest.mock('@whiskeysockets/baileys', () => ({
   __esModule: true,
   default: jest.fn(),
   useMultiFileAuthState: jest.fn(),
-  fetchLatestBaileysVersion: jest.fn(),
+  fetchLatestWaWebVersion: jest.fn(),
   getContentType: jest.fn(),
   DisconnectReason: { loggedOut: 401 },
 }));


### PR DESCRIPTION
## Description

The Baileys engine resolved its protocol version with `fetchLatestBaileysVersion()`, which reads a version hardcoded in the Baileys GitHub repository. That pin lags what WhatsApp's servers actually accept, and a stale version fails the handshake silently: pairing links (and, per upstream reports, some ordinary connections) never complete and surface no reason.

This swaps it for `fetchLatestWaWebVersion()`, which reads the version straight out of `web.whatsapp.com/sw.js`, so it always matches what WhatsApp is currently serving. Both functions are exported by the pinned `@whiskeysockets/baileys@7.0.0-rc14` (`lib/Utils/generics.d.ts:54`) and return the same `{ version }` shape, so the call site is a drop-in replacement.

Scope is one line of engine code plus the test doubles that named the old function:

- `src/engine/adapters/baileys-lifecycle.ts`: the call, and a stale comment referring to it by name
- `test/__mocks__/@whiskeysockets/baileys.ts`, `test/baileys-engine.e2e-spec.ts`, `src/engine/adapters/baileys.adapter.spec.ts`: mocks renamed to match

Behaviour is otherwise unchanged: the reconnect path still treats a failed version lookup as non-terminal, so a registry outage retries rather than killing the session.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [x] Lint passes
- [x] Self-reviewed

Existing specs were updated rather than extended: the version source is a single library call the adapter spec already exercises through its mock, so there is no new assertion that meaningfully locks it down. Documentation is the `CHANGELOG.md` `[Unreleased]` entry; no file under `docs/` names either function.

Verified locally with `npm run build`, `npm test`, `npm run lint`, `npm run format`, and `npm --prefix dashboard run build`.

## Screenshots (if applicable)

Not applicable, no user-facing surface changes.

## Related Issues

No existing issue tracks this specific cause.