### PR TITLE
fix(session): keep the bound phone when a ready reports no number

### DIFF
--- a/src/modules/session/session-engine-lifecycle-ready-row.spec.ts
+++ b/src/modules/session/session-engine-lifecycle-ready-row.spec.ts
@@ -1,0 +1,33 @@
+import { readyRowUpdate } from './session-engine-lifecycle.service';
+import { SessionStatus } from './entities/session.entity';
+
+/**
+ * whatsapp-web.js can report an empty phone at ready (client.info momentarily unreadable). The
+ * account-binding guard skips an empty incoming phone rather than rebind-rejecting it, so if the
+ * ready row write also clobbered the stored phone with '', the binding would be silently dropped
+ * until the next non-empty ready. readyRowUpdate keeps the bound number in that case.
+ */
+describe('readyRowUpdate', () => {
+  const at = new Date('2026-01-01T00:00:00.000Z');
+
+  it('writes the phone when the ready reports one', () => {
+    expect(readyRowUpdate('628111', 'Alice', at)).toEqual({
+      status: SessionStatus.READY,
+      phone: '628111',
+      pushName: 'Alice',
+      connectedAt: at,
+      lastActiveAt: at,
+    });
+  });
+
+  it('omits phone on an empty-phone ready, keeping the bound number', () => {
+    const update = readyRowUpdate('', 'Alice', at);
+    expect(update).not.toHaveProperty('phone');
+    expect(update).toMatchObject({
+      status: SessionStatus.READY,
+      pushName: 'Alice',
+      connectedAt: at,
+      lastActiveAt: at,
+    });
+  });
+});

--- a/src/modules/session/session-engine-lifecycle.service.ts
+++ b/src/modules/session/session-engine-lifecycle.service.ts
@@ -144,6 +144,25 @@ const TERMINAL_UNLINK_REASONS = new Set(['LOGOUT', 'UNPAIRED', 'UNPAIRED_IDLE', 
  * executeReconnect calls initializeEngine), so they stay in ONE service — splitting them would need
  * forwardRef(), which this codebase deliberately avoids.
  */
+/**
+ * The session-row fields a READY writes.
+ *
+ * An empty `phone` must NOT overwrite the bound number. whatsapp-web.js can momentarily report an
+ * empty phone at ready (client.info unreadable), and the account-binding guard in
+ * SessionEngineEventWiring skips an empty incoming phone rather than rebind-rejecting it, so writing
+ * it here would silently clear the stored number and drop the binding guard until the next non-empty
+ * ready. In that case keep the existing binding and update only the liveness fields.
+ */
+export function readyRowUpdate(phone: string, pushName: string, at: Date) {
+  return {
+    status: SessionStatus.READY,
+    ...(phone ? { phone } : {}),
+    pushName,
+    connectedAt: at,
+    lastActiveAt: at,
+  };
+}
+
 @Injectable()
 export class SessionEngineLifecycle {
   private readonly logger = createLogger('SessionEngineLifecycle');
@@ -777,20 +796,12 @@ export class SessionEngineLifecycle {
     // one-shot recovery budget is re-armed for a future episode.
     this.stuckAuthRecoveryUsed.delete(id);
 
-    void this.sessionRepository
-      .update(id, {
-        status: SessionStatus.READY,
-        phone,
-        pushName,
-        connectedAt: new Date(),
-        lastActiveAt: new Date(),
-      })
-      .catch(err =>
-        this.logger.warn('Failed to persist session ready state', {
-          sessionId: id,
-          error: err instanceof Error ? err.message : String(err),
-        }),
-      );
+    void this.sessionRepository.update(id, readyRowUpdate(phone, pushName, new Date())).catch(err =>
+      this.logger.warn('Failed to persist session ready state', {
+        sessionId: id,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
 
     // Best-effort snapshot of the account's own contacts' currently-active statuses. Live status
     // posts arrive through onMessage below; this just backfills what was already up before we


### PR DESCRIPTION
## Problem

`handleEngineReady` wrote the session row with `phone` taken verbatim from the ready event:

```
update(id, { status: READY, phone, pushName, connectedAt, lastActiveAt })
```

whatsapp-web.js can report an empty phone at ready when `client.info` is momentarily unreadable (the adapter emits `onReady('', '')`). The account-binding guard in `SessionEngineEventWiring` deliberately skips an empty incoming phone (it cannot compare `''` against the bound number, so it does not rebind-reject), which left `handleEngineReady` free to persist `phone: ''`. That cleared the stored number, and since the binding guard keys on the row's phone, the account-binding protection was dropped until the next non-empty ready.

## Change

The ready row write now omits the `phone` column when the ready reports an empty one, keeping the bound number and updating only the liveness fields (`status`, `pushName`, `connectedAt`, `lastActiveAt`). A non-empty phone is written as before, so a fresh session's first ready still records its number.

The field selection is extracted to a small pure `readyRowUpdate(phone, pushName, at)` helper so it can be tested directly.

## Verification

- New `session-engine-lifecycle-ready-row.spec.ts`: a non-empty phone is written; an empty phone is omitted while the liveness fields are still set.
- Full suite, `test:docs`, `tsc`, ESLint and Prettier pass locally.
