### PR TITLE
fix(engine): drop QR and pairing state that outlived the socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A WhatsApp-initiated unlink now clears the session's `phone` the way an operator logout does, so a restart
   no longer relaunches the unlinked session into a QR nobody asked for; the next successful link sets it
   again.
+- Baileys: a pairing request on a socket that has already begun closing answers the documented 409 instead of
+  a 500, and no longer writes a half-registered identity into the session's stored credentials.
+- Both engines drop the cached QR as soon as its socket or page dies, so `GET /sessions/{sessionId}/qr`
+  answers its documented 400 instead of 200 with a code that can no longer be scanned.
+
+### Documentation
+
+- The upgrade runbook and the migration guide state the `docker-compose.dev.yml` caveat before the first
+  `docker compose` command instead of after it, and name the `openwa` service substitution it needs.
 
 ## [0.23.2] - 2026-08-23
 

--- a/docs/11-operational-runbooks.md
+++ b/docs/11-operational-runbooks.md
@@ -431,6 +431,10 @@ export BACKUP_DIR="/backups/openwa"
 curl -H "X-API-Key: $API_KEY" \
   http://localhost:2785/api/infra/export-data > "$BACKUP_DIR/export-data.json"
 
+# Started with docker-compose.dev.yml (the README Quick Start)? Add `-f docker-compose.dev.yml`
+# to every docker compose command in this runbook, the Rollback block included, and write `openwa`
+# wherever a command names the `openwa-api` service (steps 6 and 7, rollback step 2).
+
 # 4. Stop services
 docker compose down
 
@@ -439,9 +443,6 @@ docker compose down
 # no `image:` tag to edit and `docker compose pull` never updates the app, so upgrade the source:
 git pull
 # or pin to a release: git checkout v<new-version>
-# Started with docker-compose.dev.yml (the README Quick Start)? Add `-f docker-compose.dev.yml`
-# to every docker compose command in this runbook, the Rollback block included, and write `openwa`
-# wherever a command names the `openwa-api` service (steps 6 and 7, rollback step 2).
 
 # 6. Build the new image
 docker compose build openwa-api

--- a/docs/14-migration-guide.md
+++ b/docs/14-migration-guide.md
@@ -681,6 +681,11 @@ chain by hand with `npm run migration:run:main`.
 # upgrade.sh — same shape for a patch or a minor
 set -e
 
+# Started with docker-compose.dev.yml (the README Quick Start)? Add `-f docker-compose.dev.yml` to
+# every docker compose command in this script and in the migration block right after it, and write
+# `openwa` wherever a command names the `openwa-api` service. Do NOT carry the flag up to the
+# `--profile postgres` commands in 14.3: postgres exists only in the production compose file.
+
 # 1. Backup: both databases + session auth + media + plugin state
 ./scripts/backup.sh
 
@@ -690,8 +695,6 @@ docker compose down
 # 3. Move to the new version
 #    The repo's compose file BUILDS the API image from source:
 git pull && docker compose up -d --build
-#    Started with docker-compose.dev.yml (the README Quick Start)? Add `-f docker-compose.dev.yml`
-#    to every docker compose command here.
 #    Deployments pinned to a published image instead (ghcr.io/rmyndharis/openwa:<version>)
 #    bump the tag in their compose file, then: docker compose pull && docker compose up -d
 

--- a/src/core/plugins/plugin-host-port-providers.spec.ts
+++ b/src/core/plugins/plugin-host-port-providers.spec.ts
@@ -20,6 +20,11 @@ import { SessionModule } from '../../modules/session/session.module';
  * hooks twice, launching two concurrent auto-start loops on every boot. The same applies to any other
  * factory that returns an injected instance (search.module.ts `SEARCH_BOOTSTRAP` returns the registry):
  * harmless while the target has no lifecycle hook, doubled the moment one is added.
