### PR TITLE
fix(baileys): surface poll, event and quoted text in inbound bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Baileys: inbound poll questions, shared event names and business button-reply selections now fill the message
+  `body` instead of arriving empty. Webhook filters, search and the dashboard see this text on both engines now.
+- Baileys: quoting a contact card or poll keeps its text in the quoted-message preview instead of an empty
+  string; the quote reuses the same body extraction as the live message.
 - `docker compose up -d` builds from a Windows clone again. Git's default `core.autocrlf=true` gave the committed
   PGDG signing key CRLF endings and the build failed with `NO_PUBKEY 7FCC7D46ACCC4CF8`. The key is now pinned to LF
   and the build strips CR, so a clone already on disk needs no re-clone. Thanks @ATZ-Jordan.

--- a/src/engine/adapters/baileys-message-mapper.spec.ts
+++ b/src/engine/adapters/baileys-message-mapper.spec.ts
@@ -2,6 +2,7 @@ import {
   BaileysIncomingFields,
   buildIncomingMessageFromBaileys,
   extractBaileysBody,
+  extractBaileysContext,
   mapBaileysMessageType,
   mapBaileysStatus,
 } from './baileys-message-mapper';
@@ -139,6 +140,52 @@ describe('extractBaileysBody (inbound text/caption + interactive shapes)', () =>
 
   it('prefers plain text over a contact card when somehow both are present', () => {
     expect(extractBaileysBody({ conversation: 'plain', contactMessage: { vcard: 'ignored' } })).toBe('plain');
+  });
+
+  it('extracts an inbound poll question across the wire content-key variants', () => {
+    expect(extractBaileysBody({ pollCreationMessage: { name: 'Lunch order?' } })).toBe('Lunch order?');
+    expect(extractBaileysBody({ pollCreationMessageV2: { name: 'Team offsite?' } })).toBe('Team offsite?');
+    expect(extractBaileysBody({ pollCreationMessageV3: { name: 'Standup time?' } })).toBe('Standup time?');
+  });
+
+  it('returns empty for a poll with no name rather than falling through to other sources', () => {
+    expect(extractBaileysBody({ pollCreationMessage: {} })).toBe('');
+    expect(extractBaileysBody({ pollCreationMessage: { name: null } })).toBe('');
+  });
+
+  it('extracts a shared event display name', () => {
+    expect(extractBaileysBody({ eventMessage: { name: 'Release party' } })).toBe('Release party');
+  });
+
+  it('extracts which business button label the user tapped', () => {
+    expect(extractBaileysBody({ buttonsResponseMessage: { selectedDisplayText: 'Yes, notify me' } })).toBe(
+      'Yes, notify me',
+    );
+    expect(extractBaileysBody({ templateButtonReplyMessage: { selectedDisplayText: 'Track order' } })).toBe(
+      'Track order',
+    );
+  });
+});
+
+describe('extractBaileysContext (quoted body shares the live body extractor)', () => {
+  const quoted = (quotedMessage: object) =>
+    extractBaileysContext({
+      imageMessage: { contextInfo: { stanzaId: 'wamid.original', quotedMessage } },
+    }).quotedMessage;
+
+  it('carries a quoted contact card as its vCard', () => {
+    const vcard = 'BEGIN:VCARD\nFN:Alice\nEND:VCARD';
+    expect(quoted({ contactMessage: { vcard } })).toEqual({ id: 'wamid.original', body: vcard });
+  });
+
+  it('carries a quoted poll question', () => {
+    expect(quoted({ pollCreationMessage: { name: 'Lunch order?' } })?.body).toBe('Lunch order?');
+  });
+
+  it('still carries captions and plain text from the classic sources', () => {
+    expect(quoted({ imageMessage: { caption: 'pic' } })?.body).toBe('pic');
+    expect(quoted({ conversation: 'the original' })?.body).toBe('the original');
+    expect(quoted({ stickerMessage: {} })?.body).toBe('');
   });
 });
 

--- a/src/engine/adapters/baileys-message-mapper.ts
+++ b/src/engine/adapters/baileys-message-mapper.ts
@@ -76,6 +76,15 @@ export interface BaileysBodyContent {
     hydratedFourRowTemplate?: { hydratedContentText?: string | null } | null;
   } | null;
   interactiveResponseMessage?: { body?: { text?: string | null } | null } | null;
+  /** A poll's question; the wire bumps the content key across versions, all carry `name`. */
+  pollCreationMessage?: { name?: string | null } | null;
+  pollCreationMessageV2?: { name?: string | null } | null;
+  pollCreationMessageV3?: { name?: string | null } | null;
+  /** A shared WhatsApp event; only its display name is surfaced as text. */
+  eventMessage?: { name?: string | null } | null;
+  /** The user tapping a business message button: which visible label they pressed. */
+  buttonsResponseMessage?: { selectedDisplayText?: string | null } | null;
+  templateButtonReplyMessage?: { selectedDisplayText?: string | null } | null;
   /** A single shared contact card. */
   contactMessage?: { vcard?: string | null } | null;
   /** Several contact cards shared together; each carries its own vCard. */
