### PR TITLE
feat(session): expose chat mute expiration in the chats list (#1473)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `GET /sessions/{sessionId}/chats` reports `muteExpiration`, the epoch-ms instant a muted chat's mute
+  ends (`0` = indefinite), alongside the existing `muted` flag
+  ([#1473](https://github.com/rmyndharis/OpenWA/issues/1473)). Thanks @usmancynosure and @purnamcommunity.
 - The dashboard's Message Tester can load bulk recipients from a `.txt` or `.csv` file, appending the
   file's lines to whatever the Recipients box already holds. One entry per line, which is what the
   box itself expects. Thanks @harry0x.

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -233,6 +233,7 @@ export interface Chat {
   archived: boolean;
   pinned: boolean;
   muted: boolean;
+  muteExpiration?: number;
 }
 
 // Engine-neutral message types (mirrors the backend's IWhatsAppEngine MessageType). The backend

--- a/docs/06-api-specification.md
+++ b/docs/06-api-specification.md
@@ -479,9 +479,9 @@ Get active chats for a session, most-recent first (paginated).
 ```
 
 `archived`, `pinned` and `muted` are the read side of the `chats/archive`, `chats/pin` and
-`chats/mute` endpoints. `muted` is a verdict, not an expiry — whatsapp-web.js derives it from
-`Chat.isMuted`, and Baileys carries a `muteEndTime` (epoch milliseconds) the gateway compares
-against now. The expiry instant itself is tracked separately in #1473.
+`chats/mute` endpoints. `muted` is the verdict; `muteExpiration`, present only when `muted` is true,
+is the instant the mute ends in epoch milliseconds (`0` = indefinite), the same unit as
+`chats/mute`'s `muteUntil`, so a value read here can be written straight back.
 
 Sorted by `timestamp` DESC (most recent first) then paginated. `timestamp` is an epoch number (seconds). `kind` is the user-facing chat discriminator — one of `individual|group|channel|status|broadcast|unknown`; `isGroup` is retained for back-compat (true only for `kind: "group"`).
 

--- a/openapi.json
+++ b/openapi.json
@@ -10470,8 +10470,13 @@
           },
           "muted": {
             "type": "boolean",
-            "description": "Whether the chat is muted right now, as set via POST /sessions/{sessionId}/chats/mute. The verdict rather than the expiry: whatsapp-web.js derives it itself from Chat.isMuted, and Baileys carries a muteEndTime that this gateway compares against now. The expiry instant itself is tracked separately in #1473.",
+            "description": "Whether the chat is muted right now, as set via POST /sessions/{sessionId}/chats/mute. The verdict rather than the expiry: whatsapp-web.js derives it itself from Chat.isMuted, and Baileys carries a muteEndTime that this gateway compares against now. muteExpiration carries the instant itself.",
             "example": false
+          },
+          "muteExpiration": {
+            "type": "number",
+            "description": "Epoch MILLISECONDS at which the mute ends, present only when muted is true; 0 means muted indefinitely. Milliseconds is the same unit as POST /sessions/{sessionId}/chats/mute muteUntil, so a value read here can be written straight back.",
+            "example": 1786003600000
           }
         },
         "required": [

--- a/sdk/go/types_chat.go
+++ b/sdk/go/types_chat.go
@@ -15,6 +15,9 @@ type ChatSummary struct {
 	Pinned      bool     `json:"pinned"`
 	// Muted reports whether the chat is muted right now, not the expiry behind it.
 	Muted bool `json:"muted"`
+	// MuteExpiration is the epoch milliseconds the mute ends, present only when muted; 0 means
+	// indefinitely. A pointer so an absent expiry and a 0 (indefinite) stay distinct on the wire.
+	MuteExpiration *int64 `json:"muteExpiration,omitempty"`
 }
 
 // SetOwnPresenceRequest is the body for SessionsService.SetOnlinePresence. Available reports

--- a/sdk/java/src/main/java/com/rmyndharis/openwa/model/ChatSummary.java
+++ b/sdk/java/src/main/java/com/rmyndharis/openwa/model/ChatSummary.java
@@ -18,4 +18,6 @@ public record ChatSummary(
     Boolean archived,
     Boolean pinned,
     /** Whether the chat is muted right now, not the expiry behind it. */
-    Boolean muted) {}
+    Boolean muted,
+    /** Epoch milliseconds the mute ends, null unless muted; 0 means indefinitely. */
+    Long muteExpiration) {}

--- a/sdk/javascript/src/types.ts
+++ b/sdk/javascript/src/types.ts
@@ -972,6 +972,8 @@ export interface ChatSummary {
   pinned: boolean;
   /** Whether the chat is muted right now, as set via {@link ChatsResource.mute}. */
   muted: boolean;
+  /** Epoch milliseconds the mute ends, present only when muted; 0 means indefinitely. */
+  muteExpiration?: number;
 }
 
 /** Body for {@link SessionsResource.setOnlinePresence}. */

--- a/sdk/python/openwa/types.py
+++ b/sdk/python/openwa/types.py
@@ -912,6 +912,8 @@ class ChatSummary(TypedDict):
     pinned: bool
     # Whether the chat is muted right now, not the expiry behind it.
     muted: bool
+    # Epoch milliseconds the mute ends, present only when muted; 0 means indefinitely.
+    muteExpiration: NotRequired[int]
 
 
 class MarkChatRequest(TypedDict):

--- a/src/engine/adapters/baileys-session-store.spec.ts
+++ b/src/engine/adapters/baileys-session-store.spec.ts
@@ -168,6 +168,20 @@ describe('BaileysSessionStore', () => {
       expect(fake.get(SID, CHAT)?.muteEndTime).toBe((nowS + 3600) * 1000);
       expect(chatOn(newStore(), { name: 'Alice' }).muted).toBe(true);
     });
+
+    it('reports muteExpiration in ms when muted, absent when not, and survives a restart', () => {
+      const endMs = Date.now() + 90 * 60 * 1000;
+      expect(chatOn(newStore(), { muteEndTime: endMs })).toMatchObject({ muted: true, muteExpiration: endMs });
+      // Restart: the fresh store's this.chats has no muteEndTime, but the persisted expiry is read back.
+      expect(chatOn(newStore(), { name: 'Alice' })).toMatchObject({ muted: true, muteExpiration: endMs });
+      // An unmuted chat carries no expiry (undefined, so omitted from the JSON payload).
+      expect(chatOn(newStore(), { muteEndTime: null }).muteExpiration).toBeUndefined();
+    });
+
+    it('normalizes a seconds-scale expiry to ms for muteExpiration', () => {
+      const nowS = Math.floor(Date.now() / 1000);
+      expect(chatOn(newStore(), { muteEndTime: nowS + 3600 }).muteExpiration).toBe((nowS + 3600) * 1000);
+    });
   });
 
   it('records the newest message per chat and surfaces it in getChats', () => {

--- a/src/engine/adapters/baileys-session-store.ts
+++ b/src/engine/adapters/baileys-session-store.ts
@@ -401,6 +401,7 @@ export class BaileysSessionStore {
       // Baileys reports a pin as an ORDER, not a flag: 0/absent means unpinned.
       pinned: st ? st.pinned : Boolean(c.pinned),
       muted: this.isMuted(st ? st.muteEndTime : c.muteEndTime),
+      muteExpiration: this.muteExpirationMs(st ? st.muteEndTime : c.muteEndTime),
     };
   }
 
@@ -420,6 +421,18 @@ export class BaileysSessionStore {
     if (!raw) return false;
     const endMs = raw < 1e12 ? raw * 1000 : raw;
     return endMs > Date.now();
+  }
+
+  /**
+   * The expiry instant (epoch ms) for {@link ChatSummary.muteExpiration}, or undefined when the chat
+   * is not muted. Same normalisation as {@link isMuted}, so the two agree: a value only survives here
+   * when it is still in the future.
+   */
+  private muteExpirationMs(muteEndTime: number | { toNumber(): number } | null | undefined): number | undefined {
+    const raw = this.toUnixSeconds(muteEndTime);
+    if (!raw) return undefined;
+    const endMs = raw < 1e12 ? raw * 1000 : raw;
+    return endMs > Date.now() ? endMs : undefined;
   }
 
   /**

--- a/src/engine/adapters/wwebjs-chat-state.spec.ts
+++ b/src/engine/adapters/wwebjs-chat-state.spec.ts
@@ -13,11 +13,11 @@ import { type WwebjsMessaging } from './wwebjs-messaging';
  * `getChatsByLabelId` returns. A field added to one and forgotten in the other is invisible until
  * a Business account lists a label, so both mappers are held to the same shape here.
  *
- * The library reports mute as a verdict already — `Chat.isMuted` — so unlike Baileys there is no
- * end-time comparison to make; `muteExpiration` is the raw stamp behind it and is deliberately not
- * what this maps. Each field is read through `Boolean()` because the page can leave any of them
- * undefined on a chat it built from a partial record, and `undefined` must land as `false` rather
- * than escape into a required boolean.
+ * The library reports mute as a verdict (`Chat.isMuted`) plus the stamp behind it
+ * (`Chat.muteExpiration`, epoch SECONDS, `-1` = forever). `muted` maps the verdict; `muteExpiration`
+ * maps the stamp as epoch ms (`0` = indefinite), present only when muted. Boolean fields read through
+ * `Boolean()` because the page can leave any of them undefined on a chat built from a partial record,
+ * and `undefined` must land as `false` rather than escape into a required boolean.
  */
 
 const logger = createLogger('wwebjs-chat-state.spec');
@@ -81,6 +81,16 @@ describe('WwebjsChats.getChats chat state', () => {
       muted: true,
     });
   });
+
+  it('maps muteExpiration to ms when muted, 0 for -1 (forever), absent when not muted', async () => {
+    const secs = 1_786_003_600;
+    expect(await listWith({ isMuted: true, muteExpiration: secs })).toMatchObject({
+      muted: true,
+      muteExpiration: secs * 1000,
+    });
+    expect((await listWith({ isMuted: true, muteExpiration: -1 })).muteExpiration).toBe(0);
+    expect((await listWith({ isMuted: false, muteExpiration: secs })).muteExpiration).toBeUndefined();
+  });
 });
 
 describe('WwebjsLabels.getChatsByLabel chat state', () => {
@@ -111,5 +121,15 @@ describe('WwebjsLabels.getChatsByLabel chat state', () => {
       pinned: false,
       muted: true,
     });
+  });
+
+  it('maps muteExpiration the same way as getChats', async () => {
+    const secs = 1_786_003_600;
+    expect(await listWith({ isMuted: true, muteExpiration: secs })).toMatchObject({
+      muted: true,
+      muteExpiration: secs * 1000,
+    });
+    expect((await listWith({ isMuted: true, muteExpiration: -1 })).muteExpiration).toBe(0);
+    expect((await listWith({ isMuted: false, muteExpiration: secs })).muteExpiration).toBeUndefined();
   });
 });

--- a/src/engine/adapters/wwebjs-chats.ts
+++ b/src/engine/adapters/wwebjs-chats.ts
@@ -62,8 +62,14 @@ export class WwebjsChats {
         lastMessage: chat.lastMessage?.type === MessageTypes.LOCATION ? '📍' : chat.lastMessage?.body || undefined,
         archived: Boolean(chat.archived),
         pinned: Boolean(chat.pinned),
-        // Chat.isMuted is already the current verdict; muteExpiration is the raw stamp behind it.
+        // Chat.isMuted is the current verdict; muteExpiration is wwjs epoch SECONDS with -1 = forever.
         muted: Boolean(chat.isMuted),
+        // Expose the expiry as ms (0 = indefinite), present only when muted, per ChatSummary.
+        muteExpiration: chat.isMuted
+          ? (chat.muteExpiration ?? 0) > 0
+            ? (chat.muteExpiration ?? 0) * 1000
+            : 0
+          : undefined,
       });
     }
 

--- a/src/engine/adapters/wwebjs-labels.ts
+++ b/src/engine/adapters/wwebjs-labels.ts
@@ -79,6 +79,12 @@ export class WwebjsLabels {
         archived: Boolean(chat.archived),
         pinned: Boolean(chat.pinned),
         muted: Boolean(chat.isMuted),
+        // wwjs muteExpiration is epoch SECONDS with -1 = forever; expose ms (0 = indefinite), muted only.
+        muteExpiration: chat.isMuted
+          ? (chat.muteExpiration ?? 0) > 0
+            ? (chat.muteExpiration ?? 0) * 1000
+            : 0
+          : undefined,
       });
     }
     return summaries;

--- a/src/engine/interfaces/whatsapp-engine.interface.ts
+++ b/src/engine/interfaces/whatsapp-engine.interface.ts
@@ -496,15 +496,18 @@ export interface ChatSummary {
   /** Pinned state, as set via `POST /sessions/{sessionId}/chats/pin`. */
   pinned: boolean;
   /**
-   * Muted state, as set via `POST /sessions/{sessionId}/chats/mute`.
-   *
-   * The verdict rather than the expiry the engines hold, deliberately: "is this chat muted right
-   * now" is what a caller needs to label a mute/unmute control, and it is what both engines answer
-   * directly — whatsapp-web.js derives `Chat.isMuted` itself, and Baileys carries a `muteEndTime`
-   * (epoch milliseconds, per the measurement in `chat-mute.spec.ts`) to compare against now. The
-   * expiry instant itself is tracked separately in #1473.
+   * Muted state, as set via `POST /sessions/{sessionId}/chats/mute`. The verdict a caller needs to
+   * label a mute/unmute control: whatsapp-web.js derives `Chat.isMuted` itself, and Baileys compares
+   * a persisted `muteEndTime` (epoch milliseconds) against now. `muteExpiration` carries the instant.
    */
   muted: boolean;
+  /**
+   * Epoch MILLISECONDS at which the mute ends, present only when `muted` is true; `0` means muted
+   * indefinitely. Milliseconds is the same unit as `POST /sessions/{sessionId}/chats/mute`
+   * `muteUntil`, so a value read here can be written straight back (`mute-chat.dto.ts` documents that
+   * unit and why a seconds value is a trap).
+   */
+  muteExpiration?: number;
 }
 
 /**

--- a/src/engine/types/whatsapp-web-js.types.ts
+++ b/src/engine/types/whatsapp-web-js.types.ts
@@ -141,6 +141,7 @@ export interface BusinessClient extends Omit<
           archived?: boolean;
           pinned?: boolean;
           isMuted?: boolean;
+          muteExpiration?: number;
         }
       | undefined
     >

--- a/src/modules/session/dto/chat-summary.dto.ts
+++ b/src/modules/session/dto/chat-summary.dto.ts
@@ -36,9 +36,18 @@ export class ChatSummaryDto {
     description:
       'Whether the chat is muted right now, as set via POST /sessions/{sessionId}/chats/mute. The ' +
       'verdict rather than the expiry: whatsapp-web.js derives it itself from Chat.isMuted, and ' +
-      'Baileys carries a muteEndTime that this gateway compares against now. The expiry instant ' +
-      'itself is tracked separately in #1473.',
+      'Baileys carries a muteEndTime that this gateway compares against now. muteExpiration carries ' +
+      'the instant itself.',
     example: false,
   })
   muted!: boolean;
+
+  @ApiPropertyOptional({
+    description:
+      'Epoch MILLISECONDS at which the mute ends, present only when muted is true; 0 means muted ' +
+      'indefinitely. Milliseconds is the same unit as POST /sessions/{sessionId}/chats/mute ' +
+      'muteUntil, so a value read here can be written straight back.',
+    example: 1786003600000,
+  })
+  muteExpiration?: number;
 }


### PR DESCRIPTION
Closes #1473.

## What

`GET /sessions/{sessionId}/chats` now reports `muteExpiration` alongside the existing `muted` flag:
the epoch MILLISECONDS a muted chat's mute ends, `0` for an indefinite mute. It is absent when the
chat is not muted, so a consumer can read *when* a mute ends, not only that one is set.

`#1472` added `muted` and `#1531` made it survive a reconnect; this adds the expiry instant on the
same foundation.

## Engine mapping

- **Baileys**: the instant comes from the persisted `chat_states` row (`#1531`), normalized to epoch
  milliseconds, so it survives a reconnect and a process restart exactly like `muted` does.
- **whatsapp-web.js**: read from `Chat.muteExpiration` (epoch seconds, `-1` for forever) and normalized
  to milliseconds; `-1`/non-positive becomes `0` (indefinite). Mapped on both `getChats` and
  `getChatsByLabel`.

Milliseconds is the same unit as `POST /sessions/{sessionId}/chats/mute` `muteUntil`, so a value read
here can be written straight back rather than hitting the seconds-scale-in-1970 trap `mute-chat.dto.ts`
documents.

## Impact

Additive and optional: no route, no existing field, no DTO field changes shape. The five SDK type
files carry `muteExpiration` as an optional field (`*int64` with `omitempty` on Go, so an indefinite
`0` stays distinct from absent). OpenAPI snapshot regenerated; `muteExpiration` is not `required`.

## Verification

Full lint and type check, `check:contract-shapes` (332 pairs), `test:docs`, `jest src/engine`, and the
full `npm test --coverage` green. The reconnect durability this rides on is covered by `#1531`'s live
PostgreSQL and Baileys verification.
