### PR TITLE
Feat/template chat composer

### DIFF
--- a/dashboard/src/components/chats/ChatComposer.tsx
+++ b/dashboard/src/components/chats/ChatComposer.tsx
@@ -1,9 +1,14 @@
 import { useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { Loader2, Paperclip, Send, Smile, X } from 'lucide-react';
-import { messageApi, type Chat, type MessageType } from '../../services/api';
-import { mergeOrAppend, type ChatMessageView } from '../../utils/chatMessages';
+import { Loader2, Paperclip, Send, Smile, X,FileText  } from 'lucide-react';
+import {
+  messageApi,
+  templateApi,
+  type Chat,
+  type MessageType,
+  type MessageTemplate,
+} from '../../services/api';import { mergeOrAppend, type ChatMessageView } from '../../utils/chatMessages';
 import { promoteChatWithSnippet } from '../../utils/chatList';
 import { buildMediaSendPayload, buildOptimisticMetadata, quotedIdOf } from '../../utils/composerSend';
 import { messagesQueryKey, useChatMessagesActions } from '../../hooks/useChatMessages';
@@ -75,6 +80,65 @@ function ChatComposer({
   const [sending, setSending] = useState<boolean>(false);
 
   const [showEmojiPicker, setShowEmojiPicker] = useState<boolean>(false);
+
+  const [showTemplatePicker, setShowTemplatePicker] = useState<boolean>(false);
+  const [templates, setTemplates] = useState<MessageTemplate[]>([]);
+  const [loadingTemplates, setLoadingTemplates] = useState<boolean>(false);
+
+
+
+    /**
+   * Loads the message templates belonging to the currently selected WhatsApp session.
+   *
+   * The composer receives `selectedSessionId` from Chats.tsx, so templates are always
+   * scoped to the same session as the open conversation.
+   *
+   * A small cancellation guard prevents an old request from updating state after the
+   * user switches sessions or the composer is unmounted.
+   */
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadTemplates = async () => {
+      if (!selectedSessionId) {
+        setTemplates([]);
+        setLoadingTemplates(false);
+        return;
+      }
+
+      setLoadingTemplates(true);
+
+      try {
+        const result = await templateApi.list(selectedSessionId);
+
+        if (!cancelled) {
+          setTemplates(result);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setTemplates([]);
+          showErrorToast(
+            t('chats.errors.loadTemplates'),
+            err instanceof Error ? err.message : undefined,
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setLoadingTemplates(false);
+        }
+      }
+    };
+
+    void loadTemplates();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedSessionId, t, showErrorToast]);
+
+
+
+
   // Monotonic token invalidating an in-flight attachment FileReader: picking a second file (or
   // removing the attachment) before `onload` fires must win over the late-arriving bytes —
   // otherwise the slower read overwrites the newer pick. Same pattern as composeImageReadSeq.
@@ -160,6 +224,17 @@ function ChatComposer({
     setMessageInput(prev => prev + emoji);
     setShowEmojiPicker(false);
   };
+
+  // 6.5. Handle sending a Templates
+  const handleTemplateSelect = (template: MessageTemplate) => {
+    const message = [template.header, template.body, template.footer]
+      .filter((part): part is string => Boolean(part?.trim()))
+      .join('\n\n');
+
+    setMessageInput(message);
+    setShowTemplatePicker(false);
+  };
+
 
   // 7. Handle sending a message / media
   const handleSend = async (e?: React.FormEvent) => {
@@ -297,6 +372,48 @@ function ChatComposer({
         </div>
       )}
 
+            {/* Template picker:
+          Shows templates belonging to the current session.
+          Selecting one only fills the message input; it does not send anything.
+          The user can edit the generated text and use the normal Send button. */}
+        {showTemplatePicker && (
+          <div className="chats-template-picker">
+            {loadingTemplates ? (
+              <div className="template-picker-loading">
+                <Loader2 className="animate-spin" size={18} />
+                <span>{t('chats.loadingTemplates')}</span>
+              </div>
+            ) : templates.length === 0 ? (
+              <div className="template-picker-empty">
+                {t('chats.noTemplates')}
+              </div>
+            ) : (
+              <select
+                className="template-select"
+                value=""
+                onChange={e => {
+                  const template = templates.find(item => item.id === e.target.value);
+                  if (template) {
+                    handleTemplateSelect(template);
+                  }
+                }}
+              >
+                <option value="">
+                  {t('Select Tempate')}
+                </option>
+
+                {templates.map(template => (
+                  <option key={template.id} value={template.id}>
+                    {template.name}
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+        )}
+
+
+
       {/* Replying preview banner */}
       {replyingTo && (
         <div className="replying-preview-banner">
@@ -342,8 +459,22 @@ function ChatComposer({
             <Smile size={20} />
           </button>
 
-          <input
-            type="text"
+          <button
+            type="button"
+            onClick={() => {
+              setShowEmojiPicker(false);
+              setShowTemplatePicker(prev => !prev);
+            }}
+            disabled={!canWrite || sending}
+            className={`btn-input-accessory ${showTemplatePicker ? 'active' : ''}`}
+            title="Templates"
+            aria-label="Templates"
+          >
+            <FileText size={20} />
+          </button>
+
+
+          <textarea
             placeholder={
               canWrite
                 ? attachment
@@ -355,6 +486,7 @@ function ChatComposer({
             onChange={e => setMessageInput(e.target.value)}
             disabled={!canWrite || sending}
             className="message-text-input"
+            rows={1}
           />
           <button
             type="submit"

--- a/dashboard/src/i18n/locales/ar.json
+++ b/dashboard/src/i18n/locales/ar.json
@@ -628,7 +628,8 @@
       "sticker": "ملصق",
       "poll": "استطلاع",
       "forward": "إعادة توجيه",
-      "bulk": "جماعي"
+      "bulk": "جماعي",
+      "template": "قوالب"
     },
     "messageContent": "محتوى الرسالة",
     "messagePlaceholder": "أدخل رسالتك هنا...",

--- a/dashboard/src/i18n/locales/de.json
+++ b/dashboard/src/i18n/locales/de.json
@@ -613,7 +613,9 @@
       "sticker": "Sticker",
       "poll": "Umfrage",
       "forward": "Weiterleiten",
-      "bulk": "Massenversand"
+      "bulk": "Massenversand",
+      "template": "Vorlagen"
+
     },
     "messageContent": "Nachrichteninhalt",
     "messagePlaceholder": "Gib hier deine Nachricht ein...",

--- a/dashboard/src/i18n/locales/en.json
+++ b/dashboard/src/i18n/locales/en.json
@@ -613,7 +613,9 @@
       "sticker": "Sticker",
       "poll": "Poll",
       "forward": "Forward",
-      "bulk": "Bulk"
+      "bulk": "Bulk",
+      "template": "Template"
+
     },
     "messageContent": "Message Content",
     "messagePlaceholder": "Enter your message here...",

--- a/dashboard/src/i18n/locales/es.json
+++ b/dashboard/src/i18n/locales/es.json
@@ -567,7 +567,10 @@
       "sticker": "Sticker",
       "poll": "Encuesta",
       "forward": "Reenviar",
-      "bulk": "Masivo"
+      "bulk": "Masivo",
+          "template": "Plantilla"
+
+      
     },
     "messageContent": "Contenido del mensaje",
     "messagePlaceholder": "Escribe tu mensaje aquí...",

--- a/dashboard/src/i18n/locales/fr.json
+++ b/dashboard/src/i18n/locales/fr.json
@@ -613,7 +613,8 @@
       "sticker": "Sticker",
       "poll": "Sondage",
       "forward": "Transférer",
-      "bulk": "En masse"
+      "bulk": "En masse",
+      "template":"Templates"
     },
     "messageContent": "Contenu du message",
     "messagePlaceholder": "Entrez votre message ici...",

--- a/dashboard/src/i18n/locales/it.json
+++ b/dashboard/src/i18n/locales/it.json
@@ -613,7 +613,8 @@
       "sticker": "Sticker",
       "poll": "Sondaggio",
       "forward": "Inoltra",
-      "bulk": "Multiplo"
+      "bulk": "Multiplo",
+      "template":"Template"
     },
     "messageContent": "Contenuto del Messaggio",
     "messagePlaceholder": "Inserisci qui il tuo messaggio...",

--- a/dashboard/src/i18n/locales/ko.json
+++ b/dashboard/src/i18n/locales/ko.json
@@ -613,7 +613,8 @@
       "sticker": "스티커",
       "poll": "투표",
       "forward": "전달",
-      "bulk": "대량"
+      "bulk": "대량",
+      "template":"템플릿"
     },
     "messageContent": "메시지 내용",
     "messagePlaceholder": "메시지를 입력하세요...",

--- a/dashboard/src/i18n/locales/pt-BR.json
+++ b/dashboard/src/i18n/locales/pt-BR.json
@@ -567,7 +567,11 @@
       "sticker": "Figurinha",
       "poll": "Enquete",
       "forward": "Encaminhar",
-      "bulk": "Em massa"
+      "bulk": "Em massa",
+      "template":"Modelos"
+
+
+      
     },
     "messageContent": "Conteúdo da mensagem",
     "messagePlaceholder": "Digite sua mensagem aqui...",

--- a/dashboard/src/i18n/locales/te.json
+++ b/dashboard/src/i18n/locales/te.json
@@ -613,7 +613,9 @@
       "sticker": "స్టిక్కర్",
       "poll": "పోల్",
       "forward": "ఫార్వార్డ్",
-      "bulk": "బల్క్"
+      "bulk": "బల్క్",
+            "template": "Template"
+
     },
     "messageContent": "సందేశం కంటెంట్",
     "messagePlaceholder": "మీ సందేశాన్ని ఇక్కడ ఎంటర్ చేయండి...",

--- a/dashboard/src/i18n/locales/tr.json
+++ b/dashboard/src/i18n/locales/tr.json
@@ -614,7 +614,7 @@
       "poll": "Anket",
       "forward": "İlet",
       "bulk": "Toplu",
-          "templates": "Şablonlar"
+      "template": "Şablonlar"
 
     },
     "messageContent": "Mesaj İçeriği",

--- a/dashboard/src/i18n/locales/tr.json
+++ b/dashboard/src/i18n/locales/tr.json
@@ -613,7 +613,9 @@
       "sticker": "Çıkartma",
       "poll": "Anket",
       "forward": "İlet",
-      "bulk": "Toplu"
+      "bulk": "Toplu",
+          "templates": "Şablonlar"
+
     },
     "messageContent": "Mesaj İçeriği",
     "messagePlaceholder": "Mesajınızı buraya girin...",

--- a/dashboard/src/i18n/locales/zh-CN.json
+++ b/dashboard/src/i18n/locales/zh-CN.json
@@ -613,7 +613,8 @@
       "sticker": "贴纸",
       "poll": "投票",
       "forward": "转发",
-      "bulk": "批量"
+      "bulk": "批量",
+      "template":"Template"
     },
     "messageContent": "消息内容",
     "messagePlaceholder": "在此输入你的消息...",

--- a/dashboard/src/i18n/locales/zh-HK.json
+++ b/dashboard/src/i18n/locales/zh-HK.json
@@ -613,7 +613,9 @@
       "sticker": "貼圖",
       "poll": "投票",
       "forward": "轉發",
-      "bulk": "批量"
+      "bulk": "批量",
+            "template":"Template"
+
     },
     "messageContent": "訊息內容",
     "messagePlaceholder": "在此輸入你的訊息...",

--- a/dashboard/src/pages/MessageTester.tsx
+++ b/dashboard/src/pages/MessageTester.tsx
@@ -4,10 +4,12 @@ import { Send, CheckCircle, XCircle, Loader2, Upload, X, Plus } from 'lucide-rea
 import {
   messageApi,
   contactApi,
+  templateApi,
   type SendMediaPayload,
   type MessageResponse,
   type BatchStatus,
   type BatchStatusResponse,
+  type MessageTemplate,
 } from '../services/api';
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { useRole } from '../hooks/useRole';
@@ -15,6 +17,8 @@ import { useSessionsQuery, useSessionGroupsQuery } from '../hooks/queries';
 import { parseBulkRecipients, BULK_MAX_RECIPIENTS } from '../utils/bulkRecipients';
 import { PageHeader } from '../components/PageHeader';
 import './MessageTester.css';
+
+
 
 interface ApiResponse {
   success: boolean;
@@ -41,6 +45,8 @@ const messageTypes = [
   'poll',
   'forward',
   'bulk',
+  'template',
+
 ] as const;
 
 // The types that share the media upload/URL block (base64 XOR url + mimetype).
@@ -99,6 +105,54 @@ export function MessageTester() {
   const [messageType, setMessageType] = useState<(typeof messageTypes)[number]>('text');
   const [content, setContent] = useState('');
   const [mediaUrl, setMediaUrl] = useState('');
+  const [selectedTemplate, setSelectedTemplate] = useState('');
+  const [templates, setTemplates] = useState<MessageTemplate[]>([]);
+  const [loadingTemplates, setLoadingTemplates] = useState(false);
+
+
+
+
+  useEffect(() => {
+    if (!session) {
+      setTemplates([]);
+      setSelectedTemplate('');
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadTemplates = async () => {
+      setLoadingTemplates(true);
+
+      try {
+        const result = await templateApi.list(session);
+
+        if (!cancelled) {
+          setTemplates(result);
+        }
+      } catch {
+        if (!cancelled) {
+          setTemplates([]);
+          setSelectedTemplate('');
+        }
+      } finally {
+        if (!cancelled) {
+          setLoadingTemplates(false);
+        }
+      }
+    };
+
+    loadTemplates();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [session]);
+
+
+
+
+
   // A locally-picked media file, read as raw base64 (the engine contract — NOT a data: URI). Mutually
   // exclusive with mediaUrl: picking a file clears the URL field; typing a URL drops the file.
   const [mediaFile, setMediaFile] = useState<{ base64: string; mimetype: string; filename: string } | null>(null);
@@ -262,7 +316,9 @@ export function MessageTester() {
       bulkRecipientList.length > 0 &&
       bulkRecipientList.length <= BULK_MAX_RECIPIENTS &&
       (delayMs === undefined || (!Number.isNaN(delayMs) && delayMs >= 1000 && delayMs <= 60000));
-  }
+  }else if (messageType === 'template') {
+  formValid = selectedTemplate.length > 0;
+}
 
   const isSendDisabled =
     !canWrite ||
@@ -395,6 +451,12 @@ export function MessageTester() {
           });
           break;
         }
+        case 'template':
+        result = await messageApi.sendTemplate(session, {
+          chatId,
+          templateId: selectedTemplate,
+        });
+        break;
         default:
           throw new Error(`Unsupported message type: ${messageType}`);
       }
@@ -560,6 +622,36 @@ export function MessageTester() {
               />
             </div>
           )}
+
+          {messageType === 'template' && (
+            <div className="form-group">
+              <label htmlFor="mt-template">
+                Template
+              </label>
+
+              <select
+                id="mt-template"
+                value={selectedTemplate}
+                onChange={e => setSelectedTemplate(e.target.value)}
+                disabled={loadingTemplates || templates.length === 0}
+              >
+                <option value="">
+                  {loadingTemplates
+                    ? 'Loading templates...'
+                    : templates.length === 0
+                      ? 'No templates available'
+                      : 'Select a template'}
+                </option>
+
+                {templates.map(template => (
+                  <option key={template.id} value={template.id}>
+                    {template.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
 
           {isMediaMessageType && (
             <>

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -1033,6 +1033,14 @@ export const messageApi = {
       method: 'POST',
       body: JSON.stringify(data),
     }),
+  sendTemplate: (
+  sessionId: string,
+  data: { chatId: string; templateId: string },
+) =>
+  request<MessageResponse>(`/sessions/${sessionId}/messages/send-template`, {
+    method: 'POST',
+    body: JSON.stringify(data),
+  }),
 };
 
 // =============================================================================
@@ -1353,3 +1361,8 @@ export const statsApi = {
   getOverview: () => request<OverviewStats>('/stats/overview'),
   getMessages: (period: StatsPeriod) => request<MessageStats>(`/stats/messages?period=${period}`),
 };
+
+
+
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -6244,6 +6244,7 @@
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
       "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "node-addon-api": "^8.0.0"


### PR DESCRIPTION
## Description

Added a template picker to the OpenWA chat composer, allowing users to browse templates from the active session.
Selecting a template loads its header, body, and footer directly into the message box for editing before sending.
Added the frontend API support and integrated the feature with the existing message-sending workflow.

## Type of Change

- [ ] New feature

## Screenshots (if applicable)
<img width="717" height="502" alt="image" src="https://github.com/user-attachments/assets/90358365-b9f0-425f-a157-9a6158f584fb" />
<img width="1087" height="141" alt="image" src="https://github.com/user-attachments/assets/bbb272d0-19d5-4345-9beb-56b4289a58dc" />

<img width="1120" height="200" alt="image" src="https://github.com/user-attachments/assets/bed11107-bfa2-4b0d-a2f5-ef18344d5e31" />

