### PR TITLE
fix(engine): match receipt keys across the lid dialect

### DIFF
--- a/src/engine/adapters/baileys-contacts.ts
+++ b/src/engine/adapters/baileys-contacts.ts
@@ -368,13 +368,17 @@ export class BaileysContacts {
     const stored = (await this.host.getStoredMessages(messageIds)) ?? [];
     // A stored key is only usable when it belongs to THIS chat. Without the check, an id from
     // another chat in the same session carried that chat's remoteJid into readMessages, so the
-    // receipt landed there while the route answered success for the chat the caller named. Both
-    // sides fold through toEngineJid so the @c.us and @s.whatsapp.net spellings of one chat still
-    // match; anything that still differs falls back to the synthesised key for the ADDRESSED chat,
-    // which is exactly what every id ran on before stored keys existed.
+    // receipt landed there while the route answered success for the chat the caller named.
+    // The comparison runs in the NEUTRAL dialect rather than the engine one: toEngineJid folds
+    // @c.us and @s.whatsapp.net together but returns @lid untouched, and Baileys stores a DM key
+    // under the peer's lid once WhatsApp addresses the chat that way. toNeutralJid resolves that
+    // lid to its phone user-part through the session's lid mapping, so both spellings of one chat
+    // still meet. Anything that still differs falls back to the synthesised key for the ADDRESSED
+    // chat, which is exactly what every id ran on before stored keys existed.
+    const chatKey = this.host.toNeutralJid(chatId);
     const keyById = new Map(
       stored
-        .filter(msg => msg.key?.id && msg.key.remoteJid && this.host.toEngineJid(msg.key.remoteJid) === remoteJid)
+        .filter(msg => msg.key?.id && msg.key.remoteJid && this.host.toNeutralJid(msg.key.remoteJid) === chatKey)
         .map(msg => [msg.key.id as string, msg.key]),
     );
     return messageIds.map(id => keyById.get(id) ?? { remoteJid, id, fromMe: false });

--- a/src/engine/adapters/baileys-send-seen.spec.ts
+++ b/src/engine/adapters/baileys-send-seen.spec.ts
@@ -1,6 +1,7 @@
 import type { WAMessage, WASocket } from '@whiskeysockets/baileys';
 import { BaileysContacts, BaileysContactsHost } from './baileys-contacts';
 import { EngineTransportError } from '../../common/errors/engine-transport.error';
+import { toNeutralJid } from '../identity/wa-id';
 
 /**
  * `readMessages` reaches `fetchPrivacySettings`, whose body is
@@ -23,7 +24,7 @@ const toEngineJid = (jid: string): string => {
 };
 
 function makeHost(overrides: Partial<Record<keyof BaileysContactsHost, unknown>>): BaileysContactsHost {
-  return {
+  const host = {
     ensureReady: () => undefined,
     logger: { warn: jest.fn(), debug: jest.fn(), info: jest.fn(), error: jest.fn() },
     normalizedSelfJid: () => '628177@s.whatsapp.net',
@@ -36,6 +37,10 @@ function makeHost(overrides: Partial<Record<keyof BaileysContactsHost, unknown>>
     toEngineJid,
     ...overrides,
   } as unknown as BaileysContactsHost;
+  // Wired the way the adapter wires it: the real fold, reading the session's lid mapping through
+  // this host's own resolvePhone, so a test can hand it a mapping and exercise the lid dialect.
+  host.toNeutralJid = (jid: string): string => toNeutralJid(jid, id => host.resolvePhone(id));
+  return host;
 }
 
 function contacts(sock: Record<string, jest.Mock>, budgetMs: number): BaileysContacts {
@@ -84,6 +89,38 @@ describe('sendSeen', () => {
 
     // Falls back to the synthesised key for the ADDRESSED chat rather than the stored one.
     expect(readMessages).toHaveBeenCalledWith([{ remoteJid: '628123@s.whatsapp.net', id: 'X1', fromMe: false }]);
+  });
+
+  it('still uses a stored key stored under the peer lid for the addressed chat', async () => {
+    // Baileys addresses a DM by the peer's lid, so the stored key's remoteJid is `<lid>@lid` while
+    // the caller names the chat by phone number. Folding through the ENGINE dialect cannot reduce a
+    // lid, so every stored key was discarded and the receipt fell back to a synthesised key that
+    // lost the real fromMe and participant.
+    const readMessages = jest.fn().mockResolvedValue(undefined);
+    const host = makeHost({
+      getSocket: () => ({ readMessages }) as unknown as WASocket,
+      resolvePhone: (jid: string) => (jid === '9988@lid' ? '628123' : null),
+      getStoredMessages: () =>
+        Promise.resolve([stored({ id: 'L1', remoteJid: '9988@lid', fromMe: true, participant: '9988@lid' })]),
+    });
+
+    await expect(new BaileysContacts(host, 500).sendSeen('628123@c.us', ['L1'])).resolves.toBe(true);
+    expect(readMessages).toHaveBeenCalledWith([
+      { id: 'L1', remoteJid: '9988@lid', fromMe: true, participant: '9988@lid' },
+    ]);
+  });
+
+  it('still rejects a lid-addressed key from another chat', async () => {
+    // Negative twin of the case above: reducing through the neutral dialect must not turn the scope
+    // check into "accept anything spelled @lid". An unmapped lid stays itself and cannot match.
+    const readMessages = jest.fn().mockResolvedValue(undefined);
+    const host = makeHost({
+      getSocket: () => ({ readMessages }) as unknown as WASocket,
+      getStoredMessages: () => Promise.resolve([stored({ id: 'L2', remoteJid: '7777@lid', fromMe: true })]),
+    });
+
+    await expect(new BaileysContacts(host, 500).sendSeen('628123@c.us', ['L2'])).resolves.toBe(true);
+    expect(readMessages).toHaveBeenCalledWith([{ remoteJid: '628123@s.whatsapp.net', id: 'L2', fromMe: false }]);
   });
 
   it('still uses a stored key whose chat is spelled in the other dialect', async () => {


### PR DESCRIPTION
`POST /sessions/{sessionId}/chats/read` resolves caller-supplied message ids through the message store and checks that each stored key belongs to the chat named in the path. That check compared both sides through `toEngineJid`, which reduces `@c.us` and `@s.whatsapp.net` to one spelling but returns `@lid` unchanged.

Baileys addresses a DM by the peer's lid once WhatsApp switches the chat to that dialect, and the message store round-trips the raw key, so the stored `remoteJid` is `<lid>@lid` while the caller names the chat by phone number. Every stored key for such a chat failed the comparison, and the receipt fell back to a synthesised key that lost the message's real `fromMe` and `participant`.

- Compare in the neutral dialect via `toNeutralJid`, which resolves a lid to its phone user-part through the session's lid mapping. The contacts host already exposes it, wired to the same resolver the rest of the adapter uses.
- An unmapped lid still reduces to itself, so a key belonging to another chat is rejected exactly as before.

The mapping is learned from the inbound message key on the same path that stores the message, so a stored key normally resolves on the first try.

## Verification

New cases in `baileys-send-seen.spec.ts` cover a lid-addressed chat whose mapping is known, plus a negative twin for a lid-addressed key from a different chat. Reverting the comparison to `toEngineJid` fails only the first, reporting `fromMe: false` with `participant` dropped.
