### PR TITLE
feat(baileys): populate body with vCard for inbound contact shares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Baileys: an inbound shared contact card's vCard now populates the message `body`, matching what
+  whatsapp-web.js already returns for its `vcard` type. Several contacts shared
+  together (`contactsArrayMessage`) are newline-joined into one multi-vCard body, in the order they
+  were shared. Previously Baileys silently dropped this text. Thanks @memarius.
+
 ### Fixed
 
 - `docker compose up -d` builds from a Windows clone again. Git's default `core.autocrlf=true` gave the committed

--- a/src/engine/adapters/baileys-message-mapper.spec.ts
+++ b/src/engine/adapters/baileys-message-mapper.spec.ts
@@ -114,6 +114,32 @@ describe('extractBaileysBody (inbound text/caption + interactive shapes)', () =>
     expect(extractBaileysBody({ interactiveMessage: {} })).toBe('');
     expect(extractBaileysBody({ templateMessage: {} })).toBe('');
   });
+
+  it('extracts a single shared contact card as its raw vCard', () => {
+    const vcard = 'BEGIN:VCARD\nVERSION:3.0\nFN:Alice\nEND:VCARD';
+    expect(extractBaileysBody({ contactMessage: { vcard } })).toBe(vcard);
+  });
+
+  it('joins multiple shared contact cards, one vCard per line, in order', () => {
+    const alice = 'BEGIN:VCARD\nFN:Alice\nEND:VCARD';
+    const bob = 'BEGIN:VCARD\nFN:Bob\nEND:VCARD';
+    expect(extractBaileysBody({ contactsArrayMessage: { contacts: [{ vcard: alice }, { vcard: bob }] } })).toBe(
+      `${alice}\n${bob}`,
+    );
+  });
+
+  it('skips a contactsArrayMessage entry with no vCard rather than injecting an empty line', () => {
+    const alice = 'BEGIN:VCARD\nFN:Alice\nEND:VCARD';
+    expect(extractBaileysBody({ contactsArrayMessage: { contacts: [{ vcard: alice }, { vcard: null }] } })).toBe(alice);
+  });
+
+  it('falls through to empty string for an empty contactsArrayMessage', () => {
+    expect(extractBaileysBody({ contactsArrayMessage: { contacts: [] } })).toBe('');
+  });
+
+  it('prefers plain text over a contact card when somehow both are present', () => {
+    expect(extractBaileysBody({ conversation: 'plain', contactMessage: { vcard: 'ignored' } })).toBe('plain');
+  });
 });
 
 describe('buildIncomingMessageFromBaileys', () => {

--- a/src/engine/adapters/baileys-message-mapper.ts
+++ b/src/engine/adapters/baileys-message-mapper.ts
@@ -76,14 +76,23 @@ export interface BaileysBodyContent {
     hydratedFourRowTemplate?: { hydratedContentText?: string | null } | null;
   } | null;
   interactiveResponseMessage?: { body?: { text?: string | null } | null } | null;
+  /** A single shared contact card. */
+  contactMessage?: { vcard?: string | null } | null;
+  /** Several contact cards shared together; each carries its own vCard. */
+  contactsArrayMessage?: { contacts?: Array<{ vcard?: string | null }> | null } | null;
 }
 
 /**
  * Extract the display text of an inbound Baileys message: plain text first, then a media caption,
  * then the WhatsApp Business interactive shapes (interactive / buttons / template / interactive-
  * response) whose text was previously dropped — the OTP/verification text businesses send via these
- * shapes (#562). Returns `''` when the message carries no extractable text. Pass the NORMALIZED
- * content (ephemeral/viewOnce/documentWithCaption wrappers already unwrapped), as the adapter does.
+ * shapes (#562), then a shared contact card's vCard(s) - mirroring what whatsapp-web.js already
+ * exposes as `body` for its `vcard` type, so the neutral `body` field carries the same content on
+ * both engines for a single shared contact instead of Baileys silently dropping it. Multiple vCards from
+ * a `contactsArrayMessage` are newline-joined; RFC 6350 allows concatenated vCards in one stream, so
+ * this is a single valid multi-card body, not string mangling. Returns `''` when the message carries
+ * no extractable text. Pass the NORMALIZED content (ephemeral/viewOnce/documentWithCaption wrappers
+ * already unwrapped), as the adapter does.
  */
 export function extractBaileysBody(content: BaileysBodyContent): string {
   return (
@@ -97,8 +106,25 @@ export function extractBaileysBody(content: BaileysBodyContent): string {
     content.templateMessage?.hydratedTemplate?.hydratedContentText ??
     content.templateMessage?.hydratedFourRowTemplate?.hydratedContentText ??
     content.interactiveResponseMessage?.body?.text ??
+    content.contactMessage?.vcard ??
+    extractContactsArrayVcards(content.contactsArrayMessage) ??
     ''
   );
+}
+
+/**
+ * Joins the vCards of a `contactsArrayMessage` into one string, in the order they were shared.
+ * Returns `undefined` (not `''`) when there are no vCards to join, so it composes with `??` in
+ * {@link extractBaileysBody} the same way every other optional-field lookup there does.
+ */
+function extractContactsArrayVcards(
+  contactsArrayMessage: BaileysBodyContent['contactsArrayMessage'],
+): string | undefined {
+  const vcards = (contactsArrayMessage?.contacts ?? [])
+    .map(contact => contact.vcard)
+    .filter((vcard): vcard is string => !!vcard);
+
+  return vcards.length > 0 ? vcards.join('\n') : undefined;
 }
 
 /**


### PR DESCRIPTION
## Description

Baileys silently dropped the text of a shared contact card: neither contactMessage nor contactsArrayMessage was read by extractBaileysBody, so the neutral body field stayed empty even though whatsapp-web.js already returns the raw vCard for its `vcard` type. Several contacts shared together are newline-joined into one multi-vCard body, in the order they were shared (RFC 6350 allows concatenated vCards in one stream).

- A single `contactMessage` contributes its vCard as-is, matching the `body` whatsapp-web.js produces for `vcard`.
- A `contactsArrayMessage` (several contacts shared together) has its vCards newline-joined, in the order they were shared - a valid single multi-vCard body per RFC 6350. whatsapp-web.js leaves a `multi_vcard` body empty, so this case is a Baileys extension rather than parity.
- Falls through to `''` when neither is present, same as every other body source in
  this function.

Message *type* classification (`contactMessage`/`contactsArrayMessage` → `contact`)
already existed in `message-mapper.ts`; this fixes the `body` text that goes with it.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (CHANGELOG `[Unreleased]`)
- [x] Lint passes
- [x] Self-reviewed

## Screenshots (if applicable)

N/A - mapper-level change, no UI impact.

## Related Issues

-
