### PR TITLE
fix(dashboard): cap the bulk-recipients file pick before reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `:main` and sha Docker images rebuild the production stage's apt layer on every build instead
   of serving it from cache, so a branch image cannot ship OS packages that Debian has since patched.
   The release path already worked this way, after a cached layer shipped stale chromium twice.
+- The Message Tester's bulk-recipients file picker refuses files over 2 MB before reading them.
 
 ## [0.23.4] - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,49 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Inbound WhatsApp Business commerce messages are no longer flattened to a bodyless `unknown`. A cart placed
-  from the catalog arrives as type `order`, carrying `order { orderId, token? }`, and a shared product card
-  as type `product`, carrying `product { productId, title?, description?, businessOwnerJid? }`. Both engines
-  populate them, and both types are accepted by webhook and automation-rule message-type filters. The order
-  token is scoped to that one order and is a correlation handle for its line items, which this API does not
-  itself resolve. On Baileys the message `body` now falls back to the customer's order note or the product
-  title instead of arriving empty; whatsapp-web.js already supplied a body of its own. Sharing a whole
-  catalog rather than one product carries no product id and stays `unknown`.
-- The Python SDK's `ChatHistoryMessage` carries the commerce `order` and `product` blocks the other
-  clients already ship, and now models the payload faithfully: the contract-required fields are
-  required, the rest are `NotRequired`, and `type`/`kind` are Literal vocabularies (`MessageType`
-  reuses the JavaScript union, `kind` the existing `ChatKind`) instead of plain strings.
+- Inbound commerce messages arrive typed `order` and `product` instead of a bodyless `unknown`, on both engines, and are accepted by webhook and automation-rule message-type filters.
+- The Python SDK's `ChatHistoryMessage` carries the commerce `order` and `product` blocks, with required fields and enums matching the contract.
 
 ### Fixed
 
