### PR TITLE
chore(deps): pin multer to 2.3.0 past three DoS advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4107,6 +4107,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -5416,9 +5417,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5433,9 +5431,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5450,9 +5445,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5467,9 +5459,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5484,9 +5473,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5501,9 +5487,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5518,9 +5501,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5535,9 +5515,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5552,9 +5529,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5569,9 +5543,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10902,9 +10873,9 @@
       }
     },
     "node_modules/multer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
-      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.3.0.tgz",
+      "integrity": "sha512-cjNbm3sttszgZeGfJR124D+jFEfkXCVAsoPBmFn9X7UxmDSFHWqE2CoEj0vrmSpuAFnqWR1Szcm9QTsiHr60Xw==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -502,6 +502,7 @@
     "tar": "^7.5.21",
     "js-yaml": "^5.2.2",
     "fast-uri": "^3.1.7",
+    "multer": "2.3.0",
     "better-sqlite3": "$better-sqlite3",
     "typeorm": {
       "ioredis": "$ioredis"


### PR DESCRIPTION
The scheduled security scan on main has been failing since this morning on three high multer advisories, all multipart denial of service: GHSA-wc9g-mqfw-jrwm (crafted multipart field names), GHSA-qfvm-cv95-jqjf (file descriptor leak on aborted uploads) and GHSA-535w-7cp7-47q4 (oversized array index in field names). The affected range is <=2.2.0, which is exactly what @nestjs/platform-express pins; every release up to 12.0.1 still asks for 2.2.0, so npm cannot move the tree on its own.

What changed: a `multer: 2.3.0` entry in the npm `overrides` map, next to the existing shell-quote, tar and fast-uri security pins, plus the lockfile resolution. 2.2.0 to 2.3.0 is same-major with an unchanged multipart API.

Verified: `npm run check:audit` passes, multer resolves to `2.3.0 overridden` under @nestjs/platform-express, and the unit (6199) and e2e (192) lanes are green on the override.

This also unblocks the audit lane on #1572, which is red on the same advisories and touches none of these files.