### PR TITLE
fix(dashboard): let the chat composer shrink with its pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - The dashboard chat room shrinks within its layout instead of overflowing it, so a long contact or group name no longer pushes the send button out of reach. Thanks @rainerigius.
+- The chat composer shrinks with its pane, so the send button stays reachable on a narrow desktop window; it was pushed outside the layout's clip below a 1014px viewport with the navigation expanded.
 
 ## [0.23.0] - 2026-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - The dashboard chat room shrinks within its layout instead of overflowing it, so a long contact or group name no longer pushes the send button out of reach. Thanks @rainerigius.
-- The chat composer shrinks with its pane, so the send button stays reachable on a narrow desktop window; it was pushed outside the layout's clip below a 1014px viewport with the navigation expanded.
+- The chat composer shrinks with its pane, so the send button stays reachable. It sat outside the layout's clip below a 1014px viewport with the navigation expanded, and on any phone 402 CSS px or narrower.
 
 ## [0.23.0] - 2026-08-20
 

--- a/dashboard/src/pages/Chats.css
+++ b/dashboard/src/pages/Chats.css
@@ -615,6 +615,10 @@
 
 .chats-page .message-text-input {
   flex: 1;
+  /* An input keeps its intrinsic width as its automatic minimum, which pinned the whole composer to
+     369px and pushed the send button outside the layout's clip on a narrow desktop window. Shrinking
+     stops at the input's own padding, so a very narrow room leaves a stub rather than a usable field. */
+  min-width: 0;
   padding: 0.75rem 1rem;
   border: 1px solid var(--border);
   border-radius: 24px;


### PR DESCRIPTION
The chat composer could not shrink below 369px however narrow its pane became, because a text input contributes its intrinsic width as its automatic minimum size. Below that the send button sat outside the clip of `.chats-layout`, unreachable by pointer and with no scrollbar to recover it. Pressing Enter still submitted the form, so the control was lost rather than the feature.

## What changed

- `min-width: 0` on `.chats-page .message-text-input`, letting the input give up its intrinsic width. The composer's minimum drops from 369px to 214px.

## Impact

Measured in headless Chromium against this branch, with the real webfont and the production custom properties and element defaults loaded. The threshold is the first viewport at which the send button no longer crosses the clip edge.

Two-pane desktop layout:

| Navigation | Before | After |
| --- | --- | --- |
| Expanded (260px) | 1014px | 859px |
| Collapsed (72px) | 826px | below 769px |

The single-pane layout below 768px was hit harder and is fully fixed. `dashboard/index.html` sets `width=device-width`, so a phone renders at its CSS width, and the send button was outside the clip on every one at or below 402 CSS px:

| Phone width | Before | After |
| --- | --- | --- |
| 320px | 82px outside | inside |
| 360px | 42px outside | inside |
| 375px | 27px outside | inside |
| 402px | flush on the edge | inside |
| 403px and wider | already inside | inside |

Both widths named in #1422 are inside what the desktop fix covers: 911 CSS px (1366x768 at 150% scaling) and 960 CSS px (a window snapped to half of a 1920px display).

## What this does not do

The issue stays open. With the navigation expanded, viewports 769px to 858px are still clipped, by up to 90px at 769px, and that band is reachable because nothing collapses the navigation automatically above 767px.

It is also a trade, not a pure win, and the earlier version of this section understated that by quoting border-box widths. The input is 189px wide before the change at every viewport where the composer exists, of which 155px is the text box. After the change it is sized to fit, so across the range this PR newly covers the visible text box is:

| Viewport | Text box before | Text box after |
| --- | --- | --- |
| 1014px | 155px | 130px |
| 960px | 155px | 76px |
| 911px | 155px | 27px |
| 900px | 155px | 16px |
| 859px to 884px | 155px | 0px |

So the change buys a reachable send button by making the field narrower, and at the bottom of the band the content box is exactly the input's own padding and border with nothing visible inside it. Typing and Enter still work and the value is correct, but the text is not visible there. The send button is the control with no substitute, which is why the trade is worth taking, but whatever closes the 769px to 858px band should also give the input a usable floor. That is recorded on the issue.

## Verification

- Threshold sweep and binary search on both navigation states, before and after, reproducing every number above. The composer's minimum was cross-checked two ways, by squeezing the pane and by summing the measured child widths, which agree at 214px.
- The room's own width is unchanged by this diff: `roomW` and `layoutW` are identical before and after at 769, 800, 900, 1000, 1024 and 1280, so nothing outside the composer moves. Every sibling inside the room measured byte-identical before and after at five widths.
- Dashboard lane locally: `lint`, `format:check`, `typecheck`, `i18n:check`, `build`, `test:unit`, all pass. Docs lane `test:docs` passes, 264 tests.
- No automated regression test for the declaration itself. jsdom reports zero for every geometry, so no test in the dashboard lane can tell it present from absent, and the repository has no visual-regression rig.

## Note

The changelog entry sits at the same anchor as the one in #1426. Whichever lands second will conflict there and needs a one line rebase. A conflicted PR in this repository gets no CI run at all and reports "no checks reported", which reads as pending rather than as never going to run, so re-check the second PR after rebasing.

Refs #1422
