### PR TITLE
chore: use synthetic values in examples and fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The channel and status pane heading truncates with an ellipsis and carries its full text in a tooltip. A long title previously ran past the panel edge, cut mid-glyph with nothing to signal it.
 - The Chats page shows one pane at a time from 769px to 888px with the navigation expanded, where two panes left the room narrower than the composer and pushed the send button out of the panel. The message field now keeps a floor rather than shrinking to nothing.
 - The reply banner's quoted name truncates with an ellipsis, and a location message's map preview is bounded by its bubble. Both previously painted outside the chat panel when the room was narrow.
+- API examples and test fixtures use synthetic identifiers throughout, so the published schema and the specs no longer carry values copied from a live account.
 
 ## [0.23.0] - 2026-08-20
 

--- a/dashboard/src/utils/instanceForm.test.ts
+++ b/dashboard/src/utils/instanceForm.test.ts
@@ -16,7 +16,7 @@ test('isValidInstanceSecret: blank → auto-generate, short → rejected, >=16 �
   assert.equal(isValidInstanceSecret('too-short'), false);
   assert.equal(isValidInstanceSecret('x'.repeat(15)), false);
   assert.equal(isValidInstanceSecret('x'.repeat(16)), true);
-  assert.equal(isValidInstanceSecret('  5t7oive8SuXwrnVgLEQs88gm  '), true); // padded real secret trims to valid
+  assert.equal(isValidInstanceSecret('  0123456789abcdef01234567  '), true); // padded value trims to a valid length
 });
 
 test('parseInstanceConfig: blank → undefined, object → parsed, invalid → not ok', () => {

--- a/openapi.json
+++ b/openapi.json
@@ -14774,12 +14774,12 @@
           "inviteCode": {
             "type": "string",
             "description": "The invite code on its own.",
-            "example": "GTvX9c8H8l718ewOH22Zk5"
+            "example": "EXAMPLEINVITECODE12345"
           },
           "inviteLink": {
             "type": "string",
             "description": "The same code as a joinable link.",
-            "example": "https://chat.whatsapp.com/GTvX9c8H8l718ewOH22Zk5"
+            "example": "https://chat.whatsapp.com/EXAMPLEINVITECODE12345"
           }
         },
         "required": [
@@ -14793,12 +14793,12 @@
           "inviteCode": {
             "type": "string",
             "description": "The invite code on its own.",
-            "example": "GTvX9c8H8l718ewOH22Zk5"
+            "example": "EXAMPLEINVITECODE12345"
           },
           "inviteLink": {
             "type": "string",
             "description": "The same code as a joinable link.",
-            "example": "https://chat.whatsapp.com/GTvX9c8H8l718ewOH22Zk5"
+            "example": "https://chat.whatsapp.com/EXAMPLEINVITECODE12345"
           },
           "message": {
             "type": "string",

--- a/scripts/patch-wwebjs-block.js
+++ b/scripts/patch-wwebjs-block.js
@@ -18,7 +18,7 @@
  *    `[blocklist] trying to block a pn contact without a chat`. Blocking requires an identity that
  *    owns a chat.
  * 3. Individual chats are keyed by LID now, while whatsapp-web.js folds every identity back to a
- *    phone number: `getContactById('148004841455867@lid')` answers `id: 6281770008896@c.us`. So the
+ *    phone number: `getContactById('100000000000000@lid')` answers `id: 628123456789@c.us`. So the
  *    id `Contact.block()` had in hand was precisely the one WhatsApp refuses.
  *
  * The fix therefore resolves the contact to the identity that actually owns the chat, and calls the

--- a/src/engine/adapters/baileys-catalog.ts
+++ b/src/engine/adapters/baileys-catalog.ts
@@ -98,9 +98,9 @@ export class BaileysCatalog {
   }
 
   /**
-   * ponytail: walks the whole cursor chain on every call (no cursor cache), so page N costs the
-   * full catalog. WhatsApp caps catalogs at ~500 products; if profiling shows the walk matters,
-   * cache pages keyed by cursor and serve offsets from the cache.
+   * Walks the whole cursor chain on every call (no cursor cache), so page N costs the full
+   * catalog. WhatsApp caps catalogs at ~500 products; if profiling shows the walk matters, cache
+   * pages keyed by cursor and serve offsets from the cache.
    *
    * The budget is computed once and shared by every page: a per-query deadline would multiply by
    * the page count, making a ten-page walk slower than the 60s stall it replaces.

--- a/src/modules/group/dto/group-response.dto.ts
+++ b/src/modules/group/dto/group-response.dto.ts
@@ -224,12 +224,12 @@ export class GroupPictureResponseDto {
 }
 
 export class GroupInviteCodeResponseDto {
-  @ApiProperty({ description: 'The invite code on its own.', example: 'GTvX9c8H8l718ewOH22Zk5' })
+  @ApiProperty({ description: 'The invite code on its own.', example: 'EXAMPLEINVITECODE12345' })
   inviteCode!: string;
 
   @ApiProperty({
     description: 'The same code as a joinable link.',
-    example: 'https://chat.whatsapp.com/GTvX9c8H8l718ewOH22Zk5',
+    example: 'https://chat.whatsapp.com/EXAMPLEINVITECODE12345',
   })
   inviteLink!: string;
 }

--- a/src/modules/message/dto/send-message.dto.spec.ts
+++ b/src/modules/message/dto/send-message.dto.spec.ts
@@ -171,7 +171,7 @@ describe('mentions WID shape', () => {
   const accepted: Array<[string, string]> = [
     ['phone @c.us (the documented form)', '628123456789@c.us'],
     ['raw protocol @s.whatsapp.net (the #156 workaround)', '628123456789@s.whatsapp.net'],
-    ['privacy id @lid (phone genuinely unknown)', '148004841455867@lid'],
+    ['privacy id @lid (phone genuinely unknown)', '100000000000000@lid'],
     ['multi-device suffix', '628123456789:12@c.us'],
   ];
 


### PR DESCRIPTION
Several API examples and test fixtures carried values copied from a live account rather than placeholders. Every other example in the same files is already synthetic (`628123456789@c.us`, `120363000000000000@g.us`, `Ada Lovelace`), so these stood out as the exceptions.

## What changed

- `GroupInviteCodeResponseDto` and `GroupInviteLinkResponseDto` use a synthetic invite code of the same 22 character shape. This value also reaches `openapi.json` and therefore the rendered API documentation, so the snapshot is regenerated with `npm run openapi:export` rather than hand-edited; the regeneration touches those four example lines and nothing else.
- `scripts/patch-wwebjs-block.js` uses the repository's usual placeholder phone number and a placeholder privacy id in its docblock. The same privacy id in `send-message.dto.spec.ts` is updated to match, so the two no longer describe one identity.
- `dashboard/src/utils/instanceForm.test.ts` uses a synthetic 24 character secret. Only the length is asserted, so the value carried no information the test needed, and the comment no longer describes it as anything but a fixture.
- A catalog helper's docblock opened with a label that carries no meaning for a reader. The label is dropped and the note itself is unchanged.

## Impact

No behaviour changes. The published schema's example values change, which is visible to anyone diffing `openapi.json` between releases, hence the changelog line.

Replacing these values does not undo their earlier publication. The invite code and the ingress secret still need rotating at the source; that is outside this change.

## Verification

- Full Lint job locally: `lint`, `format:check`, `check:versions`, `check:dockerignore`, `openapi:check`, `check:sdk-routes`, `check:sdk-coverage`, `check:sdk-events`, `check:sdk-docs`, `check:contract-shapes`, `check:audit`, and `tsc --noEmit`. All pass. `openapi:check` passing is the one that matters here, since it proves the committed snapshot matches what the code generates.
- Backend suite: 342 suites, 5897 tests, 0 failures. Docs lane: 264 tests. Dashboard lane: lint, format, typecheck, i18n parity, build and unit tests all pass. The two changed specs were also run on their own.
- Re-scanned the tree two ways afterwards, by literal grep and by parsing `openapi.json` as JSON: zero occurrences of any replaced value remain.
