### PR TITLE
fix(engine): apply the mentions a sticker send accepts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `POST /messages/send-sticker` applies the `mentions` it accepts. The route shares `SendMediaMessageDto` and docs/06 lists it among the media sends that take the field, but both adapters built the sticker content without a tag list, so a documented capability did nothing on either engine.
+
 - `POST /chats/read` answers 400 for `"messageIds": null` instead of 500. `@IsOptional` skips every validator for null as well as undefined, so the value reached the Baileys adapter and was dereferenced there. The published schema now carries `minItems` too, so it no longer advertises an empty array the server refuses.
 - A read receipt goes only to the chat the caller named. A message id belonging to another chat in the same session carried that chat's address out of the message store, so the receipt landed there while the route reported success for the chat in the path.
 - The Go client can express an empty `messageIds` again. `omitempty` on a plain slice dropped it, so a caller asking for nothing to be acknowledged silently acknowledged the newest message; the field is a pointer, so absent and empty are distinct on the wire.

--- a/src/engine/adapters/baileys-messaging.ts
+++ b/src/engine/adapters/baileys-messaging.ts
@@ -377,9 +377,13 @@ export class BaileysMessaging {
   async sendStickerMessage(chatId: string, media: MediaInput): Promise<MessageResult> {
     this.host.ensureReady();
     const { data, mimetype } = await resolveMediaBuffer(media);
+    // A sticker has neither text nor caption, but stickerMessage carries a contextInfo like every
+    // other content type, so a mention still tags the participant. The route accepts the field
+    // (send-sticker shares SendMediaMessageDto) and docs/06 lists it among the media sends that
+    // take one, so dropping it here left a documented capability doing nothing.
     return this.sendContent(
       chatId,
-      { sticker: await toWebpSticker(data, mimetype) },
+      { sticker: await toWebpSticker(data, mimetype), ...this.withMentions(media.mentions) },
       await this.quoteOption(media.quotedMessageId),
     );
   }

--- a/src/engine/adapters/baileys.adapter.spec.ts
+++ b/src/engine/adapters/baileys.adapter.spec.ts
@@ -2530,6 +2530,26 @@ describe('BaileysAdapter media sends', () => {
     expect(fakeSock.sendMessage).toHaveBeenCalledWith('628111@s.whatsapp.net', { sticker: webp });
   });
 
+  it('sendStickerMessage tags the participants it was given', async () => {
+    // A sticker has neither text nor caption, but stickerMessage carries a contextInfo like any other
+    // content type, so the tag still reaches the participant. The route accepts the field, so dropping
+    // it here left a documented capability doing nothing.
+    const adapter = await ready();
+    const webp = Buffer.from(
+      'UklGRlgAAABXRUJQVlA4WAoAAAAQAAAAAAAAAAAAQUxQSAIAAAAAf1ZQOCAwAAAA0AEAnQEqAQABAAFAJiWgAnS6AfgAA7AA/vLrf/zYFc1z7/f/0uD9Lg/S4P/SkAAA',
+      'base64',
+    );
+    await adapter.sendStickerMessage('628111@s.whatsapp.net', {
+      mimetype: 'image/webp',
+      data: webp,
+      mentions: ['62811@c.us'],
+    });
+    expect(fakeSock.sendMessage).toHaveBeenCalledWith('628111@s.whatsapp.net', {
+      sticker: webp,
+      mentions: ['62811@s.whatsapp.net'],
+    });
+  });
+
   it('uses the caller-declared mimetype over the fetched content-type for a URL', async () => {
     (loadRemoteMediaBuffer as jest.Mock).mockResolvedValue({
       data: Buffer.from([1]),

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -3940,6 +3940,33 @@ describe('outbound document mode (#989)', () => {
     // A sticker's mimetype is an instruction, not a label: whatsapp-web.js returns the media
     // unconverted once it reads as webp, so trusting a declared image/webp over bytes that are not
     // webp ships raw bytes as a sticker. The response saw the bytes; the caller did not.
+    it('passes a sticker tag list through the same options bag as any other media send', async () => {
+      const sendMessage = jest.fn().mockResolvedValue(sentMessage);
+
+      await ready({ sendMessage }).sendStickerMessage('120363@g.us', {
+        mimetype: 'image/webp',
+        data: Buffer.from([1]).toString('base64'),
+        mentions: ['62811@c.us'],
+      });
+
+      expect(sendMessage).toHaveBeenCalledWith(
+        '120363@g.us',
+        expect.anything(),
+        expect.objectContaining({ sendMediaAsSticker: true, mentions: ['62811@c.us'] }),
+      );
+
+      // Control: without a list the options bag must not gain a mentions key at all, or every untagged
+      // sticker send changes shape.
+      sendMessage.mockClear();
+      await ready({ sendMessage }).sendStickerMessage('120363@g.us', {
+        mimetype: 'image/webp',
+        data: Buffer.from([1]).toString('base64'),
+        mentions: [],
+      });
+      const [, , opts] = sendMessage.mock.calls[0] as [string, unknown, Record<string, unknown>];
+      expect(Object.keys(opts)).not.toContain('mentions');
+    });
+
     it('keeps the fetched type for a sticker, where the mimetype selects the conversion', async () => {
       (undiciFetch as jest.Mock).mockResolvedValue(remoteResponse({ 'content-type': 'image/png' }));
       const sendMessage = jest.fn().mockResolvedValue(sentMessage);

--- a/src/engine/adapters/wwebjs-messaging.ts
+++ b/src/engine/adapters/wwebjs-messaging.ts
@@ -489,6 +489,9 @@ export class WwebjsMessaging {
         this.client().sendMessage(to, messageMedia, {
           sendMediaAsSticker: true,
           ...this.quoteOptions(media.quotedMessageId),
+          // Same options bag every other media send uses, so the library tags a sticker exactly as it
+          // tags an image. Omitted when empty to leave an untagged sticker call unchanged.
+          ...(media.mentions?.length ? { mentions: media.mentions } : {}),
         }),
       media.quotedMessageId,
     );


### PR DESCRIPTION
`POST /messages/send-sticker` shares `SendMediaMessageDto`, so the route accepts a `mentions` array; `buildMediaInput` forwards it into the `MediaInput` the adapters receive; and docs/06 lists `send-sticker` among the media send routes that take the field (`docs/06-api-specification.md:123` defines the set, `:166` states they accept `mentions`).

Both adapters then built the sticker content without a tag list, so the field was accepted, carried all the way to the engine layer, and dropped there. Nothing surfaced: the send returned success and no participant was tagged, on either engine.

## Why a sticker can carry one

A sticker has neither text nor caption, but `stickerMessage` holds a `contextInfo` like every other content type, so the tag reaches the participant without a visible `@` token. This is the same reasoning the audio send path already records in `baileys-messaging.ts`. Verified against the installed protobuf: a `StickerMessage` created with `contextInfo.mentionedJid` survives an encode/decode round-trip identically to `ImageMessage`, `AudioMessage` and `ExtendedTextMessage`.

## What changed

- Baileys spreads the existing `withMentions` helper into the sticker content, matching every other media send in that adapter.
- whatsapp-web.js adds the list to the options bag it already passes to `sendMessage`, the same bag the library reads `mentions` from for every other media type. The key is omitted when no tags were given, so an untagged sticker send keeps its previous call shape.

No documentation change: docs/06 already describes this behaviour, and the fix makes the description true.

## Verification

One test per engine, each paired with a control. On Baileys the pre-existing `sendStickerMessage sends the sticker buffer` case asserts the exact content object and still passes, which proves an untagged send is byte-identical. On whatsapp-web.js the new case asserts the options bag gains `mentions` when a list is supplied and, with an empty list, that `Object.keys(options)` does not contain the key at all.

Reverting either adapter fails only that engine's case.

Full CI-derived gate green locally.
