### PR TITLE
feat(engine): bound the whatsapp-web.js browser command timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -127,11 +127,13 @@ STATUS_SEED_ON_READY=false
 # Path to a system Chromium/Chrome binary. Leave unset to use the bundled Puppeteer browser.
 # Required in the Docker image and on hosts without a bundled browser (e.g. Alpine/ARM).
 # PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
-# How long a single browser command may take before it is abandoned, in milliseconds. Default 300000
-# (5 min), above Puppeteer's own 180000. Raise it if a large account (thousands of chats) fails a
-# read with "Runtime.callFunctionOn timed out"; the renderer is still working, the command budget
-# just ran out. Must be a POSITIVE integer — 0 does not mean "no limit later", it means no timer is
-# armed at all, so a wedged browser holds the request forever instead of failing it as 503.
+# How long a single browser command may take before it is abandoned, in milliseconds. Unset means
+# Puppeteer's own budget (180000 today), so leaving it unset changes nothing. Raise it if a large account
+# (thousands of chats) fails a read with "Runtime.callFunctionOn timed out"; the renderer is still
+# working, the command budget just ran out. Must be a POSITIVE integer no greater than 2147483647:
+# 0 does not mean "no limit later", it means no timer is armed at all, so a wedged browser holds the
+# request forever instead of failing it as 503; and above 2147483647 Node's timer overflows and
+# fires after 1 ms, so the browser never finishes launching. The gateway refuses to boot on either.
 # PUPPETEER_PROTOCOL_TIMEOUT_MS=300000
 # A freshly linked account is shown a "What's new on WhatsApp Web" modal that must be acknowledged or
 # WhatsApp unlinks the companion a few minutes later. The whatsapp-web.js engine clicks it

--- a/.env.example
+++ b/.env.example
@@ -132,7 +132,7 @@ STATUS_SEED_ON_READY=false
 # (thousands of chats) fails a read with "Runtime.callFunctionOn timed out"; the renderer is still
 # working, the command budget just ran out. Must be a POSITIVE integer no greater than 2147483647:
 # 0 does not mean "no limit later", it means no timer is armed at all, so a wedged browser holds the
-# request forever instead of failing it as 503; and above 2147483647 Node's timer overflows and
+# request forever instead of failing it; and above 2147483647 Node's timer overflows and
 # fires after 1 ms, so the browser never finishes launching. The gateway refuses to boot on either.
 # PUPPETEER_PROTOCOL_TIMEOUT_MS=300000
 # A freshly linked account is shown a "What's new on WhatsApp Web" modal that must be acknowledged or

--- a/.env.example
+++ b/.env.example
@@ -127,6 +127,12 @@ STATUS_SEED_ON_READY=false
 # Path to a system Chromium/Chrome binary. Leave unset to use the bundled Puppeteer browser.
 # Required in the Docker image and on hosts without a bundled browser (e.g. Alpine/ARM).
 # PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+# How long a single browser command may take before it is abandoned, in milliseconds. Default 300000
+# (5 min), above Puppeteer's own 180000. Raise it if a large account (thousands of chats) fails a
+# read with "Runtime.callFunctionOn timed out"; the renderer is still working, the command budget
+# just ran out. Must be a POSITIVE integer — 0 does not mean "no limit later", it means no timer is
+# armed at all, so a wedged browser holds the request forever instead of failing it as 503.
+# PUPPETEER_PROTOCOL_TIMEOUT_MS=300000
 # A freshly linked account is shown a "What's new on WhatsApp Web" modal that must be acknowledged or
 # WhatsApp unlinks the companion a few minutes later. The whatsapp-web.js engine clicks it
 # automatically, matching the English button label `Continue`. If your WhatsApp Web renders the modal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `PUPPETEER_PROTOCOL_TIMEOUT_MS` sets how long a single browser command may take on the
+  whatsapp-web.js engine, defaulting to 300 000 ms, above Puppeteer's own 180 000 ms. A read that
+  walks the whole store, such as `GET /sessions/{sessionId}/chats` on an account with thousands of
+  chats, could run past the stock budget and fail with `Runtime.callFunctionOn timed out` while the
+  renderer was still working. The value must be positive: Puppeteer only arms its timer for a
+  truthy one, so `0` drops the bound instead of raising it and lets a wedged renderer hold the
+  request forever.
+
+### Changed
+
+- The whatsapp-web.js transport classifier now rules out a protocol timeout explicitly. That
+  message carries no transport-death signature on the current Puppeteer, so nothing was
+  misreporting it and behaviour is unchanged; the point is the spec, which pins the invariant in
+  both directions against the verbatim Puppeteer string so a future bump cannot start reading a
+  slow command as a dead page.
+
 ## [0.23.3] - 2026-08-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,27 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `PUPPETEER_PROTOCOL_TIMEOUT_MS` sets how long a single browser command may take on the
-  whatsapp-web.js engine. A read that walks the whole store, such as
-  `GET /sessions/{sessionId}/chats` on an account with thousands of chats, can run past Puppeteer's
-  budget and fail with `Runtime.callFunctionOn timed out` while the renderer is still working, and
-  until now there was no way to raise it short of patching the dependency. Left unset it stays at
-  Puppeteer's own budget (180 000 ms today), so an upgrade changes nothing for a deployment that
-  does not set it; raise
-  it only after seeing that error, since raising it is also how long a wedged browser holds a command
-  before the gateway can give up on it. The value must be a positive integer no greater than
-  2 147 483 647, rejected at boot on both ends: Puppeteer only arms its timer for a truthy value, so
-  `0` drops the bound instead of raising it and lets a wedged renderer hold the request forever,
-  while above 2 147 483 647 Node's timer overflows and fires after 1 ms, so the browser never
-  finishes launching.
+- `PUPPETEER_PROTOCOL_TIMEOUT_MS` raises the per-browser-command budget on the whatsapp-web.js
+  engine, for large accounts whose reads fail with `Runtime.callFunctionOn timed out`. Unset keeps
+  Puppeteer's own budget, so nothing changes for a deployment that does not set it. The gateway
+  refuses to boot on `0` or on a value above 2147483647; see docs/12 for when to reach for it.
 
 ### Changed
 
-- The whatsapp-web.js transport classifier now rules out a protocol timeout explicitly. That
-  message carries no transport-death signature on the current Puppeteer, so nothing was
-  misreporting it and behaviour is unchanged; the point is the spec, which pins the invariant in
-  both directions against the message the installed Puppeteer actually throws, so a future bump
-  cannot start reading a slow command as a dead page.
+- A whatsapp-web.js protocol timeout is no longer eligible to be classified as a dead page.
+  Behaviour is unchanged on the current Puppeteer; the guard keeps a future bump from reporting a
+  slow command as a transport death.
 
 ## [0.23.3] - 2026-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,20 +10,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `PUPPETEER_PROTOCOL_TIMEOUT_MS` sets how long a single browser command may take on the
