### PR TITLE
feat(engine): report engine patches that never applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Each engine now names the install-time patches its library is missing as it starts, rather than
+  only the message-id backport. A source install applies them with `--best-effort`, so a patch that
+  could not apply left one line in the `npm install` transcript and nothing afterwards; the
+  capability it repairs then failed with an error that named no cause. Diagnostic only, startup
+  continues. See docs/12 for the procedure.
 - The dashboard's API Keys page can limit an operator or viewer key to chosen sessions, on creation
   and on a key that already exists. Leaving the picker empty keeps access to every session, including
   ones created later, and the keys table shows each key's scope. `allowedSessions` was already

--- a/docs/12-troubleshooting-faq.md
+++ b/docs/12-troubleshooting-faq.md
@@ -665,6 +665,45 @@ rm -rf node_modules/whatsapp-web.js && npm ci
 > Pinning `WWEBJS_WEB_VERSION` does **not** work around this — the rename is present in every
 > current WhatsApp Web build, so no pin avoids it.
 
+### Issue: Startup logs say install-time patches are missing
+
+**Symptoms:**
+
+- Startup logs contain `The installed whatsapp-web.js is missing N of OpenWA's install-time patches: …`,
+  or the same line naming `@whiskeysockets/baileys`
+- One capability fails while everything around it works: an unnamed `500` from a single route,
+  block/unblock refusing every id, a status media send that never arrives, a group description that
+  cannot be set, an app-state resync that never settles
+
+**Cause:** OpenWA applies nine exact source transforms to its engine libraries at install time
+(docs/29 §29.3). The Docker image runs them without `--best-effort`, so a source shape a patcher
+cannot recognise fails the image build. A source install runs them through `scripts/postinstall.js`
+with `--best-effort`, where a patcher that cannot apply prints one line into a long `npm install`
+transcript and the install still succeeds. The usual causes are `npm install --ignore-scripts` and
+an upstream release whose shape a patcher no longer recognises. Each engine now checks its own
+patches as it starts and names the ones that did not land, so the report arrives on the machine that
+is actually affected rather than in an install log nobody kept.
+
+**Solution:**
+
+```bash
+# Which patches are missing? Works on every platform, including Windows without grep.
+node -e "const fs=require('fs'),p=require('path');for(const f of fs.readdirSync('scripts').filter(n=>n.startsWith('patch-')&&n.endsWith('.js')&&!n.endsWith('.spec.js')).sort()){const m=require('./scripts/'+f);if(typeof m.isApplied!=='function')continue;const k=f.startsWith('patch-wwebjs-')?'whatsapp-web.js':'@whiskeysockets/baileys';try{console.log((m.isApplied(p.dirname(require.resolve(k+'/package.json')))?'APPLIED    ':'NOT APPLIED')+' '+f)}catch{}}"
+
+# Apply each one it named, then restart
+node scripts/patch-wwebjs-group-description.js
+```
+
+If a patcher answers with an unsupported-shape error instead of applying, the installed library has
+moved and the transform needs re-evaluating against it. Reinstalling will not help; open an issue
+quoting the message it printed.
+
+> `patch-wwebjs-201832.js` is not in that list. It carries its own startup check and its own entry
+> above, because a partially applied backport needs different advice than one that never ran.
+
+> A patch that never applied is not fatal on its own: only the capability it repairs is affected and
+> the rest of the gateway runs normally, which is why this is easy to misread as a bug in one route.
+
 ### Issue: Reads on a large account fail with `Runtime.callFunctionOn timed out`
 
 > **Engine:** This issue applies to the `whatsapp-web.js` engine only (Chromium/Puppeteer-based). It does not affect `ENGINE_TYPE=baileys`.

--- a/docs/29-engine-capability-matrix.md
+++ b/docs/29-engine-capability-matrix.md
@@ -131,6 +131,13 @@ OpenWA ships nine exact, self-disabling source transforms over the installed eng
 patcher no-ops once the fix is present upstream, and an unrecognized source shape fails loudly
 rather than shipping a silently partial patch.
 
+"Fails loudly" holds for the image build, not for `npm install`, where `--best-effort` turns a
+refusal into one line of a long transcript. So each patcher also exports an `isApplied()` predicate,
+its own stand-down branch read back against the installed file, and each engine reports the patches
+it is missing as it starts (`src/engine/adapters/engine-patch-status.ts`; 🔧¹ keeps the separate
+check described below). The report is diagnostic, not preventive: startup continues, so a session
+reaching READY is not evidence that every patch landed. See docs/12 for the operator procedure.
+
 ### 29.3.1 The nine patches
 
 | #   | Patcher                                                    | Library target                       | What it repairs                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Stand-down predicate                                                                                                                                                                                                                                                                                                                                                  |

--- a/scripts/patch-baileys-appstate.js
+++ b/scripts/patch-baileys-appstate.js
@@ -33,8 +33,15 @@ const CHATS_PATH = path.join('lib', 'Socket', 'chats.js');
 const LOOP_FIND = `                const decoded = await extractSyncdPatches(result, config?.options);
                 for (const key in decoded) {`;
 
