### PR TITLE
chore(deps): ignore tar-stream 3.2.1 and later

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,6 +67,31 @@ updates:
       # README framework rows and the jest ESM config have to move in the same commit.
       - dependency-name: "@nestjs/*"
         versions: [">=12.0.0"]
+      # tar-stream 3.2.1 is a types-only release: index.js, extract.js, pack.js, headers.js and
+      # constants.js are byte-identical to 3.2.0. What it adds is an `exports` map with a `types`
+      # condition, so under moduleResolution nodenext with resolvePackageJsonExports its bundled
+      # declarations shadow @types/tar-stream. Those declarations do `import { Writable } from
+      # 'streamx'`, but tar-stream still asks for streamx ^2.15.0 while the tree resolves 2.25.0,
+      # which ships no declarations at all. `Extract` and `Pack` then inherit no members and both
+      # src/common/storage/storage-transfer.ts and storage.service.spec.ts stop compiling: 8 type
+      # errors in the build and 23 no-unsafe errors in lint. Proven twice, by #1489 and #1504.
+      #
+      # Dependabot cannot resolve this on its own, because streamx 2.25.0 satisfies every declared
+      # range in the tree, so it bumps tar-stream and leaves streamx alone. Adopting 3.2.1 for real
+      # is three coordinated moves rather than a version bump: an `overrides` entry forcing streamx
+      # to ^2.28.1 (2.28.0 is not enough, its `write()` returns `unknown` where 2.28.1 returns
+      # `boolean`, so a gunzip cannot pipe into an Extract), dropping the then-inert
+      # @types/tar-stream, and widening the entry-stream chunk type. That carries streamx three
+      # minors under archiver and Puppeteer's browser fetch for no runtime change at all.
+      #
+      # Pinned on the version rather than update-types because the defect rides the bundled
+      # declarations, not the semver channel: a 3.3.0 would carry the same index.d.ts and the same
+      # streamx range. Unlike the ignores above, this one freezes the line in use rather than a
+      # major line, so re-check on every tar-stream release, not only when its streamx range
+      # widens. An advisory in the frozen line still fails CI through check:audit. package.json
+      # pins tar-stream exactly at 3.2.0, so npm holds the line even while this entry is silent.
+      - dependency-name: "tar-stream"
+        versions: [">=3.2.1"]
 
   - package-ecosystem: npm
     directory: /dashboard


### PR DESCRIPTION
## Problem

tar-stream 3.2.1 has been proposed and reverted twice in one day (#1489, then #1504 within the hour). It is a types-only release: `index.js`, `extract.js`, `pack.js`, `headers.js` and `constants.js` are byte-identical to 3.2.0. What it adds is an `exports` map with a `types` condition, so under `moduleResolution: nodenext` with `resolvePackageJsonExports` its bundled declarations shadow `@types/tar-stream`. Those declarations do `import { Writable } from 'streamx'`, but tar-stream still asks for `streamx ^2.15.0` and the tree resolves 2.25.0, which ships no declarations at all. `Extract` and `Pack` inherit no members, and `src/common/storage/storage-transfer.ts` plus `storage.service.spec.ts` stop compiling: 8 type errors in the build, 23 no-unsafe errors in lint.

Dependabot cannot resolve this on its own. streamx 2.25.0 satisfies every declared range in the tree, so it bumps tar-stream and leaves streamx alone. Every future 3.2.x or 3.3.x reproduces the same failure.

## What changed

One ignore entry in the root npm block of `.github/dependabot.yml`, pinned on the version rather than `update-types` because the defect rides the bundled declarations and not the semver channel.

The comment records what adopting 3.2.1 would actually cost, which is three coordinated moves rather than a version bump: an `overrides` entry forcing streamx to `^2.28.1` (2.28.0 is not enough, its `write()` returns `unknown` where 2.28.1 returns `boolean`, so a gunzip cannot pipe into an `Extract`), dropping the then-inert `@types/tar-stream`, and widening the entry-stream chunk type. That would carry streamx three minors under archiver and Puppeteer's browser fetch in exchange for no runtime change.

## Impact

No dependency changes. Note that unlike the five entries above it, this one freezes the line currently in use rather than a major line, and ignore conditions apply to security updates too. The comment says to re-check on every tar-stream release rather than only when its streamx range widens, and `check:audit` remains the compensating control that still turns CI red on an advisory. `package.json` already pins tar-stream exactly at 3.2.0, so npm holds the line independently of this entry.

The dashboard ecosystem needs no entry: `dashboard/package-lock.json` contains no tar-stream and no streamx.

## Verification

`yaml.safe_load` parses the file to four update blocks. The root ignore list reads `typescript`, `better-sqlite3`, `audio-decode`, `@types/node`, `@nestjs/*`, `tar-stream`; the dashboard list is unchanged. The streamx signature claim was checked against the published tarballs: 2.25.0 has no `types` field, 2.28.0 first ships `index.d.ts` with `write(data: unknown): unknown`, and 2.28.1 changes it to `boolean`.
