### PR TITLE
docs(contributing): match the checklist to the CI gates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,15 +36,32 @@ Default storage is SQLite, so no external services are required to run locally.
 
 Please make sure these pass locally:
 
+Backend:
+
 ```bash
 npm run build               # NestJS build (tsc)
+npx tsc --noEmit            # also type-checks specs, which the build excludes
 npm test                    # unit tests (Jest)
+npm run test:docs           # docs-sync specs, a separate lane `npm test` does not run
 npm run lint                # ESLint
-npm run format              # Prettier
-npm --prefix dashboard run build   # dashboard type-check + build
+npm run format              # Prettier (CI runs `format:check`)
 ```
 
-- Add or update tests for behavior changes — specs are colocated as `*.spec.ts`.
+Dashboard, where CI runs each of these as its own step:
+
+```bash
+cd dashboard
+npm run lint && npm run format:check && npm run typecheck
+npm run i18n:check && npm run build && npm run test:unit
+```
+
+If you changed a DTO, a route, or an `@ApiResponse`, also run `npm run openapi:export` and
+commit the snapshot, then `npm run openapi:check` and `npm run check:contract-shapes`. The
+hand-written SDK types are compared against the schemas and will fail CI by field name.
+
+- Add or update tests for behavior changes. Backend specs are colocated as `*.spec.ts`
+  and run under Jest; dashboard tests are colocated as `*.test.ts` and run under
+  `node --test`, so a dashboard file named `*.spec.ts` is never executed.
 - Keep each PR focused on one logical change; it makes review (and credit) much easier.
 - Update `docs/` and the `CHANGELOG.md` `[Unreleased]` section when your change is
   user-visible. (Maintainers own version stamping and release cutting.)


### PR DESCRIPTION
## Problem

The pre-PR checklist in `CONTRIBUTING.md` did not reproduce CI, in four ways that each cost a contributor a red build they had no way to predict locally.

- **Dashboard tests were pointed at the wrong suffix.** The guidance said specs are colocated as `*.spec.ts`, which is the backend convention. Dashboard tests are `*.test.ts`, run by `node --experimental-strip-types --test "src/**/*.test.ts"`. A dashboard test written to the documented instruction is executed by nothing, and nothing warns about it.
- **The checklist ran one of the dashboard job's six steps.** Only `build` was listed. Its `lint`, `format:check`, `typecheck`, `i18n:check` and `test:unit` steps were unmentioned, and `typecheck` is the one that has actually failed on incoming PRs.
- **`npm test` does not run the docs-sync lane.** Those specs are excluded from the default Jest run and live in `test:docs`, so a change to the capability matrix or the changelog passes locally and fails in CI.
- **`nest build` does not type-check specs.** It uses `tsconfig.build.json`, which excludes them, while the Lint job runs `tsc --noEmit` over the whole program.

## What changed

`CONTRIBUTING.md` only. The pre-PR block is split into a backend list and a dashboard list that names all six steps in the order CI runs them, the tests bullet states both conventions and says plainly that a dashboard `*.spec.ts` is never executed, and a short note names the OpenAPI snapshot and contract gates, since a changed DTO fails them by field name and regenerating the snapshot is not discoverable.

## Verification

Every one of the fifteen commands named in the new text exists in `package.json` or `dashboard/package.json`, checked programmatically rather than by eye. `npx prettier --check CONTRIBUTING.md` passes, which matters because the root `format:check` glob covers `**/*.md`. No code or config change, so nothing else can move.
