### PR TITLE
fix(dashboard): let the chat room shrink inside its flex row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The dashboard chat room shrinks within its layout instead of overflowing it, so a long contact or group name no longer pushes the send button out of reach. Thanks @rainerigius.
+
 ## [0.23.0] - 2026-08-20
 
 ### Added

--- a/dashboard/src/pages/Chats.css
+++ b/dashboard/src/pages/Chats.css
@@ -288,6 +288,7 @@
    ============================================================================= */
 .chats-page .chats-room {
   flex: 1;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   background: var(--bg-light);

--- a/dashboard/src/pages/Chats.css
+++ b/dashboard/src/pages/Chats.css
@@ -1292,6 +1292,13 @@
   color: var(--text-secondary);
 }
 
+/* The pane icon sits between the back button and an unbreakable title. Both of its siblings opt out
+   of shrinking already; without the same opt-out the icon is the only flexible item in the row and a
+   long title collapses it to nothing. */
+.chats-page .chats-room-header > svg {
+  flex-shrink: 0;
+}
+
 .chats-page .chats-room-header h2 {
   font-size: 1rem;
   font-weight: 600;


### PR DESCRIPTION
## Description

Fix a chat layout overflow issue where the chat area could extend beyond its parent container, causing horizontal overflow on narrower layouts.

The issue was in `.chats-page .chats-room`. Since it is a flex item, its default minimum width could be determined by its content, preventing it from shrinking enough to stay within the available space.

The fix adds:
```css
min-width: 0;
```
to .chats-page .chats-room, allowing the flex item to shrink correctly inside its container and preventing the chat layout from overflowing horizontally.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated
- [x] Lint passes
- [x] Self-reviewed
