### PR TITLE
chore(deps): bump fast-uri to 3.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `browserslist` 4.28.2 to 4.28.8 in both dependency trees, closing two high-severity advisories
   (unbounded cache growth, and a crash on untrusted custom stats). Dev-only and transitive in each,
   so nothing that ships changes.
+- `fast-uri` 3.1.5 to 3.1.7 via an override, closing four high-severity advisories: two host-confusion
+  paths (skipped IDN canonicalisation, percent-encoded scheme normalisation) and two SSRF paths
+  (malformed IPv6 normalisation, repeated hostname percent-decoding). It arrives under `ajv`, whose
+  range already allows the patched version, and reaches the runtime tree through
+  `@modelcontextprotocol/sdk`, so this one does ship.
 
 ## [0.23.3] - 2026-08-24
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8808,9 +8808,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -450,6 +450,7 @@
     "ip-address": "^10.4.0",
     "tar": "^7.5.21",
     "js-yaml": "^5.2.2",
+    "fast-uri": "^3.1.7",
     "better-sqlite3": "$better-sqlite3",
     "typeorm": {
       "ioredis": "$ioredis"


### PR DESCRIPTION
`check:audit` is failing on `main` over four high-severity advisories in `fast-uri`, and the `build`
job lists `audit` in its `needs`, with `docker` behind `build`. So both are skipped rather than run on
every pull request until this clears.

All four are patched in 3.1.6 on the same major line:

| advisory | affected 3.x range | patched |
| --- | --- | --- |
| GHSA-5jgf-p345-68v8 | `>= 3.1.3, < 3.1.6` | 3.1.6 |
| GHSA-f65p-4m7j-42xc | `>= 3.0.0, < 3.1.6` | 3.1.6 |
| GHSA-fph4-wmhf-6fwf | `>= 3.1.2, < 3.1.6` | 3.1.6 |
| GHSA-jqff-g426-hqxp | `>= 3.0.0, < 3.1.6` | 3.1.6 |

## What changed

- `fast-uri` pinned to `^3.1.7` in `overrides`, alongside the five pins already there. It is reached
  only through `ajv`, whose `^3.0.1` range already admits 3.1.7, so nothing else in the tree moves:
  the lockfile diff is the three lines of that one entry.
- Not dev-only. `@modelcontextprotocol/sdk` is a runtime dependency and pulls `ajv`, so the vulnerable
  copy is in the shipped tree, not just the build tree.

## Verification

`npm run check:audit` now passes ("no unexcused high/critical advisories in the root tree"), plus
`check:versions`, the full suite (6014 passing) and `npm run test:docs` (268 passing).

One note on how the lockfile was regenerated: this repo's lockfile carries the `libc` fields that npm
11 writes, and regenerating under npm 10 silently strips all 99 of them, which would drop the
glibc/musl constraints on the optional platform binaries. It was regenerated with
`npm@11 --package-lock-only` so those fields survive; the diff is the `fast-uri` entry and nothing else.
