### PR TITLE
fix(webhook): accept poll in message-type filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The message-type filter on webhooks and automation rules accepts `poll`. The dashboard offered the option but
+  saving was refused as invalid.
 - Baileys: inbound poll questions, shared event names and business button-reply selections now fill the message
   `body` instead of arriving empty. Webhook filters, search and the dashboard see this text on both engines now.
 - Baileys: quoting a contact card or poll keeps its text in the quoted-message preview instead of an empty

--- a/src/modules/webhook/filters/filter-evaluator.spec.ts
+++ b/src/modules/webhook/filters/filter-evaluator.spec.ts
@@ -61,6 +61,12 @@ describe('evaluateFilters', () => {
     expect(evaluateFilters(f, 'message.received', msg({ type: 'text' }))).toBe(false);
   });
 
+  it('matches the poll type a webhook or automation rule may now name', () => {
+    const f = filters({ field: 'type', operator: 'isNot', value: ['poll'] });
+    expect(evaluateFilters(f, 'message.received', msg({ type: 'text' }))).toBe(true);
+    expect(evaluateFilters(f, 'message.received', msg({ type: 'poll' }))).toBe(false);
+  });
+
   it('body contains is case-insensitive by default and case-sensitive when set', () => {
     expect(
       evaluateFilters(filters({ field: 'body', operator: 'contains', value: 'hello' }), 'message.received', msg()),

--- a/src/modules/webhook/filters/filter-types.ts
+++ b/src/modules/webhook/filters/filter-types.ts
@@ -9,6 +9,8 @@
  * subscribed to several families behaves sanely without per-event filter sets.
  */
 
+import { MessageType } from '../../../engine/interfaces/whatsapp-engine.interface';
+
 export type FilterOperator = 'is' | 'isNot' | 'contains' | 'equals';
 
 /** Value shape a field resolves to, which decides how operators are applied. */
@@ -35,21 +37,30 @@ export interface FieldDefinition {
   enumValues?: readonly string[];
 }
 
-export const MESSAGE_TYPES = [
-  'text',
-  'image',
-  'video',
-  'audio',
-  'voice',
-  'document',
-  'sticker',
-  'location',
-  'contact',
-  'call',
-  'revoked',
-  'masked',
-  'unknown',
-] as const;
+/**
+ * Every neutral message type a `type` filter condition may name. Derived exhaustively from the
+ * engine-neutral {@link MessageType} union so a type added there cannot be silently rejected here:
+ * `poll` was offered by the dashboard's own copy of this list while saving was refused as invalid.
+ * The `Record<MessageType, ...>` shape makes an omitted or stale entry a compile error.
+ */
+const MESSAGE_TYPE_FLAGS: Record<MessageType, true> = {
+  text: true,
+  image: true,
+  video: true,
+  audio: true,
+  voice: true,
+  document: true,
+  sticker: true,
+  location: true,
+  contact: true,
+  poll: true,
+  call: true,
+  revoked: true,
+  masked: true,
+  unknown: true,
+};
+
+export const MESSAGE_TYPES: readonly MessageType[] = Object.keys(MESSAGE_TYPE_FLAGS) as MessageType[];
 
 // Guard rails. These bound both stored config size and per-event evaluation cost.
 export const MAX_CONDITIONS = 20;

--- a/src/modules/webhook/filters/filter-validation.spec.ts
+++ b/src/modules/webhook/filters/filter-validation.spec.ts
@@ -1,0 +1,19 @@
+import { collectFilterErrors } from './filter-validation';
+import { MESSAGE_TYPES } from './filter-types';
+
+describe('collectFilterErrors (message-type enum)', () => {
+  const typeCondition = (...types: string[]) => ({
+    conditions: [{ field: 'type', operator: 'is', value: types }],
+  });
+
+  it('accepts every neutral message type, including poll', () => {
+    // `poll` was offered by the dashboard's type picker while validation refused it, so a saved
+    // filter could never round-trip. The list must cover the whole neutral union.
+    expect(collectFilterErrors(typeCondition('poll'))).toEqual([]);
+    expect(collectFilterErrors(typeCondition(...MESSAGE_TYPES))).toEqual([]);
+  });
+
+  it('still rejects a type outside the neutral union', () => {
+    expect(collectFilterErrors(typeCondition('banana'))).toEqual(['conditions[0].value "banana" is not a valid type']);
+  });
+});


### PR DESCRIPTION
## Description

The dashboard's message-type filter picker offers `poll`, but the enum list that backs webhook and automation-rule validation never contained it, so saving a webhook or automation rule whose filter named `type: poll` was refused with "is not a valid type". The backend list was a hand-copied subset of the neutral `MessageType` union and had drifted from it.

- Derive `MESSAGE_TYPES` exhaustively from the engine-neutral `MessageType` union via a `Record<MessageType, true>` literal: adding or removing a neutral type without updating this file is now a compile error instead of silent drift.
- Cover both directions in tests: every union member (including `poll`) validates, and an unknown type is still rejected.
- Add an evaluator case for a rule matching on the poll type.

No evaluator or persistence changes: the fix only widens what validation accepts to match what the engines can actually emit and the dashboard already offers.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (CHANGELOG `[Unreleased]`)
- [x] Lint passes
- [x] Self-reviewed

## Screenshots (if applicable)

N/A - validation-level change.
