### PR TITLE
chore(deps): ignore the NestJS 12 line until its peers move

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,6 +53,20 @@ updates:
       # with the base-image Node bump.
       - dependency-name: "@types/node"
         versions: [">=23.0.0"]
+      # The NestJS 12 line cannot be adopted yet. @bull-board/nestjs (9.6.1) and @nestjs/throttler
+      # (6.5.0) both cap @nestjs/common and @nestjs/core at ^11.0.0, and neither publishes a
+      # prerelease that accepts 12, so the bump fails npm's peer resolution with ERESOLVE before a
+      # single CI job compiles anything. Two in-repo blockers sit behind that wall: @nestjs/common@12
+      # is ESM-only and neither jest lane can load it under the current transform config (271
+      # @nestjs/common and 35 @nestjs/testing import sites), and @nestjs/swagger 12 spells
+      # nullability per document version, which moves the committed openapi.json snapshot and
+      # cascades into check:contract-shapes across five SDK clients.
+      #
+      # Pinned on the version rather than update-types so the 11.x line keeps flowing. Lift when
+      # both peers admit ^12.0.0; the upgrade itself belongs on a dedicated branch, since the
+      # README framework rows and the jest ESM config have to move in the same commit.
+      - dependency-name: "@nestjs/*"
+        versions: [">=12.0.0"]
 
   - package-ecosystem: npm
     directory: /dashboard


### PR DESCRIPTION
## Problem

Dependabot's grouped major bump (#1490) moves the whole NestJS stack to 12.x, and it cannot install. `@bull-board/nestjs` (9.6.1) and `@nestjs/throttler` (6.5.0) both cap `@nestjs/common` and `@nestjs/core` at `^11.0.0`, and neither publishes a prerelease accepting 12, so `npm ci` fails with ERESOLVE before any job compiles a file. The four red checks on that PR mean "NestJS 12 cannot be installed here", not "NestJS 12 breaks the app".

Left alone it re-rebases and re-runs on every push to main, spending nine CI jobs and a failure notification per merge to reproduce the same ERESOLVE.

## What changed

- One ignore entry in the root npm block of `.github/dependabot.yml`, wildcarded to `@nestjs/*` so it covers all thirteen packages in the group.
- The comment records both the external wall and the two in-repo blockers that sit behind it, so the reason survives without an open PR to point at.

Pinned on the version rather than `update-types`, so 11.x minor and patch updates keep flowing. Same form as the four ignores already in the file.

## Impact

No dependency changes. Dependabot stops proposing the 12.x line until the entry is lifted.

Lift when both peers admit `^12.0.0`. The upgrade then belongs on a dedicated branch, not a Dependabot merge: `@nestjs/common@12` is ESM-only and neither jest lane loads it under the current transform config, `@nestjs/swagger` 12 spells nullability per document version so the committed `openapi.json` snapshot moves and cascades into `check:contract-shapes` across five SDK clients, and the README framework rows have to change in the same commit or `check:versions` fails.

## Verification

`yaml.safe_load` parses the file to four update blocks, with the root ignore list reading `typescript`, `better-sqlite3`, `audio-decode`, `@types/node`, `@nestjs/*` and the dashboard list unchanged. Peer ranges above were read from the registry today.
