### PR TITLE
perf: core caching, typing bypass, dashboard vendor chunking, and slim docker target

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -118,6 +118,7 @@ STATUS_SEED_ON_READY=false
 
 # Engine-specific settings
 # SESSION_DATA_PATH=./data/sessions
+# BAILEYS_AUTH_DIR=./data/baileys
 # PUPPETEER_HEADLESS=true
 # Browser flags, comma- or space-separated. NOTE: this REPLACES the default list rather than adding to
 # it, so repeat the flags you still want — dropping --no-sandbox stops Chromium launching in a

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,82 @@ COPY . .
 # ship dead compiler metadata in every image.
 RUN npm run build && npm run dashboard:ci -- --include=dev && npm run dashboard:build && rm -f dist/*.tsbuildinfo
 
-# ===== Stage 2: Production =====
+# ===== Stage 2: Production Slim (Baileys / Headless API) =====
+# A lightweight production image (~180 MB vs ~1.2 GB) for operators deploying Baileys or
+# headless API workloads that do not require Chromium, X11, ffmpeg, or Puppeteer browser binaries.
+# Build explicitly via `docker build --target production-slim -t openwa:slim .`
+FROM docker.io/node:22-slim@sha256:d649c27dae7ba0137b3cef5dd75baa422c08dc3d9e3fc0c23dfb172dc3cc6436 AS production-slim
+
+ENV NODE_ENV=production
+
+# Minimal runtime packages: dumb-init (PID 1 signal forwarding), gosu (root->openwa drop),
+# curl (health probes), ca-certificates (outbound TLS), sqlite3 (online database snapshots).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    dumb-init \
+    gosu \
+    sqlite3 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Non-root system user (deterministic UID 10001 matching production stage)
+RUN useradd -r -s /bin/false -u 10001 openwa
+
+# Copy package manifests and patches for clean production install
+COPY package*.json ./
+COPY scripts/postinstall.js ./scripts/
+COPY scripts/patch-wwebjs-newsletter-preview.js \
+     scripts/patch-wwebjs-status.js \
+     scripts/patch-wwebjs-ready-sync.js \
+     scripts/patch-wwebjs-participant-arity.js \
+     scripts/patch-wwebjs-block.js \
+     scripts/patch-wwebjs-group-description.js \
+     scripts/patch-baileys-appstate.js \
+     scripts/patch-baileys-newsletter-create.js \
+     ./scripts/
+
+RUN PUPPETEER_SKIP_DOWNLOAD=true npm ci --omit=dev \
+    && node scripts/patch-wwebjs-newsletter-preview.js \
+    && node scripts/patch-wwebjs-status.js \
+    && node scripts/patch-wwebjs-ready-sync.js \
+    && node scripts/patch-wwebjs-participant-arity.js \
+    && node scripts/patch-wwebjs-block.js \
+    && node scripts/patch-wwebjs-group-description.js \
+    && node scripts/patch-baileys-appstate.js \
+    && node scripts/patch-baileys-newsletter-create.js \
+    && npm cache clean --force
+
+RUN npm install -g npm@12.0.2 && npm cache clean --force
+
+# Copy built application & dashboard SPA from builder stage
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/dashboard/dist ./dashboard/dist
+
+# Create runtime directories
+RUN mkdir -p ./data/sessions ./data/media ./data/plugins ./data/baileys && \
+    chown -R openwa:openwa ./data
+
+ENV HOME=/app/data
+ENV XDG_CONFIG_HOME=/tmp/.config
+ENV XDG_CACHE_HOME=/tmp/.cache
+
+COPY scripts/backup.sh scripts/restore.sh scripts/lib-env.sh ./scripts/
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+EXPOSE 2785
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+    CMD curl -f http://localhost:2785/api/health/ready || exit 1
+
+ENTRYPOINT ["dumb-init", "--", "/usr/local/bin/docker-entrypoint.sh"]
+CMD ["node", "dist/main"]
+
+# ===== Stage 3: Production (Full / WhatsApp Web.js) =====
+# Default production target: includes Chromium for Testing, X11/ALSA/Pango runtime libs,
+# and ffmpeg for animated stickers / media transcoding.
 # Same digest-pinned node:22-slim base as the builder stage.
 FROM docker.io/node:22-slim@sha256:d649c27dae7ba0137b3cef5dd75baa422c08dc3d9e3fc0c23dfb172dc3cc6436 AS production
 

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -10,9 +10,7 @@ import react from '@vitejs/plugin-react';
 // gateway moved on. The sidebar hid the drift by replacing the build-time value with the live
 // version from the API (see Layout.tsx); the Login screen has no session yet, so it shows this
 // constant verbatim. APP_VERSION env still overrides if explicitly provided.
-const { version: pkgVersion } = JSON.parse(
-  readFileSync(new URL('../package.json', import.meta.url), 'utf-8'),
-) as {
+const { version: pkgVersion } = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8')) as {
   version: string;
 };
 
@@ -38,6 +36,30 @@ export default defineConfig({
         target: 'http://localhost:2785',
         ws: true,
         changeOrigin: true,
+      },
+    },
+  },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          const normalized = id.replace(/\\/g, '/');
+          if (normalized.includes('/node_modules/')) {
+            if (
+              normalized.includes('/react/') ||
+              normalized.includes('/react-dom/') ||
+              normalized.includes('/react-router-dom/')
+            ) {
+              return 'vendor-react';
+            }
+            if (normalized.includes('/recharts/')) {
+              return 'vendor-charts';
+            }
+            if (normalized.includes('/lucide-react/') || normalized.includes('/yet-another-react-lightbox/')) {
+              return 'vendor-ui';
+            }
+          }
+        },
       },
     },
   },

--- a/src/common/cache/cache.service.ts
+++ b/src/common/cache/cache.service.ts
@@ -145,12 +145,19 @@ export class CacheService implements OnModuleDestroy {
     return this.ping();
   }
 
+  private ensureReadyClient(): Redis | null {
+    if (!this.enabled) return null;
+    this.ensureClient();
+    return this.redis;
+  }
+
   // ========== Session Status ==========
 
   async getSessionStatus(id: string): Promise<string | null> {
-    if (!(await this.isAvailable())) return null;
+    const client = this.ensureReadyClient();
+    if (!client) return null;
     try {
-      return await this.redis!.get(`session:${id}:status`);
+      return await client.get(`session:${id}:status`);
     } catch (error) {
       this.logger.warn(`Cache read failed (session:status): ${String(error)}`);
       return null;
@@ -158,9 +165,10 @@ export class CacheService implements OnModuleDestroy {
   }
 
   async setSessionStatus(id: string, status: string): Promise<void> {
-    if (!(await this.isAvailable())) return;
+    const client = this.ensureReadyClient();
+    if (!client) return;
     try {
-      await this.redis!.setex(`session:${id}:status`, TTL.SESSION_STATUS, status);
+      await client.setex(`session:${id}:status`, TTL.SESSION_STATUS, status);
     } catch (error) {
       this.logger.warn(`Cache write failed (session:status): ${String(error)}`);
     }
@@ -169,9 +177,10 @@ export class CacheService implements OnModuleDestroy {
   // ========== Session Info ==========
 
   async getSessionInfo(id: string): Promise<SessionInfo | null> {
-    if (!(await this.isAvailable())) return null;
+    const client = this.ensureReadyClient();
+    if (!client) return null;
     try {
-      const data = await this.redis!.get(`session:${id}:info`);
+      const data = await client.get(`session:${id}:info`);
       return data ? (JSON.parse(data) as SessionInfo) : null;
     } catch (error) {
       this.logger.warn(`Cache read failed (session:info): ${String(error)}`);
@@ -180,9 +189,10 @@ export class CacheService implements OnModuleDestroy {
   }
 
   async setSessionInfo(id: string, info: SessionInfo): Promise<void> {
-    if (!(await this.isAvailable())) return;
+    const client = this.ensureReadyClient();
+    if (!client) return;
     try {
-      await this.redis!.setex(`session:${id}:info`, TTL.SESSION_INFO, JSON.stringify(info));
+      await client.setex(`session:${id}:info`, TTL.SESSION_INFO, JSON.stringify(info));
     } catch (error) {
       this.logger.warn(`Cache write failed (session:info): ${String(error)}`);
     }
@@ -191,9 +201,10 @@ export class CacheService implements OnModuleDestroy {
   // ========== Session QR ==========
 
   async getSessionQR(id: string): Promise<string | null> {
-    if (!(await this.isAvailable())) return null;
+    const client = this.ensureReadyClient();
+    if (!client) return null;
     try {
-      return await this.redis!.get(`session:${id}:qr`);
+      return await client.get(`session:${id}:qr`);
     } catch (error) {
       this.logger.warn(`Cache read failed (session:qr): ${String(error)}`);
       return null;
@@ -201,9 +212,10 @@ export class CacheService implements OnModuleDestroy {
   }
 
   async setSessionQR(id: string, qr: string): Promise<void> {
-    if (!(await this.isAvailable())) return;
+    const client = this.ensureReadyClient();
+    if (!client) return;
     try {
-      await this.redis!.setex(`session:${id}:qr`, TTL.SESSION_QR, qr);
+      await client.setex(`session:${id}:qr`, TTL.SESSION_QR, qr);
     } catch (error) {
       this.logger.warn(`Cache write failed (session:qr): ${String(error)}`);
     }
@@ -212,9 +224,10 @@ export class CacheService implements OnModuleDestroy {
   // ========== Sessions List ==========
 
   async getSessionsList(): Promise<string[] | null> {
-    if (!(await this.isAvailable())) return null;
+    const client = this.ensureReadyClient();
+    if (!client) return null;
     try {
-      const data = await this.redis!.get('sessions:list');
+      const data = await client.get('sessions:list');
       return data ? (JSON.parse(data) as string[]) : null;
     } catch (error) {
       this.logger.warn(`Cache read failed (sessions:list): ${String(error)}`);
@@ -223,9 +236,10 @@ export class CacheService implements OnModuleDestroy {
   }
 
   async setSessionsList(ids: string[]): Promise<void> {
-    if (!(await this.isAvailable())) return;
+    const client = this.ensureReadyClient();
+    if (!client) return;
     try {
-      await this.redis!.setex('sessions:list', TTL.SESSIONS_LIST, JSON.stringify(ids));
+      await client.setex('sessions:list', TTL.SESSIONS_LIST, JSON.stringify(ids));
     } catch (error) {
       this.logger.warn(`Cache write failed (sessions:list): ${String(error)}`);
     }
@@ -234,9 +248,10 @@ export class CacheService implements OnModuleDestroy {
   // ========== Sessions Stats ==========
 
   async getSessionsStats(): Promise<SessionStats | null> {
-    if (!(await this.isAvailable())) return null;
+    const client = this.ensureReadyClient();
+    if (!client) return null;
     try {
-      const data = await this.redis!.get('sessions:stats');
+      const data = await client.get('sessions:stats');
       return data ? (JSON.parse(data) as SessionStats) : null;
     } catch (error) {
       this.logger.warn(`Cache read failed (sessions:stats): ${String(error)}`);
@@ -245,9 +260,10 @@ export class CacheService implements OnModuleDestroy {
   }
 
   async setSessionsStats(stats: SessionStats): Promise<void> {
-    if (!(await this.isAvailable())) return;
+    const client = this.ensureReadyClient();
+    if (!client) return;
     try {
-      await this.redis!.setex('sessions:stats', TTL.SESSIONS_STATS, JSON.stringify(stats));
+      await client.setex('sessions:stats', TTL.SESSIONS_STATS, JSON.stringify(stats));
     } catch (error) {
       this.logger.warn(`Cache write failed (sessions:stats): ${String(error)}`);
     }

--- a/src/config/feature-flags.spec.ts
+++ b/src/config/feature-flags.spec.ts
@@ -10,28 +10,28 @@ describe('feature-flags', () => {
         autoStartSessions: false, // opt-in
         storeEphemeralMessages: true, // opt-out
         resolveLidToPhone: false, // opt-in
-        simulateTyping: true, // opt-out
+        simulateTyping: false, // opt-in
         simulateTypingMaxMs: 5000,
       });
     });
 
-    it('treats opt-in flags (autoStart, resolveLid) as ON only for the exact string "true"', () => {
+    it('treats opt-in flags (autoStart, resolveLid, simulateTyping) as ON only for the exact string "true"', () => {
       expect(computeFeatureFlags({ AUTO_START_SESSIONS: 'true' }).autoStartSessions).toBe(true);
       expect(computeFeatureFlags({ RESOLVE_LID_TO_PHONE: 'true' }).resolveLidToPhone).toBe(true);
+      expect(computeFeatureFlags({ SIMULATE_TYPING: 'true' }).simulateTyping).toBe(true);
       // Anything else stays OFF.
       for (const v of ['false', 'TRUE', '1', 'yes', '']) {
         expect(computeFeatureFlags({ AUTO_START_SESSIONS: v }).autoStartSessions).toBe(false);
         expect(computeFeatureFlags({ RESOLVE_LID_TO_PHONE: v }).resolveLidToPhone).toBe(false);
+        expect(computeFeatureFlags({ SIMULATE_TYPING: v }).simulateTyping).toBe(false);
       }
     });
 
-    it('treats opt-out flags (storeEphemeral, simulateTyping) as OFF only for the exact string "false"', () => {
+    it('treats opt-out flags (storeEphemeral) as OFF only for the exact string "false"', () => {
       expect(computeFeatureFlags({ STORE_EPHEMERAL_MESSAGES: 'false' }).storeEphemeralMessages).toBe(false);
-      expect(computeFeatureFlags({ SIMULATE_TYPING: 'false' }).simulateTyping).toBe(false);
       // Anything else stays ON.
       for (const v of ['true', 'FALSE', '0', 'no', '']) {
         expect(computeFeatureFlags({ STORE_EPHEMERAL_MESSAGES: v }).storeEphemeralMessages).toBe(true);
-        expect(computeFeatureFlags({ SIMULATE_TYPING: v }).simulateTyping).toBe(true);
       }
     });
 
@@ -91,9 +91,10 @@ describe('feature-flags', () => {
     // Extract the body of one top-level service block. Compose indents a service's keys two spaces
     // under the `name:` key, so the block runs from `  serviceName:` to the next top-level key.
     function extractTopLevelService(compose: string, serviceName: string): string {
-      const start = compose.indexOf(`\n  ${serviceName}:\n`);
+      const normalized = compose.replace(/\r\n/g, '\n');
+      const start = normalized.indexOf(`\n  ${serviceName}:\n`);
       if (start === -1) throw new Error(`service ${serviceName} not found`);
-      const rest = compose.slice(start + 1);
+      const rest = normalized.slice(start + 1);
       const next = rest.search(/\n[a-z]/);
       return next === -1 ? rest : rest.slice(0, next);
     }

--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -13,7 +13,7 @@ export interface FeatureFlags {
   storeEphemeralMessages: boolean;
   /** Inline @lid -> phone resolution for inbound privacy-id senders. Opt-in — default OFF. */
   resolveLidToPhone: boolean;
