### PR TITLE
fix(groups): refuse setGroupDescription on whatsapp-web.js instead of failing with a 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `PUT /sessions/{sessionId}/groups/{groupId}/description` now answers `501` on the whatsapp-web.js
+  engine instead of failing with a bare `500`. The library types `GroupChat.setDescription` as
+  supported, but the page job it calls (`WAWebGroupModifyInfoJob.setGroupDescription`) no longer
+  accepts the argument list it sends and throws inside the page. The description was never applied
+  either way; the route now says so. Measured on wwjs 1.34.7 with the group's description both
+  unset and set, with `setGroupSubject` as a control on the same group in the same session. Baileys
+  is unaffected and remains the engine for this route. The capability matrix and docs/29 record it
+  as a library limitation.
 - A whatsapp-web.js protocol timeout is no longer eligible to be classified as a dead page.
   Behaviour is unchanged on the current Puppeteer; the guard keeps a future bump from reporting a
   slow command as a transport death.

--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -2858,7 +2858,12 @@ No `@HttpCode`; PUT default is `200`.
 
 Change the group description. An empty string clears the description.
 
-**Auth:** API key (OPERATOR)
+**Auth:** API key (OPERATOR) · **Engines:** Baileys only — whatsapp-web.js returns `501`
+
+> **whatsapp-web.js returns `501`.** The library types `GroupChat.setDescription` as supported, but
+> the page job it calls (`WAWebGroupModifyInfoJob.setGroupDescription`) no longer accepts the
+> argument list it sends, so the description is never applied. This was previously a bare `500`.
+> See docs/29 §29.4.6 for the measurement.
 
 **Path parameters**
 
