### PR TITLE
ci: bound the apt steps so a slow mirror cannot hang a run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,10 +299,17 @@ jobs:
       - name: Install sqlite3
         # smoke-test-backup-restore.sh skips its sqlite3 .backup roundtrip case (with a notice) when
         # the host lacks the CLI; installing it here exercises that path on every run instead.
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends sqlite3
+        # Bounded, and skipped when the runner image already ships the CLI. An unbounded apt-get
+        # against a slow mirror held this job open for over an hour with every other job already
+        # green, so the run never reported and main went without a signal.
+        timeout-minutes: 5
+        run: command -v sqlite3 >/dev/null || { sudo apt-get update && sudo apt-get install -y --no-install-recommends sqlite3; }
 
       - name: Install shellcheck
-        run: sudo apt-get install -y --no-install-recommends shellcheck
+        # Runs its own update rather than inheriting one from the step above, which no longer
+        # always runs.
+        timeout-minutes: 5
+        run: command -v shellcheck >/dev/null || { sudo apt-get update && sudo apt-get install -y --no-install-recommends shellcheck; }
 
       - name: shellcheck every shell script
         # Widened from the original three (#926) now that the rest are clean too. The narrow scope was

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -278,10 +278,17 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install sqlite3
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends sqlite3
+        # Bounded, and skipped when the runner image already ships the CLI. An unbounded apt-get
+        # against a slow mirror held this job open for over an hour with every other job already
+        # green, so the run never reported and main went without a signal.
+        timeout-minutes: 5
+        run: command -v sqlite3 >/dev/null || { sudo apt-get update && sudo apt-get install -y --no-install-recommends sqlite3; }
 
       - name: Install shellcheck
-        run: sudo apt-get install -y --no-install-recommends shellcheck
+        # Runs its own update rather than inheriting one from the step above, which no longer
+        # always runs.
+        timeout-minutes: 5
+        run: command -v shellcheck >/dev/null || { sudo apt-get update && sudo apt-get install -y --no-install-recommends shellcheck; }
 
       - name: shellcheck every shell script
         run: shellcheck docker-entrypoint.sh scripts/*.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `PLUGIN_STATE_DIR` moves the plugin registry and per-plugin storage off the default `./data`. It was the one piece of state with no path knob, so a test run rewrote the developer's own registry.
 - The e2e lane sweeps the throwaway state roots it creates. Each suite gets its own, nothing removed them, and the temp directory accumulated hundreds of entries over a few days of runs.
 - e2e assertions are no longer answered by unrelated processes on the host. supertest binds its per-request listener to the wildcard address and then dials 127.0.0.1, which on macOS lets a process holding that port on 127.0.0.1 answer instead. Each suite's server now listens on loopback during init, which supertest reuses.
+- A stalled `apt-get` can no longer hold a CI run open. The scripts-smoke job installed sqlite3 and shellcheck unbounded, so a slow mirror held two main runs past an hour with every other job already green. Both steps now time out and skip the install when the runner already ships the tool.
 
 ### Tests
 


### PR DESCRIPTION
`Install sqlite3` in the scripts-smoke job held two consecutive main runs open for over an hour each while every other job had already gone green, so neither run ever reported and `main` went without a signal. The step had no timeout, so a stalled `apt-get` would have burned the six-hour job default before failing.

## What changed

- Both apt steps in `ci.yml` and `release.yml` carry `timeout-minutes: 5` and skip the install when the runner image already ships the tool, which is the common case.
- The shellcheck step runs its own `apt-get update` rather than inheriting one from the step above, which no longer always runs.
- `release.yml` carries the same job and had the same two unbounded steps, so a release cut could have stalled the same way.

## Impact

CI only. A failing install still fails the step: the short-circuit covers the tool already being present, nothing else.

## Verification

- The three branches of the new command were exercised directly: tool present short-circuits at exit 0 without calling apt, tool absent takes the install branch, and tool absent with a failing install exits 1 rather than being swallowed.
- `actionlint` at the pinned version CI uses, both workflow files parse, job counts unchanged (9 and 14), and the `docs/09` §9.6 job-table gate passes.
