### PR TITLE
fix(dashboard): keep the reply name and map preview inside the panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The chat composer shrinks with its pane, so the send button stays reachable. It sat outside the layout's clip below a 1014px viewport with the navigation expanded, and on any phone 402 CSS px or narrower.
 - The channel and status pane heading truncates with an ellipsis and carries its full text in a tooltip. A long title previously ran past the panel edge, cut mid-glyph with nothing to signal it.
 - The Chats page shows one pane at a time from 769px to 888px with the navigation expanded, where two panes left the room narrower than the composer and pushed the send button out of the panel. The message field now keeps a floor rather than shrinking to nothing.
+- The reply banner's quoted name truncates with an ellipsis, and a location message's map preview is bounded by its bubble. Both previously painted outside the chat panel when the room was narrow.
 
 ## [0.23.0] - 2026-08-20
 

--- a/dashboard/src/components/chats/ChatThread.tsx
+++ b/dashboard/src/components/chats/ChatThread.tsx
@@ -186,14 +186,7 @@ function ChatThread({
               const thumb = msg.body && msg.body.length > 100 ? `data:image/jpeg;base64,${msg.body}` : '';
               return (
                 <div className="message-location">
-                  {thumb && (
-                    <img
-                      src={thumb}
-                      alt=""
-                      onLoad={onMediaLoad}
-                      style={{ maxWidth: 220, borderRadius: 8, display: 'block', marginBottom: 4 }}
-                    />
-                  )}
+                  {thumb && <img src={thumb} alt="" onLoad={onMediaLoad} className="chat-location-media" />}
                   <span className="message-media-omitted">📍 {t('chats.media.location')}</span>
                 </div>
               );

--- a/dashboard/src/pages/Chats.css
+++ b/dashboard/src/pages/Chats.css
@@ -970,6 +970,15 @@
   text-decoration: none;
 }
 
+/* The map preview keeps its own modest cap, but bounded by the bubble the way every other media type
+   here is. As a bare pixel width it stayed 220px wide in a narrower room and ran past the panel edge. */
+.chats-page .chat-location-media {
+  max-width: min(220px, 100%);
+  border-radius: 8px;
+  display: block;
+  margin-bottom: 0.25rem;
+}
+
 .chats-page .chat-video-media {
   max-width: 100%;
   max-height: 250px;
@@ -1228,6 +1237,11 @@
   font-size: 0.8125rem;
   font-weight: 700;
   color: var(--primary-text);
+  /* Same treatment as `.replying-to-body` below. Without it a quoted name with no break opportunity
+     keeps its box but paints straight through the close button and out of the panel. */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .chats-page .replying-to-body {


### PR DESCRIPTION
Two elements in the chat pane carry no width constraint of their own, so once the room is narrow they paint through their neighbours and out past `.chats-layout`'s clip. Neither is caused by the composer work in #1425 or #1427; both are pre-existing.

## What changed

- `.chats-page .replying-to-title` gains `white-space: nowrap`, `overflow: hidden` and `text-overflow: ellipsis`. It was the only text node in the reply banner without them; its own sibling `.replying-to-body` has had all three all along.
- The location message's map preview moves from an inline `style={{ maxWidth: 220, ... }}` to a `.chats-page .chat-location-media` class with `max-width: min(220px, 100%)`. It keeps the same 220px cap but is now bounded by the bubble, which is how every other media element in a bubble is already sized. `min()` follows the existing use in `CustomSelect.css`.

## Impact

Measured in headless Chromium with the real webfont and the production globals, navigation expanded. 889px is the narrowest viewport at which the two-pane layout survives once #1427 lands, and 243px is the room there.

Reply banner, quoted name with no break opportunity, measured from the text's own rectangle because the element box reports no overflow at all:

| Quoted name | Ink relative to the close button, before |
| --- | --- |
| 12 characters | 58px clear |
| 18 characters | 10px clear |
| 25 characters | 44px across it |
| 40 characters | 162px across it, 107px past the panel edge |

After, the title is clipped inside its box and shows an ellipsis. The discriminating evidence is structural plus visual, not the rectangle: `scrollWidth` 385 against `clientWidth` 133 with a non-visible overflow, and the two screenshots hash differently. A `Range` rectangle is the wrong instrument here, since it is not clipped by an ancestor's overflow and reports where the text would sit rather than where it paints.

Map preview:

| Viewport | Room | Width before | past the edge before | Width after | past the edge after |
| --- | --- | --- | --- | --- | --- |
| 889px | 243px | 220px | 15px outside | 165px | 40px inside |
| 900px | 254px | 220px | 4px outside | 176px | 40px inside |
| 960px and wider | 314px and wider | 220px | inside | 220px | unchanged |

The cap still binds wherever there is room for it, so nothing changes on an ordinary desktop width.

## Verification

- Both tables above measured on the branch files themselves against `main`.
- The map preview is unchanged at 960px and wider, so the visual size on a normal window is untouched.
- The reply title change is visible in pixels, confirmed by differing screenshot hashes at 889px.
- Dashboard lane locally: `lint`, `format:check`, `typecheck`, `i18n:check`, `build`, `test:unit`. Docs lane `test:docs`, 264 tests. The page-CSS scope gate passes, 11 of 11.
- Removing the inline style let Prettier collapse the JSX onto one line; that reformat is in the diff and `format:check` is clean.

## Note

The changelog entry sits at the same anchor as the one in #1427. Whichever lands second needs a one line rebase there, and a conflicted PR in this repository gets no CI run at all while reporting "no checks reported", so re-check it after rebasing.

Fixes #1428
