### PR TITLE
chore(release): v0.23.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.23.3] - 2026-08-24
 
 ### Added
 

--- a/charts/openwa/Chart.yaml
+++ b/charts/openwa/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: openwa
 description: OpenWA — WhatsApp API. Single-instance StatefulSet (see values.yaml replicaCount warning).
 type: application
-version: 0.1.19
-appVersion: '0.23.2'
+version: 0.1.20
+appVersion: '0.23.3'
 keywords:
   - whatsapp
   - openwa

--- a/openapi.json
+++ b/openapi.json
@@ -9428,7 +9428,7 @@
   "info": {
     "title": "OpenWA API",
     "description": "Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API\n\n**Gateway-wide responses.** Two statuses are returned by middleware before routing, so any operation can emit them:\n\n- `415 Unsupported Media Type` — the request body carries a `Content-Encoding` other than `identity`. The aggregate in-flight body cap counts wire bytes, so a compressed body would be admitted on its compressed size and then inflated past the memory it is meant to bound. Send the body uncompressed.\n- `503 Service Unavailable` with `Retry-After` — the gateway already has too much request body data in flight. The body is not read; retry after the given delay.",
-    "version": "0.23.2",
+    "version": "0.23.3",
     "contact": {
       "name": "OpenWA",
       "url": "https://github.com/rmyndharis/OpenWA",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openwa",
-  "version": "0.23.2",
+  "version": "0.23.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openwa",
-      "version": "0.23.2",
+      "version": "0.23.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwa",
-  "version": "0.23.2",
+  "version": "0.23.3",
   "description": "Open Source WhatsApp API Gateway - Free, Self-Hosted HTTP API for WhatsApp",
   "author": "Yudhi Armyndharis & OpenWA Contributors",
   "private": true,


### PR DESCRIPTION
Version bump for v0.23.3.

- `package.json` + lockfile to 0.23.3
- `CHANGELOG.md`: `[Unreleased]` becomes `[0.23.3] - 2026-08-24`
- `charts/openwa/Chart.yaml`: `appVersion` 0.23.3, chart `version` 0.1.20
- `openapi.json` re-exported so the baked `info.version` matches

Patch rather than minor: the one `Added` entry is a log warning, with no new endpoint, response field or configuration. The `0.23.x` support band is unchanged, so `SECURITY.md` needs no edit, which `check:versions` confirms.