### PR TITLE
feat(mcp): accept mentions on the agent tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The agent tools accept `mentions` on the text, media, template and reply sends, matching the REST routes. A tool schema is not strict, so an agent that passed the field before had it dropped without an error and the message went out untagged. Not offered on the sticker tool, whose adapters build no tag list.
 - `mentions` reaches every route whose engine can carry it: `reply`, `edit`, `send-template` and each `send-bulk` item, alongside the send routes that already had it. `send-template` also gained `linkPreview`. On `edit` the tags are re-applied rather than preserved, because an edit replaces the message content. Thanks @Magnarks for the report.
 - `POST /sessions/{sessionId}/chats/unread` publishes its own `MarkChatUnreadDto` rather than sharing `MarkChatReadDto`. The body is unchanged (`chatId` alone), but a generated client sees the schema under a new name.
 - ⚠️ **Breaking (Go, Java and typed Python callers).** `markRead` and `subscribePresence` each take their own request type rather than the shared `MarkChatRequest`, which now serves `markUnread` alone. Swap the type at both call sites; the wire body is unchanged and the JavaScript and PHP clients are unaffected. `SubscribePresenceDto` had no contract-gate coverage while one type stood for two routes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The agent tools accept `mentions` on the text, media, template and reply sends, matching the REST routes. A tool schema is not strict, so an agent that passed the field before had it dropped without an error and the message went out untagged. Not offered on the sticker tool, whose adapters build no tag list.
+- The agent tools accept `mentions` on the text, media, template and reply sends, and `customLinkPreview` on the text send, matching the REST routes. A tool schema is not strict, so an agent that passed either field before had it dropped without an error. Not offered on the sticker tool, whose adapters build no tag list.
 - `mentions` reaches every route whose engine can carry it: `reply`, `edit`, `send-template` and each `send-bulk` item, alongside the send routes that already had it. `send-template` also gained `linkPreview`. On `edit` the tags are re-applied rather than preserved, because an edit replaces the message content. Thanks @Magnarks for the report.
 - `POST /sessions/{sessionId}/chats/unread` publishes its own `MarkChatUnreadDto` rather than sharing `MarkChatReadDto`. The body is unchanged (`chatId` alone), but a generated client sees the schema under a new name.
 - ⚠️ **Breaking (Go, Java and typed Python callers).** `markRead` and `subscribePresence` each take their own request type rather than the shared `MarkChatRequest`, which now serves `markUnread` alone. Swap the type at both call sites; the wire body is unchanged and the JavaScript and PHP clients are unaffected. `SubscribePresenceDto` had no contract-gate coverage while one type stood for two routes.

--- a/src/core/agent-tools/tools/message.tools.spec.ts
+++ b/src/core/agent-tools/tools/message.tools.spec.ts
@@ -311,6 +311,39 @@ describe('messageTools', () => {
     expect(sendText).not.toHaveBeenCalled();
   });
 
