### PR TITLE
feat(message): widen mentions to every text-carrying route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `mentions` reaches every route whose engine can carry it: `reply`, `edit`, `send-template` and each `send-bulk` item, alongside the send routes that already had it. `send-template` also gained `linkPreview`. On `edit` the tags are re-applied rather than preserved, because an edit replaces the message content. Thanks @Magnarks for the report.
 - `POST /sessions/{sessionId}/chats/unread` publishes its own `MarkChatUnreadDto` rather than sharing `MarkChatReadDto`. The body is unchanged (`chatId` alone), but a generated client sees the schema under a new name.
 - ⚠️ **Breaking (Go, Java and typed Python callers).** `markRead` and `subscribePresence` each take their own request type rather than the shared `MarkChatRequest`, which now serves `markUnread` alone. Swap the type at both call sites; the wire body is unchanged and the JavaScript and PHP clients are unaffected. `SubscribePresenceDto` had no contract-gate coverage while one type stood for two routes.
 

--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -163,7 +163,7 @@ There is a **single shared media byte cap**, not a per-type table. A base64 (or 
 
 ### Mentions
 
-`send-text` and the media send routes accept an optional `mentions` array of WIDs (`<phone>@c.us`) to tag participants — most useful in groups. Two things are required for WhatsApp to render a tag and notify the participant:
+`send-text`, the media send routes, `send-template`, `send-bulk` (per item), `reply` and `edit` all accept an optional `mentions` array of WIDs (`<phone>@c.us`) to tag participants — most useful in groups. On `edit` the tags are re-applied rather than preserved: an edit replaces the message content, so a rewritten body that still reads `@62811` loses the tag unless the list is sent again. Two things are required for WhatsApp to render a tag and notify the participant:
 
 1. The `mentions` array lists the WID(s), e.g. `["62811@c.us"]`.
 2. The `text`/`caption` contains the matching `@<number>` token, e.g. `Hello @62811`.
@@ -1571,8 +1571,8 @@ rejected with `400` rather than guessing which half was meant.
 Nine `send-*` routes accept an optional `quotedMessageId`: `send-text` above, and `send-image`,
 `send-video`, `send-audio`, `send-document`, `send-sticker`, `send-location`, `send-contact` and
 `send-poll` below. Supplying it turns that send into a reply, so a reply can carry media, a location,
-a contact card or a poll — not only text. `POST .../messages/reply` is unchanged and remains the text
-shorthand.
+a contact card or a poll — not only text. `POST .../messages/reply` remains the text shorthand, and
+like the send routes it accepts `mentions`.
 
 `send-template`, `send-bulk` and `send-product` do NOT accept the field, and reject it
 as an unknown property.
@@ -1626,6 +1626,8 @@ Render a stored text template (header/body/footer joined by blank lines, `{{vars
 | templateId   | string                  | Conditional | non-empty; required when `templateName` is absent | Stored template id                                          |
 | templateName | string                  | Conditional | non-empty; required when `templateId` is absent   | Stored template name                                        |
 | vars         | Record\<string,string\> | No          | object                                            | Substituted into `{{placeholder}}` tokens; defaults to `{}` |
+| mentions     | string[]                | No          | array of WIDs                                     | WIDs to @mention in the rendered body                       |
+| linkPreview  | boolean                 | No          | —                                                 | Same engine split as `send-text`; see **Link previews**     |
 
 ```json
 {
@@ -1919,11 +1921,12 @@ Reply to a message, quoting a prior message.
 
 **Request body** — `ReplyMessageDto`
 
-| Field           | Type   | Required | Constraints | Description                             |
-| --------------- | ------ | -------- | ----------- | --------------------------------------- |
-| chatId          | string | Yes      | non-empty   | Target chat                             |
-| quotedMessageId | string | Yes      | non-empty   | WhatsApp id of the message being quoted |
-| text            | string | Yes      | non-empty   | Reply text                              |
+| Field           | Type     | Required | Constraints   | Description                              |
+| --------------- | -------- | -------- | ------------- | ---------------------------------------- |
+| chatId          | string   | Yes      | non-empty     | Target chat                              |
+| quotedMessageId | string   | Yes      | non-empty     | WhatsApp id of the message being quoted  |
+| text            | string   | Yes      | non-empty     | Reply text                               |
+| mentions        | string[] | No       | array of WIDs | WIDs to @mention. See **Mentions** above |
 
 ```json
 { "chatId": "628123456789@c.us", "quotedMessageId": "true_628123456789@c.us_3EB0ABCD", "text": "Replying to you" }
@@ -2055,11 +2058,12 @@ Edit the text of a message sent by this account; also updates the stored record'
 
 **Request body** — `EditMessageDto`
 
-| Field     | Type   | Required | Constraints             | Description                                       |
-| --------- | ------ | -------- | ----------------------- | ------------------------------------------------- |
-| chatId    | string | Yes      | non-empty               | Chat containing the message                       |
-| messageId | string | Yes      | non-empty               | Message to edit (the send response's `messageId`) |
-| body      | string | Yes      | non-empty, ≤ 4096 chars | New text content                                  |
+| Field     | Type     | Required | Constraints             | Description                                       |
+| --------- | -------- | -------- | ----------------------- | ------------------------------------------------- |
+| chatId    | string   | Yes      | non-empty               | Chat containing the message                       |
+| messageId | string   | Yes      | non-empty               | Message to edit (the send response's `messageId`) |
+| body      | string   | Yes      | non-empty, ≤ 4096 chars | New text content                                  |
+| mentions  | string[] | No       | array of WIDs           | Re-applies participant tags to the new body       |
 
 ```json
 { "chatId": "628123456789@c.us", "messageId": "true_628123456789@c.us_3EB0ABCD", "body": "Corrected text" }
@@ -2095,7 +2099,7 @@ Send messages to multiple recipients as an async batch — returns immediately a
 | messages | BulkMessageItemDto[]  | Yes      | array, max 100, nested-validated | The batch items (see below); duplicate `chatId`s are collapsed before processing — first occurrence wins, order preserved |
 | options  | BulkMessageOptionsDto | No       | nested-validated                 | Pacing/error options (see below)                                                                                          |
 
-Each `BulkMessageItemDto`: `{ chatId: string, type: 'text'|'image'|'video'|'audio'|'document', content: BulkMessageContentDto, variables?: Record<string,string> }`. `content` (all fields optional, nested-validated): `text?: string`, `image?`/`video?`/`audio?`/`document?`: `{ url?, base64?, mimetype?, filename? }`, `caption?: string`.
+Each `BulkMessageItemDto`: `{ chatId: string, type: 'text'|'image'|'video'|'audio'|'document', content: BulkMessageContentDto, variables?: Record<string,string> }`. `content` (all fields optional, nested-validated): `text?: string`, `image?`/`video?`/`audio?`/`document?`: `{ url?, base64?, mimetype?, filename? }`, `caption?: string`, `mentions?: string[]` (per item; a batch fans out to many chats, and a WID is only taggable in a chat the participant is in).
 
 `BulkMessageOptionsDto`: `{ delayBetweenMessages?: number (1000–60000, default 3000), randomizeDelay?: boolean (default true), stopOnError?: boolean (default false) }`.
 

--- a/openapi.json
+++ b/openapi.json
@@ -11363,6 +11363,21 @@
               "customer": "Alice",
               "orderId": "1234"
             }
+          },
+          "mentions": {
+            "description": "WIDs to @mention (e.g. [\"62811@c.us\"]). The text/caption must also contain the @<number> token.",
+            "example": [
+              "628123456789@c.us"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "linkPreview": {
+            "type": "boolean",
+            "description": "Controls the URL preview on the rendered body, with the same engine split as send-text: whatsapp-web.js builds one by default and `false` suppresses it, while on Baileys previews are opt-in and only `true` attaches one.",
+            "example": false
           }
         },
         "required": [
@@ -11593,6 +11608,16 @@
           "text": {
             "type": "string",
             "maxLength": 4096
+          },
+          "mentions": {
+            "description": "WIDs to @mention (e.g. [\"62811@c.us\"]). The text/caption must also contain the @<number> token.",
+            "example": [
+              "628123456789@c.us"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "required": [
@@ -12130,6 +12155,16 @@
             "type": "string",
             "description": "New text body for the message",
             "maxLength": 4096
+          },
+          "mentions": {
+            "description": "WIDs to @mention (e.g. [\"62811@c.us\"]). The text/caption must also contain the @<number> token.",
+            "example": [
+              "628123456789@c.us"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "required": [
@@ -12207,6 +12242,16 @@
             "type": "string",
             "description": "Caption for media messages",
             "maxLength": 1024
+          },
+          "mentions": {
+            "description": "WIDs to @mention (e.g. [\"62811@c.us\"]). The text/caption must also contain the @<number> token.",
+            "example": [
+              "628123456789@c.us"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },

--- a/sdk/go/types_message.go
+++ b/sdk/go/types_message.go
@@ -99,6 +99,11 @@ type SendTemplateRequest struct {
 	TemplateID   string            `json:"templateId,omitempty"`
 	TemplateName string            `json:"templateName,omitempty"`
 	Vars         map[string]string `json:"vars,omitempty"`
+	// Mentions lists WIDs to @mention in the rendered body, which must carry the @<number> token.
+	Mentions []string `json:"mentions,omitempty"`
+	// LinkPreview controls the URL preview on the rendered body, with the same engine split as
+	// SendTextRequest. A pointer so an explicit false is distinguishable from "not set".
+	LinkPreview *bool `json:"linkPreview,omitempty"`
 }
 
 // SendPollRequest sends a native WhatsApp poll. Options holds the choices to
@@ -121,6 +126,8 @@ type ReplyMessageRequest struct {
 	ChatID          string `json:"chatId"`
 	QuotedMessageID string `json:"quotedMessageId"`
 	Text            string `json:"text"`
+	// Mentions lists WIDs to @mention. The text must also contain the @<number> token.
+	Mentions []string `json:"mentions,omitempty"`
 }
 
 // ForwardMessageRequest forwards a message between chats.
@@ -151,6 +158,9 @@ type EditMessageRequest struct {
 	ChatID    string `json:"chatId"`
 	MessageID string `json:"messageId"`
 	Body      string `json:"body"`
+	// Mentions re-applies participant tags: an edit REPLACES the body rather than amending it, so
+	// tags the original carried are lost unless resent.
+	Mentions []string `json:"mentions,omitempty"`
 }
 
 // ListMessagesQuery filters GET /sessions/:id/messages.
@@ -340,6 +350,9 @@ type BulkMessageContent struct {
 	Audio    *BulkMediaContent `json:"audio,omitempty"`
 	Document *BulkMediaContent `json:"document,omitempty"`
 	Caption  string            `json:"caption,omitempty"`
+	// Mentions is per item: a batch fans out to many chats, and a WID is only taggable in a chat
+	// the participant is in.
+	Mentions []string `json:"mentions,omitempty"`
 }
 
 // BulkMessageItem is one message in a bulk send. Type is one of: text, image,

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/model/BulkMessageContent.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/model/BulkMessageContent.java
@@ -1,5 +1,7 @@
 package com.rmyndharis.openwa.model;
 
+import java.util.List;
+
 /** Content payload for one bulk-send item. Populate the field matching the item's {@link BulkMessageType}. */
 public record BulkMessageContent(
     String text,
@@ -7,7 +9,14 @@ public record BulkMessageContent(
     BulkMediaRequest video,
     BulkMediaRequest audio,
     BulkMediaRequest document,
-    String caption) {
+    String caption,
+    List<String> mentions) {
+    /** Back-compatible constructor without mentions. */
+    public BulkMessageContent(
+        String text, BulkMediaRequest image, BulkMediaRequest video, BulkMediaRequest audio,
+        BulkMediaRequest document, String caption) {
+        this(text, image, video, audio, document, caption, null);
+    }
 
     public static Builder builder() {
         return new Builder();
@@ -20,6 +29,7 @@ public record BulkMessageContent(
         private BulkMediaRequest audio;
         private BulkMediaRequest document;
         private String caption;
+        private List<String> mentions;
 
         public Builder text(String v) {
             this.text = v;
@@ -51,8 +61,14 @@ public record BulkMessageContent(
             return this;
         }
 
+        /** Per item: a batch fans out to many chats, and a WID is only taggable in a chat it is in. */
+        public Builder mentions(List<String> v) {
+            this.mentions = v;
+            return this;
+        }
+
         public BulkMessageContent build() {
-            return new BulkMessageContent(text, image, video, audio, document, caption);
+            return new BulkMessageContent(text, image, video, audio, document, caption, mentions);
         }
     }
 }

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/model/EditMessageRequest.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/model/EditMessageRequest.java
@@ -1,7 +1,14 @@
 package com.rmyndharis.openwa.model;
 
+import java.util.List;
+
 /** Request body for editing the text of a message sent by this account. */
-public record EditMessageRequest(String chatId, String messageId, String body) {
+public record EditMessageRequest(String chatId, String messageId, String body, List<String> mentions) {
+    /** Back-compatible constructor without mentions. */
+    public EditMessageRequest(String chatId, String messageId, String body) {
+        this(chatId, messageId, body, null);
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -10,6 +17,7 @@ public record EditMessageRequest(String chatId, String messageId, String body) {
         private String chatId;
         private String messageId;
         private String body;
+        private List<String> mentions;
 
         public Builder chatId(String v) {
             this.chatId = v;
@@ -27,8 +35,14 @@ public record EditMessageRequest(String chatId, String messageId, String body) {
             return this;
         }
 
+        /** An edit REPLACES the body, so tags are re-applied rather than preserved. */
+        public Builder mentions(List<String> v) {
+            this.mentions = v;
+            return this;
+        }
+
         public EditMessageRequest build() {
-            return new EditMessageRequest(chatId, messageId, body);
+            return new EditMessageRequest(chatId, messageId, body, mentions);
         }
     }
 }

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/model/ReplyMessageRequest.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/model/ReplyMessageRequest.java
@@ -1,7 +1,14 @@
 package com.rmyndharis.openwa.model;
 
+import java.util.List;
+
 /** Request body for replying to a specific message. */
-public record ReplyMessageRequest(String chatId, String quotedMessageId, String text) {
+public record ReplyMessageRequest(String chatId, String quotedMessageId, String text, List<String> mentions) {
+    /** Back-compatible constructor without mentions. */
+    public ReplyMessageRequest(String chatId, String quotedMessageId, String text) {
+        this(chatId, quotedMessageId, text, null);
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -10,6 +17,7 @@ public record ReplyMessageRequest(String chatId, String quotedMessageId, String 
         private String chatId;
         private String quotedMessageId;
         private String text;
+        private List<String> mentions;
 
         public Builder chatId(String v) {
             this.chatId = v;
@@ -26,8 +34,14 @@ public record ReplyMessageRequest(String chatId, String quotedMessageId, String 
             return this;
         }
 
+        /** WIDs to @mention; the text must also contain the matching @&lt;number&gt; token. */
+        public Builder mentions(List<String> v) {
+            this.mentions = v;
+            return this;
+        }
+
         public ReplyMessageRequest build() {
-            return new ReplyMessageRequest(chatId, quotedMessageId, text);
+            return new ReplyMessageRequest(chatId, quotedMessageId, text, mentions);
         }
     }
 }

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/model/SendTemplateRequest.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/model/SendTemplateRequest.java
@@ -1,9 +1,17 @@
 package com.rmyndharis.openwa.model;
 
+import java.util.List;
 import java.util.Map;
 
 /** Request body for rendering and sending a stored message template. */
-public record SendTemplateRequest(String chatId, String templateId, String templateName, Map<String, String> vars) {
+public record SendTemplateRequest(
+    String chatId, String templateId, String templateName, Map<String, String> vars, List<String> mentions,
+    Boolean linkPreview) {
+    /** Back-compatible constructor without the send-text passthrough options. */
+    public SendTemplateRequest(String chatId, String templateId, String templateName, Map<String, String> vars) {
+        this(chatId, templateId, templateName, vars, null, null);
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -13,6 +21,8 @@ public record SendTemplateRequest(String chatId, String templateId, String templ
         private String templateId;
         private String templateName;
         private Map<String, String> vars;
+        private List<String> mentions;
+        private Boolean linkPreview;
 
         public Builder chatId(String v) {
             this.chatId = v;
@@ -37,8 +47,20 @@ public record SendTemplateRequest(String chatId, String templateId, String templ
             return this;
         }
 
+        /** WIDs to @mention in the rendered body, which must carry the matching @&lt;number&gt; token. */
+        public Builder mentions(List<String> v) {
+            this.mentions = v;
+            return this;
+        }
+
+        /** Controls the URL preview on the rendered body, with the same engine split as send-text. */
+        public Builder linkPreview(Boolean v) {
+            this.linkPreview = v;
+            return this;
+        }
+
         public SendTemplateRequest build() {
-            return new SendTemplateRequest(chatId, templateId, templateName, vars);
+            return new SendTemplateRequest(chatId, templateId, templateName, vars, mentions, linkPreview);
         }
     }
 }

--- a/sdk/javascript/src/types.ts
+++ b/sdk/javascript/src/types.ts
@@ -314,6 +314,8 @@ export interface ReplyMessageRequest {
   chatId: Jid;
   quotedMessageId: string;
   text: string;
+  /** WIDs to @mention (e.g. `["62811@c.us"]`). The text/caption must also contain the `@<number>` token. */
+  mentions?: string[];
 }
 
 export interface ForwardMessageRequest {
@@ -414,6 +416,8 @@ export interface EditMessageRequest {
   messageId: string;
   /** New text body; max 4096 chars (same cap as a send). Own messages only — 404 if not found. */
   body: string;
+  /** WIDs to @mention. An edit REPLACES the body, so tags are re-applied rather than preserved. */
+  mentions?: string[];
 }
 
 export interface SendTemplateRequest {
@@ -424,6 +428,10 @@ export interface SendTemplateRequest {
   templateName?: string;
   /** Template variables (server DTO field is `vars`). */
   vars?: Record<string, string>;
+  /** WIDs to @mention (e.g. `["62811@c.us"]`). The text/caption must also contain the `@<number>` token. */
+  mentions?: string[];
+  /** Controls the URL preview on the rendered body, with the same engine split as `send-text`. */
+  linkPreview?: boolean;
 }
 
 export interface SendPollRequest {
@@ -600,6 +608,8 @@ export interface BulkMessageContent {
   audio?: BulkMediaRequest;
   document?: BulkMediaRequest;
   caption?: string;
+  /** WIDs to @mention (e.g. `["62811@c.us"]`). The text/caption must also contain the `@<number>` token. */
+  mentions?: string[];
 }
 
 export interface BulkMessageItem {

--- a/sdk/python/openwa/types.py
+++ b/sdk/python/openwa/types.py
@@ -379,6 +379,8 @@ class ReplyMessageRequest(TypedDict):
     chatId: Jid
     quotedMessageId: str
     text: str
+    # WIDs to @mention; the text must also contain the matching @<number> token.
+    mentions: NotRequired[list[str]]
 
 
 class ForwardMessageRequest(TypedDict):
@@ -405,6 +407,8 @@ class EditMessageRequest(TypedDict):
     messageId: str
     # Same 4096-char cap as SendTextRequest.text — an edit cannot exceed what a send allows.
     body: str
+    # An edit REPLACES the body, so tags are re-applied rather than preserved.
+    mentions: NotRequired[list[str]]
 
 
 class SendTemplateRequest(TypedDict):
@@ -414,6 +418,9 @@ class SendTemplateRequest(TypedDict):
     templateId: NotRequired[str]
     templateName: NotRequired[str]
     vars: NotRequired[dict[str, str]]
+    # The rendered body is dispatched like a send-text, so it carries the same two optionals.
+    mentions: NotRequired[list[str]]
+    linkPreview: NotRequired[bool]
 
 
 class SendPollRequest(TypedDict):
@@ -583,6 +590,8 @@ class BulkMessageContent(TypedDict, total=False):
     audio: BulkMediaRequest
     document: BulkMediaRequest
     caption: str
+    # Per item: a batch fans out to many chats, and a WID is only taggable in a chat it is in.
+    mentions: list[str]
 
 
 class BulkMessageItem(TypedDict):

--- a/src/engine/adapters/baileys-messaging.ts
+++ b/src/engine/adapters/baileys-messaging.ts
@@ -428,7 +428,7 @@ export class BaileysMessaging {
     );
   }
 
-  async replyToMessage(chatId: string, quotedMsgId: string, text: string): Promise<MessageResult> {
+  async replyToMessage(chatId: string, quotedMsgId: string, text: string, mentions?: string[]): Promise<MessageResult> {
     this.host.ensureReady();
     const quoted = await this.requireStored(quotedMsgId);
     // The one requireStored path that had no chat check. whatsapp-web.js resolves the quote by
@@ -438,7 +438,7 @@ export class BaileysMessaging {
     // NOT applied to quoteOption: cross-chat quoting on the send-* routes is deliberate and
     // published in docs/06.
     this.assertStoredInChat(quoted, chatId, quotedMsgId);
-    return this.sendContent(chatId, { text }, { quoted });
+    return this.sendContent(chatId, { text, ...this.withMentions(mentions) }, { quoted });
   }
 
   async forwardMessage(fromChatId: string, toChatId: string, messageId: string): Promise<MessageResult> {
@@ -484,7 +484,7 @@ export class BaileysMessaging {
     );
   }
 
-  async editMessage(chatId: string, messageId: string, body: string): Promise<MessageResult> {
+  async editMessage(chatId: string, messageId: string, body: string, mentions?: string[]): Promise<MessageResult> {
     this.host.ensureReady();
     const target = await this.requireStored(messageId);
     // Only the account's own messages are editable: WhatsApp refuses the edit of an inbound message
@@ -502,10 +502,14 @@ export class BaileysMessaging {
     const jid = await this.toDeliverableJid(chatId);
     // Same guard as sendContent: an edit carries text, so without it the library would fetch
     // every URL in the new body through its own vulnerable generator.
+    // Tags are applied to the inner message's contextInfo BEFORE the library wraps it in the
+    // protocolMessage edit envelope, so an edit can re-tag participants. An edit REPLACES the
+    // content, so omitting mentions drops whatever tags the original carried.
+    const editContent = { text: body, ...this.withMentions(mentions), edit: target.key };
     const sent = await this.sock().sendMessage(
       jid,
-      this.previewSafe({ text: body, edit: target.key }),
-      this.previewSafeOptions({ text: body, edit: target.key }),
+      this.previewSafe(editContent),
+      this.previewSafeOptions(editContent),
     );
     return { id: sent?.key?.id ?? messageId, timestamp: this.host.toUnixSeconds(sent?.messageTimestamp) };
   }

--- a/src/engine/adapters/baileys.adapter.spec.ts
+++ b/src/engine/adapters/baileys.adapter.spec.ts
@@ -2595,6 +2595,30 @@ describe('BaileysAdapter store-backed ops', () => {
     );
   });
 
+  it('replyToMessage tags the participants it was given, de-normalized to the engine dialect', async () => {
+    fakeStore.getMessage.mockResolvedValue(stored);
+    const adapter = await ready();
+    await adapter.replyToMessage('628111@s.whatsapp.net', 'TARGET', 'hi @62811', ['62811@c.us']);
+    expect(fakeSock.sendMessage).toHaveBeenCalledWith(
+      '628111@s.whatsapp.net',
+      { text: 'hi @62811', mentions: ['62811@s.whatsapp.net'], linkPreview: null },
+      expect.objectContaining({ quoted: stored }),
+    );
+  });
+
+  it('replyToMessage sends no mentions key for an empty list, keeping an untagged reply byte-identical', async () => {
+    // Control for the case above: an empty array must not add the key, or every untagged reply would
+    // start carrying an empty contextInfo tag list.
+    fakeStore.getMessage.mockResolvedValue(stored);
+    const adapter = await ready();
+    await adapter.replyToMessage('628111@s.whatsapp.net', 'TARGET', 'my reply', []);
+    expect(fakeSock.sendMessage).toHaveBeenCalledWith(
+      '628111@s.whatsapp.net',
+      { text: 'my reply', linkPreview: null },
+      expect.objectContaining({ quoted: stored }),
+    );
+  });
+
   // The one requireStored path that had no chat check, while whatsapp-web.js resolves the quote by
   // fetching from the named chat and 404s when the id is not in it.
   it('replyToMessage throws MessageNotFoundError when the quoted key belongs to another chat', async () => {
@@ -2757,6 +2781,25 @@ describe('BaileysAdapter store-backed ops', () => {
       '628111@s.whatsapp.net',
     );
     expect(fakeSock.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('editMessage re-applies participant tags to the new body', async () => {
+    // An edit REPLACES the content, so a body that still reads "@62811" needs the tag list resent or
+    // the rewritten message loses the tag the original had.
+    fakeStore.getMessage.mockResolvedValue(ownStored);
+    fakeSock.sendMessage.mockResolvedValue({ key: { ...ownStored.key }, messageTimestamp: 1700000010 });
+    const adapter = await ready();
+    await adapter.editMessage('628111@s.whatsapp.net', 'TARGET', 'edited @62811', ['62811@c.us']);
+    expect(fakeSock.sendMessage).toHaveBeenCalledWith(
+      '628111@s.whatsapp.net',
+      {
+        text: 'edited @62811',
+        mentions: ['62811@s.whatsapp.net'],
+        edit: ownStored.key,
+        linkPreview: null,
+      },
+      expect.objectContaining({ getUrlInfo: expect.any(Function) as unknown }) as unknown,
+    );
   });
 
   it('editMessage edits via the stored key and returns the (unchanged) message id', async () => {

--- a/src/engine/adapters/baileys.adapter.ts
+++ b/src/engine/adapters/baileys.adapter.ts
@@ -317,8 +317,8 @@ export class BaileysAdapter implements IWhatsAppEngine {
     return this.messaging.sendPollMessage(chatId, poll);
   }
 
-  async replyToMessage(chatId: string, quotedMsgId: string, text: string): Promise<MessageResult> {
-    return this.messaging.replyToMessage(chatId, quotedMsgId, text);
+  async replyToMessage(chatId: string, quotedMsgId: string, text: string, mentions?: string[]): Promise<MessageResult> {
+    return this.messaging.replyToMessage(chatId, quotedMsgId, text, mentions);
   }
 
   async forwardMessage(fromChatId: string, toChatId: string, messageId: string): Promise<MessageResult> {
@@ -345,8 +345,8 @@ export class BaileysAdapter implements IWhatsAppEngine {
     return this.messaging.unpinMessage(chatId, messageId);
   }
 
-  async editMessage(chatId: string, messageId: string, body: string): Promise<MessageResult> {
-    return this.messaging.editMessage(chatId, messageId, body);
+  async editMessage(chatId: string, messageId: string, body: string, mentions?: string[]): Promise<MessageResult> {
+    return this.messaging.editMessage(chatId, messageId, body, mentions);
   }
 
   // ----- Groups -----

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -4249,6 +4249,21 @@ describe('LID resolution for individual sends (#573 — WhatsApp @c.us → @lid 
     expect(reply).toHaveBeenCalledWith('hi', '628@c.us');
   });
 
+  it('reply passes the tag list through as send options, and omits the options bag without one', async () => {
+    const reply = jest.fn().mockResolvedValue(sentMessage);
+    const quoted = { id: { _serialized: 'Q1' }, reply };
+    const getChatById = jest.fn().mockResolvedValue({ fetchMessages: jest.fn().mockResolvedValue([quoted]) });
+    const getNumberId = jest.fn().mockResolvedValue({ _serialized: '628@c.us' });
+
+    await ready({ getChatById, getNumberId }).replyToMessage('628@c.us', 'Q1', 'hi @62811', ['62811@c.us']);
+    expect(reply).toHaveBeenCalledWith('hi @62811', '628@c.us', { mentions: ['62811@c.us'] });
+
+    // Control: an empty list must not start passing an options bag to every untagged reply.
+    reply.mockClear();
+    await ready({ getChatById, getNumberId }).replyToMessage('628@c.us', 'Q1', 'hi', []);
+    expect(reply).toHaveBeenCalledWith('hi', '628@c.us');
+  });
+
   it('forward routes to the resolved @lid and recovers the id from that chat (#583 R1)', async () => {
     const forward = jest.fn().mockResolvedValue(undefined);
     const srcMsg = { id: { _serialized: 'M1' }, forward };
@@ -4280,6 +4295,19 @@ describe('editMessage', () => {
     const res = await adapter.editMessage('628@c.us', 'M1', 'new body');
     expect(edit).toHaveBeenCalledWith('new body');
     expect(res).toEqual({ id: 'M1', timestamp: 1700000002 });
+  });
+
+  it('edit re-applies participant tags, and sends no options bag when none were asked for', async () => {
+    const edit = jest.fn().mockResolvedValue({ id: { _serialized: 'M1' }, timestamp: 1700000002 });
+    const adapter = ready(chatWith([{ id: { _serialized: 'M1', id: 'RAW1' }, edit }]));
+
+    await adapter.editMessage('628@c.us', 'M1', 'new @62811', ['62811@c.us']);
+    expect(edit).toHaveBeenCalledWith('new @62811', { mentions: ['62811@c.us'] });
+
+    // Control: without tags the library call keeps its single-argument shape.
+    edit.mockClear();
+    await adapter.editMessage('628@c.us', 'M1', 'new body', []);
+    expect(edit).toHaveBeenCalledWith('new body');
   });
 
   it('also matches the bare id.id fallback (like deleteMessage)', async () => {

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -591,8 +591,8 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
     return this.messaging.sendPollMessage(chatId, poll);
   }
 
-  replyToMessage(chatId: string, quotedMsgId: string, text: string): Promise<MessageResult> {
-    return this.messaging.replyToMessage(chatId, quotedMsgId, text);
+  replyToMessage(chatId: string, quotedMsgId: string, text: string, mentions?: string[]): Promise<MessageResult> {
+    return this.messaging.replyToMessage(chatId, quotedMsgId, text, mentions);
   }
 
   forwardMessage(fromChatId: string, toChatId: string, messageId: string): Promise<MessageResult> {
@@ -722,8 +722,8 @@ export class WhatsAppWebJsAdapter extends EventEmitter implements IWhatsAppEngin
   }
 
   // Edit Message
-  editMessage(chatId: string, messageId: string, body: string): Promise<MessageResult> {
-    return this.messaging.editMessage(chatId, messageId, body);
+  editMessage(chatId: string, messageId: string, body: string, mentions?: string[]): Promise<MessageResult> {
+    return this.messaging.editMessage(chatId, messageId, body, mentions);
   }
 
   // Get Profile Picture

--- a/src/engine/adapters/wwebjs-messaging.ts
+++ b/src/engine/adapters/wwebjs-messaging.ts
@@ -521,7 +521,7 @@ export class WwebjsMessaging {
     return toMessageResult(msg);
   }
 
-  async replyToMessage(chatId: string, quotedMsgId: string, text: string): Promise<MessageResult> {
+  async replyToMessage(chatId: string, quotedMsgId: string, text: string, mentions?: string[]): Promise<MessageResult> {
     this.host.ensureReady();
     try {
       // Find the message to quote
@@ -536,7 +536,13 @@ export class WwebjsMessaging {
       // Reply's send leg hits the same `No LID for user` path as a normal send for a migrated contact,
       // so route it through sendResolved (resolve @c.us->@lid, cache, self-heal). reply(content, chatId)
       // accepts an explicit target (#583 R1).
-      const msg = await this.sendResolved(chatId, to => quotedMsg.reply(text, to));
+      // reply(content, chatId, options) takes the same options bag as sendMessage, so a quoted send
+      // tags participants exactly as a plain one does. The options argument is omitted entirely when
+      // no tags were asked for, keeping an ordinary reply's call shape untouched (same rule as the
+      // send path).
+      const msg = await this.sendResolved(chatId, to =>
+        mentions?.length ? quotedMsg.reply(text, to, { mentions }) : quotedMsg.reply(text, to),
+      );
       return toMessageResult(msg);
     } catch (error) {
       this.host.reportIfPageTransportError(error, 'replyToMessage');
@@ -750,7 +756,7 @@ export class WwebjsMessaging {
     this.host.logger.log(`Deleted message ${messageId} from chat ${chatId} (forEveryone: ${forEveryone})`);
   }
 
-  async editMessage(chatId: string, messageId: string, body: string): Promise<MessageResult> {
+  async editMessage(chatId: string, messageId: string, body: string, mentions?: string[]): Promise<MessageResult> {
     this.host.ensureReady();
     // Same lookup window as react/delete: fetchMessages sees only the 100 most recent messages.
     // NOTE: do NOT resolve chatId to @lid here — edit operates on the found message's own key, not
@@ -767,7 +773,9 @@ export class WwebjsMessaging {
     if (!message) {
       throw new MessageNotFoundError(messageId, chatId);
     }
-    const edited = await message.edit(body);
+    // An edit REPLACES the content, so tags are re-applied rather than preserved: omitting mentions
+    // drops whatever the original carried. Options omitted entirely when none were asked for.
+    const edited = mentions?.length ? await message.edit(body, { mentions }) : await message.edit(body);
     if (!edited) {
       // wwebjs RESOLVES null (instead of throwing) when the page-side edit is refused — only the
       // account's own text messages are editable; surface the refusal, not a phantom success.

--- a/src/engine/interfaces/whatsapp-engine.interface.ts
+++ b/src/engine/interfaces/whatsapp-engine.interface.ts
@@ -909,7 +909,11 @@ export interface MessagingCapability {
 
   sendPollMessage(chatId: string, poll: PollInput): Promise<MessageResult>;
 
-  replyToMessage(chatId: string, quotedMsgId: string, text: string): Promise<MessageResult>;
+  /**
+   * Reply to a message, quoting it. `mentions` tags participants exactly as on the send routes: the
+   * text must also carry the matching `@<number>` token for WhatsApp to render the tag.
+   */
+  replyToMessage(chatId: string, quotedMsgId: string, text: string, mentions?: string[]): Promise<MessageResult>;
 
   forwardMessage(fromChatId: string, toChatId: string, messageId: string): Promise<MessageResult>;
 }
@@ -930,8 +934,11 @@ export interface MessageOperationsCapability {
   /**
    * Edit the body of a text message. Only the account's OWN messages can be edited; engines reject
    * non-text or foreign messages at their own layer — the engine's error is surfaced as-is.
+   *
+   * `mentions` re-applies participant tags to the new body. An edit REPLACES the message content, so
+   * omitting it drops whatever tags the original carried rather than preserving them.
    */
-  editMessage(chatId: string, messageId: string, body: string): Promise<MessageResult>;
+  editMessage(chatId: string, messageId: string, body: string, mentions?: string[]): Promise<MessageResult>;
 
   /**
    * Star (bookmark) a message, or remove its star. Starring is a private, account-local marker —

--- a/src/modules/message/bulk-message.service.spec.ts
+++ b/src/modules/message/bulk-message.service.spec.ts
@@ -267,7 +267,11 @@ describe('BulkMessageService.processBatch', () => {
     }) as unknown as MessageBatch;
 
   beforeEach(async () => {
-    engine = { sendTextMessage: jest.fn().mockResolvedValue({ id: 'wa1', timestamp: 111 }) };
+    engine = {
+      sendTextMessage: jest.fn().mockResolvedValue({ id: 'wa1', timestamp: 111 }),
+      sendImageMessage: jest.fn().mockResolvedValue({ id: 'wa1', timestamp: 111 }),
+      sendAudioMessage: jest.fn().mockResolvedValue({ id: 'wa1', timestamp: 111 }),
+    };
     engines = new EngineRegistry();
     engines.set('s1', engine as unknown as IWhatsAppEngine);
     messageService = { saveOutgoingMessage: jest.fn().mockResolvedValue(undefined) };
@@ -770,6 +774,76 @@ describe('BulkMessageService.processBatch', () => {
     await runProcessBatch();
 
     expect(engine.sendTextMessage).toHaveBeenCalledWith('c0@c.us', 'Hi Sam');
+  });
+
+  it('tags participants per item, on the text body and on a media caption alike', async () => {
+    // Each item names its own list: a batch fans out to many chats, and a WID is only taggable in a
+    // chat the participant is actually in.
+    const batch = makeBatch(1);
+    batch.messages[0].content = { text: 'Hi @62811', mentions: ['62811@c.us'] };
+    repo.findOne.mockResolvedValue(batch);
+
+    await runProcessBatch();
+
+    expect(engine.sendTextMessage).toHaveBeenCalledWith('c0@c.us', 'Hi @62811', ['62811@c.us']);
+
+    const media = makeBatch(1);
+    media.messages[0].type = 'image';
+    media.messages[0].content = {
+      image: { base64: 'AAAA', mimetype: 'image/jpeg' },
+      caption: 'look @62811',
+      mentions: ['62811@c.us'],
+    };
+    repo.findOne.mockResolvedValue(media);
+
+    await runProcessBatch();
+
+    expect(engine.sendImageMessage).toHaveBeenCalledWith(
+      'c0@c.us',
+      expect.objectContaining({ caption: 'look @62811', mentions: ['62811@c.us'] }),
+    );
+  });
+
+  it('substitutes variables inside mentions, so a campaign can tag a different participant per item', async () => {
+    // applyVariables walks the whole content tree, so a placeholder in a WID is rendered like one in
+    // the body. That is load-bearing for a personalised batch, and nothing else pins it: a future
+    // rewrite of applyVariables that rebuilt the object field by field would drop mentions silently.
+    const batch = makeBatch(1);
+    batch.messages[0].content = { text: 'Hi @{{num}}', mentions: ['{{num}}@c.us'] };
+    batch.messages[0].variables = { num: '62811' };
+    repo.findOne.mockResolvedValue(batch);
+
+    await runProcessBatch();
+
+    expect(engine.sendTextMessage).toHaveBeenCalledWith('c0@c.us', 'Hi @62811', ['62811@c.us']);
+  });
+
+  it('tags an audio item too, which has no caption to anchor a visible @token', async () => {
+    // Audio carries no caption, but a mention still tags through contextInfo, which is why the
+    // single-send audio route accepts the field. Skipping it here would accept the list and deliver
+    // an untagged voice note, turning a clear 400 into a silent no-op for one bulk type only.
+    const batch = makeBatch(1);
+    batch.messages[0].type = 'audio';
+    batch.messages[0].content = { audio: { base64: 'AAAA', mimetype: 'audio/mpeg' }, mentions: ['62811@c.us'] };
+    repo.findOne.mockResolvedValue(batch);
+
+    await runProcessBatch();
+
+    expect(engine.sendAudioMessage).toHaveBeenCalledWith(
+      'c0@c.us',
+      expect.objectContaining({ mentions: ['62811@c.us'] }),
+    );
+  });
+
+  it('leaves an untagged batch item on its two-argument send', async () => {
+    // Control: without a list the call shape every existing batch makes is untouched.
+    const batch = makeBatch(1);
+    batch.messages[0].content = { text: 'Hi there', mentions: [] };
+    repo.findOne.mockResolvedValue(batch);
+
+    await runProcessBatch();
+
+    expect(engine.sendTextMessage).toHaveBeenCalledWith('c0@c.us', 'Hi there');
   });
 
   it('fails an item whose rendered variables grow its base64 media past the cap (no send, explicit failure)', async () => {

--- a/src/modules/message/bulk-message.service.ts
+++ b/src/modules/message/bulk-message.service.ts
@@ -40,6 +40,7 @@ import { resolveNonNegativeIntEnv } from '../../config/configuration';
 interface BulkMessageContent {
   text?: string;
   caption?: string;
+  mentions?: string[];
   image?: { url?: string; base64?: string; mimetype?: string; filename?: string };
   video?: { url?: string; base64?: string; mimetype?: string; filename?: string };
   audio?: { url?: string; base64?: string; mimetype?: string; filename?: string; ptt?: boolean };
@@ -767,24 +768,33 @@ export class BulkMessageService implements OnApplicationBootstrap {
   ): Promise<MessageResult> {
     switch (type) {
       case 'text':
-        return engine.sendTextMessage(chatId, content.text || '');
+        return content.mentions?.length
+          ? engine.sendTextMessage(chatId, content.text || '', content.mentions)
+          : engine.sendTextMessage(chatId, content.text || '');
       case 'image':
         return engine.sendImageMessage(chatId, {
           mimetype: content.image?.mimetype || 'image/jpeg',
           data: stripBase64DataUri(content.image?.base64) || content.image?.url || '',
           caption: content.caption,
+          mentions: content.mentions,
         });
       case 'video':
         return engine.sendVideoMessage(chatId, {
           mimetype: content.video?.mimetype || 'video/mp4',
           data: stripBase64DataUri(content.video?.base64) || content.video?.url || '',
           caption: content.caption,
+          mentions: content.mentions,
         });
       case 'audio':
+        // Forwarded even though audio carries no caption: a mention tags the recipient through
+        // contextInfo without visible @text, which is why the single-send audio route accepts it too
+        // (see sendAudioMessage in baileys-messaging.ts). Dropping it here would accept the field and
+        // then deliver an untagged voice note with nothing to say so.
         return engine.sendAudioMessage(chatId, {
           mimetype: content.audio?.mimetype || (content.audio?.ptt ? 'audio/ogg; codecs=opus' : 'audio/mpeg'),
           data: stripBase64DataUri(content.audio?.base64) || content.audio?.url || '',
           ptt: content.audio?.ptt,
+          mentions: content.mentions,
         });
       case 'document':
         return engine.sendDocumentMessage(chatId, {
@@ -792,6 +802,7 @@ export class BulkMessageService implements OnApplicationBootstrap {
           data: stripBase64DataUri(content.document?.base64) || content.document?.url || '',
           filename: content.document?.filename,
           caption: content.caption,
+          mentions: content.mentions,
         });
       default:
         return Promise.reject(new Error(`Unsupported message type: ${type}`));

--- a/src/modules/message/dto/bulk-message.dto.ts
+++ b/src/modules/message/dto/bulk-message.dto.ts
@@ -14,7 +14,15 @@ import {
   ArrayMaxSize,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+import { Validate } from 'class-validator';
 import { ToStrictBoolean } from '../../../common/utils/strict-boolean';
+import {
+  MENTIONS_DESCRIPTION,
+  MENTIONS_MAX,
+  MENTION_WID_MAX_LENGTH,
+  MESSAGE_TEXT_MAX_LENGTH,
+} from './send-message.dto';
+import { IsMentionWidConstraint } from './is-mention-wid.validator';
 import { BatchMessageStatus, BatchStatus } from '../entities/message-batch.entity';
 
 class BulkMediaDto {
@@ -46,10 +54,10 @@ class BulkMediaDto {
 }
 
 class BulkMessageContentDto {
-  @ApiPropertyOptional({ description: 'Text content for text messages', maxLength: 4096 })
+  @ApiPropertyOptional({ description: 'Text content for text messages', maxLength: MESSAGE_TEXT_MAX_LENGTH })
   @IsOptional()
   @IsString()
-  @MaxLength(4096)
+  @MaxLength(MESSAGE_TEXT_MAX_LENGTH)
   text?: string;
 
   // Typed nested DTOs (not bare object literals) so the global ValidationPipe's whitelist /
@@ -84,6 +92,18 @@ class BulkMessageContentDto {
   @IsString()
   @MaxLength(1024)
   caption?: string;
+
+  // Applies to the text body and to a media caption alike, matching the single-send routes. Every
+  // item in a batch names its own list: a batch fans out to many chats, and a WID is only taggable
+  // in a chat the participant is in.
+  @ApiPropertyOptional({ description: MENTIONS_DESCRIPTION, example: ['628123456789@c.us'], type: [String] })
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(MENTIONS_MAX)
+  @IsString({ each: true })
+  @MaxLength(MENTION_WID_MAX_LENGTH, { each: true })
+  @Validate(IsMentionWidConstraint, { each: true })
+  mentions?: string[];
 }
 
 class BulkMessageItemDto {

--- a/src/modules/message/dto/message-actions.dto.spec.ts
+++ b/src/modules/message/dto/message-actions.dto.spec.ts
@@ -1,3 +1,4 @@
+import { ValidationPipe } from '@nestjs/common';
 import { plainToInstance } from 'class-transformer';
 import { validate, ValidationError } from 'class-validator';
 import {
@@ -7,7 +8,9 @@ import {
   DeleteMessageDto,
   ForwardMessageDto,
   EditMessageDto,
+  ReplyMessageDto,
 } from './message-actions.dto';
+import { GLOBAL_VALIDATION_OPTIONS } from '../../../config/app-validation';
 
 /**
  * Regression locks: these endpoints previously took inline @Body literals (no
@@ -139,5 +142,49 @@ describe('message action DTOs', () => {
   it('EditMessageDto: missing messageId is rejected', async () => {
     const errs = await errorsFor(EditMessageDto, { chatId: 'x@c.us', body: 'new text' });
     expect(errs.some(e => e.property === 'messageId')).toBe(true);
+  });
+});
+
+/**
+ * These run through the REAL production pipe rather than bare `validate()`, because the defect they
+ * lock is a whitelist rejection: `forbidNonWhitelisted` answers 400 "property X should not exist"
+ * for anything the DTO does not declare, and a plain validate() call cannot see that at all.
+ */
+describe('mentions on the quoted-send and edit routes (whitelist behaviour)', () => {
+  const pipe = new ValidationPipe(GLOBAL_VALIDATION_OPTIONS);
+  const through = (metatype: unknown, value: object): Promise<unknown> =>
+    pipe.transform(value, { type: 'body', metatype: metatype as never });
+
+  const REPLY = { chatId: '120363000000000000@g.us', quotedMessageId: 'Q1', text: 'hi @62811' };
+  const EDIT = { chatId: '120363000000000000@g.us', messageId: 'M1', body: 'hi @62811' };
+
+  it('ReplyMessageDto accepts a mentions array', async () => {
+    await expect(through(ReplyMessageDto, { ...REPLY, mentions: ['62811@c.us'] })).resolves.toMatchObject({
+      mentions: ['62811@c.us'],
+    });
+  });
+
+  it('EditMessageDto accepts a mentions array', async () => {
+    await expect(through(EditMessageDto, { ...EDIT, mentions: ['62811@c.us'] })).resolves.toMatchObject({
+      mentions: ['62811@c.us'],
+    });
+  });
+
+  // Control for both cases above. Without it, a pipe whose whitelist had been switched off entirely
+  // would satisfy them just as well, and the assertions would prove nothing about the new field.
+  it('still refuses a property no DTO declares', async () => {
+    await expect(through(ReplyMessageDto, { ...REPLY, notAField: 1 })).rejects.toMatchObject({
+      response: { message: ['property notAField should not exist'] },
+    });
+    await expect(through(EditMessageDto, { ...EDIT, notAField: 1 })).rejects.toMatchObject({
+      response: { message: ['property notAField should not exist'] },
+    });
+  });
+
+  it('rejects a mentions entry that is not an individual WID', async () => {
+    // A group id is not a participant, and the shared constraint refuses it on every route that
+    // takes the field.
+    await expect(through(ReplyMessageDto, { ...REPLY, mentions: ['120363000000000000@g.us'] })).rejects.toBeDefined();
+    await expect(through(EditMessageDto, { ...EDIT, mentions: ['not-a-wid'] })).rejects.toBeDefined();
   });
 });

--- a/src/modules/message/dto/message-actions.dto.ts
+++ b/src/modules/message/dto/message-actions.dto.ts
@@ -11,9 +11,18 @@ import {
   ArrayMaxSize,
   MaxLength,
   IsIn,
+  Validate,
 } from 'class-validator';
 import { ToStrictBoolean, ToStrictNumber } from '../../../common/utils/strict-boolean';
-import { MESSAGE_TEXT_MAX_LENGTH, QUOTED_MESSAGE_ID_DESCRIPTION, QUOTED_MESSAGE_ID_EXAMPLE } from './send-message.dto';
+import {
+  MENTIONS_DESCRIPTION,
+  MENTIONS_MAX,
+  MENTION_WID_MAX_LENGTH,
+  MESSAGE_TEXT_MAX_LENGTH,
+  QUOTED_MESSAGE_ID_DESCRIPTION,
+  QUOTED_MESSAGE_ID_EXAMPLE,
+} from './send-message.dto';
+import { IsMentionWidConstraint } from './is-mention-wid.validator';
 
 /**
  * Validated DTOs for the message action endpoints. These replaced inline
@@ -148,6 +157,15 @@ export class ReplyMessageDto {
   @IsNotEmpty()
   @MaxLength(MESSAGE_TEXT_MAX_LENGTH)
   text!: string;
+
+  @ApiPropertyOptional({ description: MENTIONS_DESCRIPTION, example: ['628123456789@c.us'], type: [String] })
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(MENTIONS_MAX)
+  @IsString({ each: true })
+  @MaxLength(MENTION_WID_MAX_LENGTH, { each: true })
+  @Validate(IsMentionWidConstraint, { each: true })
+  mentions?: string[];
 }
 
 export class ForwardMessageDto {
@@ -311,10 +329,22 @@ export class EditMessageDto {
   @IsNotEmpty()
   messageId!: string;
 
-  // Same body cap as SendTextMessageDto.text — an edit cannot exceed what a send allows.
-  @ApiProperty({ description: 'New text body for the message', maxLength: 4096 })
+  // Same body cap as SendTextMessageDto.text — an edit cannot exceed what a send allows. Bound to the
+  // shared constant rather than restated, so the two cannot drift apart.
+  @ApiProperty({ description: 'New text body for the message', maxLength: MESSAGE_TEXT_MAX_LENGTH })
   @IsString()
   @IsNotEmpty()
-  @MaxLength(4096)
+  @MaxLength(MESSAGE_TEXT_MAX_LENGTH)
   body!: string;
+
+  // An edit REPLACES the message content, so tags are re-applied rather than preserved: omitting
+  // this drops whatever the original body carried.
+  @ApiPropertyOptional({ description: MENTIONS_DESCRIPTION, example: ['628123456789@c.us'], type: [String] })
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(MENTIONS_MAX)
+  @IsString({ each: true })
+  @MaxLength(MENTION_WID_MAX_LENGTH, { each: true })
+  @Validate(IsMentionWidConstraint, { each: true })
+  mentions?: string[];
 }

--- a/src/modules/message/dto/send-message.dto.ts
+++ b/src/modules/message/dto/send-message.dto.ts
@@ -16,8 +16,17 @@ import { Type } from 'class-transformer';
 import { IsMentionWidConstraint } from './is-mention-wid.validator';
 import { ToStrictBoolean } from '../../../common/utils/strict-boolean';
 
-const MENTIONS_DESCRIPTION =
+export const MENTIONS_DESCRIPTION =
   'WIDs to @mention (e.g. ["62811@c.us"]). The text/caption must also contain the @<number> token.';
+
+/**
+ * Caps for a `mentions` array, exported because the field now appears on every REST route whose
+ * engine can carry it: send, reply, edit, template and bulk. Inline literals repeated per site is
+ * how the two numbers would drift apart between endpoints that share one documented contract. The
+ * agent-tool schemas do NOT declare mentions on any tool yet, so nothing there reads these.
+ */
+export const MENTIONS_MAX = 1024;
+export const MENTION_WID_MAX_LENGTH = 64;
 
 // Single source of truth for the text-body cap, shared with the agent-tool input schemas
 // (src/core/agent-tools/tools/message.tools.ts) so MCP and REST enforce the same limit.
@@ -84,9 +93,9 @@ export class SendTextMessageDto {
   @ApiPropertyOptional({ description: MENTIONS_DESCRIPTION, example: ['628123456789@c.us'], type: [String] })
   @IsOptional()
   @IsArray()
-  @ArrayMaxSize(1024)
+  @ArrayMaxSize(MENTIONS_MAX)
   @IsString({ each: true })
-  @MaxLength(64, { each: true })
+  @MaxLength(MENTION_WID_MAX_LENGTH, { each: true })
   @Validate(IsMentionWidConstraint, { each: true })
   mentions?: string[];
 
@@ -212,9 +221,9 @@ export class SendMediaMessageDto {
   @ApiPropertyOptional({ description: MENTIONS_DESCRIPTION, example: ['628123456789@c.us'], type: [String] })
   @IsOptional()
   @IsArray()
-  @ArrayMaxSize(1024)
+  @ArrayMaxSize(MENTIONS_MAX)
   @IsString({ each: true })
-  @MaxLength(64, { each: true })
+  @MaxLength(MENTION_WID_MAX_LENGTH, { each: true })
   @Validate(IsMentionWidConstraint, { each: true })
   mentions?: string[];
 

--- a/src/modules/message/dto/send-template.dto.ts
+++ b/src/modules/message/dto/send-template.dto.ts
@@ -1,5 +1,19 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsString, IsNotEmpty, IsOptional, IsObject, ValidateIf } from 'class-validator';
+import {
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  IsObject,
+  ValidateIf,
+  IsArray,
+  ArrayMaxSize,
+  MaxLength,
+  IsBoolean,
+  Validate,
+} from 'class-validator';
+import { ToStrictBoolean } from '../../../common/utils/strict-boolean';
+import { MENTIONS_DESCRIPTION, MENTIONS_MAX, MENTION_WID_MAX_LENGTH } from './send-message.dto';
+import { IsMentionWidConstraint } from './is-mention-wid.validator';
 
 export class SendTemplateMessageDto {
   @ApiProperty({
@@ -37,4 +51,29 @@ export class SendTemplateMessageDto {
   @IsOptional()
   @IsObject()
   vars?: Record<string, string>;
+
+  // The rendered body is dispatched through the same path as send-text, so it carries the same two
+  // optionals. `quotedMessageId` is deliberately NOT among them: docs/06 publishes this route as one
+  // that rejects it.
+  @ApiPropertyOptional({ description: MENTIONS_DESCRIPTION, example: ['628123456789@c.us'], type: [String] })
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(MENTIONS_MAX)
+  @IsString({ each: true })
+  @MaxLength(MENTION_WID_MAX_LENGTH, { each: true })
+  @Validate(IsMentionWidConstraint, { each: true })
+  mentions?: string[];
+
+  @ApiPropertyOptional({
+    description:
+      'Controls the URL preview on the rendered body, with the same engine split as send-text: ' +
+      'whatsapp-web.js builds one by default and `false` suppresses it, while on Baileys previews ' +
+      'are opt-in and only `true` attaches one.',
+    example: false,
+  })
+  // Same guard as send-text: implicit conversion would turn the string "false" into true.
+  @ToStrictBoolean()
+  @IsOptional()
+  @IsBoolean()
+  linkPreview?: boolean;
 }

--- a/src/modules/message/message-send.service.spec.ts
+++ b/src/modules/message/message-send.service.spec.ts
@@ -426,6 +426,33 @@ describe('MessageSendService', () => {
       expect(mockEngine.sendTextMessage).toHaveBeenCalledWith('test@c.us', 'Hi Alice {{unknown}}');
     });
 
+    it('carries mentions and linkPreview from the template body through to the send', async () => {
+      // The rendered body is dispatched through sendText, so the two optionals it already honours
+      // reach the engine unchanged rather than being dropped at the template DTO.
+      (templateService.resolve as jest.Mock).mockResolvedValue(mockTemplate({ body: 'Hi @62811' }));
+
+      await service.sendTemplate('sess-1', {
+        chatId: 'group@g.us',
+        templateId: 'tpl-1',
+        mentions: ['62811@c.us'],
+        linkPreview: false,
+      });
+
+      expect(mockEngine.sendTextMessage).toHaveBeenCalledWith('group@g.us', 'Hi @62811', ['62811@c.us'], {
+        linkPreview: false,
+      });
+    });
+
+    it('leaves a plain template send on its two-argument call shape', async () => {
+      // Control for the case above: without either optional the call must not gain arguments, or
+      // every existing template send changes shape.
+      (templateService.resolve as jest.Mock).mockResolvedValue(mockTemplate({ body: 'Hi there' }));
+
+      await service.sendTemplate('sess-1', { chatId: 'test@c.us', templateId: 'tpl-1' });
+
+      expect(mockEngine.sendTextMessage).toHaveBeenCalledWith('test@c.us', 'Hi there');
+    });
+
     it('should propagate NotFoundException when the template cannot be resolved', async () => {
       (templateService.resolve as jest.Mock).mockRejectedValue(new NotFoundException('Template not found'));
 
@@ -924,6 +951,53 @@ describe('MessageSendService', () => {
       });
 
       expect(mockEngine.replyToMessage).toHaveBeenCalledWith('test@c.us', 'wa-quoted-1', 'This is a reply');
+    });
+
+    it('forwards the tag list to the engine, and keeps the untagged call three-argument', async () => {
+      await service.reply('sess-1', {
+        chatId: 'group@g.us',
+        quotedMessageId: 'wa-quoted-1',
+        text: 'hi @62811',
+        mentions: ['62811@c.us'],
+      });
+
+      expect(mockEngine.replyToMessage).toHaveBeenCalledWith('group@g.us', 'wa-quoted-1', 'hi @62811', ['62811@c.us']);
+
+      // Control: an empty list is not a tag request, so the call shape every existing reply makes is
+      // left untouched rather than gaining a trailing argument.
+      mockEngine.replyToMessage.mockClear();
+      await service.reply('sess-1', {
+        chatId: 'group@g.us',
+        quotedMessageId: 'wa-quoted-1',
+        text: 'plain',
+        mentions: [],
+      });
+      expect(mockEngine.replyToMessage).toHaveBeenCalledWith('group@g.us', 'wa-quoted-1', 'plain');
+    });
+
+    it('honours a plugin that rewrites the tag list, not the list the caller sent', async () => {
+      // message:sending is a moderation chokepoint. Reading the caller's own dto here instead of the
+      // gated result would send the unredacted tags while the hook reported success.
+      (hookManager.execute as jest.Mock).mockResolvedValueOnce({
+        continue: true,
+        data: {
+          input: {
+            chatId: 'group@g.us',
+            quotedMessageId: 'wa-quoted-1',
+            text: 'hi @62811',
+            mentions: ['62811@c.us'],
+          },
+        },
+      });
+
+      await service.reply('sess-1', {
+        chatId: 'group@g.us',
+        quotedMessageId: 'wa-quoted-1',
+        text: 'hi @62811 @62999',
+        mentions: ['62811@c.us', '62999@c.us'],
+      });
+
+      expect(mockEngine.replyToMessage).toHaveBeenCalledWith('group@g.us', 'wa-quoted-1', 'hi @62811', ['62811@c.us']);
     });
   });
 

--- a/src/modules/message/message-send.service.ts
+++ b/src/modules/message/message-send.service.ts
@@ -238,7 +238,12 @@ export class MessageSendService {
       );
     }
 
-    return this.sendText(sessionId, { chatId: dto.chatId, text });
+    return this.sendText(sessionId, {
+      chatId: dto.chatId,
+      text,
+      mentions: dto.mentions,
+      linkPreview: dto.linkPreview,
+    });
   }
 
   async sendImage(sessionId: string, dto: SendMediaMessageDto): Promise<MessageResponseDto> {
@@ -471,7 +476,7 @@ export class MessageSendService {
 
   async reply(
     sessionId: string,
-    dto: { chatId: string; quotedMessageId: string; text: string },
+    dto: { chatId: string; quotedMessageId: string; text: string; mentions?: string[] },
   ): Promise<MessageResponseDto> {
     const finalDto = await this.applySendingGate(sessionId, 'reply', dto);
     const engine = this.getEngine(sessionId);
@@ -499,7 +504,11 @@ export class MessageSendService {
 
     let result: MessageResult;
     try {
-      result = await engine.replyToMessage(finalDto.chatId, finalDto.quotedMessageId, finalDto.text);
+      // Widened only as far as the caller asked, exactly like the send path: a reply with no tags
+      // keeps its three-argument shape.
+      result = finalDto.mentions?.length
+        ? await engine.replyToMessage(finalDto.chatId, finalDto.quotedMessageId, finalDto.text, finalDto.mentions)
+        : await engine.replyToMessage(finalDto.chatId, finalDto.quotedMessageId, finalDto.text);
     } catch (error) {
       return this.failSend(sessionId, 'reply', message, finalDto, error);
     }

--- a/src/modules/message/message.service.spec.ts
+++ b/src/modules/message/message.service.spec.ts
@@ -115,6 +115,27 @@ describe('MessageService', () => {
       expect(sendText).toHaveBeenCalledWith('sess-1', { chatId: 'test@c.us', text: 'hi' });
       expect(result).toEqual({ messageId: 'wa-msg-1', timestamp: 1706868000 });
     });
+
+    it('passes a reply straight through with its tag list intact', async () => {
+      // This forwarder is the entry point the controller and the agent tool both call. Its parameter
+      // was an inline three-field literal while the controller already handed it a fourth, so the
+      // body reached the sender only because structural typing does not strip excess properties.
+      const reply = jest.fn().mockResolvedValue({ messageId: 'wa-msg-2', timestamp: 1706868001 });
+      const facade = new MessageService(
+        repository as Repository<Message>,
+        engines,
+        messageProjector as unknown as MessageProjector,
+        hookManager as HookManager,
+        lidMappingStore as unknown as LidMappingStoreService,
+        inertPacing(),
+        { reply } as unknown as MessageSendService,
+      );
+
+      const body = { chatId: 'g@g.us', quotedMessageId: 'Q1', text: 'hi @62811', mentions: ['62811@c.us'] };
+      await facade.reply('sess-1', body);
+
+      expect(reply).toHaveBeenCalledWith('sess-1', body);
+    });
   });
 
   // ── getMessages pagination guard ──────────────────────────────────

--- a/src/modules/message/message.service.spec.ts
+++ b/src/modules/message/message.service.spec.ts
@@ -621,6 +621,25 @@ describe('MessageService', () => {
       expect(mockEngine.editMessage).toHaveBeenCalledWith('test@c.us', 'wa-msg-1', 'redacted');
       expect(messageProjector.recordOutboundMessageEdit).toHaveBeenCalledWith('sess-1', 'wa-msg-1', 'redacted');
     });
+
+    it('honours a plugin that rewrites the tag list, not the list the caller sent', async () => {
+      // message:sending is a moderation chokepoint, so a handler that drops a WID from the list must
+      // win. Reading the caller's own dto here instead of the gated one would send the unredacted
+      // tags while the hook reported success, and no other assertion in this file would notice.
+      (hookManager.execute as jest.Mock).mockResolvedValueOnce({
+        continue: true,
+        data: { input: { chatId: 'g@g.us', messageId: 'wa-msg-1', body: 'hi @62811', mentions: ['62811@c.us'] } },
+      });
+
+      await service.editMessage('sess-1', {
+        chatId: 'g@g.us',
+        messageId: 'wa-msg-1',
+        body: 'hi @62811 @62999',
+        mentions: ['62811@c.us', '62999@c.us'],
+      });
+
+      expect(mockEngine.editMessage).toHaveBeenCalledWith('g@g.us', 'wa-msg-1', 'hi @62811', ['62811@c.us']);
+    });
   });
 
   // ── pin / unpin ───────────────────────────────────────────────────

--- a/src/modules/message/message.service.ts
+++ b/src/modules/message/message.service.ts
@@ -5,6 +5,7 @@ import { EngineRegistry } from '../../engine/engine-registry.service';
 import { MessageProjector } from '../session/message-projector.service';
 import { SendTextMessageDto, SendMediaMessageDto, SendAudioMessageDto, MessageResponseDto } from './dto';
 import { SendTemplateMessageDto } from './dto/send-template.dto';
+import { ReplyMessageDto } from './dto/message-actions.dto';
 import { Message, MessageDirection } from './entities/message.entity';
 import { HookManager, applySendingGate } from '../../core/hooks';
 import { SendPacingService } from './send-pacing.service';
@@ -193,10 +194,10 @@ export class MessageService {
     return this.sender.sendSticker(sessionId, dto);
   }
 
-  reply(
-    sessionId: string,
-    dto: { chatId: string; quotedMessageId: string; text: string },
-  ): Promise<MessageResponseDto> {
+  // Typed by the DTO rather than an inline literal, like every sibling forwarder here. The literal
+  // listed three fields while the controller already handed it a fourth, so the declaration said
+  // less than what flowed through, and a non-REST caller (the agent tool) could not pass it at all.
+  reply(sessionId: string, dto: ReplyMessageDto): Promise<MessageResponseDto> {
     return this.sender.reply(sessionId, dto);
   }
 

--- a/src/modules/message/message.service.ts
+++ b/src/modules/message/message.service.ts
@@ -480,14 +480,16 @@ export class MessageService {
 
   async editMessage(
     sessionId: string,
-    dto: { chatId: string; messageId: string; body: string },
+    dto: { chatId: string; messageId: string; body: string; mentions?: string[] },
   ): Promise<MessageResponseDto> {
     const engine = this.getEngine(sessionId);
     // An edit replaces the text the recipient sees, so it is content leaving the account and goes
     // through the same moderation chokepoint as every other sender. A plugin can rewrite `body`
     // here exactly as it can for a first send.
     const finalDto = await this.applySendingGate(sessionId, 'edit', dto);
-    const result = await engine.editMessage(finalDto.chatId, finalDto.messageId, finalDto.body);
+    const result = finalDto.mentions?.length
+      ? await engine.editMessage(finalDto.chatId, finalDto.messageId, finalDto.body, finalDto.mentions)
+      : await engine.editMessage(finalDto.chatId, finalDto.messageId, finalDto.body);
 
     // Best-effort: reflect the new body in the stored copy (mirrors deleteMessage's revoked flag),
     // serialized with the inbound edit/reaction writers through the session's per-message mutation


### PR DESCRIPTION
`POST /messages/reply` rejects a `mentions` array with `400 property mentions should not exist`, reported in #1413. The same rejection applies to `edit`, `send-template` and the `send-bulk` items: `mentions` was declared only on `send-text` and the media sends, while `forbidNonWhitelisted` turns any undeclared property into a hard 400. The engines can carry the tags on all of these routes, so the field was missing from the DTOs rather than from the engines.

## What changed

- `replyToMessage` and `editMessage` take an optional `mentions` list, forwarded by both adapters. Baileys spreads the existing `withMentions` helper into the content; whatsapp-web.js passes the options bag its library already accepts.
- The engine call is widened only when a list is actually supplied, so an untagged send keeps its previous call shape. Every pre-existing assertion on those call shapes still passes unchanged.
- `send-template` dispatches through `sendText`, so it also gained `linkPreview`. `quotedMessageId` stays out: docs/06 publishes this route as one that rejects it.
- Every `send-bulk` item type forwards its own list, audio included. Audio carries no caption, but a mention still tags through `contextInfo`, which is why the single-send audio route accepts it.
- The `mentions` caps and the 4096 text cap move to shared constants. Effective limits are unchanged: 1024/1025, 64/65 and 4096/4097 accept-reject boundaries were measured before and after.
- OpenAPI snapshot, all four typed SDK clients and docs/06 updated.

## Behaviour notes

- An edit **replaces** the message content, so tags are re-applied rather than preserved: a rewritten body loses the tags it had unless the list is sent again. Documented in docs/06 and in the DTO.
- Bulk variable substitution runs over `mentions` as it does over the rest of the content tree, so `mentions: ["{{wid}}@c.us"]` renders per item. This is now covered by a test, since nothing else pinned it.
- Java records gained back-compatible constructors, so no existing construction site breaks. Go models `linkPreview` as `*bool` (absent, false and true are three states) and `mentions` as a plain slice with `omitempty` (absent and empty both mean no tags).
- The MCP tool schemas still do not declare `mentions` on any tool. That surface is a separate change; a zod object is not strict, so an undeclared argument there is dropped silently rather than refused.

## Verification

Adapter, service and DTO tests per route, each paired with a negative control so an assertion cannot be satisfied by a permissive path. The DTO cases run through the real production validation pipe rather than bare `validate()`, so they exercise the whitelist that produced the 400 in the first place; one case asserts an unrelated unknown property is still refused.

Plugin rewrites of the list are asserted on `reply` and `edit`: `message:sending` is a moderation chokepoint, and reading the caller's own body there instead of the gated result would send the unredacted tags while the hook reported success.

Full CI-derived gate green, including `openapi:check`, `check:contract-shapes` (324 pairs), the docs lane, e2e, and `tsc` / `go build` / `mypy` / `mvn compile` across the clients.

Fixes #1413
