### PR TITLE
docs(session): describe the pairing-code 409 in terms of qr_ready

### DIFF
--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -718,7 +718,7 @@ Request an 8-char pairing code to link via phone number (alternative to QR).
 
 `status` is the lowercase session status.
 
-**Errors:** `400` validation, or session not started, or already authenticated · `401` · `403` · `404` not found · `409` conflict or engine not ready (retryable)
+**Errors:** `400` validation, or session not started, or already authenticated · `401` · `403` · `404` not found · `409` session not waiting to be linked yet; wait for `status` to read `qr_ready` and retry
 
 #### POST /api/sessions/:sessionId/presence/subscribe
 

--- a/openapi.json
+++ b/openapi.json
@@ -821,7 +821,7 @@
             "description": "Session not found"
           },
           "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
+            "description": "The session is not waiting to be linked: the engine is still connecting, or reconnecting after a drop, so the request never reached WhatsApp. Wait for `status` to read `qr_ready` and retry. A session that reads `ready` is already linked and answers `400` instead."
           }
         },
         "summary": "Request an 8-char pairing code to link via phone number (alternative to QR)",

--- a/src/common/openapi/engine-status-responses.ts
+++ b/src/common/openapi/engine-status-responses.ts
@@ -23,6 +23,16 @@ export const ENGINE_NOT_READY_409 =
   'into it — for those few seconds the answer is a `409` naming the reload; retry shortly.';
 
 /**
+ * `EngineNotReadyError` (409) on `POST /sessions/:sessionId/pairing-code`, where the generic wording
+ * above points the caller at the wrong state: both engines accept a pairing request only while the
+ * session is `qr_ready`, and a session that reads `ready` is already linked and answers `400`.
+ */
+export const PAIRING_NOT_READY_409 =
+  'The session is not waiting to be linked: the engine is still connecting, or reconnecting after a ' +
+  'drop, so the request never reached WhatsApp. Wait for `status` to read `qr_ready` and retry. A ' +
+  'session that reads `ready` is already linked and answers `400` instead.';
+
+/**
  * The catalog and status services pass a `NotFoundException` factory to `EngineRegistry.require()`
  * instead of taking its `BadRequestException` default, so on those routes an unstarted session is a
  * 404 rather than the 400 every other engine module answers. Documented rather than changed: the

--- a/src/modules/session/session.controller.ts
+++ b/src/modules/session/session.controller.ts
@@ -43,7 +43,7 @@ import { AuditService } from '../audit/audit.service';
 import { AuditAction } from '../audit/entities/audit-log.entity';
 import { RequireRole, CurrentApiKey, SessionScoped, RequireUnscopedKey } from '../auth/decorators/auth.decorators';
 import { ApiKey, ApiKeyRole } from '../auth/entities/api-key.entity';
-import { ENGINE_NOT_READY_409 } from '../../common/openapi/engine-status-responses';
+import { ENGINE_NOT_READY_409, PAIRING_NOT_READY_409 } from '../../common/openapi/engine-status-responses';
 
 @ApiTags('sessions')
 @Controller('sessions')
@@ -376,7 +376,7 @@ export class SessionController {
   @ApiResponse({ status: 201, description: 'Pairing code generated', type: PairingCodeResponseDto })
   @ApiResponse({ status: 400, description: 'Session not started or already authenticated' })
   @ApiResponse({ status: 404, description: 'Session not found' })
-  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
+  @ApiResponse({ status: 409, description: PAIRING_NOT_READY_409 })
   async requestPairingCode(
     @Param('sessionId', ParseUUIDPipe) id: string,
     @Body() dto: RequestPairingCodeDto,


### PR DESCRIPTION
`POST /sessions/{sessionId}/pairing-code` declared its 409 with the engine-wide `ENGINE_NOT_READY_409` text, which tells the caller to wait for `ready` and retry. On this route `ready` means the session is already linked and the answer is 400 (`Session is already authenticated`). The state to wait for is `qr_ready`, which is what both engines gate the request on and what `docs/examples/session-phone-number-pairing.md` says since #1442.

- `src/common/openapi/engine-status-responses.ts`: add `PAIRING_NOT_READY_409`, worded for this route.
- `src/modules/session/session.controller.ts`: use it on the pairing-code route.
- `docs/06-api-specification.md`: restate the 409 on the route's Errors line.
- `openapi.json`: regenerated with `npm run openapi:export`; the only change is that description.

No status code changes; the docs-06 contract, OpenAPI contract and session controller specs pass.