-  whatsapp-web.js engine, defaulting to 300 000 ms, above Puppeteer's own 180 000 ms. A read that
-  walks the whole store, such as `GET /sessions/{sessionId}/chats` on an account with thousands of
-  chats, could run past the stock budget and fail with `Runtime.callFunctionOn timed out` while the
-  renderer was still working. The value must be positive: Puppeteer only arms its timer for a
-  truthy one, so `0` drops the bound instead of raising it and lets a wedged renderer hold the
-  request forever.
+  whatsapp-web.js engine. A read that walks the whole store, such as
+  `GET /sessions/{sessionId}/chats` on an account with thousands of chats, can run past Puppeteer's
+  budget and fail with `Runtime.callFunctionOn timed out` while the renderer is still working, and
+  until now there was no way to raise it short of patching the dependency. Left unset it stays at
+  Puppeteer's own budget (180 000 ms today), so an upgrade changes nothing for a deployment that
+  does not set it; raise
+  it only after seeing that error, since raising it is also how long a wedged browser holds a command
+  before the gateway can give up on it. The value must be a positive integer no greater than
+  2 147 483 647, rejected at boot on both ends: Puppeteer only arms its timer for a truthy value, so
+  `0` drops the bound instead of raising it and lets a wedged renderer hold the request forever,
+  while above 2 147 483 647 Node's timer overflows and fires after 1 ms, so the browser never
+  finishes launching.
 
 ### Changed
 
 - The whatsapp-web.js transport classifier now rules out a protocol timeout explicitly. That
   message carries no transport-death signature on the current Puppeteer, so nothing was
   misreporting it and behaviour is unchanged; the point is the spec, which pins the invariant in
-  both directions against the verbatim Puppeteer string so a future bump cannot start reading a
-  slow command as a dead page.
+  both directions against the message the installed Puppeteer actually throws, so a future bump
+  cannot start reading a slow command as a dead page.
 
 ## [0.23.3] - 2026-08-24
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -67,6 +67,7 @@ services:
       - SESSION_DATA_PATH=${SESSION_DATA_PATH:-/app/data/sessions}
       - PUPPETEER_HEADLESS=${PUPPETEER_HEADLESS:-true}
       - PUPPETEER_ARGS=${PUPPETEER_ARGS:---no-sandbox,--disable-setuid-sandbox,--disable-dev-shm-usage,--disable-gpu}
+      - PUPPETEER_PROTOCOL_TIMEOUT_MS=${PUPPETEER_PROTOCOL_TIMEOUT_MS:-}
       # Optional WhatsApp Web version override. DEFAULT (empty, "latest", or "auto"): OpenWA auto-resolves a
       # settled build from the third-party wppconnect-team/wa-version registry and pins its remote HTML
       # (fetched into the web.whatsapp.com origin without an integrity check). Set "off" to disable pinning

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,6 +141,7 @@ services:
       - SESSION_DATA_PATH=${SESSION_DATA_PATH:-}
       - PUPPETEER_HEADLESS=${PUPPETEER_HEADLESS:-}
       - PUPPETEER_ARGS=${PUPPETEER_ARGS:-}
+      - PUPPETEER_PROTOCOL_TIMEOUT_MS=${PUPPETEER_PROTOCOL_TIMEOUT_MS:-}
       # Optional WhatsApp Web version override. DEFAULT (empty, "latest", or "auto"): OpenWA auto-resolves a
       # settled build from the third-party wppconnect-team/wa-version registry and pins its remote HTML
       # (fetched into the web.whatsapp.com origin without an integrity check). Set "off" to disable pinning

--- a/docs/10-devops-infrastructure.md
+++ b/docs/10-devops-infrastructure.md
@@ -466,6 +466,8 @@ SESSION_DATA_PATH=./data/sessions
 PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 PUPPETEER_HEADLESS=true
 PUPPETEER_ARGS=--no-sandbox,--disable-setuid-sandbox
+# Per-browser-command budget, ms. Default 300000. Raise for very large accounts; must stay positive.
+PUPPETEER_PROTOCOL_TIMEOUT_MS=300000
 
 # ===========================================
 # SECURITY

--- a/docs/10-devops-infrastructure.md
+++ b/docs/10-devops-infrastructure.md
@@ -466,8 +466,9 @@ SESSION_DATA_PATH=./data/sessions
 PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 PUPPETEER_HEADLESS=true
 PUPPETEER_ARGS=--no-sandbox,--disable-setuid-sandbox
-# Per-browser-command budget, ms. Default 300000. Raise for very large accounts; must stay positive.
-PUPPETEER_PROTOCOL_TIMEOUT_MS=300000
+# Optional per-browser-command budget, ms. Unset = Puppeteer's own budget. Raise only after seeing
+# "Runtime.callFunctionOn timed out"; positive integer, max 2147483647 (cost: see docs/12).
+# PUPPETEER_PROTOCOL_TIMEOUT_MS=300000
 
 # ===========================================
 # SECURITY

--- a/docs/12-troubleshooting-faq.md
+++ b/docs/12-troubleshooting-faq.md
@@ -688,13 +688,13 @@ answers `503` and takes the session down with it, and this is just a slow comman
 PUPPETEER_PROTOCOL_TIMEOUT_MS=300000
 ```
 
-Raise it by as little as the account needs, because the budget is also how long a **wedged** browser
-holds a command before the gateway can give up on it. At 300000 that window is five minutes instead
-of three, and for its duration the stuck command holds the logout fence behind it: `start` and
-`delete` for that session answer `409 SESSION_NAME_TEARDOWN_PENDING`, and `forceKill` refuses with
-`400` because the engine was already evicted. There is no measurement in this repo saying how large
-an account has to be before 180000 is too small, so treat any value above it as an escape hatch you
-reached for after seeing the error above, not as a default worth pre-emptively setting.
+Raise it by as little as the account needs. The budget bounds a command that is slow but still
+running; it is not what protects you from a **wedged** browser. A page that stops answering is
+caught by the liveness watchdog, which probes every 60 s with a 15 s timeout and treats two
+consecutive failures as a disconnect, so a wedge is picked up in roughly 75 to 135 s whatever this
+value is. There is no measurement in this repo saying how large an account has to be before 180000
+is too small, so treat any value above it as an escape hatch you reached for after seeing the error
+above, not as a default worth pre-emptively setting.
 
 > Do not set it to `0`, and do not reach for a row of nines. The gateway refuses to boot on either.
 > Puppeteer only arms its timer for a truthy value, so `0` drops the bound altogether and a wedged

--- a/docs/12-troubleshooting-faq.md
+++ b/docs/12-troubleshooting-faq.md
@@ -665,6 +665,33 @@ rm -rf node_modules/whatsapp-web.js && npm ci
 > Pinning `WWEBJS_WEB_VERSION` does **not** work around this — the rename is present in every
 > current WhatsApp Web build, so no pin avoids it.
 
+### Issue: Reads on a large account fail with `Runtime.callFunctionOn timed out`
+
+> **Engine:** This issue applies to the `whatsapp-web.js` engine only (Chromium/Puppeteer-based). It does not affect `ENGINE_TYPE=baileys`.
+
+**Symptoms:**
+
+- `GET /api/sessions/{id}/chats` (or another read that walks the whole store) fails on an account
+  with thousands of chats, while smaller accounts on the same deployment are fine
+- The error names a CDP method and the setting: `Runtime.callFunctionOn timed out. Increase the 'protocolTimeout' setting in launch/connect calls for a higher timeout if needed.`
+- The session stays `ready` and the next request works, so the page did not die
+
+**Cause:** Puppeteer gives every browser command a time budget, 180 000 ms by default, and one
+`getChats()` over a very large store can run past it. The renderer is still working; only the
+command is dropped. That is also why this is **not** treated as a dead page — a transport death
+answers `503` and takes the session down with it, and this is just a slow command on a live page.
+
+**Solution:** raise the budget for that deployment.
+
+```bash
+# 10 minutes, in .env or the environment
+PUPPETEER_PROTOCOL_TIMEOUT_MS=600000
+```
+
+> Do not set it to `0`. The gateway refuses to boot on a non-positive value: Puppeteer only arms
+> its timer for a truthy one, so `0` drops the bound altogether and a wedged renderer will hold the
+> command, and the request waiting on it, forever. A hung request is worse than a failed one.
+
 ### Issue: Media Upload Fails
 
 **Symptoms:**

--- a/docs/12-troubleshooting-faq.md
+++ b/docs/12-troubleshooting-faq.md
@@ -684,13 +684,24 @@ answers `503` and takes the session down with it, and this is just a slow comman
 **Solution:** raise the budget for that deployment.
 
 ```bash
