### PR TITLE
docs(session): name the closing-socket window in the pairing 409

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The upgrade runbook and the migration guide state the `docker-compose.dev.yml` caveat before the first
   `docker compose` command instead of after it, and name the `openwa` service substitution it needs.
+- `GET /api/health` is documented consistently as withholding `version` from unauthenticated callers.
+
+### Dependencies
+
+- `@bull-board/{api,express,nestjs}` 8.6.1 to 9.3.2 (major), plus a minor/patch group (NestJS 11.2.1,
+  BullMQ 6.2.0, AWS SDK) and a dashboard group (Vite 8.2.2, i18next 26.4.0, lucide-react 1.33).
+
+### Upgrade notes (behavior changes)
+
+- The queue dashboard's obliterate action gained a **force** option in Bull Board 9. Forcing it deletes
+  active jobs as well as queued ones, so those deliveries never reach a final attempt and no
+  `webhook_delivery_failures` row is written for them. Bull Board 8 refused outright while jobs were
+  active. The route stays ADMIN-only behind `BullBoardAuthMiddleware`.
 
 ## [0.23.2] - 2026-08-23
 

--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -719,7 +719,7 @@ Request an 8-char pairing code to link via phone number (alternative to QR).
 
 `status` is the lowercase session status.
 
-**Errors:** `400` validation, or session not started, or already authenticated · `401` · `403` · `404` not found · `409` session not waiting to be linked yet; wait for `status` to read `qr_ready` and retry (after a code was accepted, wait for `ready` instead)
+**Errors:** `400` validation, or session not started, or already authenticated · `401` · `403` · `404` not found · `409` session not waiting to be linked yet; wait for `status` to read `qr_ready` and retry (after a code was accepted, wait for `ready` instead). On Baileys a session that already reads `qr_ready` can still answer `409` while its socket is closing, for up to the WebSocket close timeout (30 s); that is retryable and the status follows shortly.
 
 #### POST /api/sessions/:sessionId/presence/subscribe
 

--- a/docs/07-api-collection.md
+++ b/docs/07-api-collection.md
@@ -1268,10 +1268,13 @@ curl -X POST "$BASE/api/auth/validate" \
 
 #### GET /api/health
 
-Basic health check (status, timestamp, version). Public.
+Basic health check (status, timestamp). Public. The running `version` is added only when the request carries a valid API key, so an unauthenticated probe gets `status` and `timestamp` alone.
 
 ```bash
 curl "$BASE/api/health"
+
+# With the version field:
+curl -H "X-API-Key: $API_KEY" "$BASE/api/health"
 ```
 
 #### GET /api/health/live

--- a/docs/13-horizontal-scaling.md
+++ b/docs/13-horizontal-scaling.md
@@ -653,7 +653,7 @@ groups:
 
 | Endpoint            | Purpose                                                                                                      |
 | ------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `/api/health`       | Basic health check — returns `status`, `timestamp`, `version`                                                |
+| `/api/health`       | Basic health check — returns `status` and `timestamp`; `version` only for an authenticated caller            |
 | `/api/health/live`  | Liveness probe (static `ok`; reflects process liveness only)                                                 |
 | `/api/health/ready` | Readiness probe — verifies the main + data databases respond (returns 503 while draining or if a DB is down) |
 

--- a/docs/14-migration-guide.md
+++ b/docs/14-migration-guide.md
@@ -682,9 +682,10 @@ chain by hand with `npm run migration:run:main`.
 set -e
 
 # Started with docker-compose.dev.yml (the README Quick Start)? Add `-f docker-compose.dev.yml` to
-# every docker compose command in this script and in the migration block right after it, and write
-# `openwa` wherever a command names the `openwa-api` service. Do NOT carry the flag up to the
-# `--profile postgres` commands in 14.3: postgres exists only in the production compose file.
+# every docker compose command in this script, in the migration block right after it, and in 14.6
+# Rollback Procedures, and write `openwa` wherever a command names the `openwa-api` service. Do NOT
+# carry the flag up to the `--profile postgres` commands in 14.3: postgres exists only in the
+# production compose file.
 
 # 1. Backup: both databases + session auth + media + plugin state
 ./scripts/backup.sh
@@ -781,6 +782,9 @@ if [ -z "$BACKUP_DIR" ] || [ -z "$TARGET_VERSION" ]; then
 fi
 
 echo "🔄 Rolling back to v${TARGET_VERSION}..."
