### PR TITLE
fix(gitattributes): force LF on *.asc so Windows checkouts don't corrupt the PGDG key

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,7 @@ Dockerfile* text eol=lf
 # A unified diff must keep LF: a CRLF context line is not a marker any applier accepts, so a Windows
 # checkout would hand `git apply`/`patch` a diff both call corrupt (#889).
 *.patch     text eol=lf
+# An ASCII-armored GPG key must keep LF: apt's signature check cannot parse a CRLF armor block, so a
+# Windows checkout (core.autocrlf=true) makes the PGDG key unreadable and the production stage's
+# `apt-get update` fails with NO_PUBKEY 7FCC7D46ACCC4CF8 / "repository is not signed".
+*.asc       text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `docker compose up -d` builds from a Windows clone again. Git's default `core.autocrlf=true` gave the committed
+  PGDG signing key CRLF endings and the build failed with `NO_PUBKEY 7FCC7D46ACCC4CF8`. The key is now pinned to LF
+  and the build strips CR, so a clone already on disk needs no re-clone. Thanks @ATZ-Jordan.
+
 ## [0.23.1] - 2026-08-21
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -145,8 +145,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # (Debian essential, present before this layer), so the layer adds 0 distinct vulnerabilities.
 # libpq5 and the postgresql-client packages themselves are clean. Recheck with:
 #   trivy image --vuln-type os,library --severity CRITICAL,HIGH --ignore-unfixed --ignorefile .trivyignore <image>
+#
+# The armored key must reach the image with LF endings. apt dearmors a `signed-by=` .asc through
+# apt-key, whose awk advances on the blank armor separator line, so a CR there yields an empty
+# keyring and NO_PUBKEY 7FCC7D46ACCC4CF8. The `.gitattributes` rule keeps fresh clones on LF; the
+# strip below repairs the Windows clones already on disk, which that rule cannot reach.
 COPY scripts/pgdg-ACCC4CF8.asc /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
-RUN echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] \
+RUN sed -i 's/\r$//' /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+    && echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] \
 http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update && apt-get install -y --no-install-recommends postgresql-client-17 \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
# fix(gitattributes): force LF on `*.asc` so Windows checkouts don't corrupt the PGDG key

## Problem

On Windows, a fresh `git clone` followed by `docker compose up -d` fails during the
production stage with a signature error, and no container is ever created:

```
#15 0.814 Err:1 http://apt.postgresql.org/pub/repos/apt bookworm-pgdg InRelease
#15 0.814   The following signatures couldn't be verified because the public key is
            not available: NO_PUBKEY 7FCC7D46ACCC4CF8
#15 2.852 W: GPG error: http://apt.postgresql.org/pub/repos/apt bookworm-pgdg InRelease:
            The following signatures couldn't be verified because the public key is not
            available: NO_PUBKEY 7FCC7D46ACCC4CF8
#15 2.852 E: The repository 'http://apt.postgresql.org/pub/repos/apt bookworm-pgdg
            InRelease' is not signed.
------
Dockerfile:149
failed to solve: process "/bin/sh -c echo \"deb [signed-by=...] ...\" > ... && apt-get
update && apt-get install -y --no-install-recommends postgresql-client-17 ..." did not
complete successfully: exit code: 100
```

This is not a network failure and not a proxy/TLS-interception failure: the repository
metadata downloads fine (note the successful `Get:` lines for deb.debian.org in the same
step). Only the signature check fails.

## Root cause

`scripts/pgdg-ACCC4CF8.asc` is committed with LF, which is correct. But `.gitattributes`
only pins LF for `*.sh`, `Dockerfile*` and `*.patch`:

```
*.sh        text eol=lf
Dockerfile* text eol=lf
*.patch     text eol=lf
```

`*.asc` is not covered, so on a Windows checkout with Git's default
`core.autocrlf=true` the armored key lands in the working tree with CRLF. `COPY` then
places that CRLF file at
`/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc`, and the `signed-by=`
verification in the next `RUN` cannot use it.

Evidence, same clone, same file:

```console
$ head -c 60 scripts/pgdg-ACCC4CF8.asc | od -c
0000000   -   -   -   -   -   B   E   G   I   N       P   G   P       P
0000020   U   B   L   I   C       K   E   Y       B   L   O   C   K   -
0000040   -   -   -   -  \r  \n  \r  \n   m   Q   I   N   B   E   6   X

$ git show HEAD:scripts/pgdg-ACCC4CF8.asc | head -c 60 | od -c
0000000   -   -   -   -   -   B   E   G   I   N       P   G   P       P
0000020   U   B   L   I   C       K   E   Y       B   L   O   C   K   -
0000040   -   -   -   -  \n  \n   m   Q   I   N   B   E   6   X   R   8
```

The committed blob is fine. Only the checkout is corrupted, which is why this never
reproduces on Linux, macOS, or CI.

### Worth noting for whoever debugs this next

GnuPG's own armor parser tolerates the CRLF file, so the obvious sanity check gives a
false all-clear and points debugging in the wrong direction:

```console
$ gpg --show-keys --with-fingerprint scripts/pgdg-ACCC4CF8.asc   # on the CRLF file
pub   rsa4096 2011-10-13 [SC]
      B97B 0AFC AA1A 47F0 44F2  44A0 7FCC 7D46 ACCC 4CF8
uid                      PostgreSQL Debian Repository
```

That is the exact fingerprint the Dockerfile comment documents, on the exact file that
makes the build fail. The key material is intact; only apt's `signed-by=` path rejects
the CRLF armor. I did not dig into which component inside apt draws the line, so treat
the precise mechanism as unconfirmed. The observed behavior is unambiguous: CRLF fails,
LF succeeds, nothing else changed.

## Fix

One line in `.gitattributes`, consistent with the three pins already there:

```
*.asc       text eol=lf
```

No change to the key file itself is needed, since the committed blob is already LF.

## Verification

On the same Windows machine that produced the failure above, after converting the
working-tree file back to LF (`sed -i 's/\r$//' scripts/pgdg-ACCC4CF8.asc`) with no other
change:

```
#30 naming to docker.io/library/openwa-openwa-api:latest done
 Image openwa-openwa-api Built
```

and then:

```console
$ docker compose ps
NAME                  STATUS                    PORTS
openwa-api            Up (healthy)              127.0.0.1:2785->2785/tcp
openwa-docker-proxy   Up

$ curl http://localhost:2785/api/health
{"status":"ok","timestamp":"2026-08-19T22:55:31.089Z"}
```

`git status` reports the `.asc` file as unmodified once the attribute is in place,
confirming the working tree now matches the committed blob.

## Environment

- Windows 11 Pro 26200, Docker Desktop with the WSL2 backend
- Docker 29.6.2 (client and server)
- Git for Windows, `core.autocrlf=true` (the installer default)
- OpenWA 0.21.0, `main`
- Build target: `linux/amd64`

## Impact

Blocks first-time `docker compose up -d` for every Windows user cloning with Git's
default configuration. The failure surfaces as a GPG/signature error, which reads like a
network, proxy or trust-store problem, so the line-ending cause is not obvious from the
message.