### PR TITLE
fix(mcp): tag a sticker send, and drop a rationale time made false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The agent tools accept `mentions` on the text, media, template and reply sends, and `customLinkPreview` on the text send, matching the REST routes. A tool schema is not strict, so an agent that passed either field before had it dropped without an error. Not offered on the sticker tool, whose adapters build no tag list.
+- The agent tools accept `mentions` on every send whose engine carries it (text, the four media sends, sticker, template and reply) and `customLinkPreview` on the text send, matching the REST routes. A tool schema is not strict, so an agent that passed either field before had it dropped without an error.
 - `mentions` reaches every route whose engine can carry it: `reply`, `edit`, `send-template` and each `send-bulk` item, alongside the send routes that already had it. `send-template` also gained `linkPreview`. On `edit` the tags are re-applied rather than preserved, because an edit replaces the message content. Thanks @Magnarks for the report.
 - `POST /sessions/{sessionId}/chats/unread` publishes its own `MarkChatUnreadDto` rather than sharing `MarkChatReadDto`. The body is unchanged (`chatId` alone), but a generated client sees the schema under a new name.
 - ⚠️ **Breaking (Go, Java and typed Python callers).** `markRead` and `subscribePresence` each take their own request type rather than the shared `MarkChatRequest`, which now serves `markUnread` alone. Swap the type at both call sites; the wire body is unchanged and the JavaScript and PHP clients are unaffected. `SubscribePresenceDto` had no contract-gate coverage while one type stood for two routes.

--- a/src/core/agent-tools/tools/message.tools.spec.ts
+++ b/src/core/agent-tools/tools/message.tools.spec.ts
@@ -344,10 +344,10 @@ describe('messageTools', () => {
     expect(sendText).not.toHaveBeenCalled();
   });
 
-  it('does not offer mentions on the sticker tool, whose adapters build no tag list', async () => {
-    // Control for the additions above: the field is added where the layer behind it carries the value,
-    // not everywhere. Both adapters build the sticker content without mentions, so declaring it here
-    // would accept the field and drop it.
+  it('tags a sticker too, now that both adapters carry the list', async () => {
+    // Excluded when this tool set was written, because neither adapter built a mention list for a
+    // sticker. Both do now, and the route has always accepted the field, so withholding it here
+    // would leave the MCP surface silently weaker than REST for the same send.
     const sendSticker = jest.fn().mockResolvedValue({ id: 'm1' });
     const tools = makeTools({ sendSticker } as unknown as MessageService);
 
@@ -357,10 +357,8 @@ describe('messageTools', () => {
       url: 'https://example.test/s.webp',
       mentions: ['62811@c.us'],
     });
-    // The KEY must be absent, not merely undefined: a schema that declared the field and forwarded it
-    // would pass an `undefined` value here and satisfy a looser assertion.
-    const [, forwarded] = sendSticker.mock.calls[0] as [string, Record<string, unknown>];
-    expect(Object.keys(forwarded)).not.toContain('mentions');
+
+    expect(sendSticker).toHaveBeenCalledWith('s1', expect.objectContaining({ mentions: ['62811@c.us'] }));
   });
 
   it('MessageForward delegates to forward', async () => {

--- a/src/core/agent-tools/tools/message.tools.ts
+++ b/src/core/agent-tools/tools/message.tools.ts
@@ -37,9 +37,6 @@ const quotedMessageIdSchema = z
  * Mirrors the REST `mentions` field. The element rule and both caps come from the DTO rather than
  * being restated here: a tool handler calls the service directly, so the ValidationPipe never runs
  * and this schema is the only thing standing between an agent and the engine.
- *
- * Not offered on the sticker tool: both adapters build the sticker content without a mention list,
- * so declaring it there would accept the field and drop it.
  */
 const mentionsSchema = z
   .array(z.string().max(MENTION_WID_MAX_LENGTH).refine(isMentionWid, 'must be an individual WID, e.g. 62811@c.us'))
@@ -346,6 +343,7 @@ export function messageTools(message: MessageService): AnyToolDescriptor[] {
         filename: z.string().max(255).optional(),
         caption: z.string().max(1024).optional(),
         quotedMessageId: quotedMessageIdSchema,
+        mentions: mentionsSchema,
       }),
       handler: input =>
         message.sendSticker(input.sessionId, {
@@ -356,6 +354,7 @@ export function messageTools(message: MessageService): AnyToolDescriptor[] {
           filename: input.filename,
           caption: input.caption,
           quotedMessageId: input.quotedMessageId,
+          mentions: input.mentions,
         }),
     }),
     defineTool({

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -3937,9 +3937,6 @@ describe('outbound document mode (#989)', () => {
       );
     });
 
-    // A sticker's mimetype is an instruction, not a label: whatsapp-web.js returns the media
-    // unconverted once it reads as webp, so trusting a declared image/webp over bytes that are not
-    // webp ships raw bytes as a sticker. The response saw the bytes; the caller did not.
     it('passes a sticker tag list through the same options bag as any other media send', async () => {
       const sendMessage = jest.fn().mockResolvedValue(sentMessage);
 
@@ -3967,6 +3964,9 @@ describe('outbound document mode (#989)', () => {
       expect(Object.keys(opts)).not.toContain('mentions');
     });
 
+    // A sticker's mimetype is an instruction, not a label: whatsapp-web.js returns the media
+    // unconverted once it reads as webp, so trusting a declared image/webp over bytes that are not
+    // webp ships raw bytes as a sticker. The response saw the bytes; the caller did not.
     it('keeps the fetched type for a sticker, where the mimetype selects the conversion', async () => {
       (undiciFetch as jest.Mock).mockResolvedValue(remoteResponse({ 'content-type': 'image/png' }));
       const sendMessage = jest.fn().mockResolvedValue(sentMessage);


### PR DESCRIPTION
`MessageSendSticker` is the one send tool that does not accept `mentions`. The stated reason, repeated in three places, is that neither adapter builds a tag list for a sticker. That is no longer true at this commit: `baileys-messaging.ts:386` spreads `withMentions(media.mentions)` into the sticker content and `wwebjs-messaging.ts:494` adds the list to the options bag, and `POST /messages/send-sticker` has always accepted the field via the shared `SendMediaMessageDto`.

The tool set was authored against the tree before the adapter change landed, and the two merged in the other order, so the exclusion shipped with a rationale that its own release falsified.

## What the release currently says about itself

`CHANGELOG.md:16` states the tool withholds the field "whose adapters build no tag list", seven lines above `CHANGELOG.md:23` stating both adapters now build one. A reader of the 0.23.0 notes gets both claims.

## What changed

- `MessageSendSticker` declares and forwards `mentions`, matching the other seven send tools and the REST route behind it.
- The exclusion test becomes an inclusion test. It was an anti-regression lock on behaviour that is no longer correct, so it would have resisted this fix rather than allowed it.
- The stale reasons go: the clause in the shared schema docblock, the one in the test name and comment, and the contradicting sentence in the changelog. The changelog entry now names sticker among the tools that take the field.
- Unrelated to the above, in the same area: a comment explaining the sticker mimetype rule in `whatsapp-web-js.adapter.spec.ts` had a newly added test land between it and the test it explains. It sits back above its own test.

## Verification

Removing `mentions` from the sticker tool's schema again fails only the new inclusion test. The full CI-derived gate is green: 5897 unit tests, e2e, docs lane, `openapi:check`, `check-contract-shapes`.

After this, every send surface that can carry a tag list accepts one on both REST and MCP, and no route accepts a field its layer drops.
