### PR TITLE
fix(baileys): resolve group-only @lid members to their phone

### DIFF
--- a/src/engine/adapters/baileys-group-lid-harvest.spec.ts
+++ b/src/engine/adapters/baileys-group-lid-harvest.spec.ts
@@ -1,0 +1,79 @@
+import type { GroupMetadata } from '@whiskeysockets/baileys';
+import type { WASocket } from '@whiskeysockets/baileys';
+import { BaileysGroups, BaileysGroupsHost, collectGroupLidTwins } from './baileys-groups';
+
+/**
+ * The group roster carries each member's phone twin inline (`participant.phoneNumber`, `metadata.ownerPn`),
+ * but `resolvePhone` reads only the lid map that 1:1 traffic feeds. A member present solely in a roster
+ * resolved to `null` on `GET /contacts/{lid}/phone` (#1510). getGroupInfo now harvests the roster twins
+ * into that map, and only the @lid-addressed ones (a phone-addressed participant would key a bogus pair).
+ */
+const meta = (over: Partial<GroupMetadata> = {}): GroupMetadata =>
+  ({
+    id: '120363000000000000@g.us',
+    subject: 'Ops',
+    owner: '111222333@lid',
+    ownerPn: '628111@s.whatsapp.net',
+    creation: 1,
+    participants: [
+      { id: '111222333@lid', phoneNumber: '628111@s.whatsapp.net', admin: 'superadmin' },
+      { id: '444555666@lid', phoneNumber: '628222@s.whatsapp.net', admin: null },
+      // @lid with no server-sent twin (non-contact privacy default): nothing to harvest.
+      { id: '777888999@lid', phoneNumber: undefined, admin: null },
+      // already phone-addressed: no lid to key, must NOT become a phone->phone pair.
+      { id: '628333@s.whatsapp.net', phoneNumber: '628333@s.whatsapp.net', admin: null },
+    ],
+    ...over,
+  }) as unknown as GroupMetadata;
+
+describe('collectGroupLidTwins', () => {
+  it('harvests only @lid participants that carry a phone twin, plus the @lid owner', () => {
+    expect(collectGroupLidTwins(meta())).toEqual([
+      { lid: '111222333@lid', pn: '628111@s.whatsapp.net' },
+      { lid: '444555666@lid', pn: '628222@s.whatsapp.net' },
+      { lid: '111222333@lid', pn: '628111@s.whatsapp.net' },
+    ]);
+  });
+
+  it('skips the owner when it is phone-addressed or has no twin', () => {
+    expect(collectGroupLidTwins(meta({ owner: '628111@s.whatsapp.net', ownerPn: undefined }))).toEqual([
+      { lid: '111222333@lid', pn: '628111@s.whatsapp.net' },
+      { lid: '444555666@lid', pn: '628222@s.whatsapp.net' },
+    ]);
+    expect(collectGroupLidTwins(meta({ owner: '111222333@lid', ownerPn: undefined }))).toEqual([
+      { lid: '111222333@lid', pn: '628111@s.whatsapp.net' },
+      { lid: '444555666@lid', pn: '628222@s.whatsapp.net' },
+    ]);
+  });
+
+  it('returns nothing for an all-phone roster (no lids to key)', () => {
+    const phoneOnly = meta({
+      owner: '628111@s.whatsapp.net',
+      ownerPn: undefined,
+      participants: [{ id: '628111@s.whatsapp.net', phoneNumber: '628111@s.whatsapp.net', admin: null }] as never,
+    });
+    expect(collectGroupLidTwins(phoneOnly)).toEqual([]);
+  });
+});
+
+describe('getGroupInfo harvests the roster twins into the lid map', () => {
+  const build = (metadata: GroupMetadata) => {
+    const addLidMappings = jest.fn();
+    const host = {
+      ensureReady: () => undefined,
+      getSocket: () => ({ groupMetadata: jest.fn().mockResolvedValue(metadata) }) as unknown as WASocket,
+      logger: { warn: jest.fn(), debug: jest.fn(), info: jest.fn(), error: jest.fn() },
+      toNeutralJid: (j: string) => j,
+      toEngineJid: (j: string) => j,
+      normalizedSelfJid: () => '628111@s.whatsapp.net',
+      addLidMappings,
+    } as unknown as BaileysGroupsHost;
+    return { groups: new BaileysGroups(host, 500), addLidMappings };
+  };
+
+  it('feeds the collected @lid twins to addLidMappings on a successful read', async () => {
+    const { groups, addLidMappings } = build(meta());
+    await groups.getGroupInfo('120363000000000000@g.us');
+    expect(addLidMappings).toHaveBeenCalledWith(collectGroupLidTwins(meta()));
+  });
+});

--- a/src/engine/adapters/baileys-group-metadata.spec.ts
+++ b/src/engine/adapters/baileys-group-metadata.spec.ts
@@ -26,6 +26,7 @@ function groups(sock: Record<string, jest.Mock>, budgetMs: number): BaileysGroup
     toNeutralJid: (j: string) => j,
     toEngineJid: (j: string) => j,
     normalizedSelfJid: () => '628177@s.whatsapp.net',
