### PR TITLE
fix(ci): rebuild the production apt layer on branch image builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -458,6 +458,11 @@ jobs:
           sbom: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # Never serve the production stage's apt layer from cache on branch builds either: a
+          # cached hit installs whatever the apt index held when the layer was first built, so a
+          # `:main` image can ship OS packages Debian has since patched. release.yml's docker
+          # build carries the same line plus the incident record that motivated it.
+          no-cache-filters: production
 
       # The image carries no USER directive by design: docker-entrypoint.sh starts as root to fix
       # named-volume ownership, then drops with `exec gosu openwa`. Nothing verified that drop —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   recreate changes that id by default, so with `AUTO_START_SESSIONS` off nothing revisited the row and
   it went on reporting an engine no process was running. The sweep now runs regardless of that flag;
   adopting a session still requires it.
+- The `:main` and sha Docker images rebuild the production stage's apt layer on every build instead
+  of serving it from cache, so a branch image cannot ship OS packages that Debian has since patched.
+  The release path already worked this way, after a cached layer shipped stale chromium twice.
 
 ## [0.23.4] - 2026-09-05
 


### PR DESCRIPTION
The docker job caches every build stage to GHA, including the production stage's apt-get layer. That layer's cache key is its own command text, so a cached hit installs whatever the apt index held when the layer was first built, and a published `:main` image can ship OS packages Debian has since patched.

release.yml already sets `no-cache-filters: production` for exactly this reason (a cached chromium layer shipped stale packages on two release attempts while bookworm-security carried the fix on both architectures). This adds the same line to ci.yml's docker build so branch images follow the rule the release path already enforces. The builder stage keeps its cache, so only the OS-package layer is rebuilt.

**Verified:** the workflow YAML parses and the input lands on the build step, mirroring the release.yml usage of the same action input.