+  it('forwards a caller-supplied link preview, and enforces the title WhatsApp requires', async () => {
+    // REST declares customLinkPreview; the tool did not, so an agent's object was stripped before the
+    // handler ran and the send went out with whatever preview the engine chose on its own.
+    const sendText = jest.fn().mockResolvedValue({ id: 'm1' });
+    const tools = makeTools({ sendText } as unknown as MessageService);
+
+    await run(tools.get('MessageSendText')!, {
+      sessionId: 's1',
+      chatId: '628111@c.us',
+      text: 'see https://example.com/launch',
+      customLinkPreview: { url: 'https://example.com/launch', title: 'We just launched' },
+    });
+    expect(sendText).toHaveBeenCalledWith(
+      's1',
+      expect.objectContaining({
+        customLinkPreview: { url: 'https://example.com/launch', title: 'We just launched' },
+      }),
+    );
+
+    // Control: the required title is enforced here, not left to the DTO, because this path never
+    // reaches the ValidationPipe.
+    sendText.mockClear();
+    await expect(
+      run(tools.get('MessageSendText')!, {
+        sessionId: 's1',
+        chatId: '628111@c.us',
+        text: 'see https://example.com/launch',
+        customLinkPreview: { url: 'https://example.com/launch' },
+      }),
+    ).rejects.toBeDefined();
+    expect(sendText).not.toHaveBeenCalled();
+  });
+
   it('does not offer mentions on the sticker tool, whose adapters build no tag list', async () => {
     // Control for the additions above: the field is added where the layer behind it carries the value,
     // not everywhere. Both adapters build the sticker content without mentions, so declaring it here

--- a/src/core/agent-tools/tools/message.tools.spec.ts
+++ b/src/core/agent-tools/tools/message.tools.spec.ts
@@ -267,6 +267,69 @@ describe('messageTools', () => {
     expect(out).toEqual({ id: 'm2' });
   });
 
+  it('forwards a tag list on the text and reply tools', async () => {
+    const sendText = jest.fn().mockResolvedValue({ id: 'm1' });
+    const reply = jest.fn().mockResolvedValue({ id: 'm2' });
+    const tools = makeTools({ sendText, reply } as unknown as MessageService);
+
+    await run(tools.get('MessageSendText')!, {
+      sessionId: 's1',
+      chatId: '120363@g.us',
+      text: 'hi @62811',
+      mentions: ['62811@c.us'],
+    });
+    expect(sendText).toHaveBeenCalledWith('s1', expect.objectContaining({ mentions: ['62811@c.us'] }));
+
+    await run(tools.get('MessageReply')!, {
+      sessionId: 's1',
+      chatId: '120363@g.us',
+      quotedMessageId: 'm1',
+      text: 'hi @62811',
+      mentions: ['62811@c.us'],
+    });
+    expect(reply).toHaveBeenCalledWith('s1', expect.objectContaining({ mentions: ['62811@c.us'] }));
+  });
+
+  it('refuses a tag that is not an individual WID, instead of dropping it', async () => {
+    // The whole point of declaring the field here. A tool schema is a plain z.object, so before it was
+    // declared an agent's `mentions` was stripped silently and the send reported success; and this path
+    // calls the service directly, so no ValidationPipe ever sees the value.
+    const sendText = jest.fn().mockResolvedValue({ id: 'm1' });
+    const tools = makeTools({ sendText } as unknown as MessageService);
+
+    // The detail lives on the response, not on .message, which reads "Bad Request Exception".
+    await expect(
+      run(tools.get('MessageSendText')!, {
+        sessionId: 's1',
+        chatId: '120363@g.us',
+        text: 'hi',
+        mentions: ['120363000000000000@g.us'],
+      }),
+    ).rejects.toMatchObject({
+      response: { message: [expect.stringContaining('individual WID') as unknown as string] },
+    });
+    expect(sendText).not.toHaveBeenCalled();
+  });
+
+  it('does not offer mentions on the sticker tool, whose adapters build no tag list', async () => {
+    // Control for the additions above: the field is added where the layer behind it carries the value,
+    // not everywhere. Both adapters build the sticker content without mentions, so declaring it here
+    // would accept the field and drop it.
+    const sendSticker = jest.fn().mockResolvedValue({ id: 'm1' });
+    const tools = makeTools({ sendSticker } as unknown as MessageService);
+
+    await run(tools.get('MessageSendSticker')!, {
+      sessionId: 's1',
+      chatId: '120363@g.us',
+      url: 'https://example.test/s.webp',
+      mentions: ['62811@c.us'],
+    });
+    // The KEY must be absent, not merely undefined: a schema that declared the field and forwarded it
+    // would pass an `undefined` value here and satisfy a looser assertion.
+    const [, forwarded] = sendSticker.mock.calls[0] as [string, Record<string, unknown>];
+    expect(Object.keys(forwarded)).not.toContain('mentions');
+  });
+
   it('MessageForward delegates to forward', async () => {
     const forward = jest.fn().mockResolvedValue({ id: 'm2' });
     const tools = makeTools({ forward } as unknown as MessageService);

--- a/src/core/agent-tools/tools/message.tools.ts
+++ b/src/core/agent-tools/tools/message.tools.ts
@@ -2,6 +2,9 @@ import { z } from 'zod';
 import { ApiKeyRole } from '../../../modules/auth/entities/api-key.entity';
 import type { MessageService } from '../../../modules/message/message.service';
 import {
+  CUSTOM_PREVIEW_DESCRIPTION_MAX_LENGTH,
+  CUSTOM_PREVIEW_TITLE_MAX_LENGTH,
+  CUSTOM_PREVIEW_URL_MAX_LENGTH,
   MENTIONS_MAX,
   MENTION_WID_MAX_LENGTH,
   MESSAGE_TEXT_MAX_LENGTH,
@@ -45,6 +48,31 @@ const mentionsSchema = z
   .describe(
     'WIDs to @mention (e.g. ["62811@c.us"]). The text or caption must also carry the matching ' +
       '@<number> token for WhatsApp to render the tag.',
+  );
+
+/**
+ * Mirrors the REST `customLinkPreview` field, whose caps come from the DTO for the same reason as
+ * `mentionsSchema` above. Baileys only: whatsapp-web.js takes a boolean and answers 501, and the
+ * field cannot be combined with `linkPreview: false`, which asks for the opposite.
+ */
+const customLinkPreviewSchema = z
+  .object({
+    url: z
+      .string()
+      .min(1)
+      .max(CUSTOM_PREVIEW_URL_MAX_LENGTH)
+      .describe('The URL as it appears in the message text; WhatsApp anchors the preview to it.'),
+    title: z
+      .string()
+      .min(1)
+      .max(CUSTOM_PREVIEW_TITLE_MAX_LENGTH)
+      .describe('Required: WhatsApp renders no preview without a title.'),
+    description: z.string().max(CUSTOM_PREVIEW_DESCRIPTION_MAX_LENGTH).optional(),
+  })
+  .optional()
+  .describe(
+    'Attach a preview you supply instead of one fetched from the URL, so nothing is fetched and it ' +
+      'works for a URL the gateway cannot reach. Baileys only: whatsapp-web.js answers 501.',
   );
 
 export function messageTools(message: MessageService): AnyToolDescriptor[] {
@@ -123,6 +151,7 @@ export function messageTools(message: MessageService): AnyToolDescriptor[] {
           ),
         quotedMessageId: quotedMessageIdSchema,
         mentions: mentionsSchema,
+        customLinkPreview: customLinkPreviewSchema,
       }),
       handler: input =>
         message.sendText(input.sessionId, {
@@ -131,6 +160,7 @@ export function messageTools(message: MessageService): AnyToolDescriptor[] {
           ...(input.linkPreview === undefined ? {} : { linkPreview: input.linkPreview }),
           quotedMessageId: input.quotedMessageId,
           mentions: input.mentions,
+          customLinkPreview: input.customLinkPreview,
         }),
     }),
     defineTool({

--- a/src/core/agent-tools/tools/message.tools.ts
+++ b/src/core/agent-tools/tools/message.tools.ts
@@ -1,7 +1,12 @@
 import { z } from 'zod';
 import { ApiKeyRole } from '../../../modules/auth/entities/api-key.entity';
 import type { MessageService } from '../../../modules/message/message.service';
-import { MESSAGE_TEXT_MAX_LENGTH } from '../../../modules/message/dto/send-message.dto';
+import {
+  MENTIONS_MAX,
+  MENTION_WID_MAX_LENGTH,
+  MESSAGE_TEXT_MAX_LENGTH,
+} from '../../../modules/message/dto/send-message.dto';
+import { isMentionWid } from '../../../modules/message/dto/is-mention-wid.validator';
 import {
   CONTACT_NAME_MAX_LENGTH,
   CONTACT_NUMBER_MAX_LENGTH,
@@ -23,6 +28,23 @@ const quotedMessageIdSchema = z
   .describe(
     'Quote an earlier message, making this send a reply. Engine-specific: whatsapp-web.js takes ' +
       'the serialized message id, Baileys the raw key id of a message it has already stored.',
+  );
+
+/**
+ * Mirrors the REST `mentions` field. The element rule and both caps come from the DTO rather than
+ * being restated here: a tool handler calls the service directly, so the ValidationPipe never runs
+ * and this schema is the only thing standing between an agent and the engine.
+ *
+ * Not offered on the sticker tool: both adapters build the sticker content without a mention list,
+ * so declaring it there would accept the field and drop it.
+ */
+const mentionsSchema = z
+  .array(z.string().max(MENTION_WID_MAX_LENGTH).refine(isMentionWid, 'must be an individual WID, e.g. 62811@c.us'))
+  .max(MENTIONS_MAX)
+  .optional()
+  .describe(
+    'WIDs to @mention (e.g. ["62811@c.us"]). The text or caption must also carry the matching ' +
+      '@<number> token for WhatsApp to render the tag.',
   );
 
 export function messageTools(message: MessageService): AnyToolDescriptor[] {
@@ -91,7 +113,7 @@ export function messageTools(message: MessageService): AnyToolDescriptor[] {
       inputSchema: z.object({
         sessionId,
         chatId: z.string().describe('Chat JID (e.g. 628123456789@c.us or groupId@g.us)'),
-        text: z.string().min(1).max(4096).describe('Text message content'),
+        text: z.string().min(1).max(MESSAGE_TEXT_MAX_LENGTH).describe('Text message content'),
         linkPreview: z
           .boolean()
           .optional()
@@ -100,6 +122,7 @@ export function messageTools(message: MessageService): AnyToolDescriptor[] {
               'unset means the engine default, and the engines differ.',
           ),
         quotedMessageId: quotedMessageIdSchema,
+        mentions: mentionsSchema,
       }),
       handler: input =>
         message.sendText(input.sessionId, {
@@ -107,6 +130,7 @@ export function messageTools(message: MessageService): AnyToolDescriptor[] {
           text: input.text,
           ...(input.linkPreview === undefined ? {} : { linkPreview: input.linkPreview }),
           quotedMessageId: input.quotedMessageId,
+          mentions: input.mentions,
         }),
     }),
     defineTool({
@@ -124,6 +148,7 @@ export function messageTools(message: MessageService): AnyToolDescriptor[] {
         filename: z.string().max(255).optional(),
         caption: z.string().max(1024).optional(),
         quotedMessageId: quotedMessageIdSchema,
+        mentions: mentionsSchema,
       }),
       handler: input =>
         message.sendImage(input.sessionId, {
@@ -134,6 +159,7 @@ export function messageTools(message: MessageService): AnyToolDescriptor[] {
           filename: input.filename,
           caption: input.caption,
           quotedMessageId: input.quotedMessageId,
+          mentions: input.mentions,
         }),
     }),
     defineTool({
@@ -151,6 +177,7 @@ export function messageTools(message: MessageService): AnyToolDescriptor[] {
         filename: z.string().max(255).optional(),
         caption: z.string().max(1024).optional(),
         quotedMessageId: quotedMessageIdSchema,
+        mentions: mentionsSchema,
       }),
       handler: input =>
         message.sendVideo(input.sessionId, {
@@ -161,6 +188,7 @@ export function messageTools(message: MessageService): AnyToolDescriptor[] {
           filename: input.filename,
           caption: input.caption,
           quotedMessageId: input.quotedMessageId,
+          mentions: input.mentions,
         }),
     }),
     defineTool({
@@ -179,6 +207,7 @@ export function messageTools(message: MessageService): AnyToolDescriptor[] {
         caption: z.string().max(1024).optional(),
         ptt: z.boolean().optional().describe('Send as a WhatsApp voice note (PTT)'),
         quotedMessageId: quotedMessageIdSchema,
+        mentions: mentionsSchema,
       }),
       handler: input =>
         message.sendAudio(input.sessionId, {
@@ -190,6 +219,7 @@ export function messageTools(message: MessageService): AnyToolDescriptor[] {
           caption: input.caption,
           ptt: input.ptt,
           quotedMessageId: input.quotedMessageId,
+          mentions: input.mentions,
         }),
     }),
     defineTool({
@@ -207,6 +237,7 @@ export function messageTools(message: MessageService): AnyToolDescriptor[] {
         filename: z.string().max(255).optional(),
         caption: z.string().max(1024).optional(),
         quotedMessageId: quotedMessageIdSchema,
+        mentions: mentionsSchema,
       }),
       handler: input =>
         message.sendDocument(input.sessionId, {
@@ -217,6 +248,7 @@ export function messageTools(message: MessageService): AnyToolDescriptor[] {
           filename: input.filename,
           caption: input.caption,
           quotedMessageId: input.quotedMessageId,
+          mentions: input.mentions,
         }),
     }),
     defineTool({
@@ -312,6 +344,7 @@ export function messageTools(message: MessageService): AnyToolDescriptor[] {
           .record(z.string(), z.string())
           .optional()
           .describe('Variables to substitute into {{placeholder}} tokens'),
+        mentions: mentionsSchema,
       }),
       handler: input =>
         message.sendTemplate(input.sessionId, {
@@ -319,6 +352,7 @@ export function messageTools(message: MessageService): AnyToolDescriptor[] {
           templateId: input.templateId,
           templateName: input.templateName,
           vars: input.vars,
+          mentions: input.mentions,
         }),
     }),
     defineTool({
@@ -332,12 +366,14 @@ export function messageTools(message: MessageService): AnyToolDescriptor[] {
         chatId: z.string().describe('Chat JID'),
         quotedMessageId: z.string().describe('ID of the message to quote/reply to'),
         text: z.string().min(1).max(MESSAGE_TEXT_MAX_LENGTH).describe('Reply text content'),
+        mentions: mentionsSchema,
       }),
       handler: input =>
         message.reply(input.sessionId, {
           chatId: input.chatId,
           quotedMessageId: input.quotedMessageId,
           text: input.text,
+          mentions: input.mentions,
         }),
     }),
     defineTool({

--- a/src/core/agent-tools/tools/tool-input-caps.spec.ts
+++ b/src/core/agent-tools/tools/tool-input-caps.spec.ts
@@ -2,7 +2,11 @@ import { plainToInstance } from 'class-transformer';
 import { validate } from 'class-validator';
 import type { MessageService } from '../../../modules/message/message.service';
 import type { GroupService } from '../../../modules/group/group.service';
-import { MESSAGE_TEXT_MAX_LENGTH } from '../../../modules/message/dto/send-message.dto';
+import {
+  MENTIONS_MAX,
+  MESSAGE_TEXT_MAX_LENGTH,
+  SendTextMessageDto,
+} from '../../../modules/message/dto/send-message.dto';
 import {
   CONTACT_NAME_MAX_LENGTH,
   CONTACT_NUMBER_MAX_LENGTH,
@@ -155,6 +159,17 @@ const PARTICIPANT_CASES: CapCase[] = [
     toolInput: { sessionId: 's1', groupId: '120363@g.us' },
     dtoClass: ParticipantsDto,
     dtoPayload: {},
+  },
+  {
+    // The tool path calls the service directly, so the ValidationPipe never runs and the zod schema
+    // is the only cap between an agent and the engine. This case fails if either side moves.
+    label: 'MessageSendText.mentions ↔ SendTextMessageDto.mentions',
+    toolName: 'MessageSendText',
+    field: 'mentions',
+    cap: MENTIONS_MAX,
+    toolInput: { sessionId: 's1', chatId: '120363@g.us', text: 'hi' },
+    dtoClass: SendTextMessageDto,
+    dtoPayload: { chatId: '120363@g.us', text: 'hi' },
   },
 ];
 

--- a/src/modules/message/dto/send-message.dto.ts
+++ b/src/modules/message/dto/send-message.dto.ts
@@ -20,10 +20,11 @@ export const MENTIONS_DESCRIPTION =
   'WIDs to @mention (e.g. ["62811@c.us"]). The text/caption must also contain the @<number> token.';
 
 /**
- * Caps for a `mentions` array, exported because the field now appears on every REST route whose
- * engine can carry it: send, reply, edit, template and bulk. Inline literals repeated per site is
- * how the two numbers would drift apart between endpoints that share one documented contract. The
- * agent-tool schemas do NOT declare mentions on any tool yet, so nothing there reads these.
+ * Caps for a `mentions` array, exported because the field appears on every REST route whose engine
+ * can carry it (send, reply, edit, template, bulk) and on the matching agent-tool schemas. Inline
+ * literals repeated per site is how the two numbers would drift apart between endpoints that share
+ * one documented contract, and the tool path needs them most: it calls the service directly, so the
+ * ValidationPipe never runs and the zod schema is the only cap there is.
  */
 export const MENTIONS_MAX = 1024;
 export const MENTION_WID_MAX_LENGTH = 64;

--- a/src/modules/message/dto/send-message.dto.ts
+++ b/src/modules/message/dto/send-message.dto.ts
@@ -29,6 +29,14 @@ export const MENTIONS_DESCRIPTION =
 export const MENTIONS_MAX = 1024;
 export const MENTION_WID_MAX_LENGTH = 64;
 
+/**
+ * Caps for a custom link preview, exported for the same reason as the mentions pair above: the
+ * agent-tool schema restates nothing, and that path never reaches the ValidationPipe.
+ */
+export const CUSTOM_PREVIEW_URL_MAX_LENGTH = 2048;
+export const CUSTOM_PREVIEW_TITLE_MAX_LENGTH = 256;
+export const CUSTOM_PREVIEW_DESCRIPTION_MAX_LENGTH = 1024;
+
 // Single source of truth for the text-body cap, shared with the agent-tool input schemas
 // (src/core/agent-tools/tools/message.tools.ts) so MCP and REST enforce the same limit.
 export const MESSAGE_TEXT_MAX_LENGTH = 4096;
@@ -52,7 +60,7 @@ export class CustomLinkPreviewDto {
   })
   @IsString()
   @IsNotEmpty()
-  @MaxLength(2048)
+  @MaxLength(CUSTOM_PREVIEW_URL_MAX_LENGTH)
   url!: string;
 
   @ApiProperty({
@@ -62,13 +70,13 @@ export class CustomLinkPreviewDto {
   })
   @IsString()
   @IsNotEmpty()
-  @MaxLength(256)
+  @MaxLength(CUSTOM_PREVIEW_TITLE_MAX_LENGTH)
   title!: string;
 
   @ApiPropertyOptional({ description: 'Preview description', example: 'Read the announcement.', maxLength: 1024 })
   @IsOptional()
   @IsString()
-  @MaxLength(1024)
+  @MaxLength(CUSTOM_PREVIEW_DESCRIPTION_MAX_LENGTH)
   description?: string;
 }
 


### PR DESCRIPTION
An agent cannot tag a participant through the MCP surface, and the failure is silent rather than loud. A tool `inputSchema` is a plain `z.object`, so an undeclared `mentions` argument is stripped by `tool-invoker.ts` before the handler runs: the send returns success and the message is delivered untagged, with nothing in the response, the schema or the docs to say the field was dropped. The identical request over REST tags correctly.

## What changed

- The text, image, video, audio, document, template and reply tools accept `mentions`, forwarding it to the service method they already call. All seven of those service entry points are typed by DTOs that carry the field.
- One shared `mentionsSchema` takes both caps and the per-entry WID rule from the DTO rather than restating them, following the same pattern `session.tools.ts` uses for `messageIds`. This path calls the service directly, so the `ValidationPipe` never runs and the zod schema is the only validation there is: an invalid WID is now refused instead of being carried to the adapter.
- **Not offered on the sticker tool.** Both adapters build the sticker content without a mention list (`baileys-messaging.ts` sends `{ sticker }`, `wwebjs-messaging.ts` sends `{ sendMediaAsSticker }`), so declaring it there would accept the field and drop it, which is exactly the defect this change removes everywhere else. A test locks the exclusion.
- `MessageSendText.text` binds to the shared cap constant the file already imports, matching `MessageReply.text` beside it. Same value, no behaviour change.

## Verification

New cases run through the real `invokeTool` path (auth → zod → handler), so they exercise the validation an agent actually hits:

- the text and reply tools forward the list;
- a group id in `mentions` is refused rather than dropped;
- the sticker tool's forwarded payload has no `mentions` key at all, asserted on `Object.keys` rather than on the value, so a schema that declared the field and passed `undefined` would still fail.

`tool-input-caps.spec.ts` gains a `MessageSendText.mentions ↔ SendTextMessageDto.mentions` case, so the MCP and REST caps cannot drift apart silently.

Full CI-derived gate green locally: 5894 unit tests, e2e, docs lane, `openapi:check`, `check-contract-shapes`.

## Also here: `customLinkPreview`

The other field REST declares and the tool did not, dropped the same silent way. Its three caps are exported from the DTO and read by the schema, which also enforces the title WhatsApp requires: this path calls the service directly, so no `ValidationPipe` ever sees the object. Baileys only, as on REST: whatsapp-web.js takes a boolean and answers 501, and the field cannot be combined with `linkPreview: false`.

A control case asserts a preview missing its title is refused by the tool rather than carried to the adapter.

Refs #1413