+    addLidMappings: jest.fn(),
   } as unknown as BaileysGroupsHost;
   return new BaileysGroups(host, budgetMs);
 }

--- a/src/engine/adapters/baileys-groups.ts
+++ b/src/engine/adapters/baileys-groups.ts
@@ -1,4 +1,4 @@
-import type { WASocket } from '@whiskeysockets/baileys';
+import type { GroupMetadata, WASocket } from '@whiskeysockets/baileys';
 import {
   Group,
   GroupInfo,
@@ -32,6 +32,8 @@ export interface BaileysGroupsHost {
   toNeutralJid(jid: string): string;
   toEngineJid(jid: string): string;
   normalizedSelfJid(): string;
+  /** Learn lid->pn pairs (write-through to the persistent table); no-ops pairs missing either side. */
+  addLidMappings(mappings: { lid?: string; pn?: string }[]): void;
 }
 
 /**
@@ -108,6 +110,30 @@ const MEMBERSHIP_REQUEST_METHODS: readonly GroupMembershipRequestMethod[] = [
   'linked_group_join',
 ];
 
+/**
+ * The lid->phone twins a group roster carries inline (`participant.phoneNumber`, `metadata.ownerPn`).
+ *
+ * `resolvePhone` (session store) reads only the lid map that 1:1 traffic, message keys, history and
+ * directed sends feed, so a member present solely in a group roster (never messaged, not a saved
+ * contact) resolves to `null` on `GET /contacts/{lid}/phone`, even though the roster just fetched
+ * carries their number (#1510). Harvesting the roster twins makes a fetched group's `@lid` members
+ * resolvable thereafter, reusing the same write-through the message-key path uses. Only `@lid`-addressed
+ * ids are harvested: a phone-addressed participant has no lid to key, and its `phoneNumber` would
+ * otherwise key a bogus phone->phone pair.
+ */
+export function collectGroupLidTwins(metadata: GroupMetadata): { lid: string; pn: string }[] {
+  const twins: { lid: string; pn: string }[] = [];
+  for (const p of metadata.participants ?? []) {
+    if (p.id?.endsWith('@lid') && p.phoneNumber) {
+      twins.push({ lid: p.id, pn: p.phoneNumber });
+    }
+  }
+  if (metadata.owner?.endsWith('@lid') && metadata.ownerPn) {
+    twins.push({ lid: metadata.owner, pn: metadata.ownerPn });
+  }
+  return twins;
+}
+
 export class BaileysGroups {
   constructor(
     private readonly host: BaileysGroupsHost,
@@ -151,6 +177,9 @@ export class BaileysGroups {
         this.queryBudgetMs,
         'WhatsApp did not answer the group metadata query in time',
       );
+      // Feed the roster's inline phone twins into the lid map so this group's @lid members become
+      // resolvable via GET /contacts/{lid}/phone even if they have never messaged this account (#1510).
+      this.host.addLidMappings(collectGroupLidTwins(metadata));
       return mapBaileysGroupInfo(metadata, jid => this.host.toNeutralJid(jid), this.host.normalizedSelfJid());
     } catch (err) {
       // Only a SERVER refusal may become null (→ service 404): the group does not exist or the

--- a/src/engine/adapters/membership-requests.spec.ts
+++ b/src/engine/adapters/membership-requests.spec.ts
@@ -230,6 +230,7 @@ function makeBaileysGroups(): { groups: BaileysGroups; sock: BaileysSockStub } {
     toNeutralJid: jid => jid.replace('@s.whatsapp.net', '@c.us'),
     toEngineJid: jid => jid.replace('@c.us', '@s.whatsapp.net'),
     normalizedSelfJid: () => '628999@c.us',
+    addLidMappings: jest.fn(),
   };
   return { groups: new BaileysGroups(host), sock };
 }


### PR DESCRIPTION
## Problem

`GET /contacts/{contactId}/phone` on the Baileys engine returns `{ "phone": null }` for any `@lid` that has only ever appeared in a group roster and never in a 1:1 message, even with `RESOLVE_LID_TO_PHONE=true`. Surfaced in #1510 after that issue's main defect was confirmed fixed on 0.23.x.

`resolvePhone` reads only the lid map fed by message keys, `lid-mapping.update`, history and directed sends. A group roster carries each member's phone twin inline (`participant.phoneNumber`, `metadata.ownerPn`), which the group mapper already reads for display but never writes back, so a member who never messaged the account has no row to resolve against.

## Change

- `getGroupInfo` harvests the roster's `@lid` twins into the lid map through the existing `addLidMappings` write-through, so fetching a group makes its members resolvable afterwards.
- Only `@lid`-addressed ids are harvested; a phone-addressed participant has no lid to key, and its number would key a bogus pair.
- Scoped to `getGroupInfo` (single group, bounded). `getGroups` fetches every group's full roster, so harvesting there would write thousands of pairs on a plain list call.

## Verification

- New `baileys-group-lid-harvest.spec.ts` covers `collectGroupLidTwins` (harvests only `@lid` + twin, skips phone-addressed and twin-less participants and owner) and that `getGroupInfo` feeds the collected twins to `addLidMappings`.
- Full test suite, `test:docs`, `tsc --noEmit`, ESLint and Prettier all pass locally.

Refs #1510.