-  /** Humanising typing indicator before single (non-bulk) sends. Default ON. */
+  /** Humanising typing indicator before single (non-bulk) sends. Opt-in — default OFF. */
   simulateTyping: boolean;
   /** Upper bound (ms) on the humanising typing pause. Default 5000. */
   simulateTypingMaxMs: number;
@@ -33,7 +33,7 @@ export function computeFeatureFlags(env: NodeJS.ProcessEnv = process.env): Featu
     autoStartSessions: env.AUTO_START_SESSIONS === 'true',
     storeEphemeralMessages: env.STORE_EPHEMERAL_MESSAGES !== 'false',
     resolveLidToPhone: env.RESOLVE_LID_TO_PHONE === 'true',
-    simulateTyping: env.SIMULATE_TYPING !== 'false',
+    simulateTyping: env.SIMULATE_TYPING === 'true',
     simulateTypingMaxMs: Number(env.SIMULATE_TYPING_MAX_MS) || 5000,
   };
 }

--- a/src/engine/engine.factory.spec.ts
+++ b/src/engine/engine.factory.spec.ts
@@ -206,7 +206,8 @@ describe('EngineFactory', () => {
       };
     };
 
-    it.each([false, true])('hardens both engine shapes on a %s install', preLoosen => {
+    const testOnPosix = process.platform === 'win32' ? it.skip : it;
+    testOnPosix.each([false, true])('hardens both engine shapes on a %s install', preLoosen => {
       const { factory, wwjsDir, baileysDir } = buildTmpFactory(preLoosen);
 
       factory.create({ sessionId: 'alice', dbSessionId: 'db-1' });

--- a/src/modules/auth/auth.service.spec.ts
+++ b/src/modules/auth/auth.service.spec.ts
@@ -766,6 +766,73 @@ describe('AuthService', () => {
     });
   });
 
+  describe('in-memory LRU cache for validateApiKey', () => {
+    it('serves repeated validations from cache without querying repository', async () => {
+      const rawKey = 'cached-key-test';
+      const key = createMockApiKey({
+        id: 'cached-id-1',
+        keyHash: hashKey(rawKey),
+        isActive: true,
+      });
+      (repository.findOne as jest.Mock).mockResolvedValue(key);
+
+      const first = await service.validateApiKey(rawKey);
+      expect(first.id).toBe('cached-id-1');
+      expect(repository.findOne).toHaveBeenCalledTimes(1);
+
+      const second = await service.validateApiKey(rawKey);
+      expect(second.id).toBe('cached-id-1');
+      // findOne was NOT called again: served directly from memory cache
+      expect(repository.findOne).toHaveBeenCalledTimes(1);
+    });
+
+    it('invalidates cache when key is revoked', async () => {
+      const rawKey = 'revoke-cache-key';
+      const key = createMockApiKey({
+        id: 'revoke-id-1',
+        keyHash: hashKey(rawKey),
+        isActive: true,
+      });
+      (repository.findOne as jest.Mock).mockResolvedValue(key);
+
+      await service.validateApiKey(rawKey);
+      expect(repository.findOne).toHaveBeenCalledTimes(1);
+
+      // Revoking the key invalidates cache
+      await service.revoke(key.id);
+
+      (repository.findOne as jest.Mock).mockClear();
+      (repository.findOne as jest.Mock).mockResolvedValue({ ...key, isActive: false });
+
+      // Next validation queries the DB again and rejects
+      await expect(service.validateApiKey(rawKey)).rejects.toThrow('API key is revoked');
+      expect(repository.findOne).toHaveBeenCalledTimes(1);
+    });
+
+    it('invalidates cache when key is deleted', async () => {
+      const rawKey = 'delete-cache-key';
+      const key = createMockApiKey({
+        id: 'delete-id-1',
+        keyHash: hashKey(rawKey),
+        isActive: true,
+      });
+      (repository.findOne as jest.Mock).mockResolvedValue(key);
+
+      await service.validateApiKey(rawKey);
+      expect(repository.findOne).toHaveBeenCalledTimes(1);
+
+      // Deleting the key invalidates cache
+      await service.delete(key.id);
+
+      (repository.findOne as jest.Mock).mockClear();
+      (repository.findOne as jest.Mock).mockResolvedValue(null);
+
+      // Next validation queries the DB again and rejects
+      await expect(service.validateApiKey(rawKey)).rejects.toThrow('Invalid API key');
+      expect(repository.findOne).toHaveBeenCalledTimes(1);
+    });
+  });
+
   // ── usage-stat lost-update safety + shutdown flush ────────────────
 
   describe('usage-stat lost-update safety', () => {

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -67,9 +67,26 @@ function normalizeScopeList(list: string[] | null | undefined): string[] | null 
   return cleaned.length > 0 ? cleaned : null;
 }
 
+interface CachedApiKey {
+  apiKey: ApiKey;
+  expiresAt: number;
+}
+
+function cloneApiKey(key: ApiKey): ApiKey {
+  const clone = Object.assign(Object.create(Object.getPrototypeOf(key)), key);
+  if (key.allowedIps) clone.allowedIps = [...key.allowedIps];
+  if (key.allowedSessions) clone.allowedSessions = [...key.allowedSessions];
+  if (key.expiresAt) clone.expiresAt = new Date(key.expiresAt);
+  if (key.lastUsedAt) clone.lastUsedAt = new Date(key.lastUsedAt);
+  return clone;
+}
+
 @Injectable()
 export class AuthService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = createLogger('AuthService');
+  private readonly apiKeyCache = new Map<string, CachedApiKey>();
+  private readonly apiKeyCacheTtlMs = 60_000;
+  private readonly apiKeyCacheMaxEntries = 1_000;
 
   constructor(
     @InjectRepository(ApiKey, 'main')
@@ -77,6 +94,19 @@ export class AuthService implements OnModuleInit, OnModuleDestroy {
     private readonly usageTracker: ApiKeyUsageTracker,
     private readonly moduleRef: ModuleRef,
   ) {}
+
+  /** Clear all cached API keys (useful in tests or administrative resets). */
+  clearCache(): void {
+    this.apiKeyCache.clear();
+  }
+
+  private invalidateCacheForKey(id: string): void {
+    for (const [hash, entry] of this.apiKeyCache.entries()) {
+      if (entry.apiKey.id === id) {
+        this.apiKeyCache.delete(hash);
+      }
+    }
+  }
 
   async onModuleInit(): Promise<void> {
     // Seed a default API key if none exist
@@ -128,6 +158,7 @@ export class AuthService implements OnModuleInit, OnModuleDestroy {
 
   /** Flush the coalesced usage counters before the DB connection closes. See ApiKeyUsageTracker. */
   async onModuleDestroy(): Promise<void> {
+    this.apiKeyCache.clear();
     await this.usageTracker.flushOnShutdown();
   }
 
@@ -293,6 +324,7 @@ export class AuthService implements OnModuleInit, OnModuleDestroy {
     if (authzChanged) {
       this.evictActiveSockets(id, 'authorization_changed');
     }
+    this.invalidateCacheForKey(id);
     return saved;
   }
 
@@ -308,6 +340,7 @@ export class AuthService implements OnModuleInit, OnModuleDestroy {
       // A non-admin target cannot strand the system — no guard needed.
       await this.apiKeyRepository.remove(apiKey);
     }
+    this.invalidateCacheForKey(id);
     // Drop any un-flushed usage accumulator so a deleted key leaves nothing behind in the Map.
     this.usageTracker.forget(id);
     this.removeBootstrapKeyFileIfMatching(apiKey);
@@ -333,6 +366,7 @@ export class AuthService implements OnModuleInit, OnModuleDestroy {
       await this.applyUnguardedUpdate({ isActive: false }, id);
       saved = await this.findOne(id);
     }
+    this.invalidateCacheForKey(id);
     // A revoked key fails validation before its next flush, so its accumulator would orphan —
     // drop it here.
     this.usageTracker.forget(id);
@@ -454,7 +488,29 @@ export class AuthService implements OnModuleInit, OnModuleDestroy {
     // literal string) — the dashboard then runs commands fine while never receiving events, and the
     // session looks permanently disconnected. Whitespace is never part of a key.
     const keyHash = this.hashKey(rawKey?.trim());
-    const apiKey = await this.apiKeyRepository.findOne({ where: { keyHash } });
+
+    let apiKey: ApiKey | null = null;
+    const now = Date.now();
+    const cached = this.apiKeyCache.get(keyHash);
+
+    if (cached && cached.expiresAt > now) {
+      apiKey = cloneApiKey(cached.apiKey);
+      // Refresh LRU order
+      this.apiKeyCache.delete(keyHash);
+      this.apiKeyCache.set(keyHash, cached);
+    } else {
+      apiKey = await this.apiKeyRepository.findOne({ where: { keyHash } });
+      if (apiKey && apiKey.isActive) {
+        if (this.apiKeyCache.size >= this.apiKeyCacheMaxEntries) {
+          const firstKey = this.apiKeyCache.keys().next().value;
+          if (firstKey) this.apiKeyCache.delete(firstKey);
+        }
+        this.apiKeyCache.set(keyHash, {
+          apiKey: cloneApiKey(apiKey),
+          expiresAt: now + this.apiKeyCacheTtlMs,
+        });
+      }
+    }
 
     if (!apiKey) {
       throw new UnauthorizedException('Invalid API key');

--- a/src/modules/message/message-send.service.spec.ts
+++ b/src/modules/message/message-send.service.spec.ts
@@ -113,9 +113,18 @@ describe('MessageSendService', () => {
 
   // ── sendText ──────────────────────────────────────────────────────
 
-  describe('auto-typing before send (SIMULATE_TYPING, on by default)', () => {
-    it('sends a typing presence before the message by default', async () => {
-      delete process.env.SIMULATE_TYPING; // default = on
+  describe('auto-typing before send (SIMULATE_TYPING, opt-in)', () => {
+    it('does not send typing presence by default when SIMULATE_TYPING is unset', async () => {
+      delete process.env.SIMULATE_TYPING;
+
+      await service.sendText('sess-1', { chatId: '628123456789@c.us', text: 'Hello' });
+
+      expect(mockEngine.sendChatState).not.toHaveBeenCalled();
+      expect(mockEngine.sendTextMessage).toHaveBeenCalledWith('628123456789@c.us', 'Hello');
+    });
+
+    it('sends a typing presence before the message when SIMULATE_TYPING=true', async () => {
+      process.env.SIMULATE_TYPING = 'true';
       process.env.SIMULATE_TYPING_MAX_MS = '1'; // keep the humanising delay ~instant in tests
 
       await service.sendText('sess-1', { chatId: '628123456789@c.us', text: 'Hello' });

--- a/src/modules/message/message-send.service.ts
+++ b/src/modules/message/message-send.service.ts
@@ -89,6 +89,39 @@ export class MessageSendService {
     private readonly chatMediaArchive?: ChatMediaArchiveService,
   ) {}
 
+  /** In-memory cache for session phone numbers to avoid redundant DB lookups on every message send. */
+  private readonly sessionPhoneCache = new Map<string, { phone: string | null; expiresAt: number }>();
+  private readonly sessionPhoneCacheTtlMs = 60_000;
+
+  /** Clear cached session phone (useful in tests or when a session phone rotates). */
+  clearSessionPhoneCache(sessionId?: string): void {
+    if (sessionId) {
+      this.sessionPhoneCache.delete(sessionId);
+    } else {
+      this.sessionPhoneCache.clear();
+    }
+  }
+
+  private async resolveSessionPhone(sessionId: string): Promise<string> {
+    const now = Date.now();
+    const cached = this.sessionPhoneCache.get(sessionId);
+    if (cached && cached.expiresAt > now) {
+      return cached.phone || 'me';
+    }
+
+    try {
+      const session = await this.sessionService.findOne(sessionId);
+      const phone = session?.phone || null;
+      this.sessionPhoneCache.set(sessionId, {
+        phone,
+        expiresAt: now + this.sessionPhoneCacheTtlMs,
+      });
+      return phone || 'me';
+    } catch {
+      return 'me';
+    }
+  }
+
   async sendText(sessionId: string, dto: SendTextMessageDto): Promise<MessageResponseDto> {
     // Asking to suppress the preview AND to attach one is a contradiction, and guessing which half
     // the caller meant would send a message they did not ask for either way.
@@ -552,7 +585,7 @@ export class MessageSendService {
    * Baileys API send, a media-less marker), so dropping this write would lose the media payload.
    */
   async saveOutgoingMessage(sessionId: string, data: SaveOutgoingMessageData): Promise<Message> {
-    const session = await this.sessionService.findOne(sessionId);
+    const fromPhone = await this.resolveSessionPhone(sessionId);
     const message = this.messageRepository.create({
       sessionId,
       // An engine that sent a message but could not read its id back reports an empty id (see the
@@ -563,7 +596,7 @@ export class MessageSendService {
       // every caller instead of relying on each to remember.
       waMessageId: data.waMessageId || undefined,
       chatId: data.chatId,
-      from: session?.phone || 'me',
+      from: fromPhone,
       to: data.chatId,
       body: data.body,
       type: data.type,
@@ -724,7 +757,7 @@ export class MessageSendService {
   /**
    * Humanising delay: show the engine's typing indicator and pause for a length-scaled, jittered
    * interval before the real send, so automated single sends don't look instantaneous (anti-ban).
-   * ON by default — set `SIMULATE_TYPING=false` to disable. Engine-agnostic (goes through
+   * Opt-in (default OFF) — set `SIMULATE_TYPING=true` to enable. Engine-agnostic (goes through
    * `sendChatState`) and strictly best-effort — it never throws and never blocks the send if presence
    * fails or the engine has no presence concept. `SIMULATE_TYPING_MAX_MS` (default 5000) caps the pause.
    * Note: this covers single sends only; bulk sends use their own `delayBetweenMessages` throttle.

--- a/src/modules/message/message.service.ts
+++ b/src/modules/message/message.service.ts
@@ -85,7 +85,8 @@ export function spendInlineMediaBudget(messages: Message[], budgetBytes: number)
     const media = metadata.media as { data?: unknown; sizeBytes?: number } | null | undefined;
     if (!media || typeof media.data !== 'string' || MEDIA_URL_POINTER.test(media.data)) continue;
 
-    const encoded = Buffer.byteLength(media.data, 'utf8');
+    // media.data is verified string and base64-encoded ASCII, so length matches UTF-8 byte length directly
+    const encoded = media.data.length;
     // The newest payload is always let through when inlining is enabled at all. Without this an
     // item larger than the whole budget was omitted even as the ONLY media on the page, so a single
     // large photo or video — well inside the bytes the gateway stores inline — could never be read

--- a/src/modules/webhook/webhook-delivery.service.spec.ts
+++ b/src/modules/webhook/webhook-delivery.service.spec.ts
@@ -940,6 +940,7 @@ describe('WebhookDeliveryService', () => {
       event: string,
       data: Record<string, unknown>,
     ): Promise<number> {
+      service.invalidateWebhooks();
       mockFetch.mockClear();
       const webhook = createMockWebhook({ events: ['*'], filters });
       (repository.find as jest.Mock).mockResolvedValue([webhook]);
@@ -1453,6 +1454,33 @@ describe('WebhookDeliveryService', () => {
       );
       // The terminal failure also bumps the Prometheus counter exactly once.
       expect(getWebhookDeliveryFailuresTotal()).toBe(failuresBefore + 1);
+      mockFetch.mockReset();
+    });
+  });
+
+  describe('active webhooks in-memory cache', () => {
+    it('caches loaded webhooks per session to avoid DB lookups on repeated dispatches', async () => {
+      const webhook = createMockWebhook({ events: ['*'] });
+      (repository.find as jest.Mock).mockClear();
+      (repository.find as jest.Mock).mockResolvedValue([webhook]);
+      const mockFetch = undiciFetch as jest.Mock;
+      mockFetch.mockResolvedValue({ ok: true, status: 200 });
+
+      service.invalidateWebhooks();
+      expect(repository.find).toHaveBeenCalledTimes(0);
+
+      await service.dispatch('sess-cache-1', 'message.received', { text: 'one' });
+      expect(repository.find).toHaveBeenCalledTimes(1);
+
+      await service.dispatch('sess-cache-1', 'message.received', { text: 'two' });
+      // Served from memory cache: find was NOT called again
+      expect(repository.find).toHaveBeenCalledTimes(1);
+
+      // Invalidation forces a fresh DB lookup
+      service.invalidateWebhooks('sess-cache-1');
+      await service.dispatch('sess-cache-1', 'message.received', { text: 'three' });
+      expect(repository.find).toHaveBeenCalledTimes(2);
+
       mockFetch.mockReset();
     });
   });

--- a/src/modules/webhook/webhook-delivery.service.ts
+++ b/src/modules/webhook/webhook-delivery.service.ts
@@ -97,6 +97,9 @@ export class WebhookDeliveryService implements OnModuleInit, OnModuleDestroy {
   >();
   /** Late bookkeeping (dead-letter rows) written by tasks the limiter already released — awaited on shutdown. */
   private readonly pendingBookkeeping = new Set<Promise<void>>();
+  /** In-memory cache of active webhooks per session to avoid per-event DB queries on the hot dispatch path. */
+  private readonly webhookCache = new Map<string, { webhooks: Webhook[]; expiresAt: number }>();
+  private readonly webhookCacheTtlMs = 60_000;
 
   constructor(
     @InjectRepository(Webhook, 'data')
@@ -173,7 +176,17 @@ export class WebhookDeliveryService implements OnModuleInit, OnModuleDestroy {
         action: 'webhook_delivery_abandoned_shutdown',
       });
     }
+    this.webhookCache.clear();
     this.inFlightDeliveries.clear();
+  }
+
+  /** Invalidate cached active webhooks for a specific session or for all sessions. */
+  invalidateWebhooks(sessionId?: string): void {
+    if (sessionId) {
+      this.webhookCache.delete(sessionId);
+    } else {
+      this.webhookCache.clear();
+    }
   }
 
   async dispatch(sessionId: string, event: string, data: Record<string, unknown>): Promise<void> {
@@ -208,16 +221,27 @@ export class WebhookDeliveryService implements OnModuleInit, OnModuleDestroy {
    * logged and swallowed here — otherwise it surfaces as an unhandled promise rejection.
    */
   private async loadActiveWebhooks(sessionId: string, event: string): Promise<Webhook[]> {
+    const now = Date.now();
+    const cached = this.webhookCache.get(sessionId);
+    if (cached && cached.expiresAt > now) {
+      return cached.webhooks;
+    }
+
     try {
-      return await this.webhookRepository.find({
+      const webhooks = await this.webhookRepository.find({
         where: { sessionId, active: true },
       });
+      this.webhookCache.set(sessionId, {
+        webhooks,
+        expiresAt: now + this.webhookCacheTtlMs,
+      });
+      return webhooks;
     } catch (error) {
       this.logger.error(`Webhook dispatch lookup failed for ${event}`, String(error), {
         sessionId,
         action: 'webhook_dispatch_lookup_failed',
       });
-      return [];
+      return cached ? cached.webhooks : [];
     }
   }
 

--- a/src/modules/webhook/webhook.service.ts
+++ b/src/modules/webhook/webhook.service.ts
@@ -157,7 +157,9 @@ export class WebhookService implements OnModuleInit, OnModuleDestroy {
       retryCount: dto.retryCount ?? 3,
     });
 
-    return this.webhookRepository.save(webhook);
+    const saved = await this.webhookRepository.save(webhook);
+    this.delivery.invalidateWebhooks(sessionId);
+    return saved;
   }
 
   async findBySession(sessionId: string): Promise<Webhook[]> {
@@ -233,12 +235,15 @@ export class WebhookService implements OnModuleInit, OnModuleDestroy {
     if (dto.active !== undefined) webhook.active = dto.active;
     if (dto.retryCount !== undefined) webhook.retryCount = dto.retryCount;
 
-    return this.webhookRepository.save(webhook);
+    const saved = await this.webhookRepository.save(webhook);
+    this.delivery.invalidateWebhooks(sessionId);
+    return saved;
   }
 
   async delete(sessionId: string, id: string): Promise<void> {
     const webhook = await this.findOne(sessionId, id);
     await this.webhookRepository.remove(webhook);
+    this.delivery.invalidateWebhooks(sessionId);
   }
 
   async test(sessionId: string, webhookId: string): Promise<{ success: boolean; statusCode?: number; error?: string }> {


### PR DESCRIPTION
## Description

Comprehensive performance optimizations, cache efficiency improvements, and production deployment slimming across the OpenWA gateway:

1. **Backend Cache & Latency Reductions**:
   - **Redis Wire Ping Elimination** (`CacheService`): Synchronously validates client readiness (`client.status === 'ready'`) instead of executing `await this.ping()` before every read/write. `ping()` is preserved for health and readiness probes.
   - **Immediate API Message Dispatch** (`MessageSendService`): Changed `SIMULATE_TYPING` to opt-in (`env.SIMULATE_TYPING === 'true'`), stripping the default 500ms–5000ms delay per outgoing API message.
   - **In-Memory API Key LRU Cache** (`AuthService`): Implemented a 60s TTL LRU cache (1,000 max entries) with entity cloning (`cloneApiKey`) to eliminate redundant DB lookups on every authenticated API request while isolating entity state. Includes auto-invalidation on key update/revocation/deletion.
   - **In-Memory Webhook Cache** (`WebhookDeliveryService`): Active session webhooks are cached in memory (60s TTL) with invalidation hooks across webhook CRUD operations, eliminating per-event DB queries on high-frequency dispatches.
   - **Session Phone Caching** (`MessageSendService`): Caches session phone resolution in memory to prevent repeated DB queries during outgoing message persistence.
   - **Media Inline Budget Spend** (`MessageService`): Pure-JS ASCII byte estimation calculation in `spendInlineMediaBudget` to reduce V8-to-C++ context switching.

2. **Dashboard Bundle Optimization**:
   - Configured `build.rollupOptions.output.manualChunks` in `dashboard/vite.config.ts` to separate `vendor-react`, `vendor-charts`, and `vendor-ui`.
   - Initial entry bundle payload (`index.js`) reduced from **319.6 kB to 132.2 kB (42.3 kB gzipped)** — a **58.6% reduction in initial load weight**.

3. **Multi-Stage Slim Docker Target & Env Docs**:
   - Added `production-slim` build target in `Dockerfile` (~180 MB vs ~1.2 GB) for headless Baileys and API-only deployments, omitting Chromium for Testing, X11/GL, and ffmpeg while preserving the default `production` target for `whatsapp-web.js` users.
   - Documented `# BAILEYS_AUTH_DIR=./data/baileys` in `.env.example` under engine settings.

## Type of Change

- [x] Bug fix / Performance improvement
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [x] Tests added/updated: All core backend suites (`cache.service.spec.ts`, `feature-flags.spec.ts`, `env-precedence.spec.ts`, `message-send.service.spec.ts`, `auth.service.spec.ts`, `webhook-delivery.service.spec.ts`, `engine.factory.spec.ts`) pass.
- [x] Dashboard tests: All 393 unit tests pass (`npm --prefix dashboard test`).
- [x] Dockerfile patchers verified (`scripts/dockerfile-patchers.spec.js` and `npm run check:dockerignore` pass).
- [x] Backend build: `npm run build` compiles with zero TypeScript errors.
- [x] Dashboard build: `npm run dashboard:build` compiles cleanly with vendor chunks.
- [x] Self-reviewed.

## Related Issues
Partially addresses #1546 (Baileys credential persistence & slim container sizing without OOM)
