### PR TITLE
fix(baileys): stop a cold-start pairing request throwing Boom 428

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Baileys: requesting a pairing code in the first second or two after `POST /sessions/{id}/start` returns the
+  documented 409 instead of a 500 with a `Connection Closed` stack trace. The socket object exists before its
+  WebSocket has finished connecting, so the send threw a raw Boom 428; the request is now gated on the session
+  reaching `qr_ready`, the same guard the whatsapp-web.js engine already carried. Clients that retry on 409 ride
+  through the window instead of surfacing an error.
+
 ## [0.23.2] - 2026-08-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Baileys: requesting a pairing code in the first second or two after `POST /sessions/{id}/start` returns the
-  documented 409 instead of a 500 with a `Connection Closed` stack trace. The socket object exists before its
-  WebSocket has finished connecting, so the send threw a raw Boom 428; the request is now gated on the session
-  reaching `qr_ready`, the same guard the whatsapp-web.js engine already carried. Clients that retry on 409 ride
-  through the window instead of surfacing an error.
+- Baileys: requesting a pairing code before the session reaches `qr_ready` answers the documented 409 instead
+  of a 500 with a `Connection Closed` stack trace, the same guard the whatsapp-web.js engine already carried.
+  Thanks @m7fz7.
 
 ## [0.23.2] - 2026-08-23
 

--- a/docs/examples/session-phone-number-pairing.md
+++ b/docs/examples/session-phone-number-pairing.md
@@ -15,6 +15,9 @@ This flow returns an 8-character pairing code that the user enters in WhatsApp o
 [Start Session]
       │
       ▼
+[Wait for status qr_ready]
+      │
+      ▼
 [Request Pairing Code]
       │
       ▼
@@ -44,9 +47,7 @@ curl -X POST http://localhost:2785/api/sessions/{sessionId}/start \
   -H "X-API-Key: $API_KEY"
 ```
 
-The session must be started before requesting a pairing code, and the engine needs a moment to
-connect after `start` returns. Poll `GET /api/sessions/{sessionId}` until `status` is `qr_ready` —
-that is the point the engine can accept a pairing request. Asking earlier returns 409.
+The session must be started before requesting a pairing code, and the engine needs a moment to connect after `start` returns. Poll `GET /api/sessions/{sessionId}` until `status` is `qr_ready`: that is the point the engine can accept a pairing request. Requesting a code before that returns 409.
 
 ## 3. Request a Pairing Code
 

--- a/docs/examples/session-phone-number-pairing.md
+++ b/docs/examples/session-phone-number-pairing.md
@@ -44,7 +44,9 @@ curl -X POST http://localhost:2785/api/sessions/{sessionId}/start \
   -H "X-API-Key: $API_KEY"
 ```
 
-The session must be started before requesting a pairing code.
+The session must be started before requesting a pairing code, and the engine needs a moment to
+connect after `start` returns. Poll `GET /api/sessions/{sessionId}` until `status` is `qr_ready` —
+that is the point the engine can accept a pairing request. Asking earlier returns 409.
 
 ## 3. Request a Pairing Code
 
@@ -92,5 +94,6 @@ After the code is accepted, the OpenWA session should move to a connected/ready 
 
 - If OpenWA returns `Session is not started`, call `POST /api/sessions/{sessionId}/start` first.
 - If OpenWA returns `Session is already authenticated`, the account is already linked and no pairing code is needed.
+- If OpenWA returns 409 `Session is not waiting to be linked`, the engine is still connecting (or reconnecting after a drop). Wait for `status` to read `qr_ready` and request again.
 - If the phone number is rejected, send digits only in international format, without `+`, spaces, or punctuation.
 - If you want to create a brand-new WhatsApp account programmatically, that is outside OpenWA's scope. OpenWA only links an existing WhatsApp account.

--- a/src/engine/adapters/baileys-lifecycle.ts
+++ b/src/engine/adapters/baileys-lifecycle.ts
@@ -762,9 +762,19 @@ export class BaileysLifecycle {
     return this.qrCode;
   }
 