-- A Baileys session retrying a dropped connection now reports the loop: `lastError` on
-  `GET /sessions/{sessionId}` says which attempt it is on and how long it has been down, the
-  `session.reconnect_loop` webhook fires every fifth attempt, and the reconnect metrics move. The
-  engine retries internally and never reported a disconnect, so an operator had nothing to look at
-  while a session sat at `initializing` for hours
-  ([#1546](https://github.com/rmyndharis/OpenWA/issues/1546)). Thanks @OdaiAhmed99 for the report.
-- The dashboard session card keeps showing the phone number, session id and last-active time while a
-  linked session reconnects, instead of the pairing placeholder that read as an unlinked account
-  ([#1546](https://github.com/rmyndharis/OpenWA/issues/1546)). Thanks @OdaiAhmed99 for the report.
-- The Sessions page reports a dead live-event feed and offers a retry, and re-reads the list once the
-  feed comes back. The socket gives up after five attempts, and the page kept rendering whatever
-  status arrived last with no indication that it had stopped updating.
-- A session left `ready` or `initializing` by a node that never came back is marked disconnected by
-  the takeover sweep. The boot reset skips a row still claimed by another node id, and a container
-  recreate changes that id by default, so with `AUTO_START_SESSIONS` off nothing revisited the row and
-  it went on reporting an engine no process was running. The sweep now runs regardless of that flag;
-  adopting a session still requires it.
-- A misspelled `LOG_LEVEL` now fails the boot naming the five accepted values instead of silently
-  logging at info (more logging than the operator asked for; Nest's `log` and Baileys' `trace` were
-  silent-info typos). Mixed case and surrounding spaces still work, matching how the value is read.
-- Dependabot can open better-sqlite3 13.x patch and minor PRs again. The ignore freezing
-  `>=13.0.0` predated the manifest itself shipping `^13.0.3` (with TypeORM's optional `^12` peer
-  pinned to the root version), so it only blocked updates, security ones included, on the line in
-  use; the freeze now starts at v14.
-- The `:main` and sha Docker images rebuild the production stage's apt layer on every build instead
-  of serving it from cache, so a branch image cannot ship OS packages that Debian has since patched.
-  The release path already worked this way, after a cached layer shipped stale chromium twice.
+- A Baileys reconnect loop is observable: `lastError` on the session, a `session.reconnect_loop` webhook every fifth attempt, and reconnect metrics ([#1546](https://github.com/rmyndharis/OpenWA/issues/1546)). Thanks @OdaiAhmed99 for the report.
+- The dashboard session card keeps the phone number, session id and last-active time while a linked session reconnects, instead of the pairing placeholder ([#1546](https://github.com/rmyndharis/OpenWA/issues/1546)). Thanks @OdaiAhmed99 for the report.
+- The Sessions page reports a dead live-event feed and re-reads the list once the feed recovers.
+- The takeover sweep marks sessions left `ready` or `initializing` by a node that never returned disconnected, regardless of `AUTO_START_SESSIONS`.
+- Branch Docker images (`:main`, sha tags) rebuild the production apt layer, so they cannot serve stale OS packages from the build cache.
 - The Message Tester's bulk-recipients file picker refuses files over 2 MB before reading them.
+- A misspelled `LOG_LEVEL` fails the boot naming the accepted values, instead of silently logging at info.
+- Dependabot can open better-sqlite3 13.x patch and minor updates again; the freeze now starts at v14.
 
 ## [0.23.4] - 2026-09-05
 

--- a/dashboard/src/i18n/locales/ar.json
+++ b/dashboard/src/i18n/locales/ar.json
@@ -674,6 +674,7 @@
     "removeFile": "إزالة الملف",
     "fileReadError": "فشل قراءة الملف",
     "fileTooLarge": "الملف كبير جدًا (الحد الأقصى 18 ميغابايت)",
+    "recipientsFileTooLarge": "ملف المستلمين كبير جدًا (الحد الأقصى 2 ميغابايت)",
     "caption": "التعليق",
     "filename": "اسم الملف",
     "captionPlaceholder": "أدخل التعليق...",

--- a/dashboard/src/i18n/locales/de.json
+++ b/dashboard/src/i18n/locales/de.json
@@ -659,6 +659,7 @@
     "removeFile": "Datei entfernen",
     "fileReadError": "Datei konnte nicht gelesen werden",
     "fileTooLarge": "Die Datei ist zu groß (max. 18 MB)",
+    "recipientsFileTooLarge": "Die Empfängerdatei ist zu groß (max. 2 MB)",
     "caption": "Beschriftung",
     "filename": "Dateiname",
     "captionPlaceholder": "Beschriftung eingeben...",

--- a/dashboard/src/i18n/locales/en.json
+++ b/dashboard/src/i18n/locales/en.json
@@ -659,6 +659,7 @@
     "removeFile": "Remove file",
     "fileReadError": "File read failed",
     "fileTooLarge": "File is too large (max 18 MB)",
+    "recipientsFileTooLarge": "The recipients file is too large (max 2 MB)",
     "caption": "Caption",
     "filename": "Filename",
     "captionPlaceholder": "Enter caption...",

--- a/dashboard/src/i18n/locales/es.json
+++ b/dashboard/src/i18n/locales/es.json
@@ -613,6 +613,7 @@
     "removeFile": "Quitar archivo",
     "fileReadError": "Error al leer el archivo",
     "fileTooLarge": "El archivo es demasiado grande (máx. 18 MB)",
+    "recipientsFileTooLarge": "El archivo de destinatarios es demasiado grande (máx. 2 MB)",
     "caption": "Pie de foto",
     "filename": "Nombre de archivo",
     "captionPlaceholder": "Escribe un pie de foto...",

--- a/dashboard/src/i18n/locales/fr.json
+++ b/dashboard/src/i18n/locales/fr.json
@@ -659,6 +659,7 @@
     "removeFile": "Supprimer le fichier",
     "fileReadError": "Échec de lecture du fichier",
     "fileTooLarge": "Le fichier est trop volumineux (max 18 Mo)",
+    "recipientsFileTooLarge": "Le fichier de destinataires est trop volumineux (max 2 Mo)",
     "caption": "Légende",
     "filename": "Nom du fichier",
     "captionPlaceholder": "Entrez une légende...",

--- a/dashboard/src/i18n/locales/he.json
+++ b/dashboard/src/i18n/locales/he.json
@@ -668,6 +668,7 @@
     "removeFile": "הסרת קובץ",
     "fileReadError": "קריאת הקובץ נכשלה",
     "fileTooLarge": "הקובץ גדול מדי (מקסימום 18 MB)",
+    "recipientsFileTooLarge": "קובץ הנמענים גדול מדי (מקסימום 2 MB)",
     "caption": "כיתוב",
     "filename": "שם קובץ",
     "captionPlaceholder": "יש להזין כיתוב...",

--- a/dashboard/src/i18n/locales/it.json
+++ b/dashboard/src/i18n/locales/it.json
@@ -659,6 +659,7 @@
     "removeFile": "Rimuovi file",
     "fileReadError": "Lettura del file non riuscita",
     "fileTooLarge": "Il file è troppo grande (max 18 MB)",
+    "recipientsFileTooLarge": "Il file dei destinatari è troppo grande (max 2 MB)",
     "caption": "Didascalia",
     "filename": "Nome File",
     "captionPlaceholder": "Inserisci una didascalia...",

--- a/dashboard/src/i18n/locales/ko.json
+++ b/dashboard/src/i18n/locales/ko.json
@@ -659,6 +659,7 @@
     "removeFile": "파일 제거",
     "fileReadError": "파일 읽기 실패",
     "fileTooLarge": "파일이 너무 큽니다 (최대 18 MB)",
+    "recipientsFileTooLarge": "수신자 파일이 너무 큽니다 (최대 2 MB)",
     "caption": "설명",
     "filename": "파일 이름",
     "captionPlaceholder": "설명을 입력하세요...",

--- a/dashboard/src/i18n/locales/pt-BR.json
+++ b/dashboard/src/i18n/locales/pt-BR.json
@@ -613,6 +613,7 @@
     "removeFile": "Remover arquivo",
     "fileReadError": "Falha ao ler o arquivo",
     "fileTooLarge": "O arquivo é muito grande (máx. 18 MB)",
+    "recipientsFileTooLarge": "O arquivo de destinatários é muito grande (máx. 2 MB)",
     "caption": "Legenda",
     "filename": "Nome do arquivo",
     "captionPlaceholder": "Digite uma legenda...",

--- a/dashboard/src/i18n/locales/te.json
+++ b/dashboard/src/i18n/locales/te.json
@@ -659,6 +659,7 @@
     "removeFile": "ఫైల్‌ను తొలగించు",
     "fileReadError": "ఫైల్ చదవడం విఫలమైంది",
     "fileTooLarge": "ఫైల్ చాలా పెద్దది (గరిష్టం 18 MB)",
+    "recipientsFileTooLarge": "గ్రహీతల ఫైల్ చాలా పెద్దది (గరిష్టం 2 MB)",
     "caption": "క్యాప్షన్",
     "filename": "ఫైల్ పేరు",
     "captionPlaceholder": "క్యాప్షన్ ఎంటర్ చేయండి...",

--- a/dashboard/src/i18n/locales/tr.json
+++ b/dashboard/src/i18n/locales/tr.json
@@ -659,6 +659,7 @@
     "removeFile": "Dosyayı kaldır",
     "fileReadError": "Dosya okunamadı",
     "fileTooLarge": "Dosya çok büyük (maks 18 MB)",
+    "recipientsFileTooLarge": "Alıcı dosyası çok büyük (maks 2 MB)",
     "caption": "Açıklama",
     "filename": "Dosya Adı",
     "captionPlaceholder": "Açıklama girin...",

--- a/dashboard/src/i18n/locales/zh-CN.json
+++ b/dashboard/src/i18n/locales/zh-CN.json
@@ -659,6 +659,7 @@
     "removeFile": "移除文件",
     "fileReadError": "文件读取失败",
     "fileTooLarge": "文件过大（最大 18 MB）",
+    "recipientsFileTooLarge": "收件人文件过大（最大 2 MB）",
     "caption": "说明文字",
     "filename": "文件名",
     "captionPlaceholder": "输入说明文字...",

--- a/dashboard/src/i18n/locales/zh-HK.json
+++ b/dashboard/src/i18n/locales/zh-HK.json
@@ -659,6 +659,7 @@
     "removeFile": "移除檔案",
     "fileReadError": "檔案讀取失敗",
     "fileTooLarge": "檔案過大（最大 18 MB）",
+    "recipientsFileTooLarge": "收件人檔案過大（最大 2 MB）",
     "caption": "說明文字",
     "filename": "檔案名稱",
     "captionPlaceholder": "輸入說明文字...",

--- a/dashboard/src/pages/MessageTester.tsx
+++ b/dashboard/src/pages/MessageTester.tsx
@@ -12,7 +12,7 @@ import {
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { useRole } from '../hooks/useRole';
 import { useSessionsQuery, useSessionGroupsQuery } from '../hooks/queries';
-import { parseBulkRecipients, BULK_MAX_RECIPIENTS } from '../utils/bulkRecipients';
+import { parseBulkRecipients, BULK_MAX_RECIPIENTS, BULK_RECIPIENTS_FILE_MAX_BYTES } from '../utils/bulkRecipients';
 import { PageHeader } from '../components/PageHeader';
 import './MessageTester.css';
 
@@ -194,6 +194,16 @@ export function MessageTester() {
     const file = e.target.files?.[0];
     e.target.value = '';
     if (!file) return;
+    // Reject before reading, mirroring the media pick above: FileReader would materialize the whole
+    // file as a string before any backend cap could weigh in.
+    if (file.size > BULK_RECIPIENTS_FILE_MAX_BYTES) {
+      setResponse({
+        success: false,
+        timestamp: new Date().toISOString(),
+        error: t('messageTester.recipientsFileTooLarge'),
+      });
+      return;
+    }
 
     const reader = new FileReader();
     reader.onload = () => {

--- a/dashboard/src/utils/bulkRecipients.ts
+++ b/dashboard/src/utils/bulkRecipients.ts
@@ -1,6 +1,12 @@
 // The backend caps a bulk batch at 100 messages (ArrayMaxSize on SendBulkMessageDto).
 export const BULK_MAX_RECIPIENTS = 100;
 
+// Pre-read cap for the recipients file picker. A phone list is bytes, not media: 2 MiB is roughly
+// 100k entries, far past the batch cap, while still stopping a mistaken multi-hundred-MB pick from
+// being materialized as a JS string before the textarea ever sees it (same shape as the media
+// upload's pre-read check in MessageTester).
+export const BULK_RECIPIENTS_FILE_MAX_BYTES = 2 * 1024 * 1024;
+
 /**
  * Parse the bulk-recipients textarea into chat IDs: trims whitespace, drops blanks, de-dupes, and
  * normalizes bare phone numbers to `<digits>@c.us`. An entry containing '@' is treated as a full


### PR DESCRIPTION
The CSV/TXT picker in the Message Tester read any pick in full with `FileReader` before the textarea ever saw it, so a mistaken multi-hundred-MB file froze or OOMed the tab with no backend cap in play. The media pickers two handlers above already guard exactly this hazard pre-read against `MEDIA_UPLOAD_MAX_BYTES`.

- Adds `BULK_RECIPIENTS_FILE_MAX_BYTES` (2 MiB, roughly a hundred thousand entries, far past the 100-recipient batch cap) next to `BULK_MAX_RECIPIENTS` in the bulk-recipients util.
- The recipients file handler applies the same pre-read check and surfaces `messageTester.recipientsFileTooLarge`, added to all 13 locales.

**Verified:** dashboard typecheck, lint, test suite and the i18n parity gate.