### PR TITLE
fix(sdk): give subscribe-presence its own request type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `POST /sessions/{sessionId}/chats/unread` publishes its own `MarkChatUnreadDto` rather than sharing `MarkChatReadDto`. The body is unchanged (`chatId` alone), but a generated client sees the schema under a new name.
+- ⚠️ **Breaking (Go and Java clients).** `subscribePresence` takes its own `SubscribePresenceRequest` rather than the shared `MarkChatRequest`, which now serves `markUnread` alone. Swap the type at the call site; the wire body is unchanged. `SubscribePresenceDto` had no contract-gate coverage while one type stood for two routes.
 
 ### Fixed
 

--- a/scripts/check-contract-shapes.mjs
+++ b/scripts/check-contract-shapes.mjs
@@ -87,6 +87,7 @@ const MAPPINGS = {
     JoinGroupRequest: 'JoinGroupDto',
     MarkChatReadRequest: 'MarkChatReadDto',
     MarkChatRequest: 'MarkChatUnreadDto',
+    SubscribePresenceRequest: 'SubscribePresenceDto',
     MessageListResponse: 'MessageListResponseDto',
     MessageRecord: 'MessageListItemDto',
     MessageResponse: 'MessageResponseDto',
@@ -165,11 +166,11 @@ const MAPPINGS = {
  * these floors as pairs are added makes the shrink loud.
  */
 const MINIMUM_MAPPED = {
-  'sdk/javascript/src/types.ts': 79,
+  'sdk/javascript/src/types.ts': 80,
   'dashboard/src/services/api.ts': 20,
-  'sdk/python/openwa/types.py': 74,
-  'sdk/go': 75,
-  'sdk/java': 79,
+  'sdk/python/openwa/types.py': 75,
+  'sdk/go': 76,
+  'sdk/java': 80,
 };
 
 /** Known drift, deliberately not gated yet — each line is a to-adjudicate follow-up. */
@@ -233,6 +234,7 @@ const PYTHON_MAPPING = {
   JoinGroupRequest: 'JoinGroupDto',
   MarkChatReadRequest: 'MarkChatReadDto',
   MarkChatRequest: 'MarkChatUnreadDto',
+  SubscribePresenceRequest: 'SubscribePresenceDto',
   MessageListResponse: 'MessageListResponseDto',
   MessageRecord: 'MessageListItemDto',
   MessageResponse: 'MessageResponseDto',
@@ -311,6 +313,7 @@ const GO_MAPPING = {
   JoinGroupRequest: 'JoinGroupDto',
   MarkChatReadRequest: 'MarkChatReadDto',
   MarkChatRequest: 'MarkChatUnreadDto',
+  SubscribePresenceRequest: 'SubscribePresenceDto',
   MessageListResponse: 'MessageListResponseDto',
   MessageRecord: 'MessageListItemDto',
   MessageResponse: 'MessageResponseDto',
@@ -393,6 +396,7 @@ const JAVA_MAPPING = {
   JoinGroupRequest: 'JoinGroupDto',
   MarkChatReadRequest: 'MarkChatReadDto',
   MarkChatRequest: 'MarkChatUnreadDto',
+  SubscribePresenceRequest: 'SubscribePresenceDto',
   MessageListResponse: 'MessageListResponseDto',
   MessageRecord: 'MessageListItemDto',
   MessageResponse: 'MessageResponseDto',

--- a/sdk/go/chats.go
+++ b/sdk/go/chats.go
@@ -24,7 +24,7 @@ func (s *ChatsService) List(ctx context.Context, sessionID string, query *ListCh
 // The subscription belongs to the connection and does NOT survive a restart or an automatic
 // reconnect, so re-issue it when the session comes back. Subscribe per chat: WhatsApp emits an
 // update on every transition, so a broad subscription is a firehose. whatsapp-web.js answers 501.
-func (s *ChatsService) SubscribePresence(ctx context.Context, sessionID string, body MarkChatRequest) (*SuccessResult, error) {
+func (s *ChatsService) SubscribePresence(ctx context.Context, sessionID string, body SubscribePresenceRequest) (*SuccessResult, error) {
 	var out SuccessResult
 	err := s.client.do(ctx, "POST", "/api/sessions/"+pathEscape(sessionID)+"/presence/subscribe", nil, body, &out)
 	return &out, err

--- a/sdk/go/routing_test.go
+++ b/sdk/go/routing_test.go
@@ -95,7 +95,7 @@ func TestRouting(t *testing.T) {
 
 		{"Chats.List", func(c *Client) { c.Chats.List(ctx, "s1", nil) }, "GET", "/api/sessions/s1/chats"},
 		{"Chats.MarkRead", func(c *Client) { c.Chats.MarkRead(ctx, "s1", MarkChatReadRequest{}) }, "POST", "/api/sessions/s1/chats/read"},
-		{"Chats.SubscribePresence", func(c *Client) { c.Chats.SubscribePresence(ctx, "s1", MarkChatRequest{}) }, "POST", "/api/sessions/s1/presence/subscribe"},
+		{"Chats.SubscribePresence", func(c *Client) { c.Chats.SubscribePresence(ctx, "s1", SubscribePresenceRequest{}) }, "POST", "/api/sessions/s1/presence/subscribe"},
 		{"Channels.Create", func(c *Client) { c.Channels.Create(ctx, "s1", CreateChannelRequest{}) }, "POST", "/api/sessions/s1/channels"},
 		{"Channels.Delete", func(c *Client) { c.Channels.Delete(ctx, "s1", "ch1") }, "POST", "/api/sessions/s1/channels/ch1/delete"},
 		{"Channels.Mute", func(c *Client) { c.Channels.Mute(ctx, "s1", "ch1", MuteChannelRequest{}) }, "POST", "/api/sessions/s1/channels/ch1/mute"},

--- a/sdk/go/types_chat.go
+++ b/sdk/go/types_chat.go
@@ -19,8 +19,13 @@ type SetOwnPresenceRequest struct {
 	Available bool `json:"available"`
 }
 
-// MarkChatRequest marks a chat unread, or subscribes to its presence.
+// MarkChatRequest marks a chat unread.
 type MarkChatRequest struct {
+	ChatID string `json:"chatId"`
+}
+
+// SubscribePresenceRequest subscribes to a chat's presence.
+type SubscribePresenceRequest struct {
 	ChatID string `json:"chatId"`
 }
 

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/model/SubscribePresenceRequest.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/model/SubscribePresenceRequest.java
@@ -1,7 +1,7 @@
 package com.rmyndharis.openwa.model;
 
-/** Request body for marking a chat unread. */
-public record MarkChatRequest(String chatId) {
+/** Request body for subscribing to a chat's presence. */
+public record SubscribePresenceRequest(String chatId) {
     public static Builder builder() {
         return new Builder();
     }
@@ -15,8 +15,8 @@ public record MarkChatRequest(String chatId) {
             return this;
         }
 
-        public MarkChatRequest build() {
-            return new MarkChatRequest(chatId);
+        public SubscribePresenceRequest build() {
+            return new SubscribePresenceRequest(chatId);
         }
     }
 }

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/resources/ChatsResource.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/resources/ChatsResource.java
@@ -11,6 +11,7 @@ import com.rmyndharis.openwa.model.DeleteChatRequest;
 import com.rmyndharis.openwa.model.ListChatsQuery;
 import com.rmyndharis.openwa.model.MarkChatReadRequest;
 import com.rmyndharis.openwa.model.MarkChatRequest;
+import com.rmyndharis.openwa.model.SubscribePresenceRequest;
 import com.rmyndharis.openwa.model.MuteChatRequest;
 import com.rmyndharis.openwa.model.PinChatRequest;
 import com.rmyndharis.openwa.model.SendChatStateRequest;
@@ -50,7 +51,7 @@ public final class ChatsResource {
      * reconnect, so re-issue it when the session comes back. Subscribe per chat: WhatsApp emits an
      * update on every transition. whatsapp-web.js answers {@code 501}.
      */
-    public SuccessResult subscribePresence(String sessionId, MarkChatRequest body) {
+    public SuccessResult subscribePresence(String sessionId, SubscribePresenceRequest body) {
         return client.request(
             HttpMethod.POST,
             "/api/sessions/" + encodeSegment(sessionId) + "/presence/subscribe",

--- a/sdk/javascript/src/resources/chats.ts
+++ b/sdk/javascript/src/resources/chats.ts
@@ -18,6 +18,7 @@ import type {
   DeleteChatRequest,
   MarkChatRequest,
   MarkChatReadRequest,
+  SubscribePresenceRequest,
   ChatPresence,
   SendChatStateRequest,
   SuccessResult,
@@ -48,7 +49,7 @@ export class ChatsResource {
    * reconnect, so re-issue it when the session comes back. Subscribe per chat: WhatsApp emits an
    * update on every transition, so a broad subscription is a firehose. whatsapp-web.js answers 501.
    */
-  subscribePresence(sessionId: string, body: MarkChatRequest): Promise<SuccessResult> {
+  subscribePresence(sessionId: string, body: SubscribePresenceRequest): Promise<SuccessResult> {
     return this.client.request<SuccessResult>({
       method: 'POST',
       path: `/api/sessions/${encodeSegment(sessionId)}/presence/subscribe`,

--- a/sdk/javascript/src/types.ts
+++ b/sdk/javascript/src/types.ts
@@ -968,8 +968,13 @@ export interface TransferChannelOwnershipRequest {
   newOwnerId: Jid;
 }
 
-/** Body for {@link ChatsResource.markUnread} and {@link ChatsResource.subscribePresence}. */
+/** Body for {@link ChatsResource.markUnread}. */
 export interface MarkChatRequest {
+  chatId: Jid;
+}
+
+/** Body for {@link ChatsResource.subscribePresence}. */
+export interface SubscribePresenceRequest {
   chatId: Jid;
 }
 

--- a/sdk/python/openwa/resources/chats.py
+++ b/sdk/python/openwa/resources/chats.py
@@ -18,6 +18,7 @@ from ..types import (
     DeleteChatRequest,
     MarkChatReadRequest,
     MarkChatRequest,
+    SubscribePresenceRequest,
     SendChatStateRequest,
     SuccessResult,
 )
@@ -38,7 +39,7 @@ class ChatsResource:
     def list(self, session_id: str, query: ListChatsQuery | None = None) -> list[ChatSummary]:
         return self._http.request("GET", f"/api/sessions/{quote_segment(session_id)}/chats", query=query)
 
-    def subscribe_presence(self, session_id: str, body: MarkChatRequest) -> SuccessResult:
+    def subscribe_presence(self, session_id: str, body: SubscribePresenceRequest) -> SuccessResult:
         """Subscribe to a chat's presence; updates arrive as presence.update events.
 
         Presence cannot be fetched from either engine, only received. The subscription belongs to

--- a/sdk/python/openwa/types.py
+++ b/sdk/python/openwa/types.py
@@ -882,7 +882,12 @@ class ChatSummary(TypedDict):
 
 
 class MarkChatRequest(TypedDict):
-    # Body for mark_unread and subscribe_presence, both of which take the chat id alone.
+    # Body for mark_unread.
+    chatId: Jid
+
+
+class SubscribePresenceRequest(TypedDict):
+    # Body for subscribe_presence.
     chatId: Jid
 
 


### PR DESCRIPTION
`SubscribePresenceDto` had no contract-shape coverage at all, and nothing said so. Four typed clients declared one `MarkChatRequest` for both `subscribePresence` and `markUnread`, and the gate mapped that type to `MarkChatUnreadDto`, so the pair being compared was not the pair that exists. The two DTOs are identical today, which is the only reason nothing failed; a field added to either would have gone unnoticed on every typed client, and the schema is not in the gate's `EXCLUDED` list either.

## What changed

- The JavaScript, Python, Go and Java clients each declare `SubscribePresenceRequest`, and `subscribePresence` takes it. `MarkChatRequest` now serves `markUnread` alone, which is what the gate already claimed.
- `check-contract-shapes` maps the new type in all four tables, and each per-client coverage floor rises by one so the pair cannot be dropped again in silence. Comparisons go from 320 to 324.

## Impact

⚠️ Breaking for the Go and Java clients: `SubscribePresence` takes the new type, so a caller passing `MarkChatRequest` no longer compiles. Swap the type at the call site. JavaScript and Python are structurally typed and unaffected. The wire body is unchanged on every client, and no server behaviour changes.

## Verification

- `check-contract-shapes` reports 324 pairs, four more than before, one per typed client. That count is the guard: had the new type not been harvested it would have stayed at 320 and the raised floors would have failed instead.
- Every SDK CI command run locally: `go vet`, `go test -race`, gofmt, `mvn -B verify`, `mypy`, `pytest`, and the JavaScript typecheck, tests and build.
- Repo gates: lint, `tsc --noEmit`, format, openapi, the four `check:sdk-*` gates, and the unit suite.