+/**
+ * The apply function's stand-down predicate: present exactly when LOOP_REPLACE was written.
+ * Interpolated below rather than restated, the way patch-baileys-newsletter-create.js does it, so
+ * the marker and the text that carries it cannot drift apart.
+ */
+const PATCHED_MARKER = 'OpenWA: query() resolves undefined on its own timeout';
+
 const LOOP_REPLACE = `                const decoded = await extractSyncdPatches(result, config?.options);
-                // OpenWA: query() resolves undefined on its own timeout, which decodes to {}. Every
+                // ${PATCHED_MARKER}, which decodes to {}. Every
                 // exit below — including the attemptsMap guard — is inside this for-in, so an empty
                 // decode would otherwise spin the while loop for the life of the socket.
                 if (!Object.keys(decoded).length) {
@@ -49,7 +56,7 @@ function applyAppStatePatch(baileysDir = DEFAULT_BAILEYS) {
     return { skipped: true, reason: `${CHATS_PATH} not found — nothing to patch` };
   }
   const source = fs.readFileSync(file, 'utf8');
-  if (source.includes('OpenWA: query() resolves undefined on its own timeout')) {
+  if (source.includes(PATCHED_MARKER)) {
     return { skipped: true, reason: 'already patched' };
   }
   const occurrences = source.split(LOOP_FIND).length - 1;
@@ -80,4 +87,17 @@ function run() {
 
 if (require.main === module) run();
 
-module.exports = { applyAppStatePatch, LOOP_FIND, LOOP_REPLACE };
+/**
+ * The stand-down branch above as a predicate, for the startup guard (engine-patch-status.ts).
+ * Unreadable reads as applied: a tree we cannot inspect is not evidence of a broken one, and the
+ * apply function treats a missing chats.js as nothing to patch rather than a fault.
+ */
+function isApplied(baileysDir = DEFAULT_BAILEYS) {
+  try {
+    return fs.readFileSync(path.join(baileysDir, CHATS_PATH), 'utf8').includes(PATCHED_MARKER);
+  } catch {
+    return true;
+  }
+}
+
+module.exports = { applyAppStatePatch, isApplied, PATCHED_MARKER, LOOP_FIND, LOOP_REPLACE };

--- a/scripts/patch-baileys-appstate.spec.js
+++ b/scripts/patch-baileys-appstate.spec.js
@@ -6,7 +6,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const { applyAppStatePatch, LOOP_FIND } = require('./patch-baileys-appstate');
+const { applyAppStatePatch, isApplied, LOOP_FIND } = require('./patch-baileys-appstate');
 
 /**
  * Same contract as the sibling patcher specs: the patcher rewrites a file this repository does not
@@ -37,6 +37,13 @@ test('bounds the loop on an empty decode', () => {
   assert.match(patched, /if \(!Object\.keys\(decoded\)\.length\) \{\n\s+break;/);
   // The original walk is preserved, not replaced.
   assert.ok(patched.includes('for (const key in decoded) {'));
+});
+
+test('isApplied tracks the transform', () => {
+  const { dir } = fakeBaileys(REAL_SHAPE);
+  assert.equal(isApplied(dir), false);
+  applyAppStatePatch(dir);
+  assert.equal(isApplied(dir), true);
 });
 
 test('is idempotent — a second run does not double-patch', () => {

--- a/scripts/patch-baileys-newsletter-create.js
+++ b/scripts/patch-baileys-newsletter-create.js
@@ -116,4 +116,17 @@ function run() {
 
 if (require.main === module) run();
 
-module.exports = { applyNewsletterCreatePatch, PARSE_FIND, PARSE_REPLACE, MARKER };
+/**
+ * The stand-down branch above as a predicate, for the startup guard (engine-patch-status.ts).
+ * Unreadable reads as applied: a tree we cannot inspect is not evidence of a broken one, and the
+ * apply function treats a missing newsletter.js as nothing to patch rather than a fault.
+ */
+function isApplied(baileysDir = DEFAULT_BAILEYS) {
+  try {
+    return fs.readFileSync(path.join(baileysDir, NEWSLETTER_PATH), 'utf8').includes(MARKER);
+  } catch {
+    return true;
+  }
+}
+
+module.exports = { applyNewsletterCreatePatch, isApplied, PARSE_FIND, PARSE_REPLACE, MARKER };

--- a/scripts/patch-baileys-newsletter-create.spec.js
+++ b/scripts/patch-baileys-newsletter-create.spec.js
@@ -6,7 +6,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const { applyNewsletterCreatePatch, PARSE_FIND, MARKER } = require('./patch-baileys-newsletter-create');
+const { applyNewsletterCreatePatch, isApplied, PARSE_FIND, MARKER } = require('./patch-baileys-newsletter-create');
 
 /**
  * Same contract as the sibling patcher specs: the patcher rewrites a file this repository does not
@@ -128,5 +128,13 @@ test('the marker the idempotence check keys on is actually written', () => {
   const { dir, file } = fakeBaileys();
   applyNewsletterCreatePatch(dir);
   assert.ok(fs.readFileSync(file, 'utf8').includes(MARKER));
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('isApplied is false on a pristine tree and true once the patch has run', () => {
+  const { dir } = fakeBaileys();
+  assert.equal(isApplied(dir), false);
+  applyNewsletterCreatePatch(dir);
+  assert.equal(isApplied(dir), true);
   fs.rmSync(dir, { recursive: true, force: true });
 });

--- a/scripts/patch-wwebjs-block.js
+++ b/scripts/patch-wwebjs-block.js
@@ -100,6 +100,21 @@ const GROUPS = [
   },
 ];
 
+/**
+ * Both groups' stand-down branch as one predicate, for the startup guard
+ * (engine-patch-status.ts). A half-patched tree is a reachable, supported state here, and it reads
+ * as NOT applied: whichever half is missing still answers an opaque 500 on every id.
+ * Unreadable reads as applied, since a tree we cannot inspect is not evidence of a broken one.
+ */
+function isApplied(wwjsDir = DEFAULT_WWJS) {
+  try {
+    const source = fs.readFileSync(path.join(wwjsDir, CONTACT_PATH), 'utf8');
+    return GROUPS.every((group) => source.includes(group.replace));
+  } catch {
+    return true;
+  }
+}
+
 function applyBlockPatches({ wwjsDir = DEFAULT_WWJS } = {}) {
   const contactFile = path.join(wwjsDir, CONTACT_PATH);
   if (!fs.existsSync(contactFile)) {
@@ -148,4 +163,4 @@ function run() {
 
 if (require.main === module) run();
 
-module.exports = { applyBlockPatches, GROUPS, findFor, replaceFor, CONTACT_PATH };
+module.exports = { applyBlockPatches, isApplied, GROUPS, findFor, replaceFor, CONTACT_PATH };

--- a/scripts/patch-wwebjs-block.spec.js
+++ b/scripts/patch-wwebjs-block.spec.js
@@ -6,7 +6,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const { applyBlockPatches, GROUPS, findFor, replaceFor } = require('./patch-wwebjs-block');
+const { applyBlockPatches, isApplied, GROUPS, findFor, replaceFor } = require('./patch-wwebjs-block');
 
 /**
  * The patcher rewrites a file this repository does not own, so what has to hold is that it fires on
@@ -77,6 +77,14 @@ test('patches block and unblock, and is idempotent', () => {
   assert.deepEqual(second.skipped, ['block', 'unblock']);
   assert.equal(fs.readFileSync(file, 'utf8'), patched, 'a second run must not change the file');
 
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('isApplied tracks the transform, false before it runs and true after', () => {
+  const { dir } = fakeWwjs(pristineSource());
+  assert.equal(isApplied(dir), false);
+  applyBlockPatches({ wwjsDir: dir });
+  assert.equal(isApplied(dir), true);
   fs.rmSync(dir, { recursive: true, force: true });
 });
 

--- a/scripts/patch-wwebjs-group-description.js
+++ b/scripts/patch-wwebjs-group-description.js
@@ -61,6 +61,19 @@ function occurrences(source, needle) {
   return source.split(needle).length - 1;
 }
 
+/**
+ * The stand-down branch below as a predicate, for the startup guard (engine-patch-status.ts).
+ * Unreadable reads as applied: a tree we cannot inspect is not evidence of a broken one.
+ */
+function isApplied(wwjsDir = DEFAULT_WWJS) {
+  try {
+    const source = fs.readFileSync(path.join(wwjsDir, GROUP_CHAT_PATH), 'utf8');
+    return occurrences(source, OPTIONS_CALL) === 1 && occurrences(source, POSITIONAL_CALL) === 0;
+  } catch {
+    return true;
+  }
+}
+
 function applyGroupDescriptionFix(wwjsDir = DEFAULT_WWJS) {
   const groupChatFile = path.join(wwjsDir, GROUP_CHAT_PATH);
   if (!fs.existsSync(groupChatFile)) {
@@ -105,4 +118,4 @@ function run() {
 
 if (require.main === module) run();
 
-module.exports = { applyGroupDescriptionFix, POSITIONAL_CALL, OPTIONS_CALL };
+module.exports = { applyGroupDescriptionFix, isApplied, POSITIONAL_CALL, OPTIONS_CALL };

--- a/scripts/patch-wwebjs-group-description.spec.js
+++ b/scripts/patch-wwebjs-group-description.spec.js
@@ -6,7 +6,12 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const { applyGroupDescriptionFix, POSITIONAL_CALL, OPTIONS_CALL } = require('./patch-wwebjs-group-description.js');
+const {
+  applyGroupDescriptionFix,
+  isApplied,
+  POSITIONAL_CALL,
+  OPTIONS_CALL,
+} = require('./patch-wwebjs-group-description.js');
 
 function makeDependency(source) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'openwa-group-description-'));
@@ -23,6 +28,16 @@ test('patches the description job call to the options object', () => {
 
   assert.deepEqual(result, { skipped: false, note: 'group description job called with an options object' });
   assert.equal(fs.readFileSync(groupChat, 'utf8'), `before\n${OPTIONS_CALL}\nafter\n`);
+});
+
+test('reports the patch as applied only once the transform has run', () => {
+  const { root } = makeDependency(`before\n${POSITIONAL_CALL}\nafter\n`);
+
+  assert.equal(isApplied(root), false);
+
+  applyGroupDescriptionFix(root);
+
+  assert.equal(isApplied(root), true);
 });
 
 test('sends an empty description as null, which clears rather than writing an empty body', () => {

--- a/scripts/patch-wwebjs-newsletter-preview.js
+++ b/scripts/patch-wwebjs-newsletter-preview.js
@@ -51,6 +51,19 @@ function applyBackport(wwjsDir = DEFAULT_WWJS) {
   return { skipped: false, note: 'destination chat context added to link previews' };
 }
 
+/**
+ * The stand-down branch above as a predicate, for the startup guard (engine-patch-status.ts).
+ * Unreadable reads as applied: a tree we cannot inspect is not evidence of a broken one.
+ */
+function isApplied(wwjsDir = DEFAULT_WWJS) {
+  try {
+    const source = fs.readFileSync(path.join(wwjsDir, UTILS_PATH), 'utf8');
+    return occurrences(source, LEGACY_CALL) === 0 && occurrences(source, CONTEXT_CALL) === 1;
+  } catch {
+    return true;
+  }
+}
+
 function run() {
   const bestEffort = process.argv.includes('--best-effort');
   try {
@@ -70,4 +83,4 @@ function run() {
 
 if (require.main === module) run();
 
-module.exports = { applyBackport, LEGACY_CALL, CONTEXT_CALL };
+module.exports = { applyBackport, isApplied, LEGACY_CALL, CONTEXT_CALL };

--- a/scripts/patch-wwebjs-newsletter-preview.spec.js
+++ b/scripts/patch-wwebjs-newsletter-preview.spec.js
@@ -6,7 +6,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const { applyBackport } = require('./patch-wwebjs-newsletter-preview.js');
+const { applyBackport, isApplied } = require('./patch-wwebjs-newsletter-preview.js');
 
 const LEGACY_CALL =
   "let preview = await window\n                    .require('WAWebLinkPreviewChatAction')\n                    .getLinkPreview(link);";
@@ -39,6 +39,14 @@ test('is idempotent when destination chat context is already present', () => {
     reason: 'installed whatsapp-web.js already passes destination chat context',
   });
   assert.equal(fs.readFileSync(utils, 'utf8'), original);
+});
+
+test('reports the patch as applied only once the transform has run', () => {
+  const { root } = makeDependency(`before\n${LEGACY_CALL}\nafter\n`);
+
+  assert.equal(isApplied(root), false);
+  applyBackport(root);
+  assert.equal(isApplied(root), true);
 });
 
 test('rejects an unknown dependency shape without changing it', () => {

--- a/scripts/patch-wwebjs-participant-arity.js
+++ b/scripts/patch-wwebjs-participant-arity.js
@@ -125,6 +125,21 @@ function occurrences(source, needle) {
   return source.split(needle).length - 1;
 }
 
+/**
+ * Every group's replacement present, for the startup guard (engine-patch-status.ts). All three
+ * actions must carry it: a tree left by the LEGACY shape above scores exactly one of three, and it
+ * still answers 500 when promoting an existing admin, so ANY would report that tree as healthy.
+ * Unreadable reads as applied, since a tree we cannot inspect is not evidence of a broken one.
+ */
+function isApplied(wwjsDir = DEFAULT_WWJS) {
+  try {
+    const source = fs.readFileSync(path.join(wwjsDir, GROUP_CHAT_PATH), 'utf8');
+    return ACTIONS.every((action) => occurrences(source, replaceFor(action)) === 1);
+  } catch {
+    return true;
+  }
+}
+
 function applyParticipantArityPatches(wwjsDir = DEFAULT_WWJS) {
   const groupChatFile = path.join(wwjsDir, GROUP_CHAT_PATH);
   if (!fs.existsSync(groupChatFile)) {
@@ -189,6 +204,7 @@ if (require.main === module) run();
 
 module.exports = {
   applyParticipantArityPatches,
+  isApplied,
   GROUPS,
   ACTIONS,
   findFor,

--- a/scripts/patch-wwebjs-participant-arity.spec.js
+++ b/scripts/patch-wwebjs-participant-arity.spec.js
@@ -8,6 +8,7 @@ const path = require('path');
 
 const {
   applyParticipantArityPatches,
+  isApplied,
   GROUPS,
   ACTIONS,
   findFor,
@@ -109,6 +110,16 @@ test('applies every group to the installed upstream shape', () => {
   }
   // The bare `{ status: 200 }` return must be gone from all three, or one of them still lies.
   assert.equal(out.split('return { status: 200 };').length - 1, 0);
+});
+
+test('isApplied is false on a pristine tree and true once the patch lands', () => {
+  // All three groups must carry their replacement: a tree left by the legacy shape scores one of
+  // three, and it still answers 500 when promoting an existing admin.
+  const { dir } = fakeWwjs(readInstalled());
+
+  assert.equal(isApplied(dir), false);
+  applyParticipantArityPatches(dir);
+  assert.equal(isApplied(dir), true);
 });
 
 test('never calls the WA Web action with an empty list', () => {

--- a/scripts/patch-wwebjs-ready-sync.js
+++ b/scripts/patch-wwebjs-ready-sync.js
@@ -76,6 +76,25 @@ function occurrences(source, needle) {
   return source.split(needle).length - 1;
 }
 
+/**
+ * The stand-down branch below as a predicate, for the startup guard (engine-patch-status.ts).
+ * Finds are counted with the replacements removed for the reason the apply loop documents: each
+ * replacement contains its own find. Unreadable reads as applied, since a tree we cannot inspect
+ * is not evidence of a broken one.
+ */
+function isApplied(wwjsDir = DEFAULT_WWJS) {
+  try {
+    const source = fs.readFileSync(path.join(wwjsDir, CLIENT_PATH), 'utf8');
+    return EDITS.every(
+      edit =>
+        occurrences(source, edit.replace) === 1 &&
+        occurrences(source.split(edit.replace).join(''), edit.find) === 0,
+    );
+  } catch {
+    return true;
+  }
+}
+
 function applyReadySyncPatch(wwjsDir = DEFAULT_WWJS) {
   const clientFile = path.join(wwjsDir, CLIENT_PATH);
   if (!fs.existsSync(clientFile)) {
@@ -124,6 +143,7 @@ if (require.main === module) run();
 
 module.exports = {
   applyReadySyncPatch,
+  isApplied,
   EDITS,
   FLAG_INIT_FIND,
   FLAG_INIT_REPLACE,

--- a/scripts/patch-wwebjs-ready-sync.spec.js
+++ b/scripts/patch-wwebjs-ready-sync.spec.js
@@ -8,6 +8,7 @@ const path = require('path');
 
 const {
   applyReadySyncPatch,
+  isApplied,
   FLAG_INIT_FIND,
   FLAG_INIT_REPLACE,
   ATTACH_MARK_FIND,
@@ -45,6 +46,15 @@ test('applies all three edits to a pristine upstream tree', () => {
   for (const replacement of [FLAG_INIT_REPLACE, ATTACH_MARK_REPLACE, HAS_SYNCED_REPLACE]) {
     assert.ok(patched.includes(replacement));
   }
+});
+
+test('isApplied is false on a pristine tree and true once the patch has run', () => {
+  const { dir } = fakeWwjs(PRISTINE);
+
+  // Each replacement contains its own find, so a raw find count would read a patched tree as pristine.
+  assert.equal(isApplied(dir), false);
+  applyReadySyncPatch(dir);
+  assert.equal(isApplied(dir), true);
 });
 
 test('is idempotent — a second run is a no-op, not a double patch', () => {

--- a/scripts/patch-wwebjs-status.js
+++ b/scripts/patch-wwebjs-status.js
@@ -120,6 +120,23 @@ function occurrences(source, needle) {
   return source.split(needle).length - 1;
 }
 
+/**
+ * Every group's stand-down branch as one predicate, for the startup guard
+ * (engine-patch-status.ts). The groups apply independently, so a tree carrying one and not the
+ * other is a reachable state and reads as NOT applied: half the repair is still a broken send.
+ * Unreadable reads as applied, since a tree we cannot inspect is not evidence of a broken one.
+ */
+function isApplied(wwjsDir = DEFAULT_WWJS) {
+  try {
+    const source = fs.readFileSync(path.join(wwjsDir, UTILS_PATH), 'utf8');
+    return GROUPS.every((group) =>
+      group.edits.every((edit) => occurrences(source, edit.find) === 0 && occurrences(source, edit.replace) === 1),
+    );
+  } catch {
+    return true;
+  }
+}
+
 function applyStatusPatches(wwjsDir = DEFAULT_WWJS) {
   const utilsFile = path.join(wwjsDir, UTILS_PATH);
   if (!fs.existsSync(utilsFile)) {
@@ -181,6 +198,7 @@ if (require.main === module) run();
 
 module.exports = {
   applyStatusPatches,
+  isApplied,
   GROUPS,
   GATING_FIND,
   GATING_REPLACE,

--- a/scripts/patch-wwebjs-status.spec.js
+++ b/scripts/patch-wwebjs-status.spec.js
@@ -8,6 +8,7 @@ const path = require('path');
 
 const {
   applyStatusPatches,
+  isApplied,
   GATING_FIND,
   GATING_REPLACE,
   MEDIA_DATA_FIND,
@@ -52,6 +53,15 @@ test('applies both repairs to a pristine upstream tree', () => {
   for (const needle of [GATING_FIND, MEDIA_DATA_FIND, MEDIA_SEND_FIND]) {
     assert.ok(!patched.includes(needle));
   }
+});
+
+/** Both groups are independent, so the predicate only reads as applied once each one has landed. */
+test('isApplied tracks the transform: false on a pristine tree, true once patched', () => {
+  const { dir } = fakeWwjs(PRISTINE);
+
+  assert.equal(isApplied(dir), false);
+  applyStatusPatches(dir);
+  assert.equal(isApplied(dir), true);
 });
 
 test('is idempotent — a second run is a no-op, not a double patch', () => {

--- a/src/common/test-lane-partition.spec.ts
+++ b/src/common/test-lane-partition.spec.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 
 /**
@@ -12,7 +12,7 @@ import { join } from 'node:path';
 describe('Test lane partition', () => {
   const repoRoot = join(__dirname, '..', '..');
   const pkg = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8')) as {
-    scripts: { 'test:docs'?: string };
+    scripts: { 'test:docs'?: string; 'test:scripts'?: string };
     jest?: { testPathIgnorePatterns?: string[]; coveragePathIgnorePatterns?: string[] };
   };
 
@@ -80,6 +80,33 @@ describe('Test lane partition', () => {
     // source path here deletes that code from the coverage ratios.
     const notASpec = coverageIgnores.filter(p => p !== '/node_modules/' && !p.endsWith('\\.spec\\.ts$'));
     expect(notASpec).toEqual([]);
+  });
+
+  /**
+   * `scripts/` has its own lane. `test:scripts` hands node:test an explicit list of positionals,
+   * and jest never looks in that directory, so the two lanes cannot cover for each other: a spec
+   * written under `scripts/` and left out of that string runs NOWHERE, and nothing fails to say so.
+   *
+   * Unlike the doc lane above there is no second list to compare against, so the comparison is
+   * against the directory itself. That also catches the reverse, a renamed or deleted spec still
+   * named by the script, which makes the whole node:test invocation exit non-zero on a file it
+   * cannot open.
+   */
+  it('runs every spec under scripts/ in the test:scripts lane', () => {
+    const isSpec = (name: string): boolean => name.endsWith('.spec.js') || name.endsWith('.spec.mjs');
+    const onDisk = readdirSync(join(repoRoot, 'scripts'))
+      .filter(isSpec)
+      .map(name => `scripts/${name}`);
+    const named = (pkg.scripts['test:scripts'] ?? '').split(/\s+/).filter(isSpec);
+
+    // Vacuity guard: an empty directory scan or an unparsed script would pass the diff below.
+    expect(onDisk.length).toBeGreaterThan(10);
+    expect(named.length).toBeGreaterThan(10);
+
+    expect({
+      neverRun: onDisk.filter(path => !named.includes(path)).sort(),
+      namedButAbsent: named.filter(path => !onDisk.includes(path)).sort(),
+    }).toEqual({ neverRun: [], namedButAbsent: [] });
   });
 
   it('names suites that exist on disk', () => {

--- a/src/engine/adapters/baileys-lifecycle.ts
+++ b/src/engine/adapters/baileys-lifecycle.ts
@@ -13,6 +13,7 @@ import { type createLogger } from '../../common/services/logger.service';
 import { BaileysAdapterConfig } from '../types/baileys.types';
 import { createBaileysLogger } from './baileys-logger';
 import { BaileysVersionResolver } from './baileys-version-resolver';
+import { unappliedPatches, unappliedPatchesMessage } from './engine-patch-status';
 import type { BaileysEvents } from './baileys-events';
 import type { BaileysHistory } from './baileys-history';
 import type { BaileysSessionStore } from './baileys-session-store';
@@ -154,6 +155,15 @@ export class BaileysLifecycle {
     if (this.intentionalClose) {
       return;
     }
+
+    // An install that skipped a Baileys patch fails later with errors that name no cause: an
+    // app-state resync that never terminates, a newsletter create that cannot parse its reply.
+    // Say so here instead, while the operator is still looking at the startup logs.
+    const unapplied = unappliedPatches('baileys');
+    if (unapplied.length) {
+      this.host.logger.error(unappliedPatchesMessage('baileys', unapplied));
+    }
+
     try {
       await this.connect();
     } catch (err) {

--- a/src/engine/adapters/engine-patch-status.spec.ts
+++ b/src/engine/adapters/engine-patch-status.spec.ts
@@ -1,0 +1,169 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { type PatchFamily, unappliedPatches, unappliedPatchesMessage } from './engine-patch-status';
+
+/**
+ * Guards the startup diagnostic for engine patches that never applied. The cost runs both ways, as
+ * it does for `wwebjs-backport-check.ts`: a missed detection restores the silence the guard exists
+ * to break, and a false alarm on every boot sends operators after patches they do not need. The
+ * "cannot tell" cases below are the second half of that, and they matter more here than in the
+ * single-patcher guard, because this one walks a directory and requires whatever it finds.
+ */
+describe('unappliedPatches', () => {
+  const tmpDirs: string[] = [];
+
+  function tmp(prefix: string): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    tmpDirs.push(dir);
+    return dir;
+  }
+
+  /** A scripts/ directory holding stub patchers, each written as the module the guard requires. */
+  function scriptsWith(modules: Record<string, string>): string {
+    const dir = tmp('openwa-patch-scripts-');
+    for (const [name, body] of Object.entries(modules)) fs.writeFileSync(path.join(dir, name), body);
+    return dir;
+  }
+
+  const patcher = (applied: boolean): string => `module.exports = { isApplied: () => ${String(applied)} };\n`;
+
+  afterAll(() => {
+    for (const dir of tmpDirs) fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('names only the patchers whose predicate answers false', () => {
+    const scripts = scriptsWith({
+      'patch-wwebjs-alpha.js': patcher(true),
+      'patch-wwebjs-beta.js': patcher(false),
+      'patch-wwebjs-gamma.js': patcher(false),
+    });
+
+    expect(unappliedPatches('wwebjs', scripts, tmp('dep-'))).toEqual(['patch-wwebjs-beta', 'patch-wwebjs-gamma']);
+  });
+
+  it('reports nothing when every patcher is applied', () => {
+    const scripts = scriptsWith({ 'patch-wwebjs-alpha.js': patcher(true) });
+
+    expect(unappliedPatches('wwebjs', scripts, tmp('dep-'))).toEqual([]);
+  });
+
+  it('keeps each family to its own patchers', () => {
+    const scripts = scriptsWith({
+      'patch-wwebjs-alpha.js': patcher(false),
+      'patch-baileys-alpha.js': patcher(false),
+    });
+
+    expect(unappliedPatches('wwebjs', scripts, tmp('dep-'))).toEqual(['patch-wwebjs-alpha']);
+    expect(unappliedPatches('baileys', scripts, tmp('dep-'))).toEqual(['patch-baileys-alpha']);
+  });
+
+  it('passes the resolved dependency directory to the predicate', () => {
+    const dep = tmp('dep-');
+    const scripts = scriptsWith({
+      'patch-wwebjs-alpha.js': 'module.exports = { isApplied: dir => dir !== process.env.OPENWA_EXPECTED_DEP };\n',
+    });
+    process.env.OPENWA_EXPECTED_DEP = dep;
+
+    try {
+      // The predicate answers false only when it was handed exactly the directory we passed in, so
+      // a guard that called isApplied() with no argument would report nothing here.
+      expect(unappliedPatches('wwebjs', scripts, dep)).toEqual(['patch-wwebjs-alpha']);
+    } finally {
+      delete process.env.OPENWA_EXPECTED_DEP;
+    }
+  });
+
+  it('ignores specs, non-patchers and anything that is not a .js file', () => {
+    const scripts = scriptsWith({
+      'patch-wwebjs-alpha.spec.js': patcher(false),
+      'patch-wwebjs-alpha.js': patcher(true),
+      'check-audit.mjs': patcher(false),
+      'wwebjs-201832.patch': 'not javascript at all',
+    });
+
+    expect(unappliedPatches('wwebjs', scripts, tmp('dep-'))).toEqual([]);
+  });
+
+  it('skips a patcher that exports no predicate rather than reporting it', () => {
+    // This is patch-wwebjs-201832.js's situation: guarded elsewhere, so it opts out by omission.
+    const scripts = scriptsWith({
+      'patch-wwebjs-legacy.js': 'module.exports = { applyBackport: () => undefined };\n',
+      'patch-wwebjs-alpha.js': patcher(false),
+    });
+
+    expect(unappliedPatches('wwebjs', scripts, tmp('dep-'))).toEqual(['patch-wwebjs-alpha']);
+  });
+
+  it('skips a patcher that cannot be required instead of failing the boot', () => {
+    const scripts = scriptsWith({
+      'patch-wwebjs-broken.js': 'this is not valid javascript {{{\n',
+      'patch-wwebjs-alpha.js': patcher(false),
+    });
+
+    expect(unappliedPatches('wwebjs', scripts, tmp('dep-'))).toEqual(['patch-wwebjs-alpha']);
+  });
+
+  it('stays quiet when there is no scripts directory to read', () => {
+    expect(unappliedPatches('wwebjs', path.join(tmp('openwa-empty-'), 'absent'), tmp('dep-'))).toEqual([]);
+  });
+
+  it('stays quiet when the dependency cannot be resolved', () => {
+    const scripts = scriptsWith({ 'patch-wwebjs-alpha.js': patcher(false) });
+
+    // Both engines are always installed here, so the only way to reach the unresolvable branch is
+    // a family with no package behind it. That stands in for the real case: an install whose
+    // engine library is absent or pruned is not an install we can judge, and the patcher stubs
+    // above would otherwise be reported as missing.
+    expect(unappliedPatches('absent-engine' as PatchFamily, scripts)).toEqual([]);
+  });
+});
+
+describe('the patchers this repository actually ships', () => {
+  const scripts = path.join(__dirname, '..', '..', '..', 'scripts');
+  const shipped = fs
+    .readdirSync(scripts)
+    .filter(f => f.startsWith('patch-') && f.endsWith('.js') && !f.endsWith('.spec.js'))
+    .sort();
+
+  it('finds the patchers at all', () => {
+    // Vacuity guard: an empty scan would make both assertions below pass without checking anything.
+    expect(shipped.length).toBeGreaterThanOrEqual(9);
+  });
+
+  it('exports a predicate from every patcher except the one guarded elsewhere', () => {
+    const withoutPredicate = shipped.filter(f => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const patcher = require(path.join(scripts, f)) as { isApplied?: unknown };
+      return typeof patcher.isApplied !== 'function';
+    });
+
+    // patch-wwebjs-201832.js is covered by wwebjs-backport-check.ts, which has its own predicate,
+    // its own message and its own docs/12 entry. It is the ONLY patcher allowed to opt out: any
+    // other name here is a patcher whose failure to apply would be silent again.
+    expect(withoutPredicate).toEqual(['patch-wwebjs-201832.js']);
+  });
+
+  it('names a family this guard understands in every patcher filename', () => {
+    // A patcher named outside both prefixes would be silently invisible to unappliedPatches.
+    const unfamiliar = shipped.filter(f => !f.startsWith('patch-wwebjs-') && !f.startsWith('patch-baileys-'));
+
+    expect(unfamiliar).toEqual([]);
+  });
+});
+
+describe('unappliedPatchesMessage', () => {
+  it('names the library, the count, every patcher and a command that fixes one', () => {
+    const message = unappliedPatchesMessage('wwebjs', ['patch-wwebjs-block', 'patch-wwebjs-status']);
+
+    expect(message).toContain('whatsapp-web.js');
+    expect(message).toContain('missing 2');
+    expect(message).toContain('patch-wwebjs-block, patch-wwebjs-status');
+    expect(message).toContain('node scripts/patch-wwebjs-block.js');
+    expect(message).toContain('docs/12-troubleshooting-faq.md');
+  });
+
+  it('names the Baileys package for the baileys family', () => {
+    expect(unappliedPatchesMessage('baileys', ['patch-baileys-appstate'])).toContain('@whiskeysockets/baileys');
+  });
+});

--- a/src/engine/adapters/engine-patch-status.ts
+++ b/src/engine/adapters/engine-patch-status.ts
@@ -1,0 +1,106 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Startup guard for OpenWA's install-time engine patches.
+ *
+ * The patches are applied two ways, and only one of them is loud. The Docker production stage runs
+ * every patcher WITHOUT `--best-effort`, so an unrecognised source shape fails the image build. A
+ * source install runs them through `scripts/postinstall.js` WITH `--best-effort`, where a patcher
+ * that cannot apply prints one line into a long `npm install` transcript and the install still
+ * succeeds. The operator then runs a tree that is missing a fix, and the symptom arrives later as
+ * exactly the opaque failure the patch existed to remove: an unnamed 500, a send that reports no
+ * message, a resync loop that never ends. None of those errors name their cause.
+ *
+ * So restate it on the machine that is actually affected, as the engine starts.
+ *
+ * Ground truth only. Each patcher exports `isApplied()`, which is that patcher's OWN stand-down
+ * branch, reading the installed file. There is deliberately no manifest and no recorded install
+ * outcome: a record can survive a dependency being reinstalled underneath it, and a guard that
+ * says "patched" about an unpatched tree is worse than no guard at all.
+ *
+ * Diagnostic, not preventive, matching `wwebjs-backport-check.ts`: startup continues, so a session
+ * reaching READY is not evidence that every patch landed.
+ *
+ * `scripts/patch-wwebjs-201832.js` is absent from this by design. It is the one patcher that
+ * already has a runtime guard (`wwebjs-backport-check.ts`, its own predicate and its own message),
+ * so it exports no `isApplied` and is skipped here rather than being reported twice or migrated in
+ * the same change. `engine-patch-status.spec.ts` pins it as the only such exception.
+ */
+
+/** Which library a patcher targets, read from its filename prefix. */
+export type PatchFamily = 'wwebjs' | 'baileys';
+
+const PACKAGE_FOR: Record<PatchFamily, string> = {
+  wwebjs: 'whatsapp-web.js',
+  baileys: '@whiskeysockets/baileys',
+};
+
+/** The one member of a patcher module this file uses. Everything else is the patcher's business. */
+interface Patcher {
+  isApplied?: (depDir?: string) => boolean;
+}
+
+/**
+ * `scripts/` as it sits beside the compiled output: `dist/engine/adapters` and `src/engine/adapters`
+ * are both three levels below the package root, so the same hop works built and under ts-jest. The
+ * production image copies the patchers in (Dockerfile), so this resolves there too.
+ */
+function defaultScriptsDir(): string {
+  return path.join(__dirname, '..', '..', '..', 'scripts');
+}
+
+/**
+ * Names of the patchers for `family` that the installed library does NOT carry, without the `.js`.
+ *
+ * Empty is the answer for every uncertainty: no `scripts/` directory, an unresolvable package, a
+ * patcher that exports no predicate. An install we cannot inspect is not evidence of a broken one,
+ * and a false alarm on every boot would send operators chasing a patch they do not need.
+ */
+export function unappliedPatches(family: PatchFamily, scriptsDir?: string, depDir?: string): string[] {
+  const dir = scriptsDir ?? defaultScriptsDir();
+
+  let resolvedDep: string;
+  try {
+    resolvedDep = depDir ?? path.dirname(require.resolve(`${PACKAGE_FOR[family]}/package.json`));
+  } catch {
+    return [];
+  }
+
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(dir);
+  } catch {
+    return [];
+  }
+
+  const prefix = `patch-${family}-`;
+  const missing: string[] = [];
+  for (const entry of entries.sort()) {
+    if (!entry.startsWith(prefix) || !entry.endsWith('.js') || entry.endsWith('.spec.js')) continue;
+    let patcher: Patcher;
+    try {
+      // Requiring a patcher does not run it: each guards its own CLI behind `require.main`. The
+      // patchers are plain CommonJS loaded by computed path, so this cannot be an import.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      patcher = require(path.join(dir, entry)) as Patcher;
+    } catch {
+      continue;
+    }
+    if (typeof patcher.isApplied !== 'function') continue;
+    if (patcher.isApplied(resolvedDep) === false) missing.push(entry.replace(/\.js$/, ''));
+  }
+  return missing;
+}
+
+/** The startup line for a non-empty `unappliedPatches` result. */
+export function unappliedPatchesMessage(family: PatchFamily, names: string[]): string {
+  return (
+    `The installed ${PACKAGE_FOR[family]} is missing ${names.length} of OpenWA's install-time ` +
+    `patches: ${names.join(', ')}. The capabilities each one repairs will fail with errors that ` +
+    'name no cause. The install skipped them, usually because it ran with --ignore-scripts or ' +
+    'because a patcher refused a source shape it did not recognise. Apply them with ' +
+    `\`node scripts/${names[0]}.js\` (or reinstall with \`npm install\`) and restart. ` +
+    'See docs/12-troubleshooting-faq.md.'
+  );
+}

