### PR TITLE
ci(release): accept the unfixed arm64 Chromium CVEs in the image scan

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -35,3 +35,44 @@ CVE-2026-69152
 # it cannot regress below it — the same invariant the brace-expansion note describes, which is what
 # keeps an ID-level ignore honest. Drop this entry once npm ships a bundle with ip-address >= 10.3.1.
 CVE-2026-69192
+# CVE-2026-76033 / -76036 / -76037 / -76038 / -76039 / -76040 / -76041 / -76043 / -76044 / -76045 /
+# -76047: Chromium, arm64 image ONLY. Eleven ids, 33 findings.
+#
+# Each lands on `chromium`, `chromium-common` and `chromium-sandbox`, which is why eleven ids produce
+# thirty-three findings. They are arm64-only by construction: Chrome for Testing publishes no
+# linux-arm64 build, so amd64 uses CfT while arm64 installs Debian's chromium (Dockerfile, TARGETARCH
+# branch). Only the arm64 image carries the Debian package, and the amd64 scan is clean.
+#
+# THE FIX EXISTS UPSTREAM BUT NOT IN DEBIAN YET. The image has 151.0.7922.137-1~deb12u1 and Trivy
+# names 151.0.7922.169-1~deb12u1 as fixed. Checked against the security mirror's own package index at
+# the time of writing: bookworm-security still serves .137 for both arm64 and amd64. The release build
+# is not stale; it fetched from bookworm-security with no cached apt layer (`no-cache-filters:
+# production`) and installed the newest version that exists. Rebuilding today changes nothing.
+#
+# Exposure, stated honestly rather than talked down. Unlike the earlier chromium batch, where two of
+# the four were sandbox escapes that `--no-sandbox` made irrelevant, NONE of these are neutralised by
+# how the container runs:
+#  - Eight are arbitrary or remote code execution in the renderer: v8 type confusion (-76038, -76047),
+#    v8 miscalculation (-76043), Dawn (-76036), WebGL use-after-free (-76045), a use-after-free
+#    (-76040), a race condition (-76044) and link following (-76037).
+#  - One is a site isolation bypass (-76033) and two are information disclosure (-76039, -76041).
+# Chromium renders content the sender controls (message bodies, link previews, images), so a crafted
+# message is a plausible path to code execution as the `openwa` user inside the arm64 container. The
+# container is the confinement boundary (cap_drop ALL, no-new-privileges, read_only rootfs), and that
+# is all that stands behind it. This is accepted deliberately so the release can ship while Debian has
+# no fixed build, NOT because it is harmless.
+#
+# Drop all eleven the moment bookworm ships chromium >= 151.0.7922.169 (watch
+# https://security-tracker.debian.org/tracker/source-package/chromium) and re-run the release scan
+# with them removed before assuming they are gone.
+CVE-2026-76033
+CVE-2026-76036
+CVE-2026-76037
+CVE-2026-76038
+CVE-2026-76039
+CVE-2026-76040
+CVE-2026-76041
+CVE-2026-76043
+CVE-2026-76044
+CVE-2026-76045
+CVE-2026-76047


### PR DESCRIPTION
The v0.23.1 image scan failed on `linux/arm64` with 33 HIGH findings, blocking promotion and the GitHub Release. This accepts them temporarily so the release can ship, with the same shape and the same honesty as the earlier chromium batch in this file.

## Why the build is not at fault

- Eleven ids across `chromium`, `chromium-common` and `chromium-sandbox`, which is why eleven produce thirty-three findings.
- arm64 only, by construction: Chrome for Testing publishes no linux-arm64 build, so amd64 uses CfT while arm64 installs Debian's chromium. The amd64 scan passed.
- The image has `151.0.7922.137-1~deb12u1`; Trivy names `151.0.7922.169-1~deb12u1` as fixed. The release build fetched from `bookworm-security` with no cached apt layer, visible as real `Get:` lines in the build log and no `CACHED` marker on the production stage, and installed the newest version that exists. I read the security mirror's own package index directly: it still serves `.137` for both architectures. There is nothing to upgrade to, and rebuilding today produces the identical image.

## Exposure, not talked down

Eight of the eleven are arbitrary or remote code execution in the renderer: v8 type confusion (76038, 76047), a v8 miscalculation (76043), Dawn (76036), a WebGL use-after-free (76045), a use-after-free (76040), a race condition (76044) and link following (76037). One is a site isolation bypass (76033) and two are information disclosure (76039, 76041).

Unlike the earlier batch, where two of four were sandbox escapes that `--no-sandbox` made irrelevant, **none of these are neutralised by how the container runs**. Chromium renders content the sender controls, so a crafted message is a plausible path to code execution as the `openwa` user inside the arm64 container, with the container itself as the only confinement boundary. This is accepted deliberately to ship, not because it is harmless.

## Drop condition

All eleven come out the moment bookworm ships `chromium >= 151.0.7922.169`, tracked at the Debian security tracker link in the file, and the scan is re-run without them before assuming they are gone. That is what happened to the previous batch, which was added and then removed once Debian caught up.

## Verification

- The eleven ids were extracted from the failing job's own output, not guessed. Cross-checked two ways: each id appears exactly three times in the findings table, and three packages times eleven ids equals the reported total of 33.
- `.trivyignore` now holds fourteen ids with no duplicates against the three already there.
- `check:audit` and the docs lane (264 tests) pass.
