### PR TITLE
ci(release): accept the npm-bundled tar CVE in the image scan

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -76,3 +76,17 @@ CVE-2026-76043
 CVE-2026-76044
 CVE-2026-76045
 CVE-2026-76047
+
+# CVE-2026-73566 — node-tar denial of service via a crafted long-path archive entry, fixed
+# upstream in 7.5.21.
+#
+# Same shape as the entries above: the only copy in the image is the one bundled inside the npm CLI
+# (/usr/local/lib/node_modules/npm/node_modules/tar, 7.5.19 in the npm release the Dockerfile
+# installs). The application tree carries no tar at all, and npm is not on the request path — the
+# entrypoint runs `node dist/main`, so reaching this code means an operator running an npm command
+# against an attacker-chosen archive inside the container.
+#
+# Drop this entry once npm ships a bundle with tar >= 7.5.21. As with brace-expansion above, the
+# root `overrides` entry pins `tar` to ^7.5.21 so this ID-level ignore cannot hide an app-tree
+# finding: npm cannot resolve the application tree below the fixed version.
+CVE-2026-73566

--- a/package-lock.json
+++ b/package-lock.json
@@ -3858,6 +3858,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {

--- a/package.json
+++ b/package.json
@@ -448,6 +448,7 @@
     "shell-quote": "^1.10.0",
     "brace-expansion": "^5.0.9",
     "ip-address": "^10.4.0",
+    "tar": "^7.5.21",
     "js-yaml": "^5.2.2",
     "better-sqlite3": "$better-sqlite3",
     "typeorm": {


### PR DESCRIPTION
Cuts the release free: v0.23.2's image scan failed on one new HIGH finding, `CVE-2026-73566` (node-tar denial of service via a crafted long-path archive entry), reported against both architectures.

## What changed

- `.trivyignore` accepts `CVE-2026-73566` with the written justification the file requires. The only copy in the image is the one bundled inside the npm CLI (`/usr/local/lib/node_modules/npm/node_modules/tar`, 7.5.19 in the npm release the Dockerfile installs); the application tree carries no tar at all, and npm is never on the request path. Fixed upstream in 7.5.21; drop the entry once npm ships that bundle.
- `package.json` adds the matching root `overrides` pin (`tar` to `^7.5.21`), the same invariant the brace-expansion and ip-address entries rely on so an ID-level ignore cannot hide an app-tree finding. `package-lock.json` picks up one lockfile-metadata line from re-resolving.

## Verification

- `npm run check:audit` passes on both dependency trees.
- The finding itself was reproduced only in the release image scan (`tar`, installed 7.5.19, fixed 7.5.21); no copy exists in either lockfile.
