### PR TITLE
docs(runbooks): authenticate the post-upgrade version check

### DIFF
--- a/docs/11-operational-runbooks.md
+++ b/docs/11-operational-runbooks.md
@@ -439,6 +439,9 @@ docker compose down
 # no `image:` tag to edit and `docker compose pull` never updates the app, so upgrade the source:
 git pull
 # or pin to a release: git checkout v<new-version>
+# Started with docker-compose.dev.yml (the README Quick Start)? Add `-f docker-compose.dev.yml`
+# to every docker compose command in this runbook, the Rollback block included, and write `openwa`
+# wherever a command names the `openwa-api` service (steps 6 and 7, rollback step 2).
 
 # 6. Build the new image
 docker compose build openwa-api
@@ -455,8 +458,8 @@ docker compose up -d
 sleep 30
 curl http://localhost:2785/api/health
 
-# 10. Verify version
-curl http://localhost:2785/api/health | jq '.version'
+# 10. Verify version (`version` is only included for an authenticated request)
+curl -H "X-API-Key: $API_KEY" http://localhost:2785/api/health | jq '.version'
 
 # 11. Verify all sessions
 curl -H "X-API-Key: $API_KEY" \
@@ -476,8 +479,8 @@ curl -X POST http://localhost:2785/api/sessions/{sessionId}/messages/send-text \
 **Verification:**
 
 ```bash
-# Correct version
-curl http://localhost:2785/api/health | jq '.version'
+# Correct version (`version` is only included for an authenticated request)
+curl -H "X-API-Key: $API_KEY" http://localhost:2785/api/health | jq '.version'
 # Expected: "<new-version>"
 
 # All sessions reconnected

--- a/docs/14-migration-guide.md
+++ b/docs/14-migration-guide.md
@@ -690,6 +690,8 @@ docker compose down
 # 3. Move to the new version
 #    The repo's compose file BUILDS the API image from source:
 git pull && docker compose up -d --build
+#    Started with docker-compose.dev.yml (the README Quick Start)? Add `-f docker-compose.dev.yml`
+#    to every docker compose command here.
 #    Deployments pinned to a published image instead (ghcr.io/rmyndharis/openwa:<version>)
 #    bump the tag in their compose file, then: docker compose pull && docker compose up -d
 
@@ -702,8 +704,8 @@ for i in {1..30}; do
   sleep 2
 done
 
-# 5. Confirm the running version
-curl -s http://localhost:2785/api/health | jq '.version'
+# 5. Confirm the running version (`version` is only included for an authenticated request)
+curl -s -H "X-API-Key: $API_KEY" http://localhost:2785/api/health | jq '.version'
 
 # 6. Verify sessions came back
 curl -s -H "X-API-Key: $API_KEY" \


### PR DESCRIPTION
Two gaps in the upgrade runbooks that a Docker operator hits.

- The version check after an upgrade (`docs/11` steps 10 and the verification block, `docs/14` step 5) called `GET /api/health` without an API key. Since 0.19.0 the `version` field is only included for an authenticated request, so the documented command printed `null`. The three snippets now pass `X-API-Key`.
- Every upgrade snippet targets the production compose file, while the README Quick Start installs with `docker-compose.dev.yml` (service `openwa`, bind-mounted `./data`). Both runbooks now say to add `-f docker-compose.dev.yml` in that case.

Docs only.
