### PR TITLE
test(config): floor coverage on the eight unfloored modules

### DIFF
--- a/docs/09-testing-strategy.md
+++ b/docs/09-testing-strategy.md
@@ -186,7 +186,7 @@ authoritative gate. Current policy:
 
 | Scope                       | Branches | Functions | Lines | Statements |
 | --------------------------- | -------- | --------- | ----- | ---------- |
-| Global                      | 61%      | 70%       | 68%   | 67%        |
+| Global                      | 54%      | 68%       | 60%   | 61%        |
 | `src/common/cache/`         | 34%      | 33%       | 42%   | 42%        |
 | `src/common/security/`      | 85%      | 95%       | 93%   | 92%        |
 | `src/common/services/`      | 82%      | 91%       | 90%   | 88%        |
@@ -202,25 +202,33 @@ authoritative gate. Current policy:
 | `src/modules/audit/`        | 59%      | 45%       | 73%   | 70%        |
 | `src/modules/auth/`         | 76%      | 85%       | 86%   | 86%        |
 | `src/modules/automation/`   | 67%      | 86%       | 83%   | 79%        |
+| `src/modules/call/`         | 62%      | 57%       | 82%   | 79%        |
+| `src/modules/catalog/`      | 68%      | 88%       | 89%   | 87%        |
+| `src/modules/channel/`      | 73%      | 41%       | 76%   | 75%        |
 | `src/modules/chat-media/`   | 75%      | 72%       | 84%   | 84%        |
 | `src/modules/contact/`      | 82%      | 92%       | 89%   | 88%        |
 | `src/modules/docker/`       | 84%      | 93%       | 92%   | 92%        |
 | `src/modules/events/`       | 72%      | 84%       | 84%   | 82%        |
 | `src/modules/group/`        | 67%      | 65%       | 79%   | 79%        |
+| `src/modules/health/`       | 77%      | 66%       | 90%   | 87%        |
 | `src/modules/infra/`        | 75%      | 76%       | 89%   | 88%        |
 | `src/modules/integration/`  | 76%      | 83%       | 90%   | 89%        |
+| `src/modules/label/`        | 39%      | 42%       | 45%   | 44%        |
 | `src/modules/mcp/`          | 62%      | 76%       | 78%   | 78%        |
 | `src/modules/media/`        | 69%      | 86%       | 89%   | 88%        |
 | `src/modules/message/`      | 75%      | 66%       | 86%   | 85%        |
 | `src/modules/metrics/`      | 64%      | 58%       | 70%   | 67%        |
 | `src/modules/plugins/`      | 69%      | 64%       | 77%   | 76%        |
+| `src/modules/profile/`      | 78%      | 84%       | 88%   | 85%        |
 | `src/modules/queue/`        | 74%      | 81%       | 95%   | 95%        |
 | `src/modules/search/`       | 69%      | 86%       | 78%   | 78%        |
 | `src/modules/session/`      | 75%      | 79%       | 88%   | 87%        |
+| `src/modules/settings/`     | 50%      | 0%        | 85%   | 81%        |
 | `src/modules/stats/`        | 67%      | 63%       | 78%   | 76%        |
 | `src/modules/status-store/` | 79%      | 79%       | 92%   | 91%        |
 | `src/modules/status/`       | 70%      | 60%       | 83%   | 82%        |
 | `src/modules/template/`     | 76%      | 87%       | 91%   | 89%        |
+| `src/modules/takeover/`     | 74%      | 70%       | 85%   | 83%        |
 | `src/modules/webhook/`      | 72%      | 89%       | 90%   | 87%        |
 
 When raising a floor, set it about five points below that scope's measured coverage, so it catches

--- a/package.json
+++ b/package.json
@@ -201,10 +201,10 @@
     "coverageDirectory": "../coverage",
     "coverageThreshold": {
       "global": {
-        "branches": 61,
-        "functions": 70,
-        "lines": 68,
-        "statements": 67
+        "branches": 54,
+        "functions": 68,
+        "lines": 60,
+        "statements": 61
       },
       "./src/common/cache/": {
         "branches": 34,
@@ -415,6 +415,54 @@
         "functions": 89,
         "lines": 90,
         "statements": 87
+      },
+      "./src/modules/call/": {
+        "branches": 62,
+        "functions": 57,
+        "lines": 82,
+        "statements": 79
+      },
+      "./src/modules/catalog/": {
+        "branches": 68,
+        "functions": 88,
+        "lines": 89,
+        "statements": 87
+      },
+      "./src/modules/channel/": {
+        "branches": 73,
+        "functions": 41,
+        "lines": 76,
+        "statements": 75
+      },
+      "./src/modules/health/": {
+        "branches": 77,
+        "functions": 66,
+        "lines": 90,
+        "statements": 87
+      },
+      "./src/modules/label/": {
+        "branches": 39,
+        "functions": 42,
+        "lines": 45,
+        "statements": 44
+      },
+      "./src/modules/profile/": {
+        "branches": 78,
+        "functions": 84,
+        "lines": 88,
+        "statements": 85
+      },
+      "./src/modules/settings/": {
+        "branches": 50,
+        "functions": 0,
+        "lines": 85,
+        "statements": 81
+      },
+      "./src/modules/takeover/": {
+        "branches": 74,
+        "functions": 70,
+        "lines": 85,
+        "statements": 83
       }
     },
     "testEnvironment": "node",


### PR DESCRIPTION
jest.coverageThreshold scoped 23 module directories but left call, catalog, channel, health, label, profile, settings and takeover without one, so a coverage collapse in exactly the newest code was invisible while every sibling module was floored.

Floors follow the docs/09 9.5 policy: about five points under the measured level, then re-checked in units so every floor still passes with two newly uncovered units of its metric. That unit rule dominates the small denominators: settings' two functions floor at 0, channel's 24 functions at 41. docs/09 9.5 gains the eight rows, which its parity spec requires.

jest removes files matched by a path key from the global group, so flooring these eight also shrinks what Global grades; Global moves to the shrunken pool's policy floor (54/68/60/61). Nothing weakens: every file that left the global pool is now held to its own per-module floor.

**Verified:** a full `jest --coverage` run passes with zero threshold failures and the `docs-coverage-policy` spec is green.