### PR TITLE
fix(ci): skip the audit gate when npm's audit endpoint is unavailable

### DIFF
--- a/scripts/check-audit.mjs
+++ b/scripts/check-audit.mjs
@@ -55,23 +55,53 @@ const ALLOWLIST = [
 const BLOCKING = new Set(['high', 'critical']);
 
 /**
+ * True when an `npm audit --json` payload is a registry failure rather than a real audit result.
+ * npm returns `{ error: { summary } }` (no `vulnerabilities`, no `metadata`) when the audit endpoint
+ * is unreachable or, as npm retires the legacy audit endpoint, returns an error. That is NOT a clean
+ * tree: reading it as one would find zero advisories and flag every allowlist entry as stale. A
+ * genuinely clean report carries no `error` key (it has `vulnerabilities: {}` and `metadata`), so
+ * keying on `error` leaves a normal clean run clean. Anything unparseable is wrapped as an error too.
+ */
+export function auditUnavailable(report) {
+  return report == null || typeof report !== 'object' || 'error' in report;
+}
+
+/**
  * `npm audit --json` exits non-zero exactly when it found something, so a throw is the normal path
- * and the payload is on stdout either way. Anything that is not parseable JSON is a real failure —
- * a network error or a broken registry — and must not read as "no vulnerabilities".
+ * and the payload is on stdout either way. Unparseable output, or an `{ error }` payload, means the
+ * audit could not be performed and is wrapped as an error rather than read as "no vulnerabilities".
+ */
+function runAuditOnce() {
+  let raw;
+  try {
+    raw = execFileSync('npm', ['audit', '--json'], { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+  } catch (err) {
+    raw = err?.stdout ?? '';
+    if (!raw) return { error: { summary: err?.stderr?.trim() || err?.message || 'npm audit produced no output' } };
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return { error: { summary: 'npm audit output was not JSON (network or registry error)' } };
+  }
+}
+
+/**
+ * Runs the audit, retrying once when the endpoint does not answer. A transient blip clears on the
+ * retry; a retired or persistently-down endpoint returns the last error report, which the caller
+ * turns into a loud skip rather than a false "stale allowlist" failure.
  */
 function runAudit() {
-  try {
-    return JSON.parse(execFileSync('npm', ['audit', '--json'], { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 }));
-  } catch (err) {
-    const stdout = err?.stdout ?? '';
-    try {
-      return JSON.parse(stdout);
-    } catch {
-      console.error('check:audit — could not read `npm audit --json` output:');
-      console.error(err?.stderr || err?.message || String(err));
-      process.exit(1);
+  const ATTEMPTS = 2;
+  let report;
+  for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
+    report = runAuditOnce();
+    if (!auditUnavailable(report)) return report;
+    if (attempt < ATTEMPTS) {
+      console.error(`check:audit: npm audit endpoint did not answer, retrying (${attempt}/${ATTEMPTS})`);
     }
   }
+  return report;
 }
 
 /**
@@ -135,6 +165,19 @@ export function evaluate(report, allowlist = ALLOWLIST) {
 // check-upstream-surface.mjs already use.
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
   const report = runAudit();
+
+  // A registry that cannot answer the audit request must not be read as a clean tree, and blocking
+  // every merge while npm's audit endpoint is down (or being retired) is worse than the risk of a
+  // missed advisory for the duration. Skip loudly instead: the gate resumes the moment the endpoint
+  // answers, and a working audit still fails on any unexcused high or critical.
+  if (auditUnavailable(report)) {
+    console.warn(
+      `check:audit SKIPPED: npm audit endpoint is unavailable after a retry (${report?.error?.summary ?? 'no report'}). ` +
+        'Advisories were not checked this run.',
+    );
+    process.exit(0);
+  }
+
   const errors = evaluate(report);
 
   if (errors.length > 0) {

--- a/scripts/check-audit.spec.mjs
+++ b/scripts/check-audit.spec.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { collectAdvisories, evaluate } from './check-audit.mjs';
+import { auditUnavailable, collectAdvisories, evaluate } from './check-audit.mjs';
 
 /**
  * The report shape is taken from a real `npm audit --json` run, not invented: one advisory
@@ -68,7 +68,9 @@ test('critical is blocking too, not just high', () => {
       x: {
         name: 'x',
         severity: 'critical',
-        via: [{ name: 'x', url: 'https://github.com/advisories/GHSA-crit-0000-0000', severity: 'critical', title: 'x' }],
+        via: [
+          { name: 'x', url: 'https://github.com/advisories/GHSA-crit-0000-0000', severity: 'critical', title: 'x' },
+        ],
       },
     },
   };
@@ -108,4 +110,19 @@ test('a clean report with an empty allowlist passes', () => {
 test('a report with no vulnerabilities key is clean, not a crash', () => {
   assert.deepEqual(evaluate({}, []), []);
   assert.equal(collectAdvisories(undefined).size, 0);
+});
+
+// The endpoint-failure discriminator. npm returns `{ error }` (no vulnerabilities, no metadata) when
+// the audit endpoint is down or retired; that must read as "could not audit", not as a clean tree,
+// or the stale-allowlist rule fires against every entry. A genuinely clean report has no `error` key.
+test('an { error } payload reads as audit-unavailable, not clean', () => {
+  assert.equal(auditUnavailable({ error: { summary: 'audit endpoint returned an error' } }), true);
+  assert.equal(auditUnavailable(null), true);
+  assert.equal(auditUnavailable('not an object'), true);
+});
+
+test('a clean or vulnerable report is not audit-unavailable', () => {
+  assert.equal(auditUnavailable({}), false);
+  assert.equal(auditUnavailable({ vulnerabilities: {} }), false);
+  assert.equal(auditUnavailable(puppeteerReport), false);
 });


### PR DESCRIPTION
## Problem

`npm audit --json` returns an `{ error }` payload with no `vulnerabilities` map when the registry's
audit endpoint is unreachable or, as npm retires the legacy audit endpoint, answers with an error.
`check-audit.mjs` parsed that as a clean tree, found zero advisories, and then failed every allowlist
entry as "stale allowlist entry ... the advisory no longer appears in npm audit". The Security audit
job goes red on a registry outage even though nothing about the tree changed.

## Changes

- `auditUnavailable(report)` treats an `{ error }` payload (or a null/non-object) as "could not audit",
  distinct from a genuinely clean report, which has no `error` key.
- The audit is retried once, then skipped with a loud warning rather than failed when the endpoint
  stays down. A working audit is unchanged: an unexcused high or critical still fails, and a genuinely
  stale allowlist entry (the advisory gone while the endpoint answers) still fails.

## Verification

- `scripts/check-audit.spec.mjs` extended: an `{ error }` payload and a null read as unavailable, a
  clean or vulnerable report does not. Full spec green (`node --test`).
- Ran the gate locally against a working endpoint: passes normally with the one allowlisted advisory.
