### PR TITLE
docs(session): drop the 409 that GET /qr never answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `POST /sessions/{sessionId}/pairing-code`: the 409 description in the OpenAPI contract and API reference
+  now says to wait for `qr_ready`, not `ready`, which on this route means the session is already linked.
+- `GET /sessions/{sessionId}/qr` no longer declares a 409: the route reads the engine's cached QR and never
+  answers one. Its 400 already covers the not-ready case.
+
 ### Fixed
 
 - Baileys: requesting a pairing code before the session reaches `qr_ready` answers the documented 409 instead

--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -356,7 +356,7 @@ Get the QR code (PNG data URL) for session authentication.
 
 `status` is the session's current lowercase status.
 
-**Errors:** `400` session not started / QR not ready yet / already authenticated · `401` · `403` · `404` not found · `409` conflict or engine not ready (retryable)
+**Errors:** `400` session not started / QR not ready yet / already authenticated · `401` · `403` · `404` not found
 
 #### GET /api/sessions/:sessionId/groups
 

--- a/openapi.json
+++ b/openapi.json
@@ -768,9 +768,6 @@
           },
           "404": {
             "description": "Session not found"
-          },
-          "409": {
-            "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           }
         },
         "summary": "Get QR code for session authentication",

--- a/src/engine/interfaces/whatsapp-engine.interface.ts
+++ b/src/engine/interfaces/whatsapp-engine.interface.ts
@@ -865,7 +865,10 @@ export interface SessionLifecycleCapability {
 
   getQRCode(): string | null;
 
-  /** Request an 8-char pairing code to link via phone number instead of scanning the QR. */
+  /**
+   * Request an 8-char pairing code to link via phone number instead of scanning the QR. Only valid while
+   * the engine is QR_READY; both adapters throw EngineNotReadyError (409) in any other status.
+   */
   requestPairingCode(phoneNumber: string): Promise<string>;
 
   getPhoneNumber(): string | null;

--- a/src/modules/session/session.controller.ts
+++ b/src/modules/session/session.controller.ts
@@ -360,7 +360,6 @@ export class SessionController {
     description: 'QR code not ready or session already authenticated',
   })
   @ApiResponse({ status: 404, description: 'Session not found' })
-  @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   async getQRCode(@Param('sessionId', ParseUUIDPipe) id: string): Promise<QRCodeResponseDto> {
     const qrCode = await this.sessionService.getQRCode(id);
     await this.auditService.logInfo(AuditAction.SESSION_QR_GENERATED, {


### PR DESCRIPTION
`GET /sessions/{sessionId}/qr` declared a 409 it never answers: the service reads the engine's cached QR through a plain getter and reports the not-ready case as 400, so nothing on that path throws `EngineNotReadyError`.

- `src/modules/session/session.controller.ts`: drop the 409 response from the QR route; `openapi.json` regenerated with `npm run openapi:export`.
- `docs/06-api-specification.md`: drop the 409 from that route's Errors line.
- `src/engine/interfaces/whatsapp-engine.interface.ts`: document that `requestPairingCode` is only valid while the engine is `QR_READY`, which both adapters enforce.
- `CHANGELOG.md`: entries for this and for the pairing-code 409 wording from #1444.

Contract specs (docs-06, OpenAPI, changelog sections, session controller) and every `check:sdk-*` / `check:contract-shapes` gate pass.