+ *
+ * `useExisting` is typed `any`, so unlike the factory it replaced it does NOT check that the service
+ * still satisfies the port. That check lives on the classes instead: each one carries
+ * `implements Plugin*Port`, so a signature drift fails `tsc --noEmit` rather than surfacing as a
+ * runtime TypeError inside a plugin capability call.
  */
 describe('plugin host port providers', () => {
   const MODULES = [PluginsModule, IntegrationModule, MessageModule, SearchModule, SessionModule];

--- a/src/engine/adapters/baileys-lifecycle.ts
+++ b/src/engine/adapters/baileys-lifecycle.ts
@@ -770,8 +770,12 @@ export class BaileysLifecycle {
   /**
    * Cheap local liveness check for the session watchdog. Genuine dead-connection detection is owned
    * by Baileys' built-in keepalive, which surfaces a close event (408) within ~35 s of a silent
-   * drop — and the close handler above drops the status to INITIALIZING for the whole reconnect
-   * backoff, so READY + a live socket is sufficient here.
+   * drop — and the close handler above then drops the status to INITIALIZING for the whole reconnect
+   * backoff, so READY + a live socket is sufficient here. Note the status trails the dead transport:
+   * Baileys emits that close only after `await ws.close()` resolves, which on a black-holed socket
+   * waits out ws's 30 s close timeout, so this reports live for that window too. Acceptable for the
+   * watchdog, whose next interval catches it; NOT sufficient for a request guard, which is why
+   * requestPairingCode below also tests `ws.isOpen`.
    */
   // eslint-disable-next-line @typescript-eslint/require-await
   async probeLiveness(): Promise<boolean> {
@@ -783,14 +787,22 @@ export class BaileysLifecycle {
   }
 
   /**
-   * Gated on QR_READY, not on the socket merely existing: `this.sock` is assigned the moment makeWASocket
-   * returns, before the WebSocket is open, and Baileys' sendNode throws a raw Boom 428 until it is. QR_READY
-   * is set from the post-handshake `connection.update { qr }` event and every close drops it, so it is the
-   * exact window a pairing request can succeed in. Same guard, for the same reason, as the whatsapp-web.js
-   * engine's requestPairingCode.
+   * Gated on QR_READY AND a live WebSocket, not on the socket merely existing: `this.sock` is assigned the
+   * moment makeWASocket returns, before the WebSocket is open, and Baileys' sendNode throws a raw Boom 428
+   * until it is. QR_READY is set from the post-handshake `connection.update { qr }` event, so it opens the
+   * window; it does not close it promptly, which is why the status alone is not enough. Baileys emits its
+   * `connection.update { connection: 'close' }` only after `await ws.close()` resolves, and `ws` leaves a
+   * black-holed socket in CLOSING for its 30 s close timeout, so the status keeps reading QR_READY for up to
+   * half a minute after the connection stopped carrying anything. `ws.isOpen` is the same predicate Baileys'
+   * own sendRawMessage tests and the same liveness check handleQrCode makes before publishing. It matters
+   * beyond the status code here: requestPairingCode writes `creds.me` and emits `creds.update`, which we
+   * persist, BEFORE it sends, so a request in that window leaves the next connect trying to log in as a
+   * device that was never registered. The whatsapp-web.js engine needs no equivalent operand: its page and
+   * browser death listeners fire handlePuppeteerDeath, which drops the status in the same tick, so there
+   * the status is not the stale value it is here.
    */
   async requestPairingCode(phoneNumber: string): Promise<string> {
-    if (!this.sock || this.status !== EngineStatus.QR_READY) {
+    if (!this.sock?.ws.isOpen || this.status !== EngineStatus.QR_READY) {
       throw new EngineNotReadyError('Session is not waiting to be linked. Start it and wait for the QR stage.');
     }
     return this.sock.requestPairingCode(phoneNumber);
@@ -813,6 +825,15 @@ export class BaileysLifecycle {
   private setStatus(status: EngineStatus): void {
     if (this.status === status) {
       return;
+    }
+    // The cached QR belongs to the socket that produced it, so it dies with the QR_READY window.
+    // Enforced in the funnel rather than at each exit: every close sub-branch (intentional, 401, 440,
+    // 403, transient), the accepted link and every teardown route through here, and the exits that
+    // did not clear it by hand kept serving a dead QR over GET /qr for the whole reconnect backoff.
+    // Safe after the no-op guard above: a non-null qrCode implies QR_READY, so an unchanged status
+    // that is not QR_READY already has a null cache.
+    if (status !== EngineStatus.QR_READY) {
+      this.qrCode = null;
     }
     this.status = status;
     this.host.getOnStateChanged()?.(status);

--- a/src/engine/adapters/baileys.adapter.spec.ts
+++ b/src/engine/adapters/baileys.adapter.spec.ts
@@ -624,6 +624,42 @@ describe('BaileysAdapter lifecycle & status', () => {
     return adapter;
   }
 
+  // Baileys emits its close update only after `await ws.close()` resolves, and ws parks a black-holed
+  // socket in CLOSING for its 30 s close timeout, so QR_READY outlives the usable connection. Sending in
+  // that window makes Baileys throw a raw Boom 428, which with no global exception filter surfaces as a
+  // 500 instead of the documented 409, after it has already written creds.me and emitted creds.update.
+  it('requestPairingCode rejects on a closing socket while the status still reads QR_READY', async () => {
+    const adapter = await initializeAtQrReady();
+    fakeSock.ws.isOpen = false; // ws.close() has run; the close event has not landed yet
+
+    // The status is genuinely still QR_READY, so the rejection can only come from the liveness check.
+    expect(adapter.getStatus()).toBe(EngineStatus.QR_READY);
+    await expect(adapter.requestPairingCode('628999')).rejects.toBeInstanceOf(EngineNotReadyError);
+    // Proves the library is never entered, so creds.me / creds.update / saveCreds never fire.
+    expect(fakeSock.requestPairingCode).not.toHaveBeenCalled();
+  });
+
+  // The cached QR belongs to the socket that produced it: once the socket closes nothing can accept that
+  // scan, so GET /qr must answer its documented 400 rather than 200 with a code that can never link.
+  it.each([
+    ['a transient close', 515, EngineStatus.INITIALIZING],
+    ['a terminal close', 403, EngineStatus.FAILED],
+  ])('drops the cached QR on %s', async (_label, statusCode, expected) => {
+    const adapter = await initializeAtQrReady();
+    expect(adapter.getQRCode()).not.toBeNull();
+    jest.useFakeTimers({ doNotFake: ['setImmediate'] });
+    try {
+      fakeSock.fire('connection.update', {
+        connection: 'close',
+        lastDisconnect: { error: { output: { statusCode } } },
+      });
+      expect(adapter.getStatus()).toBe(expected);
+      expect(adapter.getQRCode()).toBeNull();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('a drop after the QR was published moves the status off QR_READY, so requestPairingCode rejects again', async () => {
     const adapter = await initializeAtQrReady();
     jest.useFakeTimers({ doNotFake: ['setImmediate'] });

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -2118,6 +2118,31 @@ describe('WhatsAppWebJsAdapter ready reconciliation (#251/#273)', () => {
     expect(onQRCode).toHaveBeenCalledTimes(1);
   });
 
+  // The cached QR belongs to the page that produced it. A Chromium crash or tab close while the operator
+  // is looking at the QR is the reachable vector: handlePuppeteerDeath fires at QR_READY, the session
+  // keeps the engine registered across its reconnect backoff, and GET /qr kept answering 200 with a code
+  // whose page is gone instead of the documented 400.
+  it('drops the cached QR when the page dies at QR_READY', async () => {
+    (qrcode.toDataURL as unknown as jest.Mock).mockClear();
+    const adapter = newAdapter();
+    const pupPage = Object.assign(new EventEmitter(), { evaluate: jest.fn().mockResolvedValue(true) });
+    const { client } = attachFakeClient(adapter, { pupPage: pupPage as unknown as FakeClient['pupPage'] });
+    // The death listeners are armed by runInitAttempt, not by setupEventHandlers.
+    (adapter as unknown as { attachPuppeteerLifecycleListeners: () => void }).attachPuppeteerLifecycleListeners();
+    const qrDone = deferredVoid();
+    (adapter as unknown as { callbacks: { onQRCode: jest.Mock } }).callbacks.onQRCode = jest.fn(() => qrDone.resolve());
+
+    client.emit('qr', '2@abc');
+    await qrDone.promise;
+    expect(adapter.getStatus()).toBe(EngineStatus.QR_READY);
+    expect(adapter.getQRCode()).not.toBeNull();
+
+    pupPage.emit('close');
+
+    expect(adapter.getStatus()).toBe(EngineStatus.DISCONNECTED);
+    expect(adapter.getQRCode()).toBeNull();
+  });
+
   // #982: whatsapp-web.js does NOT destroy the client on LOGOUT — it deletes the auth profile and
   // re-runs inject() on the SAME browser, which re-arms the QR handler. The session lifecycle only
   // tears the engine down after the reconnect backoff (~5s by default, operator-raisable to 300s), so

--- a/src/engine/adapters/wwebjs-lifecycle.ts
+++ b/src/engine/adapters/wwebjs-lifecycle.ts
@@ -722,6 +722,13 @@ export class WwebjsLifecycle {
     if (status === EngineStatus.DISCONNECTED) {
       this.disconnectReported = true;
     }
+    // The cached QR belongs to the page that produced it, so it dies with the QR_READY window. Same
+    // funnel placement as the Baileys engine: only the 'authenticated' and init-retry exits cleared the
+    // cache by hand, so a browser or page death, a failed init, an auth failure and teardown all left a
+    // dead QR to be served over GET /qr for the whole reconnect backoff.
+    if (status !== EngineStatus.QR_READY) {
+      this.qrCode = null;
+    }
     this.status = status;
     this.host.getCallbacks().onStateChanged?.(status);
     this.host.emitState(status);

--- a/src/modules/integration/conversation-mapping.service.ts
+++ b/src/modules/integration/conversation-mapping.service.ts
@@ -3,6 +3,9 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { QueryDeepPartialEntity, Repository } from 'typeorm';
 import { ConversationMapping, HandoverState } from './entities/conversation-mapping.entity';
 import { isUniqueViolation } from '../../common/utils/db-errors';
+// Type-only: PluginsModule binds this class to PLUGIN_CONVERSATION_MAPPING_PORT with a `useExisting`
+// alias, which TypeScript does not check, so `implements` is what keeps the two in step.
+import type { PluginConversationMappingPort } from '../../core/plugins/plugin-host-ports';
 
 export interface MappingKey {
   sessionId: string;
@@ -30,7 +33,7 @@ export class ConversationMappingConflict extends Error {
 }
 
 @Injectable()
-export class ConversationMappingService {
+export class ConversationMappingService implements PluginConversationMappingPort {
   constructor(@InjectRepository(ConversationMapping, 'data') private readonly repo: Repository<ConversationMapping>) {}
 
   async upsert(key: MappingKey, providerConversationId: string, patch?: Partial<ConversationMapping>): Promise<void> {

--- a/src/modules/integration/plugin-instance.service.ts
+++ b/src/modules/integration/plugin-instance.service.ts
@@ -5,6 +5,9 @@ import { Repository } from 'typeorm';
 import { PluginInstance } from './entities/plugin-instance.entity';
 import type { PluginConfigSchema } from '../../core/plugins/plugin.interfaces';
 import { redactSecretConfig, restoreSecretConfig, SECRET_SENTINEL } from '../plugins/redact-config';
+// Type-only: the module binds this class to PLUGIN_INSTANCE_PORT with a `useExisting` alias, which
+// TypeScript does not check, so `implements` is what keeps the two in step.
+import type { PluginInstancePort } from '../../core/plugins/plugin-host-ports';
 
 // A supplied ingress secret must be a real, guessing-resistant value; an empty/short one would make the
 // public HMAC forgeable. Absent => auto-generate. Trimmed so pasted whitespace can't slip a weak secret in.
@@ -25,7 +28,7 @@ export class InstanceExistsError extends Error {
 }
 
 @Injectable()
-export class PluginInstanceService {
+export class PluginInstanceService implements PluginInstancePort {
   constructor(@InjectRepository(PluginInstance, 'data') private readonly repo: Repository<PluginInstance>) {}
 
   async mint(

--- a/src/modules/message/message.service.ts
+++ b/src/modules/message/message.service.ts
@@ -15,6 +15,9 @@ import { LidMappingStoreService } from '../../engine/identity/lid-mapping-store.
 import { ChatMediaArchiveService } from '../chat-media/chat-media-archive.service';
 import { StorageService, isMissingObjectError } from '../../common/storage/storage.service';
 import { MessageSendService, SaveOutgoingMessageData } from './message-send.service';
+// Type-only: the module binds this class to PLUGIN_MESSAGE_PORT with a `useExisting` alias, which
+// TypeScript does not check, so `implements` is what keeps the two in step.
+import type { PluginMessagePort } from '../../core/plugins/plugin-host-ports';
 
 // Re-exported for existing importers (bulk send shares the rendered-template cap with the send path).
 export { DEFAULT_TEMPLATE_RENDER_MAX_CHARS } from './message-send.service';
@@ -110,7 +113,7 @@ function inertMimetype(mimetype: string): string {
 }
 
 @Injectable()
-export class MessageService {
+export class MessageService implements PluginMessagePort {
   private readonly logger = createLogger('MessageService');
 
   constructor(

--- a/src/modules/search/search-provider.registry.ts
+++ b/src/modules/search/search-provider.registry.ts
@@ -1,5 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import type { SearchProvider } from './search.types';
+// Type-only: the module binds this class to PLUGIN_SEARCH_REGISTRY_PORT with a `useExisting` alias,
+// which TypeScript does not check, so `implements` is what keeps the two in step.
+import type { PluginSearchRegistryPort } from '../../core/plugins/plugin-host-ports';
 
 /**
  * Holds the set of registered SearchProviders and the currently active one.
@@ -7,7 +10,7 @@ import type { SearchProvider } from './search.types';
  * active() returns null when nothing is registered → the route 501s.
  */
 @Injectable()
-export class SearchProviderRegistry {
+export class SearchProviderRegistry implements PluginSearchRegistryPort {
   private readonly providers = new Map<string, SearchProvider>();
   private activeId: string | null = null;
 

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -30,6 +30,9 @@ import { resolveFeatureFlags } from '../../config/feature-flags';
 import { IWhatsAppEngine, ChatSummary, ChatState } from '../../engine/interfaces/whatsapp-engine.interface';
 import { createLogger } from '../../common/services/logger.service';
 import { HookManager } from '../../core/hooks';
+// Type-only: the module binds this class to PLUGIN_SESSION_PORT with a `useExisting` alias, which
+// TypeScript does not check, so `implements` is what keeps the two in step.
+import type { PluginSessionPort } from '../../core/plugins/plugin-host-ports';
 
 /** Stagger before the single transient-launch retry; short - the claim is held while it waits. */
 const SESSION_START_RETRY_DELAY_MS = 2_000;
@@ -78,7 +81,7 @@ export const AUTOSTART_THROTTLE_MS = 2_000;
  * its public surface toward the controller and the feature modules is unchanged by the split.
  */
 @Injectable()
-export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicationBootstrap {
+export class SessionService implements OnModuleDestroy, OnModuleInit, OnApplicationBootstrap, PluginSessionPort {
   private readonly logger = createLogger('SessionService');
 
   // Live engine instances, owned by the shared EngineRegistry (the narrow port feature modules


### PR DESCRIPTION
Three defects around the QR and pairing window, plus the compile-time check the plugin ports lost when they moved to `useExisting`.

**Engine**

- Both adapters cached the QR their socket or page produced and cleared it only when the link was accepted. Baileys closes with a 408 once it runs out of QR refs (roughly every 160 s while nobody scans) and the whatsapp-web.js engine reaches the same state after a browser or page death; the engine stays registered across the reconnect backoff, so `GET /sessions/{sessionId}/qr` answered 200 with a code nothing could accept instead of its documented 400. The cache is now cleared in the status funnel each adapter already routes every exit through, so no exit can leak it again.
- Baileys accepted a pairing request whenever the status read `qr_ready`. The status trails the transport: Baileys emits its close update only after `await ws.close()` resolves, and `ws` parks a black-holed socket in CLOSING until its 30 s close timeout. A request in that window threw a raw Boom 428, which without a global exception filter surfaces as a 500 rather than the documented 409, and it did so only after writing `creds.me` and emitting `creds.update`, which we persist, leaving the next connect trying to log in as a device that was never registered. The guard now also tests `ws.isOpen`, the predicate the QR publish path and Baileys' own send already use.

**Plugins**

- Binding each `PLUGIN_*_PORT` with `useExisting` dropped the only place TypeScript verified that the service still satisfies its port: the replaced factory carried a `: PluginXPort` return annotation, while `ExistingProvider.useExisting` is typed `any` and consumers resolve the token through an unchecked `ModuleRef.get<..., Port>` cast. The five classes now declare the conformance. Imports are type-only, so nothing is emitted and the provider-cycle deferral the ports exist for is untouched.

**Docs**

- The `docker-compose.dev.yml` caveat in the upgrade runbook and the migration guide sat after the compose commands it governs, inside a `set -e` script. Both files derive the same project name from the directory and share `container_name: openwa-api`, so running those commands against the production file leaves the dev container up and then fails the recreate on a name conflict. The note now precedes the first compose command in both, and the migration guide gained the service-name half its runbook twin already had (the dev file calls the app service `openwa`, so `docker compose run --rm openwa-api` aborts with "no such service"). The flag is scoped to the upgrade steps rather than the whole guide, since 14.3 drives the built-in `postgres` profile, which exists only in the production file.

**Risk**

No API or schema change. The pairing guard only rejects requests that already failed, one stack frame earlier and with the documented status code instead of a 500. Clearing the QR cache moves `GET /qr` from a 200 carrying an unusable code to the 400 that route already documents.

**Verification**

Four regression tests added, each confirmed to fail without its fix. Full unit suite 344 suites / 5933 tests, e2e 22 suites / 181 tests, plus `tsc --noEmit`, ESLint, `format:check`, `openapi:check` and every `check:*` gate. The restored port check was verified by adding a member to a port and confirming `tsc` fails where it previously passed.