-# 10 minutes, in .env or the environment
-PUPPETEER_PROTOCOL_TIMEOUT_MS=600000
+# 5 minutes, in .env or the environment. Unset means Puppeteer's own 180000.
+PUPPETEER_PROTOCOL_TIMEOUT_MS=300000
 ```
 
-> Do not set it to `0`. The gateway refuses to boot on a non-positive value: Puppeteer only arms
-> its timer for a truthy one, so `0` drops the bound altogether and a wedged renderer will hold the
-> command, and the request waiting on it, forever. A hung request is worse than a failed one.
+Raise it by as little as the account needs, because the budget is also how long a **wedged** browser
+holds a command before the gateway can give up on it. At 300000 that window is five minutes instead
+of three, and for its duration the stuck command holds the logout fence behind it: `start` and
+`delete` for that session answer `409 SESSION_NAME_TEARDOWN_PENDING`, and `forceKill` refuses with
+`400` because the engine was already evicted. There is no measurement in this repo saying how large
+an account has to be before 180000 is too small, so treat any value above it as an escape hatch you
+reached for after seeing the error above, not as a default worth pre-emptively setting.
+
+> Do not set it to `0`, and do not reach for a row of nines. The gateway refuses to boot on either.
+> Puppeteer only arms its timer for a truthy value, so `0` drops the bound altogether and a wedged
+> renderer will hold the command, and the request waiting on it, forever — a hung request is worse
+> than a failed one. Above `2147483647` Node's timer overflows, warns `TimeoutOverflowWarning`, and
+> fires after 1 ms instead, so every command in the launch handshake fails with this same error and
+> the browser never starts.
 
 ### Issue: Media Upload Fails
 

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -53,6 +53,15 @@ export function resolveNonNegativeIntEnv(raw: string | undefined, fallback: numb
 }
 
 /**
+ * Largest delay Node's timers accept. Above this a `setTimeout` overflows its 32-bit signed field,
+ * warns `TimeoutOverflowWarning`, and fires after 1 ms instead — so an operator reaching for an
+ * "effectively unlimited" budget by typing a row of nines gets the shortest possible one. Puppeteer
+ * arms `protocolTimeout` with a plain `setTimeout` (`common/CallbackRegistry.js`), so the ceiling
+ * applies to it directly and the browser never finishes launching.
+ */
+export const MAX_TIMER_MS = 2147483647;
+
+/**
  * The UI locale Chromium is pinned to. WhatsApp Web renders its chrome — including the new-account
  * onboarding modal the whatsapp-web.js adapter dismisses (#982) — in the browser's language, and that
  * detector matches visible English text. Without a pin the language is whatever the launched binary
@@ -211,10 +220,17 @@ export default () => ({
       // uses Puppeteer's bundled Chromium. Required on hosts where the bundled binary
       // is missing or incompatible (Alpine, ARM, custom base images).
       executablePath: process.env.PUPPETEER_EXECUTABLE_PATH || undefined,
-      // How long one CDP command may take. Above Puppeteer's own 180 000 ms, which a single
-      // `client.getChats()` can exceed on an account with thousands of chats. Bounded, never
-      // disabled — see wwebjs-lifecycle.ts for why a falsy value is not "no limit".
-      protocolTimeoutMs: parseInt(process.env.PUPPETEER_PROTOCOL_TIMEOUT_MS || '300000', 10),
+      // How long one CDP command may take. An account with thousands of chats can push a single
+      // `client.getChats()` past Puppeteer's own budget; raising this is the escape hatch. Left
+      // UNDEFINED rather than defaulted to Puppeteer's number, so an unset or out-of-range value
+      // means "whatever puppeteer-core's `timeout ?? 180_000` says" instead of pinning today's
+      // figure here and silently outliving it. Out of range is not clamped either: see
+      // wwebjs-lifecycle.ts for why a falsy value is not "no limit", and MAX_TIMER_MS above for
+      // why a huge one is not either.
+      protocolTimeoutMs: (() => {
+        const n = parseInt(process.env.PUPPETEER_PROTOCOL_TIMEOUT_MS || '', 10);
+        return Number.isFinite(n) && n > 0 && n <= MAX_TIMER_MS ? n : undefined;
+      })(),
     },
     sessionDataPath: process.env.SESSION_DATA_PATH || './data/sessions',
     // Baileys engine (used when ENGINE_TYPE=baileys). Multi-file auth state base dir; each session

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -211,6 +211,10 @@ export default () => ({
       // uses Puppeteer's bundled Chromium. Required on hosts where the bundled binary
       // is missing or incompatible (Alpine, ARM, custom base images).
       executablePath: process.env.PUPPETEER_EXECUTABLE_PATH || undefined,
+      // How long one CDP command may take. Above Puppeteer's own 180 000 ms, which a single
+      // `client.getChats()` can exceed on an account with thousands of chats. Bounded, never
+      // disabled — see wwebjs-lifecycle.ts for why a falsy value is not "no limit".
+      protocolTimeoutMs: parseInt(process.env.PUPPETEER_PROTOCOL_TIMEOUT_MS || '300000', 10),
     },
     sessionDataPath: process.env.SESSION_DATA_PATH || './data/sessions',
     // Baileys engine (used when ENGINE_TYPE=baileys). Multi-file auth state base dir; each session

--- a/src/config/env-precedence.ts
+++ b/src/config/env-precedence.ts
@@ -111,6 +111,7 @@ export const BLANK_SHADOWED_ENV_KEYS: string[] = [
   'PUPPETEER_HEADLESS',
   'SESSION_DATA_PATH',
   'PUPPETEER_ARGS',
+  'PUPPETEER_PROTOCOL_TIMEOUT_MS',
   // Rate-limit values are blank-forwarded by Compose so a host value can take precedence without an
   // empty forward masking the lower-priority loaded .env / data/.env.generated value.
   'RATE_LIMIT_SHORT_TTL',

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -284,6 +284,9 @@ export function validateEnv(config: EnvConfig): EnvConfig {
     'SESSION_LEASE_HEARTBEAT_MS',
     'SESSION_TAKEOVER_SWEEP_MS',
     'SESSION_PROXY_TIMEOUT_MS',
+    // Positive-only is the POINT here, not a convention: 0 arms no Puppeteer timer at all, so a
+    // wedged renderer holds the request forever (see wwebjs-lifecycle.ts).
+    'PUPPETEER_PROTOCOL_TIMEOUT_MS',
   ]) {
     checkPositiveInt(key);
   }

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -9,6 +9,10 @@ type EnvConfig = Record<string, unknown>;
 // DATABASE_NAME still points at the (now unused) default file.
 const MAIN_DB_DEFAULT_PATH = './data/main.sqlite';
 
+// Duplicated rather than imported from configuration.ts (see MAIN_DB_DEFAULT_PATH above); the spec
+// asserts the two agree.
+const MAX_TIMER_MS = 2147483647;
+
 /**
  * Collision guard shared by boot validation (validateEnv below) and the migration CLI
  * (src/database/data-source.ts / data-source-main.ts — the TypeORM CLI never runs ConfigModule's
@@ -289,6 +293,20 @@ export function validateEnv(config: EnvConfig): EnvConfig {
     'PUPPETEER_PROTOCOL_TIMEOUT_MS',
   ]) {
     checkPositiveInt(key);
+  }
+
+  // The ceiling matters for the same reason from the other side: the docs forbid 0, so an operator
+  // who wants an effectively unlimited budget reaches for a row of nines. Rejected at boot rather
+  // than clamped, so they learn the value they wrote is not the value they would have got.
+  {
+    const raw = str('PUPPETEER_PROTOCOL_TIMEOUT_MS');
+    const n = raw !== undefined && DECIMAL_INTEGER.test(raw) ? Number(raw) : NaN;
+    if (Number.isInteger(n) && n > MAX_TIMER_MS) {
+      errors.push(
+        `PUPPETEER_PROTOCOL_TIMEOUT_MS must not exceed ${MAX_TIMER_MS} ms (got "${raw}"): Node's ` +
+          `timers overflow above that and fire after 1 ms, so the browser never finishes launching`,
+      );
+    }
   }
 
   // A heartbeat that does not fit inside the lease renews too late to matter: the claim lapses

