### PR TITLE
docs(sdk): document the webhook secret minimum in every client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   slow command as a transport death.
 - `GET /sessions/{sessionId}/contacts` declares `503` in the contract and answers it when the
   whatsapp-web.js page dies mid-read, instead of a bare `500`. Thanks @Deyvis17GY.
+- All five clients now document the 16-character minimum on a webhook `secret`, and that an empty
+  string clears it on update. The constraint is unchanged; until now only the gateway named it, in a
+  `400`.
 
 ### Fixed
 

--- a/sdk/go/types_webhook.go
+++ b/sdk/go/types_webhook.go
@@ -87,6 +87,9 @@ type WebhookFilters struct {
 }
 
 // CreateWebhookRequest registers a webhook. RetryCount is 0–5 (default 3).
+//
+// Secret is optional and signs every delivery as X-OpenWA-Signature: sha256=<hex>. The gateway
+// enforces a 16-character minimum and answers 400 below it; omit Secret for unsigned deliveries.
 type CreateWebhookRequest struct {
 	URL        string            `json:"url"`
 	Events     []string          `json:"events"`
@@ -106,6 +109,9 @@ type CreateWebhookRequest struct {
 // Filters cannot use the same trick — a nil pointer marshals away under omitempty, and dropping
 // omitempty would send "filters": null on EVERY update, clearing filters nobody asked to touch. Set
 // ClearFilters instead; MarshalJSON turns it into the explicit null the server reads.
+//
+// The gateway's 16-character minimum on Secret applies here too, with one exception: the empty
+// string is the documented "clear the secret" value and is accepted.
 type UpdateWebhookRequest struct {
 	URL        string             `json:"url,omitempty"`
 	Events     []string           `json:"events,omitempty"`

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/model/CreateWebhookRequest.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/model/CreateWebhookRequest.java
@@ -36,7 +36,10 @@ public record CreateWebhookRequest(
             return this;
         }
 
-        /** HMAC secret; signed as {@code X-OpenWA-Signature: sha256=…}. */
+        /**
+         * HMAC secret; signed as {@code X-OpenWA-Signature: sha256=…}. At least 16 characters, or
+         * the gateway answers 400. Leave unset for unsigned deliveries. Never returned by a read.
+         */
         public Builder secret(String v) {
             this.secret = v;
             return this;

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/model/UpdateWebhookRequest.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/model/UpdateWebhookRequest.java
@@ -38,7 +38,11 @@ public record UpdateWebhookRequest(
             return this;
         }
 
-        /** HMAC secret; signed as {@code X-OpenWA-Signature: sha256=…}. */
+        /**
+         * HMAC secret; signed as {@code X-OpenWA-Signature: sha256=…}. Held to the same 16-character
+         * minimum as the create request, with one exception: {@code ""} is the documented
+         * "clear the secret" value and is accepted.
+         */
         public Builder secret(String v) {
             this.secret = v;
             return this;

--- a/sdk/javascript/src/types.ts
+++ b/sdk/javascript/src/types.ts
@@ -912,7 +912,10 @@ export interface WebhookFilters {
 export interface CreateWebhookRequest {
   url: string;
   events?: WebhookEvent[];
-  /** HMAC secret; signed as `X-OpenWA-Signature: sha256=…`. */
+  /**
+   * HMAC secret; signed as `X-OpenWA-Signature: sha256=…`. At least 16 characters, or the gateway
+   * answers 400. Omit for unsigned deliveries. Never returned by a read.
+   */
   secret?: string;
   headers?: Record<string, string>;
   filters?: WebhookFilters | null;
@@ -920,6 +923,10 @@ export interface CreateWebhookRequest {
   retryCount?: number;
 }
 
+/**
+ * Every field is a partial update. `secret: ''` and `headers: {}` are the documented "clear it"
+ * values; any other secret is still held to the 16-character minimum.
+ */
 export type UpdateWebhookRequest = Partial<CreateWebhookRequest> & { active?: boolean };
 
 export interface WebhookResponse {

--- a/sdk/php/src/Resources/WebhooksResource.php
+++ b/sdk/php/src/Resources/WebhooksResource.php
@@ -59,6 +59,10 @@ class WebhooksResource
     }
 
     /**
+     * A `secret` in $body signs every delivery as `X-OpenWA-Signature: sha256=<hex>`. The gateway
+     * enforces a 16-character minimum on it and answers 400 below that; omit it for unsigned
+     * deliveries. Neither `secret` nor `headers` is returned by a read.
+     *
      * @param array<string,mixed> $body
      * @return array<string,mixed>
      */
@@ -73,6 +77,10 @@ class WebhooksResource
     }
 
     /**
+     * Partial update: an absent key is left alone. The create route's 16-character minimum on
+     * `secret` applies here too, with one exception: `''` is the documented "clear the secret"
+     * value and is accepted, as `[]` is for `headers`.
+     *
      * @param array<string,mixed> $body
      * @return array<string,mixed>
      */

--- a/sdk/python/openwa/types.py
+++ b/sdk/python/openwa/types.py
@@ -849,6 +849,8 @@ class WebhookFilters(TypedDict):
 class CreateWebhookRequest(TypedDict):
     url: str
     events: NotRequired[list[WebhookEvent]]
+    # HMAC secret, signed as ``X-OpenWA-Signature: sha256=<hex>``. At least 16 characters; the
+    # gateway answers 400 below that. Omit for unsigned deliveries. Never returned by a read.
     secret: NotRequired[str]
     headers: NotRequired[dict[str, str]]
     filters: NotRequired[WebhookFilters | None]
@@ -862,6 +864,8 @@ class UpdateWebhookRequest(TypedDict, total=False):
     # optional. Every field here is a partial update.
     url: str
     events: list[WebhookEvent]
+    # Same 16-character minimum as the create request, with one exception: the empty string is the
+    # documented "clear the secret" value and is accepted.
     secret: str
     headers: dict[str, str]
     filters: WebhookFilters | None


### PR DESCRIPTION
The gateway has enforced a 16-character minimum on a webhook `secret` for some time. None of the five
clients said so, so a caller reading only their SDK saw an ordinary optional string, sent a short
secret, and got a `400` naming a constraint their client never mentioned. #1491 was the server-side
half of this; the clients are the other half.

## Changes

Each client now states the rule where a caller actually sets the field:

- Go: `CreateWebhookRequest` and `UpdateWebhookRequest` doc comments.
- JavaScript: the `secret` TSDoc on `CreateWebhookRequest`, and a note on the `UpdateWebhookRequest`
  alias, which had none.
- Python: field comments on both `TypedDict`s.
- Java: the `secret(...)` builder Javadoc on both request records.
- PHP: the `create()` and `update()` docblocks, since that client takes an untyped array body and the
  docblock is the only place the shape can be described.

Each says three things: the floor, that an empty string is the documented "clear the secret" value on
update, and that the field never comes back on a read.

## Risk

None. Comments and one changelog line; no signature, type or behaviour changes.

## Verification

`check:sdk-docs`, `check:sdk-coverage`, `check:sdk-routes`, `check:sdk-events` and
`check:contract-shapes` pass. The JavaScript SDK typechecks, builds and passes its 89 tests; the
Python file compiles. The remaining language toolchains are not installed locally, so Java, PHP and Go
are left to their CI jobs.
