### PR TITLE
chore(release): v0.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.1] - 2026-08-21
+
 ### Fixed
 
 - The dashboard chat room shrinks within its layout instead of overflowing it, so a long contact or group name no longer pushes the send button out of reach. Thanks @rainerigius.

--- a/charts/openwa/Chart.yaml
+++ b/charts/openwa/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: openwa
 description: OpenWA — WhatsApp API. Single-instance StatefulSet (see values.yaml replicaCount warning).
 type: application
-version: 0.1.17
-appVersion: '0.23.0'
+version: 0.1.18
+appVersion: '0.23.1'
 keywords:
   - whatsapp
   - openwa

--- a/openapi.json
+++ b/openapi.json
@@ -9425,7 +9425,7 @@
   "info": {
     "title": "OpenWA API",
     "description": "Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API\n\n**Gateway-wide responses.** Two statuses are returned by middleware before routing, so any operation can emit them:\n\n- `415 Unsupported Media Type` — the request body carries a `Content-Encoding` other than `identity`. The aggregate in-flight body cap counts wire bytes, so a compressed body would be admitted on its compressed size and then inflated past the memory it is meant to bound. Send the body uncompressed.\n- `503 Service Unavailable` with `Retry-After` — the gateway already has too much request body data in flight. The body is not read; retry after the given delay.",
-    "version": "0.23.0",
+    "version": "0.23.1",
     "contact": {
       "name": "OpenWA",
       "url": "https://github.com/rmyndharis/OpenWA",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openwa",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openwa",
-      "version": "0.23.0",
+      "version": "0.23.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwa",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API for WhatsApp",
   "author": "Yudhi Armyndharis & OpenWA Contributors",
   "private": true,


### PR DESCRIPTION
Cuts 0.23.1. Everything since 0.23.0 is a fix or a chore with no breaking change, and `docs/14-migration-guide.md` states the policy for this line: on `0.x` a breaking change bumps the minor and everything else is a patch.

## What changed

- `package.json`, `package-lock.json` (root and `packages[""]` only), `charts/openwa/Chart.yaml` `appVersion`, and the chart's own `version` 0.1.17 to 0.1.18.
- `openapi.json` `info.version`, regenerated with `npm run openapi:export` rather than edited, so the value flows from `package.json`. The regeneration changes that one line and nothing else.
- `CHANGELOG.md` gains a `[0.23.1] - 2026-08-21` heading below the empty `[Unreleased]`, matching the shape of the previous cut.

Two files the previous cut touched are deliberately untouched here:

- `SECURITY.md` already reads `0.23.x`, which a patch stays inside. The last cut changed it only because the minor moved.
- The Known Upgrade Hazards table in `docs/14-migration-guide.md` is hazard driven rather than release driven; this release carries no migration or behaviour hazard, so it gets no row.

## Verification

- Full Lint job locally: `lint`, `format:check`, `check:versions`, `check:dockerignore`, `openapi:check`, the four `check:sdk-*` gates, `check:contract-shapes`, `check:audit`, and `tsc --noEmit`. All pass.
- Backend suite 342 suites / 5897 tests, docs lane 264 tests, dashboard lane lint, format, typecheck, i18n parity, build and unit tests. All pass.
- Version coherence checked at every location that carries it: `package.json`, both lock entries, `openapi.json`, and the chart all read 0.23.1.
- The lock file's `@tootallnate/quickjs-emscripten` dependency is itself at 0.23.0; only the two entries describing this package were touched, verified by asserting exactly two changed lines.