@@ -86,13 +95,13 @@ export interface BaileysBodyContent {
  * Extract the display text of an inbound Baileys message: plain text first, then a media caption,
  * then the WhatsApp Business interactive shapes (interactive / buttons / template / interactive-
  * response) whose text was previously dropped — the OTP/verification text businesses send via these
- * shapes (#562), then a shared contact card's vCard(s) - mirroring what whatsapp-web.js already
- * exposes as `body` for its `vcard` type, so the neutral `body` field carries the same content on
- * both engines for a single shared contact instead of Baileys silently dropping it. Multiple vCards from
- * a `contactsArrayMessage` are newline-joined; RFC 6350 allows concatenated vCards in one stream, so
- * this is a single valid multi-card body, not string mangling. Returns `''` when the message carries
- * no extractable text. Pass the NORMALIZED content (ephemeral/viewOnce/documentWithCaption wrappers
- * already unwrapped), as the adapter does.
+ * shapes (#562), then the text-shaped non-conversation content whose display text whatsapp-web.js
+ * already exposes as `body` and Baileys used to drop silently: a poll's question, a shared event's
+ * name, which button label the user tapped, and a shared contact card's vCard(s). Multiple vCards
+ * from a `contactsArrayMessage` are newline-joined; RFC 6350 allows concatenated vCards in one
+ * stream, so this is a single valid multi-card body, not string mangling. Returns `''` when the
+ * message carries no extractable text. Pass the NORMALIZED content (ephemeral/viewOnce/
+ * documentWithCaption wrappers already unwrapped), as the adapter does.
  */
 export function extractBaileysBody(content: BaileysBodyContent): string {
   return (
@@ -106,6 +115,12 @@ export function extractBaileysBody(content: BaileysBodyContent): string {
     content.templateMessage?.hydratedTemplate?.hydratedContentText ??
     content.templateMessage?.hydratedFourRowTemplate?.hydratedContentText ??
     content.interactiveResponseMessage?.body?.text ??
+    content.pollCreationMessage?.name ??
+    content.pollCreationMessageV2?.name ??
+    content.pollCreationMessageV3?.name ??
+    content.eventMessage?.name ??
+    content.buttonsResponseMessage?.selectedDisplayText ??
+    content.templateButtonReplyMessage?.selectedDisplayText ??
     content.contactMessage?.vcard ??
     extractContactsArrayVcards(content.contactsArrayMessage) ??
     ''
@@ -242,21 +257,11 @@ export function extractBaileysContext(content: BaileysContextContent): BaileysMe
   };
 
   if (contextInfo?.quotedMessage && contextInfo.stanzaId) {
-    const qm = contextInfo.quotedMessage as {
-      conversation?: string | null;
-      extendedTextMessage?: { text?: string | null } | null;
-      imageMessage?: { caption?: string | null } | null;
-      videoMessage?: { caption?: string | null } | null;
-      documentMessage?: { caption?: string | null } | null;
-    };
-    const qBody =
-      qm.conversation ??
-      qm.extendedTextMessage?.text ??
-      qm.imageMessage?.caption ??
-      qm.videoMessage?.caption ??
-      qm.documentMessage?.caption ??
-      '';
-    context.quotedMessage = { id: contextInfo.stanzaId, body: qBody };
+    // The quote's body comes from the SAME extractor as the live message, so a quoted contact card,
+    // poll or interactive shape carries its text instead of an empty string — matching wwjs, whose
+    // quote is a full Message and therefore shows the same body it would show unquoted.
+    const qm = contextInfo.quotedMessage as BaileysBodyContent;
+    context.quotedMessage = { id: contextInfo.stanzaId, body: extractBaileysBody(qm) };
   }
 
   return context;


### PR DESCRIPTION
## Description

Inbound messages whose display text lives outside the plain-text and caption fields arrived on Baileys with an empty neutral `body`: a poll's question, a shared event's name and the business button label the user tapped were all classified by `mapBaileysMessageType` but never read by `extractBaileysBody`, while whatsapp-web.js carries this text in its `body`. The same gap applied to quoted messages: `extractBaileysContext` built the quote's body from a hand-rolled five-source chain, so quoting a contact card or poll produced an empty preview.

- `extractBaileysBody` now reads the poll question (`pollCreationMessage{,V2,V3}.name`), the shared event's name (`eventMessage.name`) and the tapped button label (`buttonsResponseMessage` / `templateButtonReplyMessage` `selectedDisplayText`).
- A quoted message's body is derived by the same extractor as the live message, so quotes carry captions, vCards, poll questions and button selections instead of an empty string.
- No type classification changes: polls stay `poll`; events and button replies stay `unknown`, matching what whatsapp-web.js surfaces today.

Impact: webhook `body` filters, automation rules, full-text search, the stats by-type chart and the dashboard chat list see this text where they previously saw nothing, and an inbound poll renders its question in the dashboard instead of an empty bubble. Poll options remain unavailable downstream (unchanged).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Tests added/updated (new extractor cases, plus first direct coverage for the quoted-body sources)
- [x] Documentation updated (CHANGELOG `[Unreleased]`)
- [x] Lint passes
- [x] Self-reviewed

## Screenshots (if applicable)

N/A - adapter-level change, no UI redesign.
