### PR TITLE
fix(contacts): read ids via readWid and skip unreadable entries with a count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A whatsapp-web.js protocol timeout is no longer eligible to be classified as a dead page.
   Behaviour is unchanged on the current Puppeteer; the guard keeps a future bump from reporting a
   slow command as a transport death.
+- `GET /sessions/{sessionId}/contacts` declares `503` in the contract and answers it when the
+  whatsapp-web.js page dies mid-read, instead of a bare `500`. Thanks @Deyvis17GY.
 
 ### Fixed
 
@@ -37,6 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and the library still calls it positionally, so `widToGroupJid` threw inside the page. A new
   install-time patch (🔧⁹, docs/29) sends the options object; an empty description still clears.
   `setGroupSubject` was never affected and Baileys is unchanged. Thanks @purnamcommunity.
+- whatsapp-web.js contact reads resolve the renamed `$1` serialized-id field, so contacts keep their
+  `id` on a WhatsApp Web build that renamed it; an entry with no readable id is skipped and counted
+  in the log. Thanks @Deyvis17GY.
 - Inbound media whose download fails now keeps the `media` envelope with `omitted: true` and the declared
   size, on both engines, instead of dropping the field and looking like a message that never had media.
 - Webhook filters and automation rules gated on `hasMedia` now match those messages.

