### PR TITLE
docs(main): describe what runs before listen() binds the port

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -240,11 +240,13 @@ async function bootstrap() {
 }
 
 // A failed bootstrap MUST terminate the process with a non-zero code, not just set `process.exitCode`:
-// listen() runs the FULL init (sessions, Redis, pg, Chromium) before binding the port, so a bind failure
-// (EADDRINUSE) would otherwise leave a zombie process — no HTTP port, yet still holding the event loop
-// open and running WhatsApp sessions, invisible to Docker's restart policy. runBootstrapOrExit logs the
-// failure, runs a bounded best-effort app.close() teardown, then exits(1); a successful boot returns
-// without touching exit. Puppeteer's own `exit` handlers kill any browser children still up.
+// listen() runs the full module init (database, Redis, plugin registration) before binding the port, and
+// the detached session auto-start (SessionService.onApplicationBootstrap) is already launching engines by
+// then, so a bind failure (EADDRINUSE) would otherwise leave a zombie process: no HTTP port, yet still
+// holding the event loop open and running WhatsApp sessions, invisible to Docker's restart policy.
+// runBootstrapOrExit logs the failure, runs a bounded best-effort app.close() teardown, then exits(1); a
+// successful boot returns without touching exit. Puppeteer's own `exit` handlers kill any browser
+// children still up.
 void runBootstrapOrExit(bootstrap, {
   logger: createLogger('Bootstrap'),
   closeApp: () => (appInstance ? appInstance.close() : Promise.resolve()),


### PR DESCRIPTION
Comment-only change to `src/main.ts`.

The note above `runBootstrapOrExit` still said that `listen()` runs the full init, sessions and Chromium included, before binding the port. Session auto-start has been detached from the bootstrap hook since v0.16.0 (fdd762e6), so the sentence now names what actually precedes the bind (database, Redis, plugin registration) and why a bind failure can still leave engines running: the detached auto-start is already launching them by then.
