### PR TITLE
chore(release): v0.23.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Added
-
-- Baileys: an inbound shared contact card's vCard now populates the message `body`, matching what
-  whatsapp-web.js already returns for its `vcard` type. Several contacts shared
-  together (`contactsArrayMessage`) are newline-joined into one multi-vCard body, in the order they
-  were shared. Previously Baileys silently dropped this text. Thanks @memarius.
+## [0.23.2] - 2026-08-23
 
 ### Fixed
 
+- Baileys: an inbound shared contact card's vCard now populates the message `body` instead of being silently
+  dropped, matching what whatsapp-web.js returns for its `vcard` type. Several contacts shared
+  together (`contactsArrayMessage`) are newline-joined into one multi-vCard body, in the order they were
+  shared. Thanks @memarius.
 - The message-type filter on webhooks and automation rules accepts `poll`. The dashboard offered the option but
   saving was refused as invalid.
 - Baileys: inbound poll questions, shared event names and business button-reply selections now fill the message

--- a/charts/openwa/Chart.yaml
+++ b/charts/openwa/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: openwa
 description: OpenWA — WhatsApp API. Single-instance StatefulSet (see values.yaml replicaCount warning).
 type: application
-version: 0.1.18
-appVersion: '0.23.1'
+version: 0.1.19
+appVersion: '0.23.2'
 keywords:
   - whatsapp
   - openwa

--- a/openapi.json
+++ b/openapi.json
@@ -9425,7 +9425,7 @@
   "info": {
     "title": "OpenWA API",
     "description": "Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API\n\n**Gateway-wide responses.** Two statuses are returned by middleware before routing, so any operation can emit them:\n\n- `415 Unsupported Media Type` — the request body carries a `Content-Encoding` other than `identity`. The aggregate in-flight body cap counts wire bytes, so a compressed body would be admitted on its compressed size and then inflated past the memory it is meant to bound. Send the body uncompressed.\n- `503 Service Unavailable` with `Retry-After` — the gateway already has too much request body data in flight. The body is not read; retry after the given delay.",
-    "version": "0.23.1",
+    "version": "0.23.2",
     "contact": {
       "name": "OpenWA",
       "url": "https://github.com/rmyndharis/OpenWA",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openwa",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openwa",
-      "version": "0.23.1",
+      "version": "0.23.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwa",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "description": "Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API for WhatsApp",
   "author": "Yudhi Armyndharis & OpenWA Contributors",
   "private": true,


### PR DESCRIPTION
Cuts 0.23.2. Everything since 0.23.1 is a fix with no breaking change, and `docs/14-migration-guide.md` states the policy for this line: on `0.x` a breaking change bumps the minor and everything else is a patch.

## What changed

- `package.json`, `package-lock.json` (root and `packages[""]` only), `charts/openwa/Chart.yaml` `appVersion`, and the chart's own `version` 0.1.18 to 0.1.19.
- `openapi.json` `info.version`, regenerated with `npm run openapi:export` rather than edited, so the value flows from `package.json`. The regeneration changes that one line and nothing else.
- The `[Unreleased]` section is dated as `[0.23.2]`. Its contact-card entry moves under **Fixed**, since the change restores text Baileys previously dropped rather than adding surface; the version choice keeps this release patch-only per the migration guide's upgrade matrix.