+  /**
+   * Gated on QR_READY, not on the socket merely existing — the same guard, for the same reason, as
+   * the whatsapp-web.js engine's requestPairingCode. `this.sock` is assigned the moment
+   * makeWASocket returns, seconds before the WebSocket finishes connecting, and Baileys' sendNode
+   * throws a raw Boom 428 ('Connection Closed') whenever `ws.isOpen` is false — which surfaced as a
+   * 500 with a stack trace on every cold-start pairing request. QR_READY is exactly the window this
+   * can work in: it is set from the `connection.update { qr }` event, which WhatsApp only sends
+   * once the noise handshake is done, and every transient close drops the status back to
+   * INITIALIZING for the reconnect, so it also covers a socket that died after a QR was published.
+   */
   async requestPairingCode(phoneNumber: string): Promise<string> {
-    if (!this.sock) {
-      throw new EngineNotReadyError('Cannot request a pairing code before the engine is initialized.');
+    if (!this.sock || this.status !== EngineStatus.QR_READY) {
+      throw new EngineNotReadyError('Session is not waiting to be linked. Start it and wait for the QR stage.');
     }
     return this.sock.requestPairingCode(phoneNumber);
   }

--- a/src/engine/adapters/baileys-lifecycle.ts
+++ b/src/engine/adapters/baileys-lifecycle.ts
@@ -763,14 +763,11 @@ export class BaileysLifecycle {
   }
 
   /**
-   * Gated on QR_READY, not on the socket merely existing — the same guard, for the same reason, as
-   * the whatsapp-web.js engine's requestPairingCode. `this.sock` is assigned the moment
-   * makeWASocket returns, seconds before the WebSocket finishes connecting, and Baileys' sendNode
-   * throws a raw Boom 428 ('Connection Closed') whenever `ws.isOpen` is false — which surfaced as a
-   * 500 with a stack trace on every cold-start pairing request. QR_READY is exactly the window this
-   * can work in: it is set from the `connection.update { qr }` event, which WhatsApp only sends
-   * once the noise handshake is done, and every transient close drops the status back to
-   * INITIALIZING for the reconnect, so it also covers a socket that died after a QR was published.
+   * Gated on QR_READY, not on the socket merely existing: `this.sock` is assigned the moment makeWASocket
+   * returns, before the WebSocket is open, and Baileys' sendNode throws a raw Boom 428 until it is. QR_READY
+   * is set from the post-handshake `connection.update { qr }` event and every close drops it, so it is the
+   * exact window a pairing request can succeed in. Same guard, for the same reason, as the whatsapp-web.js
+   * engine's requestPairingCode.
    */
   async requestPairingCode(phoneNumber: string): Promise<string> {
     if (!this.sock || this.status !== EngineStatus.QR_READY) {

--- a/src/engine/adapters/baileys.adapter.spec.ts
+++ b/src/engine/adapters/baileys.adapter.spec.ts
@@ -569,9 +569,26 @@ describe('BaileysAdapter lifecycle & status', () => {
     await expect(adapter.requestPairingCode('628999')).rejects.toBeInstanceOf(EngineNotReadyError);
   });
 
-  it('requestPairingCode delegates to the socket', async () => {
+  // The socket object exists from the moment makeWASocket returns, but its WebSocket is still
+  // connecting: sending then makes Baileys throw a raw Boom 428 that surfaces as a 500.
+  it('requestPairingCode throws EngineNotReadyError while the socket is still connecting', async () => {
     const adapter = newAdapter();
     await adapter.initialize(noopCallbacks({}));
+    await expect(adapter.requestPairingCode('628999')).rejects.toBeInstanceOf(EngineNotReadyError);
+    expect(fakeSock.requestPairingCode).not.toHaveBeenCalled();
+  });
+
+  it('requestPairingCode delegates to the socket once a QR has been published', async () => {
+    let resolveQr!: () => void;
+    const qrPublished = new Promise<void>(resolve => {
+      resolveQr = resolve;
+    });
+    const onQRCode = jest.fn(() => resolveQr());
+    const adapter = newAdapter();
+    await adapter.initialize(noopCallbacks({ onQRCode }));
+    fakeSock.fire('connection.update', { qr: 'QR-STRING' });
+    await qrPublished;
+
     await expect(adapter.requestPairingCode('628999')).resolves.toBe('ABCD-EFGH');
     expect(fakeSock.requestPairingCode).toHaveBeenCalledWith('628999');
   });


### PR DESCRIPTION
## Description

Requesting a pairing code straight after `POST /sessions/{id}/start` blows up with a 500 and a stack trace in the console:

```
ERROR [ExceptionsHandler] Error: Connection Closed
    at sendRawMessage (baileys/src/Socket/socket.ts:144:10)
    at sendNode (baileys/src/Socket/socket.ts:165:10)
    at Object.requestPairingCode (baileys/src/Socket/socket.ts:778:9)
    at async SessionService.requestPairingCode (src/modules/session/session.service.ts:587:25)
  output: { statusCode: 428, error: 'Precondition Required', message: 'Connection Closed' }
```

The Baileys guard only checked that the socket object exists:

```ts
if (!this.sock) { throw new EngineNotReadyError(...) }
```

But `this.sock` is assigned the moment `makeWASocket` returns, a good while before the WebSocket has actually connected, and Baileys' `sendRawMessage` throws a raw Boom 428 whenever `ws.isOpen` is false. So anything that starts a session and asks for a code right away lands in that window.

The whatsapp-web.js engine already guards this exact case on `QR_READY` (see the comment on `wwebjs-lifecycle.ts` `requestPairingCode` — same failure, different library). The Baileys engine never got the equivalent, so this just mirrors it. `QR_READY` is the right gate: it's set from the `connection.update { qr }` event, which WhatsApp only sends once the noise handshake is done, and every transient close drops the status back to `INITIALIZING`, so a socket that dies after publishing a QR is covered too.

Callers now get the 409 that's already documented on the endpoint (`ENGINE_NOT_READY_409`), which retrying clients ride through instead of surfacing an error. No response shape changes, and no status code that was previously documented for this endpoint changes.

Reproduced and verified against a local gateway:

```
# before
23:09:22.672  POST /start         -> 200
23:09:27.617  POST /pairing-code  -> 500   (Boom 428 in the console)

# after
23:09:27.617  POST /pairing-code  -> 409   "Session is not waiting to be linked."
23:09:28      QR generated
23:09:45.375  POST /pairing-code  -> 201   {"pairingCode":"684TLD1P","status":"qr_ready"}
```

The window was 0.4-1.5s across runs, so a client on a 3s retry only ever waits one cycle.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [x] Lint passes
- [x] Self-reviewed

The old `requestPairingCode delegates to the socket` spec called `initialize()` and expected success, which the guard now correctly rejects, so it's split in two: one asserting the 409 path while the socket is still connecting (and that the socket call is never reached), one firing `connection.update { qr }` first and asserting the delegation still works.

`npm run build`, `npm run lint`, `npm test` (5913 passed), `npm run format` and the dashboard build all pass locally.

Docs: the pairing example now says to poll for `qr_ready` before requesting, with a troubleshooting entry for the 409, plus a CHANGELOG `[Unreleased]` entry.

## Screenshots (if applicable)

n/a

## Related Issues

None open for this one.
