### PR TITLE
fix(config): reject a misspelled LOG_LEVEL at boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   recreate changes that id by default, so with `AUTO_START_SESSIONS` off nothing revisited the row and
   it went on reporting an engine no process was running. The sweep now runs regardless of that flag;
   adopting a session still requires it.
+- A misspelled `LOG_LEVEL` now fails the boot naming the five accepted values instead of silently
+  logging at info (more logging than the operator asked for; Nest's `log` and Baileys' `trace` were
+  silent-info typos). Mixed case and surrounding spaces still work, matching how the value is read.
 
 ## [0.23.4] - 2026-09-05
 

--- a/src/config/env.validation.spec.ts
+++ b/src/config/env.validation.spec.ts
@@ -317,6 +317,22 @@ describe('validateEnv', () => {
     expect(() => validateEnv({})).not.toThrow();
   });
 
+  it('rejects a LOG_LEVEL misspelling instead of silently logging at info', () => {
+    // Plausible spellings from neighbouring vocabularies that this repo's LogLevel does not carry;
+    // every one of them silently meant INFO before this check existed.
+    expect(() => validateEnv({ LOG_LEVEL: 'warning' })).toThrow(/LOG_LEVEL/);
+    expect(() => validateEnv({ LOG_LEVEL: 'log' })).toThrow(/LOG_LEVEL/); // Nest's spelling
+    expect(() => validateEnv({ LOG_LEVEL: 'trace' })).toThrow(/LOG_LEVEL/); // Baileys' vocabulary
+    // The reader (main.ts) trims and lowercases before matching, so these keep booting.
+    expect(() => validateEnv({ LOG_LEVEL: 'DEBUG' })).not.toThrow();
+    expect(() => validateEnv({ LOG_LEVEL: ' warn ' })).not.toThrow();
+    // The five real levels, and unset (meaning INFO), all pass.
+    for (const level of ['error', 'warn', 'info', 'debug', 'verbose']) {
+      expect(() => validateEnv({ LOG_LEVEL: level })).not.toThrow();
+    }
+    expect(() => validateEnv({})).not.toThrow();
+  });
+
   it('rejects a sqlite data DB path that collides with the internal main database file', () => {
     // The 'main' (auth/audit) and 'data' connections must be separate SQLite files; sharing one
     // file means two migration ledgers + synchronize policies on the same tables.

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -480,6 +480,20 @@ export function validateEnv(config: EnvConfig): EnvConfig {
     errors.push(`SEARCH_PROVIDER must be one of: auto, builtin-fts, none (got ${JSON.stringify(provider)})`);
   }
 
+  // LOG_LEVEL is read in main.ts by exact match after trim+toLowerCase, so any casing works today
+  // and only a MISSPELLING differs: every unrecognised value silently means INFO, which is MORE
+  // logging than the operator asked for (Nest-adjacent spellings like 'log', 'trace' or 'fatal'
+  // included, none of them this repo's vocabulary). Validate the normalised form, mirroring the
+  // read site exactly (same philosophy as MEDIA_DOWNLOAD_ENABLED above): nothing that works today
+  // is refused, and a misspelling fails the boot instead of quietly logging at info.
+  const LOG_LEVEL_VALUES = ['error', 'warn', 'info', 'debug', 'verbose'];
+  const rawLogLevel = str('LOG_LEVEL');
+  if (rawLogLevel !== undefined && !LOG_LEVEL_VALUES.includes(rawLogLevel.toLowerCase())) {
+    errors.push(
+      `LOG_LEVEL must be one of ${LOG_LEVEL_VALUES.map(v => `"${v}"`).join(', ')} (got ${JSON.stringify(rawLogLevel)})`,
+    );
+  }
+
   if (errors.length > 0) {
     throw new Error(`Invalid environment configuration:\n  - ${errors.join('\n  - ')}`);
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,8 @@ import { RedisIoAdapter } from './modules/events/redis-io.adapter';
 let appInstance: INestApplication | undefined;
 
 async function bootstrap() {
-  // Apply the operator-configured log verbosity (LOG_LEVEL) before anything logs. Unset/invalid → INFO.
+  // Apply the operator-configured log verbosity (LOG_LEVEL) before anything logs. Unset means INFO;
+  // a misspelling never reaches here, env.validation.ts rejects it at boot.
   const requestedLevel = process.env.LOG_LEVEL?.trim().toLowerCase();
   if (requestedLevel && (Object.values(LogLevel) as string[]).includes(requestedLevel)) {
     LoggerService.setLogLevel(requestedLevel as LogLevel);


### PR DESCRIPTION
LOG_LEVEL was the one knob that silently forgave a typo: main.ts matches the value against the repo's LogLevel enum after trim and lowercase, and any miss falls back to INFO with no boot error, so an operator writing `warning`, `log` or `trace` got MORE logging than asked in a config layer that fail-fasts every other typo.

The validation mirrors the read site exactly (same philosophy as MEDIA_DOWNLOAD_ENABLED): the normalised form is checked, so nothing that works today is refused, mixed casing and padding included, and a misspelling fails the boot naming the five accepted values.

**Verified:** the env validation specs (including the new case: `warning`/`log`/`trace` rejected, `DEBUG` and ` warn ` accepted), the docs-env and precedence gates, and a real boot: `LOG_LEVEL=warning` exits 1 with the aggregate message, `LOG_LEVEL=' WARN '` boots.