### PR TITLE
docs(api): correct the muteExpiration write-back contract for indefinite mutes

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -10476,7 +10476,7 @@
           },
           "muteExpiration": {
             "type": "number",
-            "description": "Epoch MILLISECONDS at which the mute ends, present only when muted is true; 0 means muted indefinitely. Milliseconds is the same unit as POST /sessions/{sessionId}/chats/mute muteUntil, so a value read here can be written straight back.",
+            "description": "Epoch MILLISECONDS at which the mute ends, present only when muted is true; 0 means muted indefinitely. Milliseconds is the same unit as POST /sessions/{sessionId}/chats/mute muteUntil, so a finite value can be written straight back. The 0 an indefinite mute reports is the exception: muteUntil requires a real future instant, so re-apply an indefinite mute with a far-future timestamp rather than 0.",
             "example": 1786003600000
           }
         },

--- a/src/engine/interfaces/whatsapp-engine.interface.ts
+++ b/src/engine/interfaces/whatsapp-engine.interface.ts
@@ -504,8 +504,10 @@ export interface ChatSummary {
   /**
    * Epoch MILLISECONDS at which the mute ends, present only when `muted` is true; `0` means muted
    * indefinitely. Milliseconds is the same unit as `POST /sessions/{sessionId}/chats/mute`
-   * `muteUntil`, so a value read here can be written straight back (`mute-chat.dto.ts` documents that
-   * unit and why a seconds value is a trap).
+   * `muteUntil`, so a FINITE value can be written straight back (`mute-chat.dto.ts` documents that
+   * unit and why a seconds value is a trap). The `0` an indefinite mute reports is the exception:
+   * `muteUntil` requires a real future instant, so re-apply an indefinite mute with a far-future
+   * timestamp rather than `0`.
    */
   muteExpiration?: number;
 }

--- a/src/modules/session/dto/chat-summary.dto.ts
+++ b/src/modules/session/dto/chat-summary.dto.ts
@@ -46,7 +46,9 @@ export class ChatSummaryDto {
     description:
       'Epoch MILLISECONDS at which the mute ends, present only when muted is true; 0 means muted ' +
       'indefinitely. Milliseconds is the same unit as POST /sessions/{sessionId}/chats/mute ' +
-      'muteUntil, so a value read here can be written straight back.',
+      'muteUntil, so a finite value can be written straight back. The 0 an indefinite mute reports ' +
+      'is the exception: muteUntil requires a real future instant, so re-apply an indefinite mute ' +
+      'with a far-future timestamp rather than 0.',
     example: 1786003600000,
   })
   muteExpiration?: number;


### PR DESCRIPTION
`ChatSummary.muteExpiration` reports `0` for an indefinitely muted chat (whatsapp-web.js maps WhatsApp's `-1` "mute forever" to `0`). The field documented itself as always writable straight back to `POST /sessions/{sessionId}/chats/mute` `muteUntil`, but that route requires a real future instant (`@Min(1)`) and rejects `0` with a `400`. A client that followed the contract, reading `muteExpiration: 0` and writing it back, therefore got a rejection.

This corrects the description on `ChatSummary.muteExpiration` (DTO and engine interface): a finite value round-trips, and the `0` an indefinite mute reports is the exception, re-applied with a far-future timestamp rather than `0`. Behaviour is unchanged; the OpenAPI snapshot is regenerated for the amended description.