--- a/src/engine/adapters/wwebjs-lifecycle.ts
+++ b/src/engine/adapters/wwebjs-lifecycle.ts
@@ -14,6 +14,7 @@ import { resolveAuthTimeoutMs, resolveEngineInitTimeoutMs } from '../engine-init
 import { killOrphanedChromiumProcesses, removeStaleSingletonFiles } from './chromium-profile-hygiene';
 import { isSupportedProxyUrl, buildProxyLaunchConfig } from './wwebjs-proxy';
 import { BACKPORT_MISSING_MESSAGE, isBackportMissing } from './wwebjs-backport-check';
+import { unappliedPatches, unappliedPatchesMessage } from './engine-patch-status';
 import { type WhatsAppWebJsConfig } from './whatsapp-web-js.adapter';
 
 /**
@@ -168,6 +169,12 @@ export class WwebjsLifecycle {
     // (#889) — say so here instead, while the operator is still looking at the startup logs.
     if (isBackportMissing()) {
       this.host.logger.error(BACKPORT_MISSING_MESSAGE);
+    }
+
+    // The other seven whatsapp-web.js patchers fail the same way and were equally silent about it.
+    const unapplied = unappliedPatches('wwebjs');
+    if (unapplied.length) {
+      this.host.logger.error(unappliedPatchesMessage('wwebjs', unapplied));
     }
 
     try {

--- a/src/engine/engine-parity.spec.ts
+++ b/src/engine/engine-parity.spec.ts
@@ -126,6 +126,7 @@ function prefixEngine(file: string): AdapterKey | undefined {
 const SHARED = 'shared' as const;
 const UNPREFIXED_FILE_ENGINES: Record<string, readonly AdapterKey[] | typeof SHARED> = {
   'chromium-profile-hygiene.ts': ['wwjs'],
+  'engine-patch-status.ts': SHARED,
   'inbound-media-cap.ts': SHARED,
   'message-mapper.ts': SHARED,
   'safe-link-preview.ts': ['baileys'],


### PR DESCRIPTION
## Description

OpenWA applies nine exact source transforms to its engine libraries at install time. The Docker
production stage runs them without `--best-effort`, so a source shape a patcher cannot recognise
fails the image build. A source install runs them through `scripts/postinstall.js` **with**
`--best-effort`, where a patcher that cannot apply prints one line into a long `npm install`
transcript and the install still succeeds. The operator then runs a tree missing a fix, and the
symptom arrives later as exactly the opaque failure that patch existed to remove: an unnamed `500`
from one route, block and unblock refusing every id, an app-state resync that never settles.

Eight of the nine were silent about this. Only `patch-wwebjs-201832.js` reported itself, through
`wwebjs-backport-check.ts`, as the wwjs session starts.

This is not hypothetical. On a checkout whose `node_modules` predates #1487, the new predicate
reports `patch-wwebjs-group-description` as not applied, which is correct and was previously
invisible.

## What changed

- Every patcher except `patch-wwebjs-201832.js` exports `isApplied(depDir)`. Each one is that
  patcher's own stand-down branch, reusing the constants it already had rather than restating any
  patched text, so the guard and the patcher cannot disagree about what "patched" means.
- New `src/engine/adapters/engine-patch-status.ts` walks `scripts/patch-*.js` for a family, calls
  each predicate against the resolved package directory, and returns the names that answer false.
  Both engines call it from `initialize()`.
- `scripts/patch-baileys-appstate.js` hoists its stand-down literal into `PATCHED_MARKER` and
  interpolates it into `LOOP_REPLACE`, the way `patch-baileys-newsletter-create.js` already does.
  `LOOP_REPLACE` is byte-identical to before, asserted before and after.
- `docs/12` gains an operator entry with a cross-platform one-liner that names the missing patches;
  `docs/29` §29.3 records the mechanism and its limits.
- Separately, `src/common/test-lane-partition.spec.ts` now checks `test:scripts` against the
  contents of `scripts/`. That list is hand-written and jest never looks in that directory, so a
  spec added there and left out of the string ran in no lane at all. It happens to be complete
  today, so this only bites on future drift.

## Design notes

Ground truth, not a manifest. Every predicate reads the installed file. A recorded install outcome
would outlive the dependency being reinstalled underneath it, and a guard that calls an unpatched
tree healthy is worse than no guard.

Uncertainty never alarms. An unresolvable package, an absent `scripts/`, an unreadable tree or a
patcher that fails to load all read as "cannot tell" and report nothing. A false alarm on every boot
would send operators chasing patches they do not need.

`patch-wwebjs-201832.js` is deliberately excluded. It already has its own predicate, message and
`docs/12` entry, and its stand-down is a strict eleven-site check whose semantics differ from the
loose marker `isBackportMissing` tests today. Folding those together changes existing behaviour and
belongs in its own change. The guard skips any patcher exporting no predicate, and
`engine-patch-status.spec.ts` pins `patch-wwebjs-201832.js` as the only permitted exception so a
patcher added later cannot opt out by accident.

## Impact

Diagnostic only. Startup continues either way, so a session reaching READY is still not evidence
that every patch landed. No route, contract or engine behaviour changes.

## Verification

- `test:cov` 5981 passed. `engine-patch-status.ts` is at 100% lines, branches, functions and
  statements; `src/engine/adapters/` rises to 91.96/84.04/91.03/92.20 against floors of
  86/78/85/86.
- `test:scripts` 130 passed, up from 122: one round-trip test per patcher asserting `isApplied` is
  false on a pristine fixture and true once that patcher's apply function has run, each reusing the
  fixture its spec already had.
- The new lane gate was verified to bite by dropping a spec from `test:scripts` and confirming it
  fails, then restoring it.
- `lint` 0 errors, `format:check` clean, `tsc --noEmit` clean.