+
+# Started with docker-compose.dev.yml (the README Quick Start)? Add `-f docker-compose.dev.yml` to
+# every docker compose command below, and write `openwa` wherever one names the `openwa-api` service.
 
 # 1. Stop current
 docker compose down

--- a/docs/21-glossary.md
+++ b/docs/21-glossary.md
@@ -118,7 +118,7 @@ Browser mode that runs without a GUI. Puppeteer runs Chrome in headless mode.
 
 ### Health Check
 
-Endpoints to check system health: `/api/health` (basic status and running version), `/api/health/live` (liveness) and `/api/health/ready` (readiness — probes both databases, and reports 503 while the process is draining). All three are public and exempt from rate limiting. The `/api` prefix is applied globally with no exclusions, so the unprefixed paths do not exist — container and Kubernetes probes must use the prefixed form.
+Endpoints to check system health: `/api/health` (basic status; the running version is added only for an authenticated caller), `/api/health/live` (liveness) and `/api/health/ready` (readiness — probes both databases, and reports 503 while the process is draining). All three are public and exempt from rate limiting. The `/api` prefix is applied globally with no exclusions, so the unprefixed paths do not exist — container and Kubernetes probes must use the prefixed form.
 
 ### Hook
 

--- a/docs/examples/session-phone-number-pairing.md
+++ b/docs/examples/session-phone-number-pairing.md
@@ -47,7 +47,7 @@ curl -X POST http://localhost:2785/api/sessions/{sessionId}/start \
   -H "X-API-Key: $API_KEY"
 ```
 
-The session must be started before requesting a pairing code, and the engine needs a moment to connect after `start` returns. Poll `GET /api/sessions/{sessionId}` until `status` is `qr_ready`: that is the point the engine can accept a pairing request. Requesting a code before that returns 409.
+The session must be started before requesting a pairing code, and the engine needs a moment to connect after `start` returns. Poll `GET /api/sessions/{sessionId}` until `status` is `qr_ready`: that is the point the engine can accept a pairing request. Requesting a code before that returns 409. Treat `qr_ready` as the signal to try, not a guarantee: on Baileys the socket can already be closing while the status has not caught up, so a 409 is still possible for a few seconds and is worth one retry.
 
 ## 3. Request a Pairing Code
 
@@ -95,6 +95,6 @@ After the code is accepted, the OpenWA session should move to a connected/ready 
 
 - If OpenWA returns `Session is not started`, call `POST /api/sessions/{sessionId}/start` first.
 - If OpenWA returns `Session is already authenticated`, the account is already linked and no pairing code is needed.
-- If OpenWA returns 409 `Session is not waiting to be linked`, the engine is still connecting (or reconnecting after a drop). Wait for `status` to read `qr_ready` and request again. After a code was accepted the same 409 is answered until the session is `ready`; do not request another code then.
+- If OpenWA returns 409 `Session is not waiting to be linked`, the engine is still connecting (or reconnecting after a drop). Wait for `status` to read `qr_ready` and request again. After a code was accepted the same 409 is answered until the session is `ready`; do not request another code then. On Baileys the same 409 can also answer while `status` already reads `qr_ready`, for as long as the WebSocket takes to finish closing (up to 30 s on a silently dropped connection); retry rather than treating it as a bad state.
 - If the phone number is rejected, send digits only in international format, without `+`, spaces, or punctuation.
 - If you want to create a brand-new WhatsApp account programmatically, that is outside OpenWA's scope. OpenWA only links an existing WhatsApp account.

--- a/openapi.json
+++ b/openapi.json
@@ -818,7 +818,7 @@
             "description": "Session not found"
           },
           "409": {
-            "description": "The session is not waiting to be linked: the engine is still connecting, or reconnecting after a drop, so the request never reached WhatsApp. Wait for `status` to read `qr_ready` and retry. Once a code has been accepted the session moves through `authenticating` and `initializing` to `ready` and answers this until then; wait for `ready` in that case. A session that reads `ready` is already linked and answers `400` instead."
+            "description": "The session is not waiting to be linked: the engine is still connecting, or reconnecting after a drop, so the request never reached WhatsApp. Wait for `status` to read `qr_ready` and retry. Once a code has been accepted the session moves through `authenticating` and `initializing` to `ready` and answers this until then; wait for `ready` in that case. A session that reads `ready` is already linked and answers `400` instead. One window answers this while the session still reads `qr_ready`: on the Baileys engine a socket that has begun closing stops accepting a pairing request before the status catches up, which on a silently dropped connection takes until the WebSocket's close timeout (30 s); retry, and the status follows shortly."
           }
         },
         "summary": "Request an 8-char pairing code to link via phone number (alternative to QR)",

--- a/src/common/openapi/engine-status-responses.ts
+++ b/src/common/openapi/engine-status-responses.ts
@@ -26,13 +26,22 @@ export const ENGINE_NOT_READY_409 =
  * `EngineNotReadyError` (409) on `POST /sessions/:sessionId/pairing-code`, where the generic wording
  * above points the caller at the wrong state: both engines accept a pairing request only while the
  * session is `qr_ready`, and a session that reads `ready` is already linked and answers `400`.
+ *
+ * `qr_ready` is necessary but not sufficient on Baileys, hence the closing-socket sentence: the guard
+ * also tests `ws.isOpen`, and the status trails the transport because Baileys emits its close only
+ * after `await ws.close()` resolves. Same shape as the reload window ENGINE_NOT_READY_409 names, and
+ * for the same reason: a caller that treats the documented status as sufficient would otherwise read
+ * a legitimate retryable 409 as a bad state.
  */
 export const PAIRING_NOT_READY_409 =
   'The session is not waiting to be linked: the engine is still connecting, or reconnecting after a ' +
   'drop, so the request never reached WhatsApp. Wait for `status` to read `qr_ready` and retry. Once a ' +
   'code has been accepted the session moves through `authenticating` and `initializing` to `ready` and ' +
   'answers this until then; wait for `ready` in that case. A session that reads `ready` is already ' +
-  'linked and answers `400` instead.';
+  'linked and answers `400` instead. One window answers this while the session still reads ' +
+  '`qr_ready`: on the Baileys engine a socket that has begun closing stops accepting a pairing ' +
+  'request before the status catches up, which on a silently dropped connection takes until the ' +
+  "WebSocket's close timeout (30 s); retry, and the status follows shortly.";
 
 /**
  * The catalog and status services pass a `NotFoundException` factory to `EngineRegistry.require()`


### PR DESCRIPTION
Four documentation and contract gaps found while re-checking everything on main since v0.23.2. No code behavior changes.

**Pairing-code 409 contract**

The Baileys pairing guard also tests `ws.isOpen`, but the 409 description still told callers that waiting for `status` to read `qr_ready` was sufficient. The status trails the transport: Baileys emits its close only after `await ws.close()` resolves, so on a silently dropped connection the socket stops accepting a pairing request while the session still reads `qr_ready`, for as long as the WebSocket close timeout. A client following the documented procedure gets a 409 with its precondition already satisfied, and nothing in the response distinguishes it from the states the text does describe. The window is now named the way the generic engine-not-ready 409 already names its own reload window, mirrored in the API reference and the pairing example, with the OpenAPI snapshot re-exported.

**Rollback not covered by the dev-compose caveat**

The migration guide's caveat named the upgrade script and the migration block but not 14.6 Rollback Procedures, whose bare `docker compose down` and `up -d --build` need the same `-f docker-compose.dev.yml`. Its runbook twin covers its own rollback block. The note now says so, and is repeated at the rollback script itself since a reader reaches it without passing through the upgrade section.

**Health version claim**

`GET /api/health` withholds `version` from unauthenticated callers. The runbook and migration guide were corrected for this; the API collection, the scaling endpoint table and the glossary still advertised it as part of the public response.

**Changelog**

The release ships a Bull Board major that adds a force option to the queue dashboard's obliterate action. Forcing it deletes active jobs as well as queued ones, so those deliveries never reach a final attempt and no `webhook_delivery_failures` row is written, which is the durable record `queue.module.ts` relies on. Version 8 refused outright while jobs were active. Recorded as an upgrade note, alongside a Dependencies section: release notes are cut by slicing the changelog between version headings, so without it the published notes carry no dependency delta at all.

**Verification**

`tsc --noEmit`, ESLint, `format:check`, `openapi:check`, all seven `check:*` gates, 344 suites / 5933 unit tests, and the 24-suite docs lane. The only source change is a contract description constant; the guard itself is untouched.