@@ -2885,7 +2890,7 @@ No `@HttpCode`; PUT default is `200`.
 { "success": true, "message": "Group description updated" }
 ```
 
-**Errors:** `400` validation (`description` missing / not a string) / session not started · `401` missing/invalid `X-API-Key` · `403` key lacks OPERATOR role · `409` conflict or engine not ready (retryable) · `503` session not ready or dependency unavailable (retryable)
+**Errors:** `400` validation (`description` missing / not a string) / session not started · `401` missing/invalid `X-API-Key` · `403` key lacks OPERATOR role · `409` conflict or engine not ready (retryable) · `501` the active engine cannot set a group description (whatsapp-web.js) · `503` session not ready or dependency unavailable (retryable)
 
 #### POST /api/sessions/:sessionId/groups/:groupId/leave
 

--- a/docs/29-engine-capability-matrix.md
+++ b/docs/29-engine-capability-matrix.md
@@ -307,7 +307,7 @@ socket is caught by the transport instead. No REST route: the session watchdog p
 | `revokeGroupInviteCode`          | ✅                  | ✅               | ✅              |
 | `getGroupJoinInfo`               | ✅                  | ✅               | ✅              |
 | `setGroupSubject`                | ✅                  | ✅               | ✅              |
-| `setGroupDescription`            | ✅                  | ✅               | ✅              |
+| `setGroupDescription`            | ✅                  | ❌ lib           | ⚠️ baileys only |
 | `setGroupPicture`                | ✅                  | ✅               | ✅              |
 | `deleteGroupPicture`             | ✅                  | ✅               | ✅              |
 | `setGroupMessagesAdminsOnly`     | ✅                  | ✅               | ✅              |
@@ -386,9 +386,9 @@ answers 501.
 | `rejectCall`          | ✅                  | ✅               | ✅              |
 | `createCallLink`      | ✅                  | ✅               | ✅              |
 
-**Totals:** 112 methods → 224 adapter cells: **199 ✅, 25 ❌** (2 adapter-gaps, 23
-library-limitations, 0 uncertain) across 24 methods. From the REST caller's side: **90** methods
-work on any engine (89 fully supported + 2 store-backed status reads), **11** are Baileys-only,
+**Totals:** 112 methods → 224 adapter cells: **198 ✅, 26 ❌** (2 adapter-gaps, 24
+library-limitations, 0 uncertain) across 25 methods. From the REST caller's side: **89** methods
+work on any engine (87 fully supported + 2 store-backed status reads), **13** are Baileys-only,
 **9** are wwjs-only (the 2 store-backed rows excluded); `sendCatalog`, unavailable on both engines,
 is not exposed.
 
@@ -658,17 +658,17 @@ with zero OpenWA surface. Baileys-only; whatsapp-web.js has no community API at 
 
 **Chats** (9)
 
-| Library method   | OpenWA exposure                                                                                                                                                                                                                                                                                                                                                                          |
-| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `archiveChat`    | ✅ `archiveChat`                                                                                                                                                                                                                                                                                                                                                                         |
-| `getChatById`    | ✅ `muteChannel`, `sendSeen`, `clearChatMessages`, `markUnread`, `deleteChat`, `sendChatState`, `getGroupInfo`, `addParticipants`, `leaveGroup`, `setGroupSubject`, `setGroupDescription`, `getGroupInviteCode`, `revokeGroupInviteCode`, `getChatLabels`, `replyToMessage`, `forwardMessage`, `reactToMessage`, `getMessageReactions`, `getChatHistory`, `deleteMessage`, `editMessage` |
-| `getChats`       | ✅ `getChats`, `getGroups`                                                                                                                                                                                                                                                                                                                                                               |
-| `markChatUnread` | ❌ **not exposed**                                                                                                                                                                                                                                                                                                                                                                       |
-| `muteChat`       | ✅ `muteChat`                                                                                                                                                                                                                                                                                                                                                                            |
-| `pinChat`        | ✅ `pinChat`                                                                                                                                                                                                                                                                                                                                                                             |
-| `unarchiveChat`  | ✅ `archiveChat`                                                                                                                                                                                                                                                                                                                                                                         |
-| `unmuteChat`     | ✅ `muteChat`                                                                                                                                                                                                                                                                                                                                                                            |
-| `unpinChat`      | ✅ `pinChat`                                                                                                                                                                                                                                                                                                                                                                             |
+| Library method   | OpenWA exposure                                                                                                                                                                                                                                                                                                                                                   |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `archiveChat`    | ✅ `archiveChat`                                                                                                                                                                                                                                                                                                                                                  |
+| `getChatById`    | ✅ `muteChannel`, `sendSeen`, `clearChatMessages`, `markUnread`, `deleteChat`, `sendChatState`, `getGroupInfo`, `addParticipants`, `leaveGroup`, `setGroupSubject`, `getGroupInviteCode`, `revokeGroupInviteCode`, `getChatLabels`, `replyToMessage`, `forwardMessage`, `reactToMessage`, `getMessageReactions`, `getChatHistory`, `deleteMessage`, `editMessage` |
+| `getChats`       | ✅ `getChats`, `getGroups`                                                                                                                                                                                                                                                                                                                                        |
+| `markChatUnread` | ❌ **not exposed**                                                                                                                                                                                                                                                                                                                                                |
+| `muteChat`       | ✅ `muteChat`                                                                                                                                                                                                                                                                                                                                                     |
+| `pinChat`        | ✅ `pinChat`                                                                                                                                                                                                                                                                                                                                                      |
+| `unarchiveChat`  | ✅ `archiveChat`                                                                                                                                                                                                                                                                                                                                                  |
+| `unmuteChat`     | ✅ `muteChat`                                                                                                                                                                                                                                                                                                                                                     |
+| `unpinChat`      | ✅ `pinChat`                                                                                                                                                                                                                                                                                                                                                      |
 
 **Groups** (7)
 
@@ -947,14 +947,14 @@ adapter boundary — none silently stubs.
 Recomputed from `engine-capability-matrix.ts`, `upstream-surface.snapshot.json`, and a scan of the
 adapter sources — re-derive the same way when anything changes:
 
-- **112** interface methods → **224** adapter cells: **199 ✅** / **25 ❌** (2 adapter-gaps, 23
-  library-limitations, 0 uncertain), spanning **24** methods.
-- Of the 199 ✅ cells, **9 wwjs cells carry an explicit patch dependency** (4 × 🔧² status send,
+- **112** interface methods → **224** adapter cells: **198 ✅** / **26 ❌** (2 adapter-gaps, 24
+  library-limitations, 0 uncertain), spanning **25** methods.
+- Of the 198 ✅ cells, **9 wwjs cells carry an explicit patch dependency** (4 × 🔧² status send,
   1 × 🔧³ channel link preview, 1 × 🔧⁴ ready-sync, 3 × 🔧⁷ participant arity) and one baileys cell
   does (1 × 🔧⁶ newsletter-create parse); the whole wwjs column additionally
   depends on 🔧¹, the whole Baileys column on 🔧⁵ — so every row rests on a patch on each side,
   even though no row carries a row-level mark on both.
-- REST caller's view: **90** engine-neutral (88 + 2 store-backed status reads), **12** Baileys-only,
+- REST caller's view: **89** engine-neutral (87 + 2 store-backed status reads), **13** Baileys-only,
   **9** wwjs-only; `sendCatalog` (unavailable on both engines) is not exposed.
 - Full engine inventory (29.5), split by the exposure legend rather than lumped: Baileys **152**
   socket methods — 48 wired into interface methods, 5 internal wiring, 29 plumbing, **70 ❌ not

--- a/openapi.json
+++ b/openapi.json
@@ -5603,6 +5603,9 @@
           "409": {
             "description": "The session is not connected — an engine exists for it but is not `ready`: disconnected, reconnecting, or still initializing, so the request never reached WhatsApp. Wait for `ready` and retry. A session that was never started answers `400` instead, and the session lifecycle routes answer `409` for a conflicting state rather than this. One window answers this while the session still reads `ready`: WhatsApp Web periodically reloads its own page and the engine re-injects into it — for those few seconds the answer is a `409` naming the reload; retry shortly."
           },
+          "501": {
+            "description": "The active engine cannot set a group description. Answered by whatsapp-web.js only: the library types GroupChat.setDescription as supported, but the page job it calls no longer accepts the argument list it sends, so the change can never be applied. Baileys answers this route normally — see docs/29 for the measurement."
+          },
           "503": {
             "description": "WhatsApp did not answer within the request budget. The change may or may not have been applied — the gateway stopped waiting for a confirmation that never came."
           }

--- a/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
+++ b/src/engine/adapters/whatsapp-web-js.adapter.spec.ts
@@ -5732,9 +5732,13 @@ describe('WhatsAppWebJsAdapter group join + settings + own profile', () => {
       );
     });
 
-    // The nine write routes that previously threw a bare Error('Chat is not a group') for a
-    // non-group id (surfacing as an opaque 500) now share this guard: unknown id, 1:1 id and
-    // status id are all GroupNotFoundError (404), like the guarded settings writes above.
+    // The write routes that previously threw a bare Error('Chat is not a group') for a non-group id
+    // (surfacing as an opaque 500) now share this guard: unknown id, 1:1 id and status id are all
+    // GroupNotFoundError (404), like the guarded settings writes above.
+    //
+    // setGroupDescription is deliberately absent: it refuses with EngineNotSupportedError (501)
+    // before resolving a chat at all, so there is no id for a 404 to describe. Which id was passed
+    // does not change the answer when the operation does not work on any of them.
     it.each([
       ['addParticipants', (a: WhatsAppWebJsAdapter) => a.addParticipants('628111@c.us', ['628222@c.us'])],
       ['removeParticipants', (a: WhatsAppWebJsAdapter) => a.removeParticipants('628111@c.us', ['628222@c.us'])],
@@ -5742,7 +5746,6 @@ describe('WhatsAppWebJsAdapter group join + settings + own profile', () => {
       ['demoteParticipants', (a: WhatsAppWebJsAdapter) => a.demoteParticipants('628111@c.us', ['628222@c.us'])],
       ['leaveGroup', (a: WhatsAppWebJsAdapter) => a.leaveGroup('628111@c.us')],
       ['setGroupSubject', (a: WhatsAppWebJsAdapter) => a.setGroupSubject('628111@c.us', 'New subject')],
-      ['setGroupDescription', (a: WhatsAppWebJsAdapter) => a.setGroupDescription('628111@c.us', 'New description')],
       ['getGroupInviteCode', (a: WhatsAppWebJsAdapter) => a.getGroupInviteCode('628111@c.us')],
       ['revokeGroupInviteCode', (a: WhatsAppWebJsAdapter) => a.revokeGroupInviteCode('628111@c.us')],
     ])('%s answers 404 (GroupNotFoundError) when the id is not a group', async (_name, call) => {
@@ -6117,27 +6120,36 @@ describe('WhatsAppWebJsAdapter honest outcomes (no phantom success)', () => {
     },
   );
 
-  describe('setGroupSubject / setGroupDescription (library boolean is honored)', () => {
-    it.each([
-      ['setGroupSubject', 'setSubject'],
-      ['setGroupDescription', 'setDescription'],
-    ] as const)('%s throws EngineRefusedError when wwebjs resolves false', async (method, libMethod) => {
-      const chat = groupChat({ [libMethod]: jest.fn().mockResolvedValue(false) });
+  describe('setGroupSubject (library boolean is honored)', () => {
+    it('throws EngineRefusedError when wwebjs resolves false', async () => {
+      const chat = groupChat({ setSubject: jest.fn().mockResolvedValue(false) });
       const adapter = readyAdapter({ getChatById: jest.fn().mockResolvedValue(chat) });
-      await expect(
-        (adapter as unknown as Record<string, (g: string, v: string) => Promise<void>>)[method](GROUP, 'New'),
-      ).rejects.toBeInstanceOf(EngineRefusedError);
+      await expect(adapter.setGroupSubject(GROUP, 'New')).rejects.toBeInstanceOf(EngineRefusedError);
     });
 
-    it.each([
-      ['setGroupSubject', 'setSubject'],
-      ['setGroupDescription', 'setDescription'],
-    ] as const)('%s resolves on true', async (method, libMethod) => {
-      const chat = groupChat({ [libMethod]: jest.fn().mockResolvedValue(true) });
+    it('resolves on true', async () => {
+      const chat = groupChat({ setSubject: jest.fn().mockResolvedValue(true) });
       const adapter = readyAdapter({ getChatById: jest.fn().mockResolvedValue(chat) });
-      await expect(
-        (adapter as unknown as Record<string, (g: string, v: string) => Promise<void>>)[method](GROUP, 'New'),
-      ).resolves.toBeUndefined();
+      await expect(adapter.setGroupSubject(GROUP, 'New')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('setGroupDescription (non-functional against the live page)', () => {
+    // Paired with setGroupSubject above on purpose: the two used to share one it.each because both
+    // were believed to honour the same boolean. They no longer behave alike, and the split is the
+    // point — subject still works, description does not, and a shared case would hide that.
+    //
+    // wwebjs's setDescription is typed Promise<boolean>, so a mock resolving true made this look
+    // supported for as long as the test never left the mock. Live, the injected evaluate reaches
+    // widToGroupJid with an undefined Wid and throws, surfacing as a 500. Asserting the 501 keeps
+    // a green suite from re-implying support the engine does not have.
+    it('throws EngineNotSupportedError even when the library would resolve true', async () => {
+      const setDescription = jest.fn().mockResolvedValue(true);
+      const chat = groupChat({ setDescription });
+      const adapter = readyAdapter({ getChatById: jest.fn().mockResolvedValue(chat) });
+      await expect(adapter.setGroupDescription(GROUP, 'New')).rejects.toBeInstanceOf(EngineNotSupportedError);
+      // Never reaches the library: no evaluate is injected, so no 500 can escape.
+      expect(setDescription).not.toHaveBeenCalled();
     });
   });
 

--- a/src/engine/adapters/wwebjs-groups.ts
+++ b/src/engine/adapters/wwebjs-groups.ts
@@ -325,13 +325,23 @@ export class WwebjsGroups {
     }
   }
 
-  async setGroupDescription(groupId: string, description: string): Promise<void> {
-    const chat = await this.requireGroupChat(groupId);
-    // Same discarded-boolean contract as setSubject (index.d.ts:1984).
-    const ok = await chat.setDescription(description);
-    if (!ok) {
-      throw new EngineRefusedError(`Failed to set the description for group ${groupId} — admin rights required`);
-    }
+  // Typed as supported (index.d.ts:1984) but non-functional against the current WhatsApp Web
+  // build. GroupChat.setDescription injects an evaluate that calls the page's
+  // WAWebGroupModifyInfoJob.setGroupDescription(chatWid, description, newId, descId); inside the
+  // page that reaches widToGroupJid with an undefined Wid and throws
+  // "Cannot read properties of undefined (reading 'toJid')", which surfaced to callers as a bare
+  // 500. setGroupSubject builds its Wid through the same createWid call and works, so the Wid
+  // itself is fine — the description job's parameter shape is what drifted, and the argument list
+  // wwjs sends no longer lands the Wid where the page reads it. Measured live on this account both
+  // with descId undefined (group had no description) and defined (description added first): the
+  // same throw either way, so it is not the first-description case. The signature belongs to the
+  // minified page bundle, not to the library, so there is nothing here to patch around. An honest
+  // 501 beats a 500 that reads like an outage. Baileys sets descriptions normally on the same
+  // account.
+  // eslint-disable-next-line @typescript-eslint/require-await, @typescript-eslint/no-unused-vars
+  async setGroupDescription(_groupId: string, _description: string): Promise<void> {
+    this.host.ensureReady();
+    throw new EngineNotSupportedError('setGroupDescription');
   }
 
   async getGroupInviteCode(groupId: string): Promise<string> {

--- a/src/engine/engine-capability-matrix.ts
+++ b/src/engine/engine-capability-matrix.ts
@@ -329,10 +329,10 @@ export const CURATED_CAPABILITY_EXCEPTIONS: Record<string, MethodCapability> = {
       "wwjs Message.star()/unstar() → Promise<void> (index.d.ts:1336-1338) — void, so there is no refusal signal to map, unlike pin; baileys chatModify({star:{messages:[{id,fromMe}],star}}, jid) (Types/Chat.d.ts:83-89) — needs the stored key's fromMe, since the same id means different messages depending on direction",
   },
   setGroupDescription: {
-    wwjs: { status: 'supported' },
+    wwjs: { status: 'not-available', rootCause: 'library-limitation' },
     baileys: { status: 'supported' },
     evidence:
-      'wwjs GroupChat.setDescription(description) → boolean (index.d.ts:1984; false → adapter throws EngineRefusedError); baileys groupUpdateDescription(jid, description?) (Socket/groups.d.ts:21)',
+      "baileys groupUpdateDescription(jid, description?) (Socket/groups.d.ts:21). wwjs GroupChat.setDescription is typed Promise<boolean> (index.d.ts:1984) but its injected evaluate calls the page's WAWebGroupModifyInfoJob.setGroupDescription(chatWid, description, newId, descId) (GroupChat.js:439), which reaches widToGroupJid with an undefined Wid and throws TypeError \"Cannot read properties of undefined (reading 'toJid')\" — measured live on wwjs 1.34.7, the latest published release, reaching the caller as a bare 500. Measured BOTH with descId undefined (group had no description) and with it defined (description added from the phone first): identical throw, so the first-description case is not the variable. setGroupSubject builds its Wid via the same WAWebWidFactory.createWid and succeeds on the same group in the same session, so createWid is not at fault — the description job's parameter shape is what drifted, and wwjs's argument list no longer lands the Wid where the page reads it. The signature lives in the minified page bundle rather than the library, so it cannot be patched around; adapter throws EngineNotSupportedError. Same class as createGroup/findImpl",
   },
   setGroupEphemeral: {
     wwjs: { status: 'not-available', rootCause: 'library-limitation' },

--- a/src/modules/group/group.controller.ts
+++ b/src/modules/group/group.controller.ts
@@ -402,6 +402,14 @@ export class GroupController {
   @ApiResponse({ status: 200, description: 'Description updated', type: GroupAckResponseDto })
   @ApiResponse({ status: 403, description: 'The engine refused the change — admin rights are required' })
   @ApiResponse({
+    status: 501,
+    description:
+      'The active engine cannot set a group description. Answered by whatsapp-web.js only: the ' +
+      'library types GroupChat.setDescription as supported, but the page job it calls no longer ' +
+      'accepts the argument list it sends, so the change can never be applied. Baileys answers ' +
+      'this route normally — see docs/29 for the measurement.',
+  })
+  @ApiResponse({
     status: 503,
     description:
       'WhatsApp did not answer within the request budget. The change may or may not have been applied — ' +


### PR DESCRIPTION
## Description

Split out of #1472 at review request.

`PUT /sessions/{sessionId}/groups/{groupId}/description` fails on the whatsapp-web.js engine and
has been surfacing as a bare `500`. whatsapp-web.js types `GroupChat.setDescription` as
`Promise<boolean>`, but its injected evaluate calls the page's
`WAWebGroupModifyInfoJob.setGroupDescription(chatWid, description, newId, descId)`, which reaches
`widToGroupJid` with an undefined Wid and throws
`TypeError: Cannot read properties of undefined (reading 'toJid')`. The argument list the library
sends no longer lands the Wid where the page reads it.

The adapter now throws `EngineNotSupportedError` (`501`) instead. The description was never applied
either way; this makes the route say so rather than reading like an outage.

### Measurement

Measured live on wwjs 1.34.7, the latest published release:

- with `descId` undefined (group had no description) and with it defined (description added from
  the phone first) — identical throw, so the first-description case is not the variable
- `setGroupSubject` as a control on the same group in the same session succeeds, and it builds its
  Wid through the same `WAWebWidFactory.createWid`, so `createWid` is not at fault
- Baileys sets descriptions normally on the same account

The signature lives in the minified page bundle rather than in the library, so there is nothing in
`whatsapp-web.js` to patch around for this.

### Contract

- `docs/29` §29.4.6 row, and the totals it feeds: **199→198 ✅**, **25→26 ❌**, library-limitations
  **23→24**, methods carrying a ❌ **24→25**, REST-neutral **90→89**, Baileys-only **12→13**.
  `setGroupDescription` also drops out of the `getChatById` exposure list, since the adapter now
  refuses before reaching the client.
- `@ApiResponse({ status: 501 })` on `group.controller.ts:396`, with the matching docs/06 errors
  line, engines note and callout, and a regenerated `openapi.json`.
- CHANGELOG under `### Changed`, since a caller on whatsapp-web.js sees a different status than
  before.

Two figures in the §29.4 totals were already wrong before this change and are corrected in passing:
`89 fully supported` should have read 88, which contradicted §29.8's own `88 + 2`, and
`11 are Baileys-only` should have read 12. Neither is covered by `docs-29-counts.spec.ts` — it
checks the bolded totals, not these parentheticals.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

A caller on whatsapp-web.js gets `501` where it previously got `500`. Both are failures and the
description was applied in neither, so no working call changes behaviour — but an integration that
matched on `500` will see a different status.

## Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [x] Lint passes
- [x] Self-reviewed

Locally: `test` (5939), `test:docs` (264), `lint`, `format:check`, `openapi:check`,
`check:contract-shapes` (324 pairs), `check:sdk-routes`, `check:sdk-docs`.

## Screenshots (if applicable)

N/A — engine/contract-level change, no UI in this repo.

## Related Issues

Split out of #1472.