--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -2278,7 +2278,7 @@ List all contacts for a session, returned as an in-memory paginated window.
 ]
 ```
 
-**Errors:** `400` session is not started · `401` missing/invalid API key, or key not scoped to this session · `409` conflict or engine not ready (retryable)
+**Errors:** `400` session is not started · `401` missing/invalid API key, or key not scoped to this session · `409` conflict or engine not ready (retryable) · `503` the WhatsApp page died while reading contacts (retry shortly)
 
 #### GET /api/sessions/:sessionId/contacts/blocked
 

--- a/openapi.json
+++ b/openapi.json
@@ -4398,6 +4398,9 @@
           },
           "409": {
             "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
+          },
+          "503": {
+            "description": "The WhatsApp page died while reading contacts, retry shortly"
           }
         },
         "summary": "Get all contacts for a session",

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -5624,15 +5624,92 @@ describe('WhatsAppWebJsAdapter page transport error detection (wedged page fast-
     },
   );
 
-  it('detects a transport error from a getter too (getContacts)', async () => {
+  it('converts a transport error from a getter into a 503 (getContacts)', async () => {
     const getContacts = jest.fn().mockRejectedValue(new Error('Protocol error: Target closed'));
     const { adapter, onDisconnected } = readyAdapter({ getContacts });
 
-    await expect(adapter.getContacts()).rejects.toThrow('Protocol error: Target closed');
-
-    expect(onDisconnected).toHaveBeenCalledTimes(1);
+    await expect(adapter.getContacts()).rejects.toBeInstanceOf(EngineTransportError);
     expect(onDisconnected).toHaveBeenCalledWith('Page transport error during getContacts');
-    expect(adapter.getStatus()).toBe(EngineStatus.DISCONNECTED);
+  });
+
+  // #1476: a raw wwebjs contact carries its wid under `_serialized` or, on a renamed WA Web build,
+  // under `$1` (see readWid). Both shapes must map to the same library-agnostic Contact.
+  it('maps both the `_serialized` and the renamed `$1` id shapes in getContacts', async () => {
+    const raw = [
+      {
+        id: { _serialized: '111@c.us' },
+        name: 'Alice',
+        pushname: 'Ally',
+        number: '111',
+        isMyContact: true,
+        isBlocked: false,
+      },
+      { id: { $1: '222@c.us' }, name: 'Bob', pushname: 'Bobby', number: '222', isMyContact: false, isBlocked: true },
+    ];
+    const getContacts = jest.fn().mockResolvedValue(raw);
+    const { adapter } = readyAdapter({ getContacts });
+
+    await expect(adapter.getContacts()).resolves.toEqual([
+      { id: '111@c.us', name: 'Alice', pushName: 'Ally', number: '111', isMyContact: true, isBlocked: false },
+      { id: '222@c.us', name: 'Bob', pushName: 'Bobby', number: '222', isMyContact: false, isBlocked: true },
+    ]);
+  });
+
+  // #1476: an entry with no readable wid under either name (a shape wwebjs itself sometimes returns)
+  // must not reject the whole address book — it is dropped and counted instead.
+  it('skips a contact with no readable id and counts it in the warn log, keeping the rest', async () => {
+    const good1 = { id: { _serialized: '111@c.us' }, name: 'Alice', number: '111' };
+    const unreadable = { id: {}, name: 'Ghost', number: '000' };
+    const good2 = { id: { $1: '222@c.us' }, name: 'Bob', number: '222' };
+    const getContacts = jest.fn().mockResolvedValue([good1, unreadable, good2]);
+    const { adapter } = readyAdapter({ getContacts });
+    const logger = (adapter as unknown as { logger: { warn: (m: string) => void } }).logger;
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+
+    const contacts = await adapter.getContacts();
+
+    expect(contacts.map(c => c.id)).toEqual(['111@c.us', '222@c.us']);
+    expect(warnSpy).toHaveBeenCalledWith('Skipped 1 contact(s) without a serialized id');
+  });
+
+  // A rejection that carries no transport-death signature is an ordinary failure, not a dead page —
+  // it must reach the caller unchanged and leave the session READY, unlike the 503 case above.
+  it('propagates a non-transport rejection from getContacts untouched and leaves the session READY', async () => {
+    const getContacts = jest.fn().mockRejectedValue(new Error('Evaluation failed: TypeError: x is not a function'));
+    const { adapter, onDisconnected } = readyAdapter({ getContacts });
+
+    await expect(adapter.getContacts()).rejects.toThrow('Evaluation failed: TypeError: x is not a function');
+
+    expect(onDisconnected).not.toHaveBeenCalled();
+    expect(adapter.getStatus()).toBe(EngineStatus.READY);
+  });
+
+  it('getContactById maps the renamed `$1` id shape too', async () => {
+    const getContactById = jest.fn().mockResolvedValue({
+      id: { $1: '333@c.us' },
+      name: 'Cara',
+      pushname: 'C',
+      number: '333',
+      isMyContact: true,
+      isBlocked: false,
+    });
+    const { adapter } = readyAdapter({ getContactById });
+
+    await expect(adapter.getContactById('333@c.us')).resolves.toEqual({
+      id: '333@c.us',
+      name: 'Cara',
+      pushName: 'C',
+      number: '333',
+      isMyContact: true,
+      isBlocked: false,
+    });
+  });
+
+  it('getContactById returns null for an entry with no readable id', async () => {
+    const getContactById = jest.fn().mockResolvedValue({ id: {}, name: 'Ghost', number: '000' });
+    const { adapter } = readyAdapter({ getContactById });
+
+    await expect(adapter.getContactById('000@c.us')).resolves.toBeNull();
   });
 
   // joinGroupViaInviteCode answers 503 for a transport failure (a refused invite is no longer

--- a/src/engine/adapters/wwebjs-contacts.ts
+++ b/src/engine/adapters/wwebjs-contacts.ts
@@ -28,7 +28,7 @@ export class WwebjsContacts {
    * unguarded (the shape that lets a single bad entry reject the whole request).
    */
   private toContact(c: RawWwebjsContact): Contact | null {
-    const id = readWid(c.id as unknown as SerializedWid);
+    const id = readWid(c.id);
     if (!id) return null;
     return {
       id,

--- a/src/engine/adapters/wwebjs-contacts.ts
+++ b/src/engine/adapters/wwebjs-contacts.ts
@@ -5,6 +5,9 @@ import { userPart } from '../identity/wa-id';
 import { readWid, type SerializedWid } from '../types/whatsapp-web-js.types';
 import { type WwebjsEngineHost } from './wwebjs-host';
 
+/** The raw whatsapp-web.js contact element type, kept local so the wwebjs `Contact` type never leaks. */
+type RawWwebjsContact = Awaited<ReturnType<Client['getContacts']>>[number];
+
 /**
  * Contact operations extracted from WhatsAppWebJsAdapter. The adapter keeps the public methods as
  * thin forwarders and injects the shared host surface (./wwebjs-host) via closures, so the delegate
@@ -18,37 +21,65 @@ export class WwebjsContacts {
     return this.host.getClient();
   }
 
+  /**
+   * Map a raw whatsapp-web.js contact to the library-agnostic {@link Contact}. The id is read
+   * through {@link readWid} so both the `_serialized` and post-rename `$1` shapes resolve; a
+   * contact with no readable id returns null so callers can skip it instead of dereferencing
+   * unguarded (the shape that lets a single bad entry reject the whole request).
+   */
+  private toContact(c: RawWwebjsContact): Contact | null {
+    const id = readWid(c.id as unknown as SerializedWid);
+    if (!id) return null;
+    return {
+      id,
+      name: c.name || undefined,
+      pushName: c.pushname || undefined,
+      number: c.number,
+      isMyContact: c.isMyContact,
+      isBlocked: c.isBlocked,
+    };
+  }
+
   async getContacts(): Promise<Contact[]> {
     this.host.ensureReady();
-    try {
-      const contacts = await this.client().getContacts();
 
-      return contacts.map(c => ({
-        id: c.id._serialized,
-        name: c.name || undefined,
-        pushName: c.pushname || undefined,
-        number: c.number,
-        isMyContact: c.isMyContact,
-        isBlocked: c.isBlocked,
-      }));
+    let raw: RawWwebjsContact[];
+    try {
+      raw = await this.client().getContacts();
     } catch (error) {
-      this.host.reportIfPageTransportError(error, 'getContacts');
+      // A dead page surfaces here as a raw Puppeteer error; convert it to the documented transport
+      // failure the way wwebjs-chats.ts does, so a transport death answers 503 instead of a bare 500.
+      if (this.host.isPageTransportError(error)) {
+        this.host.reportIfPageTransportError(error, 'getContacts');
+        throw new EngineTransportError('Transport died while reading contacts');
+      }
       throw error;
     }
+
+    // Read every id through readWid (so the `_serialized`->`$1` rename lands here too) and skip
+    // entries with no readable id, counted and logged like the chats path, rather than dropping
+    // the whole address book silently.
+    const contacts: Contact[] = [];
+    let skipped = 0;
+    for (const c of raw) {
+      const mapped = this.toContact(c);
+      if (!mapped) {
+        skipped++;
+        continue;
+      }
+      contacts.push(mapped);
+    }
+    if (skipped > 0) {
+      this.host.logger.warn(`Skipped ${skipped} contact(s) without a serialized id`);
+    }
+    return contacts;
   }
 
   async getContactById(contactId: string): Promise<Contact | null> {
     this.host.ensureReady();
     try {
       const contact = await this.client().getContactById(contactId);
-      return {
-        id: contact.id._serialized,
-        name: contact.name || undefined,
-        pushName: contact.pushname || undefined,
-        number: contact.number,
-        isMyContact: contact.isMyContact,
-        isBlocked: contact.isBlocked,
-      };
+      return this.toContact(contact);
     } catch (error) {
       // Unlike the avatar lookup, a throw here can legitimately mean the contact is absent:
       // `window.WWebJS.getContact` has no try/catch and reads `contact.isBusiness` straight off

--- a/src/modules/contact/contact.controller.ts
+++ b/src/modules/contact/contact.controller.ts
@@ -28,6 +28,7 @@ export class ContactController {
     type: [ContactDto],
   })
   @ApiResponse({ status: 400, description: 'Session not ready' })
+  @ApiResponse({ status: 503, description: 'The WhatsApp page died while reading contacts, retry shortly' })
   @ApiResponse({ status: 409, description: ENGINE_NOT_READY_409 })
   @ApiQuery({ name: 'limit', required: false, description: 'Max contacts to return (1–1000, default 1000)' })
   @ApiQuery({ name: 'offset', required: false, description: 'Number of contacts to skip (for paging)' })


### PR DESCRIPTION
## What

Rework the whatsapp-web.js contacts mapping along the lines suggested in review.

- Fold getContacts and getContactById (identical six-field mapping) into one
  `toContact(c)` helper that reads the id through `readWid`, so the
  `_serialized`->`$1` rename lands on both reads; returns null for an unreadable id.
- getContacts skips unreadable entries, counted and logged
  (`Skipped N contact(s) without a serialized id`), matching wwebjs-chats.ts,
  instead of dropping the address book silently.
- Fixes getContactById returning 404 for a contact whose id only differs by the rename.
- Convert getContacts' dead-page rethrow to `EngineTransportError` (503) to match
  the sibling read in wwebjs-chats.ts.

## Note

Reframed to "Refs #1476": the page-level cause isn't established yet. Happy to split
the transport-error change into its own PR or add a unit test if preferred.