### PR TITLE
feat(sdk-python): carry the commerce order and product history types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   itself resolve. On Baileys the message `body` now falls back to the customer's order note or the product
   title instead of arriving empty; whatsapp-web.js already supplied a body of its own. Sharing a whole
   catalog rather than one product carries no product id and stays `unknown`.
+- The Python SDK's `ChatHistoryMessage` carries the commerce `order` and `product` blocks the other
+  clients already ship, and now models the payload faithfully: the contract-required fields are
+  required, the rest are `NotRequired`, and `type`/`kind` are Literal vocabularies (`MessageType`
+  reuses the JavaScript union, `kind` the existing `ChatKind`) instead of plain strings.
 
 ### Fixed
 

--- a/scripts/check-contract-shapes.mjs
+++ b/scripts/check-contract-shapes.mjs
@@ -172,7 +172,7 @@ const MAPPINGS = {
 const MINIMUM_MAPPED = {
   'sdk/javascript/src/types.ts': 82,
   'dashboard/src/services/api.ts': 21,
-  'sdk/python/openwa/types.py': 77,
+  'sdk/python/openwa/types.py': 78,
   'sdk/go': 78,
   'sdk/java': 82,
 };
@@ -220,6 +220,7 @@ const PYTHON_MAPPING = {
   BulkMessageItem: 'BulkMessageItemDto',
   BulkMessageResponse: 'BulkMessageResponseDto',
   CallLinkResponse: 'CallLinkResponseDto',
+  ChatHistoryMessage: 'ChatHistoryMessageDto',
   ChatSummary: 'ChatSummaryDto',
   CreateCallLinkRequest: 'CreateCallLinkDto',
   CreateChannelRequest: 'CreateChannelDto',

--- a/sdk/python/openwa/types.py
+++ b/sdk/python/openwa/types.py
@@ -46,6 +46,24 @@ BulkMessageType = Literal["text", "image", "video", "audio", "document"]
 BatchMessageStatus = Literal["pending", "sent", "failed", "cancelled"]
 BatchLifecycleStatus = Literal["pending", "processing", "completed", "failed", "cancelled"]
 ChatKind = Literal["individual", "group", "channel", "status", "broadcast", "unknown"]
+MessageType = Literal[
+    "text",
+    "image",
+    "video",
+    "audio",
+    "voice",
+    "document",
+    "sticker",
+    "location",
+    "contact",
+    "poll",
+    "call",
+    "revoked",
+    "order",
+    "product",
+    "masked",
+    "unknown",
+]
 WebhookEvent = Literal[
     "message.received", "message.sent", "message.ack", "message.failed", "message.revoked",
     "message.reaction", "message.edited", "session.status", "session.qr", "session.authenticated",
@@ -523,6 +541,24 @@ class MessageCall(TypedDict, total=False):
     missed: bool
 
 
+class MessageOrder(TypedDict):
+    """Order block on a live history message, present on ``order`` messages only: the cart the
+    customer placed from the business catalog, plus the single-order token for its items."""
+
+    orderId: str
+    token: NotRequired[str]
+
+
+class MessageProduct(TypedDict):
+    """Product block on a live history message, present on ``product`` messages only: the catalog
+    product shared into the chat."""
+
+    productId: str
+    title: NotRequired[str]
+    description: NotRequired[str]
+    businessOwnerJid: NotRequired[str]
+
+
 class MessageContact(TypedDict, total=False):
     """Sender contact block. History carries ``pushName`` only; the richer fields arrive on
     ``message.received`` when ``WEBHOOK_CONTACT_DETAILS`` is enabled."""
@@ -553,26 +589,27 @@ ChatHistoryMessage = TypedDict(
         "to": Jid,
         "chatId": Jid,
         "body": str,
-        "type": str,
+        "type": MessageType,
         "timestamp": int,
         "fromMe": bool,
         "isGroup": bool,
-        "isStatusBroadcast": bool,
-        "kind": str,
-        "ephemeralDuration": int,
-        "author": Jid,
-        "mentionedIds": list,
-        "call": MessageCall,
-        "isLidSender": bool,
-        "senderPhone": Optional[str],
-        "contact": MessageContact,
-        "backgroundColor": str,
-        "font": int,
-        "media": ChatHistoryMedia,
-        "quotedMessage": QuotedMessage,
-        "location": MessageLocation,
+        "kind": ChatKind,
+        "isStatusBroadcast": NotRequired[bool],
+        "ephemeralDuration": NotRequired[int],
+        "author": NotRequired[Jid],
+        "mentionedIds": NotRequired[list],
+        "call": NotRequired[MessageCall],
+        "isLidSender": NotRequired[bool],
+        "senderPhone": NotRequired[Optional[str]],
+        "contact": NotRequired[MessageContact],
+        "backgroundColor": NotRequired[str],
+        "font": NotRequired[int],
+        "media": NotRequired[ChatHistoryMedia],
+        "quotedMessage": NotRequired[QuotedMessage],
+        "location": NotRequired[MessageLocation],
+        "order": NotRequired[MessageOrder],
+        "product": NotRequired[MessageProduct],
     },
-    total=False,
 )
 
 


### PR DESCRIPTION
The commerce history types landed on the JavaScript, Go and Java clients and the dashboard, but the Python client's `ChatHistoryMessage` still modeled the live history payload without the `order` and `product` blocks, and nothing could see the gap: the pair was absent from `PYTHON_MAPPING` in check-contract-shapes, so the gate had no opinion about the model.

Mapping the pair also forced the model to tell the truth about the rest of the payload: `ChatHistoryMessage` was `total=False` (every field optional) and typed `type`/`kind` as plain strings, while the contract carries ten required fields and two enums.

- Adds `MessageOrder` and `MessageProduct` TypedDicts (`orderId` required, `token` optional; `productId` required, `title`/`description`/`businessOwnerJid` optional), wired into `ChatHistoryMessage`.
- Required fields are now plain, optional ones `NotRequired`; `type` reuses a new `MessageType` Literal mirroring the JavaScript union, `kind` the existing `ChatKind`.
- `PYTHON_MAPPING` gains the pair and the Python floor rises 77 to 78.

**Verified:** `check:contract-shapes` reports 333 conforming pairs, the module imports on Python 3.9 with the runtime annotations checked, and the sdk routes/events/coverage/docs gates stay green.