### PR TITLE
fix(dashboard): extend the narrow band to the width it still clipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - The dashboard chat room shrinks within its layout instead of overflowing it, so a long contact or group name no longer pushes the send button out of reach. Thanks @rainerigius.
-- The chat composer shrinks with its pane, so the send button stays reachable. It sat outside the layout's clip below a 1014px viewport with the navigation expanded, and on any phone 402 CSS px or narrower.
+- The chat composer shrinks with its pane, so the send button stays reachable. It sat outside the layout's clip below a 1015px viewport with the navigation expanded, and on any phone 403 CSS px or narrower.
 - The channel and status pane heading truncates with an ellipsis and carries its full text in a tooltip. A long title previously ran past the panel edge, cut mid-glyph with nothing to signal it.
-- The Chats page shows one pane at a time from 769px to 888px with the navigation expanded, where two panes left the room narrower than the composer and pushed the send button out of the panel. The message field now keeps a floor rather than shrinking to nothing.
+- The Chats page shows one pane at a time from 769px to 889px with the navigation expanded, where two panes left the room narrower than the composer and pushed the send button out of the panel. The message field now keeps a floor rather than shrinking to nothing.
 - The reply banner's quoted name truncates with an ellipsis, and a location message's map preview is bounded by its bubble. Both previously painted outside the chat panel when the room was narrow.
 
 ## [0.23.0] - 2026-08-20

--- a/dashboard/src/pages/Chats.css
+++ b/dashboard/src/pages/Chats.css
@@ -901,15 +901,15 @@
   }
 }
 
-/* Between the mobile breakpoint and 888px the two-pane layout leaves the room narrower than the
+/* Between the mobile breakpoint and 889px the two-pane layout leaves the room narrower than the
    composer's 244px minimum, so the send button fell outside the panel's clip with no scrollbar to
    recover it. In that band the panes swap one at a time instead, the way they already do on a phone.
-   Bounded on both sides on purpose: at 768px and below the mobile shell owns the layout, and from 889px
-   the room fits the composer again. The upper bound tracks that minimum, so it moves if the composer's
-   own width does. Keyed to the navigation as well as the viewport, because the room is `viewport - 646`
-   only while the nav is expanded; collapsed it already fits and none of this should apply.
-   `.main-content.expanded` is Layout's class for the COLLAPSED nav. */
-@media (min-width: 769px) and (max-width: 888px) {
+   Bounded on both sides on purpose: at 768px and below the mobile shell owns the layout, and from 890px
+   the room fits the composer again. The room is `viewport - 646`, so the bound is 646 + 244 - 1; it
+   moves if the composer's own minimum does. Keyed to the navigation as well as the viewport, because
+   that arithmetic only holds while the nav is expanded; collapsed it already fits and none of this
+   should apply. `.main-content.expanded` is Layout's class for the COLLAPSED nav. */
+@media (min-width: 769px) and (max-width: 889px) {
   .main-content:not(.expanded) .chats-page .chats-layout {
     flex-direction: column;
   }


### PR DESCRIPTION
The band that swaps the chat panes ended one pixel short. The room is `viewport - 646` with the navigation expanded and the composer's minimum is 244px, so the first viewport at which two panes fit is 890, not 889. At exactly 889px the two-pane layout was kept and one pixel column of the send button fell outside the panel's clip.

## Root cause of the off-by-one

The measurement that set the bound compared the send button's right edge against `.chats-layout`'s **border box**. `overflow: hidden` clips at the **padding box**, and that element carries a 1px border, so every threshold derived that way was low by exactly one. Three published figures inherit it, and all three are corrected here.

| Figure | Published | Measured |
| --- | --- | --- |
| Band upper bound | 888px | **889px** |
| Composer clip started below | 1014px | **1015px** |
| Phone widths affected | 402px and narrower | **403px and narrower** |

## What changed

- `@media (min-width: 769px) and (max-width: 888px)` becomes `889px`.
- The block comment stated "from 889px the room fits the composer again" and claimed the bound tracks the composer's minimum. Neither was true; it now states the arithmetic it is derived from, `646 + 244 - 1`.
- The two changelog figures above are corrected in place.

## Impact

Measured against the built bundles (`index-*.css` plus `Chats-*.css` from `npm run build`), not the source file, with the real webfont. `sendVsClip` is the send button's right edge against the layout's padding box, the actual clip edge; negative is inside.

| Viewport | Before | After |
| --- | --- | --- |
| 888px | column, −24.0 | column, −24.0 |
| 889px | row, layout overflow 1px, **+1.0 (clipped)** | column, overflow 0, −24.0 |
| 890px | row, 0.0 | row, 0.0 |
| 891px | row, −1.0 | row, −1.0 |

Navigation collapsed is unchanged at 888, 889 and 890, as it was before: that state never clipped.

## Verification

- A 53 width sweep from 769px to 1440px, one pixel apart across 881..900 and wider steps outside it, asserting per row that the rendered viewport matched the requested one and that the webfont was loaded: **0 empty rows, 0 widths where the layout overflows or the send button crosses the clip**. Before this change that sweep reports 889px.
- Boundary table above reproduced on the built bundle, so it reflects what ships rather than the source file.
- Dashboard lane: lint, format:check, typecheck, i18n parity, unit tests. Docs lane: 264 tests. The page-CSS scope gate passes, 11 of 11.

Refs #1422
