### PR TITLE
fix(baileys): drop sender-key distribution noise on the live path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The Baileys live path drops contentless protocol traffic (sender-key distributions, message-history notices) instead of delivering it as a bodyless `unknown` `message.received`, matching what the history path already does ([#1568](https://github.com/rmyndharis/OpenWA/issues/1568)). Thanks @berodcdev for the report.
 - The group invite-code read, over REST or the MCP `GroupGetInviteCode` tool, requires the OPERATOR role; the code is a transferable join capability, so a VIEWER key can no longer extract it.
 - A Baileys reconnect loop is observable: `lastError` on the session, a `session.reconnect_loop` webhook every fifth attempt, and reconnect metrics ([#1546](https://github.com/rmyndharis/OpenWA/issues/1546)). Thanks @OdaiAhmed99 for the report.
 - The dashboard session card keeps the phone number, session id and last-active time while a linked session reconnects, instead of the pairing placeholder ([#1546](https://github.com/rmyndharis/OpenWA/issues/1546)). Thanks @OdaiAhmed99 for the report.

--- a/src/engine/adapters/baileys-events.ts
+++ b/src/engine/adapters/baileys-events.ts
@@ -303,6 +303,18 @@ export class BaileysEvents {
         return;
       }
 
+      // --- contentless protocol traffic: don't emit onMessage ---
+      // Baileys' getContentType only matches keys named `conversation` or containing `Message`, and
+      // excludes senderKeyDistributionMessage BY NAME, so a sender-key distribution (Signal traffic
+      // every group participant emits on first write or key rotation), a messageHistoryNotice or any
+      // other suffix-less proto resolves here as contentType `undefined`, never as its own key.
+      // These carry no user content yet reached consumers as bodyless `unknown` message.received
+      // events (#1568). mapHistoryMessage drops exactly this set via its `!contentType` guard, and
+      // emitOwnSendEcho has always skipped undefined the same way, so live inbound must agree.
+      if (!contentType || contentType === 'senderKeyDistributionMessage') {
+        return;
+      }
+
       // --- Normal message: enrich + emit ---
       const incoming = await this.mapMessage(msg, contentType, { skipMediaDownload: opts?.skipMedia });
       if (msg.key.fromMe === true) {

--- a/src/engine/adapters/baileys.adapter.spec.ts
+++ b/src/engine/adapters/baileys.adapter.spec.ts
@@ -2580,6 +2580,95 @@ describe('BaileysAdapter inbound fan-out', () => {
     expect(event.senderId).toBe('628111@c.us'); // canonicalized to the neutral dialect
   });
 
+  it('senderKeyDistributionMessage: emits nothing and stores nothing (protocol noise the history path drops, #1568)', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+    const baileys = jest.requireMock('@whiskeysockets/baileys') as { getContentType: jest.Mock };
+    // Real baileys 7.x getContentType EXCLUDES senderKeyDistributionMessage by name and only matches
+    // keys named `conversation` or containing `Message`, so an SKDM-only message resolves to
+    // undefined, never to 'senderKeyDistributionMessage'. The mock must return the realistic value
+    // or the test pins a code path production cannot reach.
+    baileys.getContentType.mockReturnValue(undefined);
+
+    const onMessage = jest.fn();
+    const adapter = newAdapter();
+    await adapter.initialize({ onMessage });
+    fakeSock.fire('messages.upsert', {
+      type: 'notify',
+      messages: [
+        {
+          key: {
+            remoteJid: '120363@g.us',
+            fromMe: false,
+            id: 'SKDM1',
+            participant: '628222@s.whatsapp.net',
+          },
+          message: {
+            senderKeyDistributionMessage: { axolotlSenderKeyDistributionMessage: 'R1NFMTIx...' },
+          },
+          messageTimestamp: 1700000025,
+        },
+      ],
+    });
+    await new Promise(r => setImmediate(r));
+    // A sender-key distribution is Signal protocol traffic every group participant emits on first
+    // write or key rotation; it carries no user content. The history mapper already returns null
+    // for it, so the live path must not deliver a bodyless `unknown` message.received either.
+    expect(onMessage).not.toHaveBeenCalled();
+    expect(fakeStore.put).not.toHaveBeenCalled();
+  });
+
+  it('learns the lid pair carried on a dropped sender-key distribution before dropping it (#1568)', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+    const baileys = jest.requireMock('@whiskeysockets/baileys') as { getContentType: jest.Mock };
+    // Call order matches message order: the SKDM resolves to undefined (dropped), the following
+    // real message to 'conversation'.
+    baileys.getContentType.mockReturnValueOnce(undefined).mockReturnValueOnce('conversation');
+
+    const onMessage = jest.fn();
+    const adapter = newAdapter();
+    await adapter.initialize({ onMessage });
+    // An SKDM is the first stanza a fresh @lid group sender emits; its key carries the only
+    // lid->phone pair. recordKeyLidMappings runs BEFORE the contentless drop, so the pair must be
+    // learned even though the message itself never reaches consumers.
+    fakeSock.fire('messages.upsert', {
+      type: 'notify',
+      messages: [
+        {
+          key: {
+            remoteJid: '120363@g.us',
+            fromMe: false,
+            id: 'SKDM_LID',
+            participant: '111@lid',
+            participantAlt: '628111@s.whatsapp.net',
+          },
+          message: { senderKeyDistributionMessage: { axolotlSenderKeyDistributionMessage: 'eA==' } },
+          messageTimestamp: 1700000030,
+        },
+      ],
+    });
+    await new Promise(r => setImmediate(r));
+    expect(onMessage).not.toHaveBeenCalled(); // dropped, not delivered
+
+    // The sender's real message follows, keyed by the bare lid with no Alt of its own; the pair
+    // learned from the dropped SKDM's key must resolve its author to the phone.
+    fakeSock.fire('messages.upsert', {
+      type: 'notify',
+      messages: [
+        {
+          key: { remoteJid: '120363@g.us', fromMe: false, id: 'REAL_LID', participant: '111@lid' },
+          message: { conversation: 'first real message' },
+          messageTimestamp: 1700000031,
+        },
+      ],
+    });
+    await new Promise(r => setImmediate(r));
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const msg = onMessage.mock.calls[0][0] as { author?: string; body: string };
+    expect(msg.author).toBe('628111@c.us');
+    expect(msg.body).toBe('first real message');
+  });
+
   it('media download failure: logs the error and emits the omitted marker (no throw)', async () => {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     const baileys = jest.requireMock('@whiskeysockets/baileys') as {


### PR DESCRIPTION
A group participant emits a sender-key distribution every time they first write to a group or rotate their Sender Key, and Baileys surfaces it through `messages.upsert` like any other message. Baileys' `getContentType` excludes `senderKeyDistributionMessage` by name and only matches keys named `conversation` or containing `Message`, so this traffic (and its siblings like `messageHistoryNotice`) resolves to contentType `undefined`. The live inbound handler only special-cased `protocolMessage` and `reactionMessage`, so undefined-content messages reached consumers as `message.received` with `type: "unknown"` and an empty body, indistinguishable from real content. The history mapper already returns `null` for the same set via its `!contentType` clause (and the own-send echo has always skipped undefined the same way), so the live and history paths disagreed, and in group-heavy deployments these events were a large share of the stream (the reporter measured 46% of stored rows on one installation).

What changed:

- `processInboundMessage` returns early when the normalized content has no resolvable type (`!contentType || contentType === 'senderKeyDistributionMessage'`, mirroring `mapHistoryMessage`'s drop condition): no `onMessage` emission, no message-store write, no chat-preview seed. `recordKeyLidMappings` runs before the guard, so lid learning from a dropped key still happens; media types all contain `Message`, so nothing with downloadable content is dropped.
- A regression test in the adapter inbound fan-out suite mocks `getContentType` with the value the real library produces for SKDM-only content (`undefined`), pins that such an upsert fires no callback and stores nothing, and documents why the realistic mock matters: `'senderKeyDistributionMessage'` is a value the real function never returns.
- A second test pins that the lid->phone pair carried on a dropped SKDM's key is still learned: a fresh `@lid` group sender's first real message resolves to their phone only because learning precedes the drop.
- Changelog entry under Unreleased.

Verified with the full unit suite (`npm test`, 6204 passing) plus `tsc --noEmit` and ESLint on the changed files. The first test was written before the guard and failed against an earlier draft whose guard compared `contentType === 'senderKeyDistributionMessage'` directly, which is dead code under the real library semantics; that failure is what pinned the correct condition.

Scope: this covers the contentless-protocol slice of the report (sender-key distributions, message-history notices, and other keys Baileys' type resolver cannot name). The `Message`-suffixed shapes the reporter also measured (`pollUpdateMessage`, `secretEncryptedMessage`, `encReactionMessage`, `questionMessage`, `albumMessage`) still arrive as `unknown` with an empty body, on both the live and history paths; naming or dropping them needs a `MessageType` union change that ripples into the webhook filter enum, the SDK clients and the OpenAPI snapshot, so it belongs to its own change.

Addresses part of #1568