--- a/src/engine/adapters/whatsapp-web-js.adapter.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.ts
@@ -76,6 +76,8 @@ export interface WhatsAppWebJsConfig {
     headless?: boolean;
     args?: string[];
     executablePath?: string;
+    /** Per-CDP-command budget handed to Puppeteer. Must be positive — see wwebjs-lifecycle. */
+    protocolTimeoutMs?: number;
   };
   // Phase 3: Proxy per session
   proxy?: {

--- a/src/engine/adapters/wwebjs-lifecycle.ts
+++ b/src/engine/adapters/wwebjs-lifecycle.ts
@@ -339,13 +339,12 @@ export class WwebjsLifecycle {
         ...(this.host.config.puppeteer?.executablePath
           ? { executablePath: this.host.config.puppeteer.executablePath }
           : {}),
-        // Per-CDP-command budget, spread only for a POSITIVE value so an unset or malformed config
-        // keeps Puppeteer's own 180 000 ms default rather than being handed a falsy one:
-        // `common/CallbackRegistry.js` arms the timer under `if (timeout)`, so 0 or NaN arms none
-        // and a wedged renderer holds the command — and the request behind it — indefinitely.
-        // A dead page must surface as a 503, never as a hang.
-        ...(typeof this.host.config.puppeteer?.protocolTimeoutMs === 'number' &&
-        this.host.config.puppeteer.protocolTimeoutMs > 0
+        // Per-CDP-command budget, spread only when the host configured one — configuration.ts
+        // leaves it undefined otherwise, and puppeteer-core nullish-coalesces a missing value to
+        // its own 180 000 ms (`cdp/Connection.js`). What must never reach it is a FALSY one:
+        // `common/CallbackRegistry.js` arms the timer under `if (timeout)`, so 0 arms none and a
+        // wedged renderer holds the command, and the request behind it, indefinitely.
+        ...(this.host.config.puppeteer?.protocolTimeoutMs !== undefined
           ? { protocolTimeout: this.host.config.puppeteer.protocolTimeoutMs }
           : {}),
       },

--- a/src/engine/adapters/wwebjs-lifecycle.ts
+++ b/src/engine/adapters/wwebjs-lifecycle.ts
@@ -339,6 +339,15 @@ export class WwebjsLifecycle {
         ...(this.host.config.puppeteer?.executablePath
           ? { executablePath: this.host.config.puppeteer.executablePath }
           : {}),
+        // Per-CDP-command budget, spread only for a POSITIVE value so an unset or malformed config
+        // keeps Puppeteer's own 180 000 ms default rather than being handed a falsy one:
+        // `common/CallbackRegistry.js` arms the timer under `if (timeout)`, so 0 or NaN arms none
+        // and a wedged renderer holds the command — and the request behind it — indefinitely.
+        // A dead page must surface as a 503, never as a hang.
+        ...(typeof this.host.config.puppeteer?.protocolTimeoutMs === 'number' &&
+        this.host.config.puppeteer.protocolTimeoutMs > 0
+          ? { protocolTimeout: this.host.config.puppeteer.protocolTimeoutMs }
+          : {}),
       },
       ...(authTimeoutMs !== undefined ? { authTimeoutMs } : {}),
       ...(proxyAuthentication ? { proxyAuthentication } : {}),
@@ -646,9 +655,22 @@ export class WwebjsLifecycle {
   private static readonly PAGE_TRANSPORT_ERROR_PATTERN =
     /protocol error|target closed|targetclosederror|detached frame|session closed|connection closed/i;
 
+  /**
+   * A per-command CDP timeout is NOT a death: the renderer is merely slower than the budget, and
+   * the next command may succeed. On Puppeteer 24.38.0 this message carries none of the signatures
+   * above, so the guard changes no current behaviour — it pins the intent.
+   *
+   * Matched on the FULL puppeteer phrase, not a bare `timed out`: a broad exclusion would also
+   * swallow a genuine death whose message happens to mention a timeout.
+   */
+  private static readonly PROTOCOL_TIMEOUT_PATTERN = /timed out\. increase the 'protocoltimeout'/i;
+
   /** Whether the error carries a dead page/transport signature (see PAGE_TRANSPORT_ERROR_PATTERN). */
   isPageTransportError(error: unknown): boolean {
     const message = error instanceof Error ? error.message : String(error);
+    if (WwebjsLifecycle.PROTOCOL_TIMEOUT_PATTERN.test(message)) {
+      return false;
+    }
     return WwebjsLifecycle.PAGE_TRANSPORT_ERROR_PATTERN.test(message);
   }
 

--- a/src/engine/adapters/wwebjs-lifecycle.ts
+++ b/src/engine/adapters/wwebjs-lifecycle.ts
@@ -8,6 +8,7 @@ import {
 } from '../interfaces/whatsapp-engine.interface';
 import { EngineNotReadyError } from '../../common/errors/engine-not-ready.error';
 import { type createLogger } from '../../common/services/logger.service';
+import { MAX_TIMER_MS } from '../../config/configuration';
 import { resolveWebVersionPin } from '../wa-web-version';
 import { resolveAuthTimeoutMs, resolveEngineInitTimeoutMs } from '../engine-init-timeout';
 import { killOrphanedChromiumProcesses, removeStaleSingletonFiles } from './chromium-profile-hygiene';
@@ -318,6 +319,19 @@ export class WwebjsLifecycle {
     proxyAuthentication: { username: string; password: string } | undefined,
     versionPin: Awaited<ReturnType<typeof resolveWebVersionPin>>,
   ): Promise<void> {
+    // Range-checked at the sink, not only in configuration.ts: a plugin config written through
+    // `PUT /api/plugins/whatsapp-web.js/config` is validated as an object and merged over the env
+    // blob at every boot, so it can carry a value the config layer never saw. Both bounds are
+    // load-bearing. `common/CallbackRegistry.js` arms the timer under `if (timeout)`, so 0 arms
+    // none and a wedged renderer holds the command, and the request behind it, indefinitely; above
+    // MAX_TIMER_MS Node's timer overflows and fires after 1 ms, so the browser never launches.
+    const configuredProtocolTimeout = this.host.config.puppeteer?.protocolTimeoutMs;
+    const protocolTimeout =
+      typeof configuredProtocolTimeout === 'number' &&
+      configuredProtocolTimeout > 0 &&
+      configuredProtocolTimeout <= MAX_TIMER_MS
+        ? configuredProtocolTimeout
+        : undefined;
     const client = new Client({
       authStrategy: new LocalAuth({
         clientId: this.host.config.sessionId,
@@ -339,14 +353,9 @@ export class WwebjsLifecycle {
         ...(this.host.config.puppeteer?.executablePath
           ? { executablePath: this.host.config.puppeteer.executablePath }
           : {}),
-        // Per-CDP-command budget, spread only when the host configured one — configuration.ts
-        // leaves it undefined otherwise, and puppeteer-core nullish-coalesces a missing value to
-        // its own 180 000 ms (`cdp/Connection.js`). What must never reach it is a FALSY one:
-        // `common/CallbackRegistry.js` arms the timer under `if (timeout)`, so 0 arms none and a
-        // wedged renderer holds the command, and the request behind it, indefinitely.
-        ...(this.host.config.puppeteer?.protocolTimeoutMs !== undefined
-          ? { protocolTimeout: this.host.config.puppeteer.protocolTimeoutMs }
-          : {}),
+        // Per-CDP-command budget, spread only when the host configured a usable one (see above).
+        // Absent, puppeteer-core nullish-coalesces to its own 180 000 ms (`cdp/Connection.js`).
+        ...(protocolTimeout !== undefined ? { protocolTimeout } : {}),
       },
       ...(authTimeoutMs !== undefined ? { authTimeoutMs } : {}),
       ...(proxyAuthentication ? { proxyAuthentication } : {}),

--- a/src/engine/adapters/wwebjs-protocol-timeout.spec.ts
+++ b/src/engine/adapters/wwebjs-protocol-timeout.spec.ts
@@ -1,0 +1,110 @@
+import { Client } from 'whatsapp-web.js';
+import { WhatsAppWebJsAdapter } from './whatsapp-web-js.adapter';
+
+/**
+ * The per-CDP-command budget handed to Puppeteer, and the one error it produces.
+ *
+ * Two invariants worth pinning: the option must never reach Puppeteer falsy (that arms no timer at
+ * all, so a wedged renderer hangs the request — see wwebjs-lifecycle.ts), and a protocol timeout
+ * must never be read as a dead page.
+ */
+describe('whatsapp-web.js protocol timeout', () => {
+  const SESSION_ID = 'sess-protocol-timeout';
+  let clientInitSpy: jest.SpyInstance;
+  let savedWebVersion: string | undefined;
+
+  const launchedPuppeteerOptions = async (
+    protocolTimeoutMs?: number,
+  ): Promise<{ protocolTimeout?: number } | undefined> => {
+    const adapter = new WhatsAppWebJsAdapter({
+      sessionId: SESSION_ID,
+      sessionDataPath: './data/sessions',
+      puppeteer: { protocolTimeoutMs },
+    });
+    await adapter.initialize({});
+    return (adapter as unknown as { client: { options: { puppeteer?: { protocolTimeout?: number } } } }).client.options
+      .puppeteer;
+  };
+
+  beforeEach(() => {
+    // Keep initialize() offline: 'off' skips the wa-version registry fetch in resolveWebVersionPin.
+    savedWebVersion = process.env.WWEBJS_WEB_VERSION;
+    process.env.WWEBJS_WEB_VERSION = 'off';
+    // Build the real wwebjs Client — that is what carries the launch options — but launch no browser.
+    clientInitSpy = jest
+      .spyOn(Client.prototype as unknown as { initialize: () => Promise<void> }, 'initialize')
+      .mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    clientInitSpy.mockRestore();
+    if (savedWebVersion === undefined) {
+      delete process.env.WWEBJS_WEB_VERSION;
+    } else {
+      process.env.WWEBJS_WEB_VERSION = savedWebVersion;
+    }
+  });
+
+  it('hands a configured budget to the Client as puppeteer.protocolTimeout', async () => {
+    expect(await launchedPuppeteerOptions(300_000)).toMatchObject({ protocolTimeout: 300_000 });
+  });
+
+  it('omits the option when unset, leaving Puppeteer its own 180 000 ms default', async () => {
+    const options = await launchedPuppeteerOptions(undefined);
+
+    // Absent, not zero: passing 0 through would DISABLE the timer rather than fall back.
+    expect(options).not.toHaveProperty('protocolTimeout');
+  });
+
+  it.each([
+    ['zero', 0],
+    ['negative', -1],
+    ['NaN, e.g. from a malformed env value', Number.NaN],
+  ])('omits the option for a %s value rather than arming no timer', async (_label, value) => {
+    expect(await launchedPuppeteerOptions(value)).not.toHaveProperty('protocolTimeout');
+  });
+
+  describe('the transport classifier', () => {
+    const classify = (message: string): boolean => {
+      const adapter = new WhatsAppWebJsAdapter({
+        sessionId: SESSION_ID,
+        sessionDataPath: './data/sessions',
+        puppeteer: {},
+      });
+      return (adapter as unknown as { isPageTransportError: (error: unknown) => boolean }).isPageTransportError(
+        new Error(message),
+      );
+    };
+
+    /**
+     * Verbatim from Puppeteer 24.38.0 `common/CallbackRegistry.js`, where the leading label is the
+     * CDP method name. Pinning the real string is the point: a paraphrase would keep passing while
+     * the message the library actually throws drifted out from under the guard.
+     */
+    const PUPPETEER_PROTOCOL_TIMEOUT =
+      "Runtime.callFunctionOn timed out. Increase the 'protocolTimeout' setting in launch/connect calls for a higher timeout if needed.";
+
+    it('does not treat a protocol timeout as a dead page', () => {
+      // The renderer is slower than the budget, not gone — the next command may well succeed.
+      // Reporting death here would tear down a live session and answer 503 for a working page.
+      expect(classify(PUPPETEER_PROTOCOL_TIMEOUT)).toBe(false);
+    });
+
+    it.each([
+      'Protocol error (Runtime.callFunctionOn): Session closed.',
+      'Protocol error (Page.navigate): Target closed',
+      'Attempted to use detached Frame',
+      'Connection closed',
+    ])('still reports a genuine transport death: %s', message => {
+      // The 503-on-dead-page contract, pinned from the other side: narrowing the classifier for
+      // timeouts must not cost a single real death signature.
+      expect(classify(message)).toBe(true);
+    });
+
+    it('reports a death whose message also mentions a timeout', () => {
+      // Why the guard matches Puppeteer's full phrase instead of a bare /timed out/: the broad
+      // version swallows this, turning a reportable dead page into a silent one.
+      expect(classify('Protocol error (Runtime.callFunctionOn): Session closed. Request timed out')).toBe(true);
+    });
+  });
+});

--- a/src/engine/adapters/wwebjs-protocol-timeout.spec.ts
+++ b/src/engine/adapters/wwebjs-protocol-timeout.spec.ts
@@ -1,12 +1,15 @@
+import { Callback } from 'puppeteer-core/lib/cjs/puppeteer/common/CallbackRegistry.js';
 import { Client } from 'whatsapp-web.js';
+import configuration, { MAX_TIMER_MS } from '../../config/configuration';
+import { validateEnv } from '../../config/env.validation';
 import { WhatsAppWebJsAdapter } from './whatsapp-web-js.adapter';
 
 /**
  * The per-CDP-command budget handed to Puppeteer, and the one error it produces.
  *
- * Two invariants worth pinning: the option must never reach Puppeteer falsy (that arms no timer at
- * all, so a wedged renderer hangs the request — see wwebjs-lifecycle.ts), and a protocol timeout
- * must never be read as a dead page.
+ * Three invariants worth pinning: the value is range-checked before it leaves the config layer,
+ * the option reaches the Client when set and is absent when not, and a protocol timeout is never
+ * read as a dead page. The death signatures themselves are covered in whatsapp-web-js.adapter.spec.
  */
 describe('whatsapp-web.js protocol timeout', () => {
   const SESSION_ID = 'sess-protocol-timeout';
@@ -49,19 +52,50 @@ describe('whatsapp-web.js protocol timeout', () => {
     expect(await launchedPuppeteerOptions(300_000)).toMatchObject({ protocolTimeout: 300_000 });
   });
 
-  it('omits the option when unset, leaving Puppeteer its own 180 000 ms default', async () => {
+  it('omits the option when unset, leaving Puppeteer its own default', async () => {
     const options = await launchedPuppeteerOptions(undefined);
 
-    // Absent, not zero: passing 0 through would DISABLE the timer rather than fall back.
+    // Truly absent: `toHaveProperty` passes on a present-but-undefined key, so this is the check
+    // that the option was never spread rather than spread as undefined.
     expect(options).not.toHaveProperty('protocolTimeout');
   });
 
-  it.each([
-    ['zero', 0],
-    ['negative', -1],
-    ['NaN, e.g. from a malformed env value', Number.NaN],
-  ])('omits the option for a %s value rather than arming no timer', async (_label, value) => {
-    expect(await launchedPuppeteerOptions(value)).not.toHaveProperty('protocolTimeout');
+  describe('the bounds this knob exists to enforce', () => {
+    it('rejects a non-positive or over-range value at boot instead of handing it to Puppeteer', () => {
+      expect(() => validateEnv({ PUPPETEER_PROTOCOL_TIMEOUT_MS: '0' })).toThrow(/positive integer/);
+      expect(() => validateEnv({ PUPPETEER_PROTOCOL_TIMEOUT_MS: '-1' })).toThrow(/positive integer/);
+      expect(() => validateEnv({ PUPPETEER_PROTOCOL_TIMEOUT_MS: 'abc' })).toThrow(/positive integer/);
+      // The row of nines an operator reaches for when the docs forbid 0.
+      expect(() => validateEnv({ PUPPETEER_PROTOCOL_TIMEOUT_MS: String(MAX_TIMER_MS + 1) })).toThrow(/must not exceed/);
+      expect(() => validateEnv({ PUPPETEER_PROTOCOL_TIMEOUT_MS: '999999999999' })).toThrow(/must not exceed/);
+      expect(() => validateEnv({ PUPPETEER_PROTOCOL_TIMEOUT_MS: String(MAX_TIMER_MS) })).not.toThrow();
+      expect(() => validateEnv({ PUPPETEER_PROTOCOL_TIMEOUT_MS: '300000' })).not.toThrow();
+    });
+
+    it('leaves the option unset for anything out of range, never falsy', () => {
+      const parsed = (raw?: string): number | undefined => {
+        const saved = process.env.PUPPETEER_PROTOCOL_TIMEOUT_MS;
+        if (raw === undefined) delete process.env.PUPPETEER_PROTOCOL_TIMEOUT_MS;
+        else process.env.PUPPETEER_PROTOCOL_TIMEOUT_MS = raw;
+        try {
+          return (configuration() as { engine: { puppeteer: { protocolTimeoutMs?: number } } }).engine.puppeteer
+            .protocolTimeoutMs;
+        } finally {
+          if (saved === undefined) delete process.env.PUPPETEER_PROTOCOL_TIMEOUT_MS;
+          else process.env.PUPPETEER_PROTOCOL_TIMEOUT_MS = saved;
+        }
+      };
+
+      // A blank compose forward is "unset", not 0.
+      expect(parsed(undefined)).toBeUndefined();
+      expect(parsed('')).toBeUndefined();
+      expect(parsed('0')).toBeUndefined();
+      expect(parsed('-1')).toBeUndefined();
+      expect(parsed('abc')).toBeUndefined();
+      expect(parsed(String(MAX_TIMER_MS + 1))).toBeUndefined();
+      expect(parsed('300000')).toBe(300_000);
+      expect(parsed(String(MAX_TIMER_MS))).toBe(MAX_TIMER_MS);
+    });
   });
 
   describe('the transport classifier', () => {
@@ -77,28 +111,29 @@ describe('whatsapp-web.js protocol timeout', () => {
     };
 
     /**
-     * Verbatim from Puppeteer 24.38.0 `common/CallbackRegistry.js`, where the leading label is the
-     * CDP method name. Pinning the real string is the point: a paraphrase would keep passing while
-     * the message the library actually throws drifted out from under the guard.
+     * Provoked from the INSTALLED puppeteer-core rather than copied from it. The guard exists to
+     * survive a message the library may reshape on a version bump, so a hand-written literal would
+     * keep passing while the real string drifted out from under it — the one drift this test is
+     * here to catch. Driving the real `Callback` is also what shows the label is the bare CDP
+     * method name, with no `Protocol error (...)` prefix for the death pattern to match.
      */
-    const PUPPETEER_PROTOCOL_TIMEOUT =
-      "Runtime.callFunctionOn timed out. Increase the 'protocolTimeout' setting in launch/connect calls for a higher timeout if needed.";
+    const puppeteerProtocolTimeoutMessage = async (): Promise<string> => {
+      const callback = new Callback(1, 'Runtime.callFunctionOn', 1);
+      try {
+        await callback.promise;
+      } catch (error) {
+        return error instanceof Error ? error.message : String(error);
+      }
+      throw new Error('puppeteer-core did not reject on an expired protocolTimeout');
+    };
 
-    it('does not treat a protocol timeout as a dead page', () => {
-      // The renderer is slower than the budget, not gone — the next command may well succeed.
-      // Reporting death here would tear down a live session and answer 503 for a working page.
-      expect(classify(PUPPETEER_PROTOCOL_TIMEOUT)).toBe(false);
-    });
+    it('does not treat a protocol timeout as a dead page', async () => {
+      const message = await puppeteerProtocolTimeoutMessage();
 
-    it.each([
-      'Protocol error (Runtime.callFunctionOn): Session closed.',
-      'Protocol error (Page.navigate): Target closed',
-      'Attempted to use detached Frame',
-      'Connection closed',
-    ])('still reports a genuine transport death: %s', message => {
-      // The 503-on-dead-page contract, pinned from the other side: narrowing the classifier for
-      // timeouts must not cost a single real death signature.
-      expect(classify(message)).toBe(true);
+      // Guard the guard: if a bump ever drops the phrase this classifier keys on, fail here rather
+      // than silently start reporting slow reads as deaths.
+      expect(message).toMatch(/timed out\. Increase the 'protocolTimeout'/);
+      expect(classify(message)).toBe(false);
     });
 
     it('reports a death whose message also mentions a timeout', () => {

--- a/src/engine/adapters/wwebjs-protocol-timeout.spec.ts
+++ b/src/engine/adapters/wwebjs-protocol-timeout.spec.ts
@@ -60,6 +60,16 @@ describe('whatsapp-web.js protocol timeout', () => {
     expect(options).not.toHaveProperty('protocolTimeout');
   });
 
+  it('omits the option for a value configuration.ts would never produce', async () => {
+    // The config layer is not the only writer: a plugin config (PUT /api/plugins/{id}/config) is
+    // validated as an object and merged over the env blob at boot, so the sink enforces the bounds
+    // too. 0 arms no timer at all; over MAX_TIMER_MS overflows Node's and fires after 1 ms.
+    expect(await launchedPuppeteerOptions(0)).not.toHaveProperty('protocolTimeout');
+    expect(await launchedPuppeteerOptions(-1)).not.toHaveProperty('protocolTimeout');
+    expect(await launchedPuppeteerOptions(MAX_TIMER_MS + 1)).not.toHaveProperty('protocolTimeout');
+    expect(await launchedPuppeteerOptions(MAX_TIMER_MS)).toMatchObject({ protocolTimeout: MAX_TIMER_MS });
+  });
+
   describe('the bounds this knob exists to enforce', () => {
     it('rejects a non-positive or over-range value at boot instead of handing it to Puppeteer', () => {
       expect(() => validateEnv({ PUPPETEER_PROTOCOL_TIMEOUT_MS: '0' })).toThrow(/positive integer/);
@@ -134,6 +144,11 @@ describe('whatsapp-web.js protocol timeout', () => {
       // than silently start reporting slow reads as deaths.
       expect(message).toMatch(/timed out\. Increase the 'protocolTimeout'/);
       expect(classify(message)).toBe(false);
+
+      // The case that makes the carve-out load-bearing rather than decorative: puppeteer's own
+      // `_reject` formats a rejected command as `Protocol error (label): message`, which the death
+      // pattern matches. Without the carve-out this reads as a dead page.
+      expect(classify(`Protocol error (Runtime.callFunctionOn): ${message}`)).toBe(false);
     });
 
     it('reports a death whose message also mentions a timeout', () => {

--- a/src/engine/builtin/whatsapp-web-js/index.spec.ts
+++ b/src/engine/builtin/whatsapp-web-js/index.spec.ts
@@ -20,7 +20,12 @@ describe('WhatsAppWebJsPlugin.createEngine (opaque config)', () => {
     const plugin = new WhatsAppWebJsPlugin();
     withContext(plugin, {
       sessionDataPath: '/data/sessions',
-      puppeteer: { headless: false, args: ['--single-process'], executablePath: '/usr/bin/chromium' },
+      puppeteer: {
+        headless: false,
+        args: ['--single-process'],
+        executablePath: '/usr/bin/chromium',
+        protocolTimeoutMs: 300_000,
+      },
     });
 
     plugin.createEngine({ sessionId: 'sess-1', proxyUrl: 'http://p', proxyType: 'http' });
@@ -29,7 +34,14 @@ describe('WhatsAppWebJsPlugin.createEngine (opaque config)', () => {
       expect.objectContaining({
         sessionId: 'sess-1',
         sessionDataPath: '/data/sessions',
-        puppeteer: { headless: false, args: ['--single-process'], executablePath: '/usr/bin/chromium' },
+        // protocolTimeoutMs is asserted with a value, not just carried: an object with the key
+        // present-but-undefined equals one without it, so a dropped hop would pass unnoticed.
+        puppeteer: {
+          headless: false,
+          args: ['--single-process'],
+          executablePath: '/usr/bin/chromium',
+          protocolTimeoutMs: 300_000,
+        },
         proxy: { url: 'http://p', type: 'http' },
       }),
     );

--- a/src/engine/builtin/whatsapp-web-js/index.ts
+++ b/src/engine/builtin/whatsapp-web-js/index.ts
@@ -48,13 +48,14 @@ export class WhatsAppWebJsPlugin implements IEnginePlugin {
     // per-call config carries only engine-neutral fields (sessionId, proxy).
     const engineConfig = (this.context?.config ?? this.registeredConfig ?? {}) as {
       sessionDataPath?: string;
-      puppeteer?: { headless?: boolean; args?: string[]; executablePath?: string };
+      puppeteer?: { headless?: boolean; args?: string[]; executablePath?: string; protocolTimeoutMs?: number };
     };
     const puppeteer = engineConfig.puppeteer ?? {};
     const sessionDataPath = engineConfig.sessionDataPath ?? './data/sessions';
     const headless = puppeteer.headless ?? true;
     const puppeteerArgs = puppeteer.args ?? ['--no-sandbox', '--disable-setuid-sandbox'];
     const executablePath = puppeteer.executablePath;
+    const protocolTimeoutMs = puppeteer.protocolTimeoutMs;
 
     return new WhatsAppWebJsAdapter({
       sessionId,
@@ -63,6 +64,7 @@ export class WhatsAppWebJsPlugin implements IEnginePlugin {
         headless,
         args: puppeteerArgs,
         executablePath,
+        protocolTimeoutMs,
       },
       proxy: proxyUrl
         ? {

--- a/src/engine/engine.factory.ts
+++ b/src/engine/engine.factory.ts
@@ -232,6 +232,7 @@ export class EngineFactory implements OnModuleInit {
         headless: this.configService.get<boolean>('engine.puppeteer.headless') ?? true,
         args: this.configService.get<string[]>('engine.puppeteer.args') ?? ['--no-sandbox', '--disable-setuid-sandbox'],
         executablePath: this.configService.get<string>('engine.puppeteer.executablePath'),
+        protocolTimeoutMs: this.configService.get<number>('engine.puppeteer.protocolTimeoutMs'),
       },
       proxy: options.proxyUrl
         ? {


### PR DESCRIPTION
greetings from Argentina!!!

This is the `protocolTimeout` piece from the #1307 review, split out on its own as suggested there. Nothing from the pagination side is included.

I rewrote this description after your review, so it describes the branch as it stands now rather than as I first opened it. The short version: the default is gone rather than raised, the value is bounded from above, and the two tests that could not fail are gone.

## The problem

Puppeteer drops any CDP command after 180s (`cdp/Connection.js`: `this.#timeout = timeout ?? 180_000`). One `client.getChats()` on an account with a few thousand chats can run past that, so the read fails with `Runtime.callFunctionOn timed out …` even though the renderer is fine and the session is still `ready`.

The part I can actually prove is the second half: there is no way to change it. `protocolTimeout` appears nowhere in `src/`, `.env.example` or `docs/`, so an operator who hits this has to fork or patch `node_modules`.

## About the missing measurement

You asked for one and I do not have it. You also found #199, #628 and #368, where the timeout was ending a hang caused by something else rather than failing a healthy slow read, and I could not turn up anything that contradicts that. So I am not going to claim a number from the mechanism alone.

That means the escape-hatch framing you offered is the one this takes. The default is not 300000, and it is not 180000 either. Unset leaves the launch option absent, so puppeteer-core's own `timeout ?? 180_000` applies. I did think about writing 180000 into `configuration.ts` for symmetry, but that pins today's figure in code that has no way to notice a bump, and it would make the parity `.env.example`, `docs/10` and the CHANGELOG all claim quietly false one release later.

There is a side effect worth calling out. It makes the launch-option presence check load-bearing. On the previous revision `configuration.ts` always returned a number, so the option was always spread, and `it('omits the option when unset')` passed with the entire spread deleted. It fails now.

Since nothing changes for anyone who leaves it unset, the CHANGELOG entry is a plain `### Added` rather than the behaviour change filed under it before.

## The knob

`PUPPETEER_PROTOCOL_TIMEOUT_MS`. Positive integer, at most 2147483647, rejected at boot on both ends.

`0` is refused because `common/CallbackRegistry.js` arms the timer under `if (timeout)`, so a falsy value arms nothing. I drove the installed registry to be sure rather than reading it off the source:

```
protocolTimeout=50  ->  rejected: Runtime.callFunctionOn timed out. Increase the 'protocolTimeout' …
protocolTimeout=0   ->  no timer, still pending
```

So `0` does not relax the bound, it removes it, and a wedged renderer would sit on the command with the HTTP request stuck behind it. That is the 503-on-a-dead-page contract turned off by an env var.

The ceiling is the one you asked for. `checkPositiveInt` only bounded from below, so anything above `2147483647` reached Puppeteer intact:

```
TimeoutOverflowWarning: 2147483648 does not fit into a 32-bit signed integer.
Timeout duration was set to 1.
```

Every command in the launch handshake then fails with `Target.setDiscoverTargets timed out. Increase the 'protocolTimeout' setting`, which is the error the new troubleshooting entry tells the operator to raise the value for. Your point about the docs forbidding `0` and steering people at a row of nines is the reason this matters, not the arithmetic. Both ends are rejected at boot rather than clamped, so they find out the value they wrote is not the value they would have got.

`configuration.ts` uses the guarded form the other positive-only `*_MS` knobs use. That removed the `typeof === 'number' && > 0` guard from the launch options and three of the five launch-option cases with it, since the range is enforced at the config layer now.

Plumbing follows the existing engine knobs (`configuration.ts` → factory / `engine/builtin/whatsapp-web-js` → adapter config → launch options), plus `.env.example`, both compose forwards, and the `BLANK_SHADOWED_ENV_KEYS` entry those need. The key also moved inside the `checkPositiveInt` array literal, so `docs-env-example.spec.ts`'s extractor picks it up from the validator instead of relying on `env-precedence.ts` to carry it.

## Docs

`docs/12` recommended 600000 and said nothing about what raising it costs. It uses 300000 now and adds the part that was missing: the budget is also how long a wedged browser holds a command before the gateway can give up on it. At 300000 that is five minutes instead of three, and for that whole window the stuck command holds the logout fence behind it, so `start` and `delete` answer `409 SESSION_NAME_TEARDOWN_PENDING` and `forceKill` refuses with `400` because the engine was already evicted. It also says outright that there is no measurement here, so anything above the default is something you reach for after seeing the error, not a value to set up front.

`docs/10` had it as a live assignment of 300000 inside the copy-paste production `.env` template, which told every operator to do exactly what `docs/12` says not to. It is commented out like the other optional knobs.

## The carve-out

You left this to me, so it stays, and the label from last time still applies: it changes nothing today. puppeteer-core 24.38.0 emits that message from one site with no `Protocol error (…)` prefix, none of the `PAGE_TRANSPORT_ERROR_PATTERN` signatures appear in it, and deleting the guard leaves the suite green. It earns its place by failing if the message drifts, not by covering a branch.

What changed is that it can now detect the drift at all. The spec provokes the message from the installed puppeteer-core (`new Callback(1, 'Runtime.callFunctionOn', 1)`) instead of the literal I had copied by hand. You were right that the old version could not fail on the one thing it existed to catch.

Two tests are gone. The falsy-budget probe exercised no code in this repo and survived every revert of the PR. The four death-signature cases duplicate the six in `whatsapp-web-js.adapter.spec.ts` -- yours has `TargetClosedError: page closed` and a second Target-closed shape on top of my four, and I checked none of the six matches the timeout pattern, so the guard cannot swallow them.

Six tests remain. I checked each against a revert of the code it guards: the launch-option spread, the boot rejection, the config range and the message-drift assertion all fail when their production code is removed.

## Testing

`wwebjs-protocol-timeout.spec.ts` passes, 6 tests.

`npm test` shows no change against the pre-change baseline here, and this time I baselined it instead of asserting it: the four suites that fail on my machine fail identically with the branch stashed, 9 failed / 605 passed either way, and they are the known Windows `ps` and POSIX-permission ones.

`npm run test:docs` passes 262 including `docs-env-example.spec.ts`. The one failing suite there, `docs-ci-jobs`, fails the same way on a clean `upstream/main`.

`tsc --noEmit` and `eslint` are clean, and `prettier --check` is clean on every touched file.

CI on this branch is yours to approve. I know the run I linked last time was on my fork and does not count as evidence here.
