### PR TITLE
feat(session): expose chat mute state in the chats list (#1473)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `GET /sessions/{sessionId}/chats` now reports each chat's mute state: `isMuted` and, when muted,
+  `muteExpiration` (Unix seconds, `0` = muted indefinitely). Both fields are optional and absent when the
+  active engine cannot report mute state, so a consumer can tell "unknown" apart from "not muted" — e.g. an
+  automation rule that must never reply in a muted chat. Mapped on both engines. Closes #1473.
+
 ## [0.23.3] - 2026-08-24
 
 ### Added

--- a/openapi.json
+++ b/openapi.json
@@ -10246,6 +10246,16 @@
           "lastMessage": {
             "type": "string",
             "example": "hi"
+          },
+          "isMuted": {
+            "type": "boolean",
+            "description": "Whether the chat is currently muted. Absent when the active engine cannot report mute state (so a consumer can tell \"unknown\" apart from \"not muted\").",
+            "example": true
+          },
+          "muteExpiration": {
+            "type": "number",
+            "description": "Unix seconds at which the mute expires (same unit as `timestamp`). `0` means muted indefinitely. Only present when `isMuted` is true.",
+            "example": 1700003600
           }
         },
         "required": [

--- a/src/engine/adapters/baileys-session-store.spec.ts
+++ b/src/engine/adapters/baileys-session-store.spec.ts
@@ -64,6 +64,7 @@ describe('BaileysSessionStore', () => {
         unreadCount: 2,
         timestamp: 200,
         lastMessage: 'newest',
+        isMuted: false, // no muteEndTime on the chat -> not muted
       },
     ]);
     expect(store.lastMessage('628111@s.whatsapp.net')).toEqual({
@@ -108,6 +109,38 @@ describe('BaileysSessionStore', () => {
 
   it('lastMessage returns null for an unknown chat', () => {
     expect(store.lastMessage('unknown@s.whatsapp.net')).toBeNull();
+  });
+
+  // Mute state exposure (#1473). Baileys stores muteEndTime as epoch MILLISECONDS with a negative
+  // sentinel for "indefinitely"; the neutral shape reports epoch SECONDS with 0 = indefinite.
+  describe('mute state (#1473)', () => {
+    const chat = (muteEndTime: number | null): void =>
+      store.upsertChats([{ id: '628111@s.whatsapp.net', name: 'Alice', muteEndTime }]);
+
+    it('reports isMuted:false and no expiration for a chat with no mute set', () => {
+      chat(null);
+      expect(store.listChats()[0]).toEqual(expect.objectContaining({ isMuted: false }));
+      expect(store.listChats()[0]).not.toHaveProperty('muteExpiration');
+    });
+
+    it('reports a future mute end as muted, converting milliseconds to seconds', () => {
+      const endMs = Date.now() + 3_600_000; // 1h out
+      chat(endMs);
+      expect(store.listChats()[0]).toEqual(
+        expect.objectContaining({ isMuted: true, muteExpiration: Math.floor(endMs / 1000) }),
+      );
+    });
+
+    it('treats a negative sentinel as muted indefinitely (expiration 0)', () => {
+      chat(-1);
+      expect(store.listChats()[0]).toEqual(expect.objectContaining({ isMuted: true, muteExpiration: 0 }));
+    });
+
+    it('treats an elapsed mute end as no longer muted', () => {
+      chat(Date.now() - 1000); // already passed
+      expect(store.listChats()[0]).toEqual(expect.objectContaining({ isMuted: false }));
+      expect(store.listChats()[0]).not.toHaveProperty('muteExpiration');
+    });
   });
 
   describe('getEphemeralExpiration (#473)', () => {

--- a/src/engine/adapters/baileys-session-store.ts
+++ b/src/engine/adapters/baileys-session-store.ts
@@ -388,7 +388,33 @@ export class BaileysSessionStore {
       unreadCount: c.unreadCount ?? 0,
       timestamp: last?.timestamp ?? this.toUnixSeconds(c.conversationTimestamp),
       lastMessage: last?.text,
+      ...this.neutralMuteState(c.muteEndTime),
     };
+  }
+
+  /**
+   * Map Baileys' `muteEndTime` to the neutral `{ isMuted, muteExpiration }` shape. Unlike
+   * `conversationTimestamp`, `muteEndTime` is epoch MILLISECONDS (measured, not read off the proto —
+   * see the note in `chat-mute.spec.ts`), with a negative sentinel for "muted indefinitely" and
+   * null/0 for "not muted". `muteExpiration` is returned in epoch SECONDS to match `timestamp`
+   * (`0` = indefinite), and a mute whose end is already in the past reads as unmuted — the same
+   * elapsed-aware view whatsapp-web.js's own `isMuted` gives.
+   */
+  private neutralMuteState(muteEndTime: number | { toNumber(): number } | null | undefined): {
+    isMuted?: boolean;
+    muteExpiration?: number;
+  } {
+    const raw = muteEndTime == null ? 0 : typeof muteEndTime === 'number' ? muteEndTime : muteEndTime.toNumber();
+    if (raw === 0) {
+      return { isMuted: false };
+    }
+    if (raw < 0) {
+      return { isMuted: true, muteExpiration: 0 };
+    }
+    if (Date.now() >= raw) {
+      return { isMuted: false };
+    }
+    return { isMuted: true, muteExpiration: Math.floor(raw / 1000) };
   }
 
   /**

--- a/src/engine/adapters/baileys.adapter.spec.ts
+++ b/src/engine/adapters/baileys.adapter.spec.ts
@@ -4250,6 +4250,7 @@ describe('BaileysAdapter contact + chat reads', () => {
       unreadCount: 1,
       timestamp: 1700000010,
       lastMessage: 'hi',
+      isMuted: false, // no muteEndTime on the history chat -> not muted (#1473)
     });
   });
 

--- a/src/engine/adapters/chat-mute.spec.ts
+++ b/src/engine/adapters/chat-mute.spec.ts
@@ -203,3 +203,45 @@ describe('BaileysContacts.muteChat', () => {
     await expect(contacts.muteChat('628123@c.us', MUTE_UNTIL)).rejects.toBeInstanceOf(EngineTransportError);
   });
 });
+
+// Read-back of mute state through getChats (#1473). whatsapp-web.js exposes an authoritative
+// isMuted plus muteExpiration in epoch SECONDS (-1 = indefinitely); the neutral shape reports the
+// same seconds with 0 = indefinitely, and only when the chat is muted.
+describe('WwebjsChats.getChats mute mapping (#1473)', () => {
+  function makeChatsWith(rawChats: unknown[]): WwebjsChats {
+    const client = { getChats: jest.fn().mockResolvedValue(rawChats) };
+    const host = {
+      ensureReady: jest.fn(),
+      getClient: () => client as unknown as Client,
+      logger,
+      isPageTransportError: () => false,
+      reportIfPageTransportError: jest.fn(),
+    } as unknown as WwebjsEngineHost;
+    return new WwebjsChats(host, {} as unknown as WwebjsMessaging);
+  }
+
+  const raw = (over: Record<string, unknown>): Record<string, unknown> => ({
+    id: { _serialized: '628123@c.us' },
+    name: 'Alice',
+    isGroup: false,
+    unreadCount: 0,
+    timestamp: 1700000000,
+    ...over,
+  });
+
+  it('maps a timed mute to isMuted:true and the same epoch-seconds expiration', async () => {
+    const [chat] = await makeChatsWith([raw({ isMuted: true, muteExpiration: 1700003600 })]).getChats();
+    expect(chat).toEqual(expect.objectContaining({ isMuted: true, muteExpiration: 1700003600 }));
+  });
+
+  it('normalises the -1 "indefinitely" sentinel to 0', async () => {
+    const [chat] = await makeChatsWith([raw({ isMuted: true, muteExpiration: -1 })]).getChats();
+    expect(chat).toEqual(expect.objectContaining({ isMuted: true, muteExpiration: 0 }));
+  });
+
+  it('reports isMuted:false and omits the expiration for an unmuted chat', async () => {
+    const [chat] = await makeChatsWith([raw({ isMuted: false, muteExpiration: 0 })]).getChats();
+    expect(chat).toEqual(expect.objectContaining({ isMuted: false }));
+    expect(chat).not.toHaveProperty('muteExpiration');
+  });
+});

--- a/src/engine/adapters/wwebjs-chats.ts
+++ b/src/engine/adapters/wwebjs-chats.ts
@@ -51,6 +51,12 @@ export class WwebjsChats {
         continue;
       }
 
+      // whatsapp-web.js populates isMuted (authoritative — it already accounts for an elapsed mute)
+      // and muteExpiration in epoch SECONDS, with -1 for "muted indefinitely". Normalise -1 (and any
+      // non-positive value) to the neutral 0-means-indefinite contract, and only surface an
+      // expiration when the chat is actually muted.
+      const isMuted = Boolean(chat.isMuted);
+
       summaries.push({
         id,
         name: chat.name || id,
@@ -60,6 +66,8 @@ export class WwebjsChats {
         timestamp: chat.timestamp || 0,
         // A location message's body is the base64 map thumbnail; don't surface it as the chat preview.
         lastMessage: chat.lastMessage?.type === MessageTypes.LOCATION ? '📍' : chat.lastMessage?.body || undefined,
+        isMuted,
+        ...(isMuted ? { muteExpiration: chat.muteExpiration > 0 ? chat.muteExpiration : 0 } : {}),
       });
     }
 

--- a/src/engine/interfaces/whatsapp-engine.interface.ts
+++ b/src/engine/interfaces/whatsapp-engine.interface.ts
@@ -491,6 +491,17 @@ export interface ChatSummary {
   unreadCount: number;
   timestamp: number;
   lastMessage?: string;
+  /**
+   * Whether the chat is currently muted. Left `undefined` when the active engine cannot report mute
+   * state, so a consumer can distinguish "unknown" from "not muted" and fail closed (e.g. an
+   * automation rule that must never reply in a muted chat).
+   */
+  isMuted?: boolean;
+  /**
+   * Epoch SECONDS at which the mute expires — same unit as `timestamp`. `0` means muted with no
+   * expiry (indefinitely). Only meaningful when `isMuted` is true; omitted otherwise.
+   */
+  muteExpiration?: number;
 }
 
 /**

--- a/src/modules/session/dto/chat-summary.dto.ts
+++ b/src/modules/session/dto/chat-summary.dto.ts
@@ -25,4 +25,20 @@ export class ChatSummaryDto {
 
   @ApiPropertyOptional({ example: 'hi' })
   lastMessage?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Whether the chat is currently muted. Absent when the active engine cannot report mute state ' +
+      '(so a consumer can tell "unknown" apart from "not muted").',
+    example: true,
+  })
+  isMuted?: boolean;
+
+  @ApiPropertyOptional({
+    description:
+      'Unix seconds at which the mute expires (same unit as `timestamp`). `0` means muted ' +
+      'indefinitely. Only present when `isMuted` is true.',
+    example: 1700003600,
+  })
+  muteExpiration?: number;
 }


### PR DESCRIPTION
Closes #1473.

## What

Adds two optional fields to the chat summary returned by `GET /sessions/{sessionId}/chats`:

- `isMuted?: boolean` — current mute state; left `undefined` when the active engine cannot report it, so "unknown" stays distinct from "not muted" (a consumer enforcing "never reply in a muted chat" can fail closed).
- `muteExpiration?: number` — Unix **seconds** the mute ends (same unit as `timestamp`), `0` = muted indefinitely; only set when muted.

Optional + additive, so it is non-breaking.

## Why

The API could mute a chat (`POST /chats/mute`) but never report whether a chat *is* muted, which blocks the common automation rule "never auto-reply in a chat the user muted".

## Engine mapping

Both engines normalise to the same seconds / 0-indefinite contract:

- **whatsapp-web.js**: from `Chat.isMuted` / `Chat.muteExpiration` (already epoch seconds; the `-1` "forever" sentinel is normalised to `0`).
- **baileys**: from `Chat.muteEndTime`, which is epoch **milliseconds** (per the measured note in `chat-mute.spec.ts`) with a negative sentinel for indefinite — converted to seconds, and treated as unmuted once the end instant has elapsed.

Controller and service pass the shape through unchanged.

## Tests / checks

Unit tests added for both adapters' mappings; OpenAPI snapshot regenerated. Locally green: `tsc --noEmit`, full unit suite (5940), e2e (181), `test:docs` (engine-parity / changelog / OpenAPI contract), lint, `openapi:check`.